### PR TITLE
Display remote folder size

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -17,8 +17,7 @@
     <string-array name="actionbar_sortby">
     	<item>A-Z</item>
     	<item>Newest - Oldest</item>
-    	<!-- TODO re-enable when server-side folder size calculation is available   
-    	<item>Biggest - Smallest</item>  -->
+    	<item>Biggest - Smallest</item>
     </string-array>
     <!-- TODO re-enable when "Accounts" is available in Navigation Drawer -->
     <!--<string name="drawer_item_accounts">Accounts</string>-->

--- a/src/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -42,6 +42,7 @@ import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.MimeType;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -811,7 +812,7 @@ public class FileDataStorageManager {
 
     private OCFile createRootDir() {
         OCFile file = new OCFile(OCFile.ROOT_PATH);
-        file.setMimetype("DIR");
+        file.setMimetype(MimeType.DIRECTORY);
         file.setParentId(FileDataStorageManager.ROOT_PARENT_ID);
         saveFile(file);
         return file;

--- a/src/com/owncloud/android/datamodel/OCFile.java
+++ b/src/com/owncloud/android/datamodel/OCFile.java
@@ -23,8 +23,6 @@
 package com.owncloud.android.datamodel;
 
 
-import java.io.File;
-
 import android.content.ContentResolver;
 import android.net.Uri;
 import android.os.Parcel;
@@ -32,6 +30,9 @@ import android.os.Parcelable;
 import android.webkit.MimeTypeMap;
 
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.utils.MimeType;
+
+import java.io.File;
 
 import third_parties.daveKoeller.AlphanumComparator;
 
@@ -200,7 +201,7 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
      * @return true if it is a folder
      */
     public boolean isFolder() {
-        return mMimeType != null && mMimeType.equals("DIR");
+        return mMimeType != null && mMimeType.equals(MimeType.DIRECTORY);
     }
 
     /**

--- a/src/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/src/com/owncloud/android/operations/CreateFolderOperation.java
@@ -21,16 +21,16 @@
 
 package com.owncloud.android.operations;
 
-import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.OwnCloudClient;
-import com.owncloud.android.lib.resources.files.CreateRemoteFolderOperation;
 import com.owncloud.android.lib.common.operations.OnRemoteOperationListener;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.files.CreateRemoteFolderOperation;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.MimeType;
 
 
 /**
@@ -111,7 +111,7 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
             }
         } else { // Create directory on DB
             OCFile newDir = new OCFile(mRemotePath);
-            newDir.setMimetype("DIR");
+            newDir.setMimetype(MimeType.DIRECTORY);
             long parentId = getStorageManager().
                     getFileByPath(FileStorageUtils.getParentPath(mRemotePath)).getFileId();
             newDir.setParentId(parentId);

--- a/src/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -397,8 +397,7 @@ public class RefreshFolderOperation extends RemoteOperation {
                 // eTag will not be updated unless file CONTENTS are synchronized
                 updatedFile.setEtag(localFile.getEtag());
                 if (updatedFile.isFolder()) {
-                    updatedFile.setFileLength(localFile.getFileLength());
-                        // TODO move operations about size of folders to FileContentProvider
+                    updatedFile.setFileLength(remoteFile.getFileLength());
                 } else if (mRemoteFolderChanged && remoteFile.isImage() &&
                         remoteFile.getModificationTimestamp() !=
                                 localFile.getModificationTimestamp()) {

--- a/src/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/com/owncloud/android/operations/UploadFileOperation.java
@@ -45,6 +45,7 @@ import com.owncloud.android.lib.resources.files.UploadRemoteFileOperation;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.utils.ConnectivityUtils;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.MimeType;
 import com.owncloud.android.utils.MimetypeIconUtil;
 import com.owncloud.android.utils.UriUtils;
 
@@ -509,7 +510,7 @@ public class UploadFileOperation extends SyncOperation {
         }
         if (parent != null) {
             OCFile createdFolder = new OCFile(remotePath);
-            createdFolder.setMimetype("DIR");
+            createdFolder.setMimetype(MimeType.DIRECTORY);
             createdFolder.setParentId(parent.getFileId());
             getStorageManager().saveFile(createdFolder);
             return createdFolder;

--- a/src/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/com/owncloud/android/providers/FileContentProvider.java
@@ -51,6 +51,7 @@ import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.MimeType;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -127,7 +128,7 @@ public class FileContentProvider extends ContentProvider {
                     boolean isDir;
                     while (!children.isAfterLast()) {
                         childId = children.getLong(children.getColumnIndex(ProviderTableMeta._ID));
-                        isDir = "DIR".equals(children.getString(
+                        isDir = MimeType.DIRECTORY.equals(children.getString(
                                 children.getColumnIndex(ProviderTableMeta.FILE_CONTENT_TYPE)
                         ));
                         //remotePath = children.getString(children.getColumnIndex(ProviderTableMeta.FILE_PATH));

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -571,6 +571,8 @@ public class FileDisplayActivity extends HookActivity
                                             case 1:
                                                 sortByDate(false);
                                                 break;
+                                            case 2:
+                                                sortBySize(false);
                                         }
 
                                         dialog.dismiss();

--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -217,8 +217,8 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                         }
 
                     } else { //Folder
-                        fileSizeSeparatorV.setVisibility(View.GONE);
-                        fileSizeV.setVisibility(View.GONE);
+//                        fileSizeSeparatorV.setVisibility(View.GONE);
+//                        fileSizeV.setVisibility(View.GONE);
                     }
 
                 case GRID_ITEM:

--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -215,10 +215,6 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                                 checkBoxV.setVisibility(View.VISIBLE);
                             }
                         }
-
-                    } else { //Folder
-//                        fileSizeSeparatorV.setVisibility(View.GONE);
-//                        fileSizeV.setVisibility(View.GONE);
                     }
 
                 case GRID_ITEM:

--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -20,6 +20,22 @@
 
 package com.owncloud.android.utils;
 
+import android.accounts.Account;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Environment;
+import android.os.StatFs;
+import android.preference.PreferenceManager;
+import android.webkit.MimeTypeMap;
+
+import com.owncloud.android.MainApp;
+import com.owncloud.android.R;
+import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.files.RemoteFile;
+
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
@@ -29,22 +45,6 @@ import java.util.Locale;
 import java.util.Vector;
 
 import third_parties.daveKoeller.AlphanumComparator;
-
-import com.owncloud.android.MainApp;
-import com.owncloud.android.R;
-import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.utils.Log_OC;
-import com.owncloud.android.lib.resources.files.RemoteFile;
-
-import android.accounts.Account;
-import android.annotation.SuppressLint;
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
-import android.net.Uri;
-import android.os.Environment;
-import android.os.StatFs;
-import android.webkit.MimeTypeMap;
 
 
 /**
@@ -198,7 +198,7 @@ public class FileStorageUtils {
     public static OCFile fillOCFile(RemoteFile remote) {
         OCFile file = new OCFile(remote.getRemotePath());
         file.setCreationTimestamp(remote.getCreationTimestamp());
-        if (remote.getMimeType().equalsIgnoreCase("DIR")){
+        if (remote.getMimeType().equalsIgnoreCase(MimeType.DIRECTORY)){
             file.setFileLength(remote.getSize());
         } else {
             file.setFileLength(remote.getLength());

--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -198,7 +198,11 @@ public class FileStorageUtils {
     public static OCFile fillOCFile(RemoteFile remote) {
         OCFile file = new OCFile(remote.getRemotePath());
         file.setCreationTimestamp(remote.getCreationTimestamp());
-        file.setFileLength(remote.getLength());
+        if (remote.getMimeType().equalsIgnoreCase("DIR")){
+            file.setFileLength(remote.getSize());
+        } else {
+            file.setFileLength(remote.getLength());
+        }
         file.setMimetype(remote.getMimeType());
         file.setModificationTimestamp(remote.getModifiedTimestamp());
         file.setEtag(remote.getEtag());
@@ -236,8 +240,8 @@ public class FileStorageUtils {
         case 1:
             files = FileStorageUtils.sortByDate(files);
             break;
-        case 2: 
-           // mFiles = FileStorageUtils.sortBySize(mSortAscending);
+        case 2:
+            files = FileStorageUtils.sortBySize(files);
             break;
         }
        
@@ -278,39 +282,38 @@ public class FileStorageUtils {
         return files;
     }
 
-//    /**
-//     * Sorts list by Size
-//     * @param sortAscending true: ascending, false: descending
-//     */
-//    public static Vector<OCFile> sortBySize(Vector<OCFile> files){
-//        final Integer val;
-//        if (mSortAscending){
-//            val = 1;
-//        } else {
-//            val = -1;
-//        }
-//        
-//        Collections.sort(files, new Comparator<OCFile>() {
-//            public int compare(OCFile o1, OCFile o2) {
-//                if (o1.isFolder() && o2.isFolder()) {
-//                    Long obj1 = getFolderSize(new File(FileStorageUtils.getDefaultSavePathFor(mAccount.name, o1)));
-//                    return val * obj1.compareTo(getFolderSize(new File(FileStorageUtils.getDefaultSavePathFor(mAccount.name, o2))));
-//                }
-//                else if (o1.isFolder()) {
-//                    return -1;
-//                } else if (o2.isFolder()) {
-//                    return 1;
-//                } else if (o1.getFileLength() == 0 || o2.getFileLength() == 0){
-//                    return 0;
-//                } else {
-//                    Long obj1 = o1.getFileLength();
-//                    return val * obj1.compareTo(o2.getFileLength());
-//                }
-//            }
-//        });
-//        
-//        return files;
-//    }
+    /**
+     * Sorts list by Size
+     */
+    public static Vector<OCFile> sortBySize(Vector<OCFile> files){
+        final Integer val;
+        if (mSortAscending){
+            val = 1;
+        } else {
+            val = -1;
+        }
+
+        Collections.sort(files, new Comparator<OCFile>() {
+            public int compare(OCFile o1, OCFile o2) {
+                if (o1.isFolder() && o2.isFolder()) {
+                    Long obj1 = o1.getFileLength();
+                    return val * obj1.compareTo(o2.getFileLength());
+                }
+                else if (o1.isFolder()) {
+                    return -1;
+                } else if (o2.isFolder()) {
+                    return 1;
+                } else if (o1.getFileLength() == 0 || o2.getFileLength() == 0){
+                    return 0;
+                } else {
+                    Long obj1 = o1.getFileLength();
+                    return val * obj1.compareTo(o2.getFileLength());
+                }
+            }
+        });
+
+        return files;
+    }
 
     /**
      * Sorts list by Name
@@ -338,27 +341,6 @@ public class FileStorageUtils {
         });
         
         return files;
-    }
-    
-    /**
-     * Local Folder size
-     * @param dir File
-     * @return Size in bytes
-     */
-    public static long getFolderSize(File dir) {
-        if (dir.exists()) {
-            long result = 0;
-            File[] fileList = dir.listFiles();
-            for(int i = 0; i < fileList.length; i++) {
-                if(fileList[i].isDirectory()) {
-                    result += getFolderSize(fileList[i]);
-                } else {
-                    result += fileList[i].length();
-                }
-            }
-            return result;
-        }
-        return 0;
     }
 
     /**

--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -253,18 +253,13 @@ public class FileStorageUtils {
      * @param files
      */
     public static Vector<OCFile> sortByDate(Vector<OCFile> files){
-        final Integer val;
-        if (mSortAscending){
-            val = 1;
-        } else {
-            val = -1;
-        }
+        final int multiplier = mSortAscending ? 1 : -1;
         
         Collections.sort(files, new Comparator<OCFile>() {
             public int compare(OCFile o1, OCFile o2) {
                 if (o1.isFolder() && o2.isFolder()) {
                     Long obj1 = o1.getModificationTimestamp();
-                    return val * obj1.compareTo(o2.getModificationTimestamp());
+                    return multiplier * obj1.compareTo(o2.getModificationTimestamp());
                 }
                 else if (o1.isFolder()) {
                     return -1;
@@ -274,7 +269,7 @@ public class FileStorageUtils {
                     return 0;
                 } else {
                     Long obj1 = o1.getModificationTimestamp();
-                    return val * obj1.compareTo(o2.getModificationTimestamp());
+                    return multiplier * obj1.compareTo(o2.getModificationTimestamp());
                 }
             }
         });
@@ -286,18 +281,13 @@ public class FileStorageUtils {
      * Sorts list by Size
      */
     public static Vector<OCFile> sortBySize(Vector<OCFile> files){
-        final Integer val;
-        if (mSortAscending){
-            val = 1;
-        } else {
-            val = -1;
-        }
+        final int multiplier = mSortAscending ? 1 : -1;
 
         Collections.sort(files, new Comparator<OCFile>() {
             public int compare(OCFile o1, OCFile o2) {
                 if (o1.isFolder() && o2.isFolder()) {
                     Long obj1 = o1.getFileLength();
-                    return val * obj1.compareTo(o2.getFileLength());
+                    return multiplier * obj1.compareTo(o2.getFileLength());
                 }
                 else if (o1.isFolder()) {
                     return -1;
@@ -307,7 +297,7 @@ public class FileStorageUtils {
                     return 0;
                 } else {
                     Long obj1 = o1.getFileLength();
-                    return val * obj1.compareTo(o2.getFileLength());
+                    return multiplier * obj1.compareTo(o2.getFileLength());
                 }
             }
         });
@@ -320,23 +310,18 @@ public class FileStorageUtils {
      * @param files     files to sort
      */
     public static Vector<OCFile> sortByName(Vector<OCFile> files){
-        final Integer val;
-        if (mSortAscending){
-            val = 1;
-        } else {
-            val = -1;
-        }
+        final int multiplier = mSortAscending ? 1 : -1;
 
         Collections.sort(files, new Comparator<OCFile>() {
             public int compare(OCFile o1, OCFile o2) {
                 if (o1.isFolder() && o2.isFolder()) {
-                    return val * new AlphanumComparator().compare(o1, o2);
+                    return multiplier * new AlphanumComparator().compare(o1, o2);
                 } else if (o1.isFolder()) {
                     return -1;
                 } else if (o2.isFolder()) {
                     return 1;
                 }
-                return val * new AlphanumComparator().compare(o1, o2);
+                return multiplier * new AlphanumComparator().compare(o1, o2);
             }
         });
         

--- a/src/com/owncloud/android/utils/MimeType.java
+++ b/src/com/owncloud/android/utils/MimeType.java
@@ -1,7 +1,25 @@
+/**
+ *   Nextcloud Android client application
+ *
+ *   Copyright (C) 2016 Nextcloud
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2+,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 package com.owncloud.android.utils;
 
 /**
- * Created by scherzia on 13.07.2016.
+ * Class containing the mime types.
  */
 public class MimeType {
     public static final String DIRECTORY = "DIR";

--- a/src/com/owncloud/android/utils/MimeType.java
+++ b/src/com/owncloud/android/utils/MimeType.java
@@ -1,0 +1,8 @@
+package com.owncloud.android.utils;
+
+/**
+ * Created by scherzia on 13.07.2016.
+ */
+public class MimeType {
+    public static final String DIRECTORY = "DIR";
+}

--- a/src/com/owncloud/android/utils/MimetypeIconUtil.java
+++ b/src/com/owncloud/android/utils/MimetypeIconUtil.java
@@ -276,7 +276,7 @@ public class MimetypeIconUtil {
         MIMETYPE_TO_ICON_MAPPING.put("text/x-python", R.drawable.file_code);
         MIMETYPE_TO_ICON_MAPPING.put("text/x-shellscript", R.drawable.file_code);
         MIMETYPE_TO_ICON_MAPPING.put("web", R.drawable.file_code);
-        MIMETYPE_TO_ICON_MAPPING.put("DIR", R.drawable.ic_menu_archive);
+        MIMETYPE_TO_ICON_MAPPING.put(MimeType.DIRECTORY, R.drawable.ic_menu_archive);
     }
 
     /**


### PR DESCRIPTION
Folder size is now shown by remote computed folder size.

originally opened by @tobiasKaminsky on oC repo, rebased to latest master now.

According to the original discussion in the PR 1655 this will not work for Servers with oC version below 8 so it will always work for Nextcloud version > 9.x. So we are imho save here.

Please review @przybylski @tobiasKaminsky (I will do one too).

Since this is a minot change we might add this to the 1.2.0 release. Comments? :)