### PR TITLE
Two level thumbcache + async I/O

### DIFF
--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -304,32 +304,22 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
             if (!file.isFolder()) {
                 if (file.isImage() && file.getRemoteId() != null){
                     // Thumbnail in Cache?
-                    Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                            String.valueOf(file.getRemoteId())
-                            );
-                    if (thumbnail != null && !file.needsUpdateThumbnail()){
-                        fileIcon.setImageBitmap(thumbnail);
-                    } else {
-                        // generate new Thumbnail
-                        if (ThumbnailsCacheManager.cancelPotentialWork(file, fileIcon)) {
-                            final ThumbnailsCacheManager.ThumbnailGenerationTask task =
-                                    new ThumbnailsCacheManager.ThumbnailGenerationTask(
-                                            fileIcon, mStorageManager, mAccount
-                                            );
-                            if (thumbnail == null) {
-                                thumbnail = ThumbnailsCacheManager.mDefaultImg;
-                            }
-                            final ThumbnailsCacheManager.AsyncDrawable asyncDrawable =
-                                    new ThumbnailsCacheManager.AsyncDrawable(
-                                    mContext.getResources(), 
-                                    thumbnail, 
-                                    task
-                                    );
-                            fileIcon.setImageDrawable(asyncDrawable);
-                            task.execute(file);
-                        }
+                    Bitmap thumbnail = ThumbnailsCacheManager.mDefaultImg; // ThumbnailsCacheManager.getBitmapFromDiskCache(String.valueOf(file.getRemoteId()));
+                    // request Thumbnail in background task
+                    if (ThumbnailsCacheManager.cancelPotentialWork(file, fileIcon)) {
+                        final ThumbnailsCacheManager.ThumbnailGenerationTask task =
+                                new ThumbnailsCacheManager.ThumbnailGenerationTask(
+                                        fileIcon, mStorageManager, mAccount
+                                );
+                        final ThumbnailsCacheManager.AsyncDrawable asyncDrawable =
+                                new ThumbnailsCacheManager.AsyncDrawable(
+                                        mContext.getResources(),
+                                        thumbnail,
+                                        task
+                                );
+                        fileIcon.setImageDrawable(asyncDrawable);
+                        task.execute(file);
                     }
-
                     if (file.getMimetype().equalsIgnoreCase("image/png")) {
                         fileIcon.setBackgroundColor(mContext.getResources()
                                 .getColor(R.color.background_color));


### PR DESCRIPTION
Just compare to the normal version, while scrolling in a folder

fixed a bug, which retriggered thumbnail loading, after a thumbnail was loaded and the view was scrolled at the end of the view (beginning and and aswell as backscroll).

All I/O is now done in a AsyncTask, even cache I/O on the flash, as it really introduced stutter, because flash read access aswell as JPEG->Bitmap Decoding is done on the UI Thread.

I added a bitmap in memory cache for thumbnails (LRUCache), this cache is queried in the AsyncTask aswell (should not be).

I think final solution would be

Check Memory Bitmap Cache
  Hit -> Use the bitmap directly on UI Thread
  Miss -> Start AsyncTask and query JPEG DiskCache
     Hit -> Decode and set the save bitmap in memcache aswell as set it on the UI Thread
     Miss -> generate the thumbnail, save in both caches and update bitmap in UI Thread

Otherwise scrolling large folders with a lot of Thumbs is a pain / looks stuttery.