### PR TITLE
HotFix master branch: Set fixed lib version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     /// dependencies for app building
     compile name: 'touch-image-view'
 
-    compile 'com.github.nextcloud:android-library:-SNAPSHOT'
+    compile 'com.github.nextcloud:android-library:1.0.1'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'


### PR DESCRIPTION
For some reason jitpack is not refreshing the snapshot build so the branch won't build thus I created a lib release 1.0.1 and set the dependency to 1.0.1 instead of -SNAPSHOT

ATM This is necessary in order to get master to compile again. Sorry for any inconvenience :(