### PR TITLE
Release 1.1.0 stable

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -20,8 +20,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.owncloud.android"
-    android:versionCode="10010002"
-    android:versionName="1.1.0 RC2" >
+    android:versionCode="10010099"
+    android:versionName="1.1.0">
 
     <uses-sdk
         android:minSdkVersion="14"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 1.1.0 RC1 (June 27, 2016)
+## 1.1.0 (July 6, 2016)
 
 - New main menu to switch accounts easily
 - Ability to open Nextcloud hosted files (read-only) from other apps that support the standard file chooser (requires Android 4.4 / KitKat or higher)
 - "Select all files" for upload within a folder
-- optional feature to auto-create monthly folders for your instant uploads
-- revamped login screen
+- Optional feature to auto-create monthly folders for your instant uploads
+- Revamped login screen
+- Minor bugfixes
 
 ## 1.0.1 (June 20, 2016)
 


### PR DESCRIPTION
Version number bumped accordingly, version name "1.1.0" and updated changelog.

Please review @tobiasKaminsky @przybylski @jancborchardt @LukasReschke 

PS: Please +1 if changes are fine with you, merge will be done prior to releasing 1.1.0 stable which is in the near future since the RCs are very stable and no crashes&ANRs have been reported on Google Play or in the forums that haven't been fixed yet. Btw the changelog now only documents stable releases since I don't think documenting all RCs for eternity doesn't make sense.