### PR TITLE
use hashCode() instead of getRemoteId() on OCFile

### DIFF
--- a/src/com/owncloud/android/datamodel/OCFile.java
+++ b/src/com/owncloud/android/datamodel/OCFile.java
@@ -657,4 +657,13 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
         return (permissions != null && permissions.contains(PERMISSION_SHARED_WITH_ME));
     }
 
+    /**
+     * hashCode is derive from remoteId of the file, so the hash code is
+     * identical for the same file on the remote server
+     * @return
+     */
+    @Override
+    public int hashCode() {
+        return this.getRemoteId().hashCode();
+    }
 }

--- a/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -246,7 +246,7 @@ public class ThumbnailsCacheManager {
         private Bitmap doOCFileInBackground() {
             OCFile file = (OCFile)mFile;
 
-            final String imageKey = String.valueOf(file.getRemoteId());
+            final String imageKey = String.valueOf(file.hashCode());
 
             // Check disk cache in background thread
             Bitmap thumbnail = getBitmapFromDiskCache(imageKey);

--- a/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -401,7 +401,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                     upload.getUploadStatus() == UploadStatus.UPLOAD_SUCCEEDED)) {
                 // Thumbnail in Cache?
                 Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                        String.valueOf(fakeFileToCheatThumbnailsCacheManagerInterface.getRemoteId())
+                        String.valueOf(fakeFileToCheatThumbnailsCacheManagerInterface.hashCode())
                 );
                 if (thumbnail != null && !fakeFileToCheatThumbnailsCacheManagerInterface.needsUpdateThumbnail()) {
                     fileIcon.setImageBitmap(thumbnail);

--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -305,7 +305,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                 if (file.isImage() && file.getRemoteId() != null){
                     // Thumbnail in Cache?
                     Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                            String.valueOf(file.getRemoteId())
+                            String.valueOf(file.hashCode())
                             );
                     if (thumbnail != null && !file.needsUpdateThumbnail()){
                         fileIcon.setImageBitmap(thumbnail);

--- a/src/com/owncloud/android/ui/adapter/UploaderAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/UploaderAdapter.java
@@ -94,7 +94,7 @@ public class UploaderAdapter extends SimpleAdapter {
         if (file.isImage() && file.getRemoteId() != null){
              // Thumbnail in Cache?
             Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                    String.valueOf(file.getRemoteId())
+                    String.valueOf(file.hashCode())
             );
             if (thumbnail != null && !file.needsUpdateThumbnail()){
                 fileIcon.setImageBitmap(thumbnail);


### PR DESCRIPTION
It´s possible to generate cacheKeys in the same maner for File and OCFile isntances that way