### PR TITLE
Log.wtf() should not be used unless an assertion fails

### DIFF
--- a/src/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -205,7 +205,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        //Log_OC.wtf(TAG,  "onCreate init");
+        //Log_OC.e(TAG,  "onCreate init");
         super.onCreate(savedInstanceState);
 
         // Workaround, for fixing a problem with Android Library Suppor v7 19
@@ -285,7 +285,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         /// initialize block to be moved to single Fragment to retrieve and validate credentials 
         initAuthorizationPreFragment(savedInstanceState);
 
-        //Log_OC.wtf(TAG,  "onCreate end");
+        //Log_OC.e(TAG,  "onCreate end");
     }
 
     private void initAuthTokenType() {
@@ -602,7 +602,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
      */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-        //Log_OC.wtf(TAG, "onSaveInstanceState init" );
+        //Log_OC.e(TAG, "onSaveInstanceState init" );
         super.onSaveInstanceState(outState);
 
         /// global state
@@ -642,7 +642,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         }
         mAsyncTask = null;
 
-        //Log_OC.wtf(TAG, "onSaveInstanceState end" );
+        //Log_OC.e(TAG, "onSaveInstanceState end" );
     }
 
     @Override
@@ -759,7 +759,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 queryParameters);
         
         if (mOperationsServiceBinder != null) {
-            //Log_OC.wtf(TAG, "getting access token..." );
+            //Log_OC.e(TAG, "getting access token..." );
             mWaitingForOpId = mOperationsServiceBinder.queueNewOperation(getServerInfoIntent);
         }
     }
@@ -836,7 +836,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             if (mOperationsServiceBinder != null) {
                 mWaitingForOpId = mOperationsServiceBinder.queueNewOperation(getServerInfoIntent);
             } else {
-              Log_OC.wtf(TAG, "Server check tried with OperationService unbound!" );
+              Log_OC.e(TAG, "Server check tried with OperationService unbound!" );
             }
             
         } else {
@@ -1869,7 +1869,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
 
     private void doOnResumeAndBound() {
-        //Log_OC.wtf(TAG, "registering to listen for operation callbacks" );
+        //Log_OC.e(TAG, "registering to listen for operation callbacks" );
         mOperationsServiceBinder.addOperationListener(AuthenticatorActivity.this, mHandler);
         if (mWaitingForOpId <= Integer.MAX_VALUE) {
             mOperationsServiceBinder.dispatchResultIfFinished((int)mWaitingForOpId, this);

--- a/src/com/owncloud/android/files/BootupBroadcastReceiver.java
+++ b/src/com/owncloud/android/files/BootupBroadcastReceiver.java
@@ -48,7 +48,7 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (!intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
-            Log_OC.wtf(TAG, "Incorrect action sent " + intent.getAction());
+            Log_OC.e(TAG, "Incorrect action sent " + intent.getAction());
             return;
         }
         Log_OC.d(TAG, "Starting file observer service...");

--- a/src/com/owncloud/android/files/FileOperationsHelper.java
+++ b/src/com/owncloud/android/files/FileOperationsHelper.java
@@ -127,7 +127,7 @@ public class FileOperationsHelper {
             }
 
         } else {
-            Log_OC.wtf(TAG, "Trying to open a NULL OCFile");
+            Log_OC.e(TAG, "Trying to open a NULL OCFile");
         }
     }
 
@@ -166,7 +166,7 @@ public class FileOperationsHelper {
                 mWaitingForOpId = mFileActivity.getOperationsServiceBinder().queueNewOperation(service);
 
             } else {
-                Log_OC.wtf(TAG, "Trying to share a NULL OCFile");
+                Log_OC.e(TAG, "Trying to share a NULL OCFile");
                 // TODO user-level error?
             }
 
@@ -193,7 +193,7 @@ public class FileOperationsHelper {
                 mWaitingForOpId = mFileActivity.getOperationsServiceBinder().queueNewOperation(service);
 
             } else {
-                Log_OC.wtf(TAG, "Trying to share a NULL OCFile");
+                Log_OC.e(TAG, "Trying to share a NULL OCFile");
             }
         } else {
             // Show a Message
@@ -229,7 +229,7 @@ public class FileOperationsHelper {
             mWaitingForOpId = mFileActivity.getOperationsServiceBinder().queueNewOperation(service);
 
         } else {
-            Log_OC.wtf(TAG, "Trying to share a NULL OCFile");
+            Log_OC.e(TAG, "Trying to share a NULL OCFile");
         }
     }
 
@@ -422,7 +422,7 @@ public class FileOperationsHelper {
             chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
 
         } else {
-            Log_OC.wtf(TAG, "Trying to send a NULL OCFile");
+            Log_OC.e(TAG, "Trying to send a NULL OCFile");
         }
     }
 

--- a/src/com/owncloud/android/services/OperationsService.java
+++ b/src/com/owncloud/android/services/OperationsService.java
@@ -365,7 +365,7 @@ public class OperationsService extends Service {
             if (undispatched != null) {
                 listener.onRemoteOperationFinish(undispatched.first, undispatched.second);
                 return true;
-                //Log_OC.wtf(TAG, "Sending callback later");
+                //Log_OC.e(TAG, "Sending callback later");
             } else {
                 return (!mServiceHandler.mPendingOperations.isEmpty());
             }
@@ -432,7 +432,7 @@ public class OperationsService extends Service {
          */
         private void nextOperation() {
             
-            //Log_OC.wtf(TAG, "nextOperation init" );
+            //Log_OC.e(TAG, "nextOperation init" );
             
             Pair<Target, RemoteOperation> next = null;
             synchronized(mPendingOperations) {

--- a/src/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/src/com/owncloud/android/ui/activity/BaseActivity.java
@@ -152,7 +152,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             mStorageManager = new FileDataStorageManager(getAccount(), getContentResolver());
             mCapabilities = mStorageManager.getCapability(mCurrentAccount.name);
         } else {
-            Log_OC.wtf(TAG, "onAccountChanged was called with NULL account associated!");
+            Log_OC.e(TAG, "onAccountChanged was called with NULL account associated!");
         }
     }
 

--- a/src/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
+++ b/src/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
@@ -72,7 +72,7 @@ public class ConflictsResolveActivity extends FileActivity implements OnConflict
                 finish();
                 return;
             default:
-                Log_OC.wtf(TAG, "Unhandled conflict decision " + decision);
+                Log_OC.e(TAG, "Unhandled conflict decision " + decision);
                 return;
         }
 

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -352,12 +352,12 @@ public class FileDisplayActivity extends HookActivity
             }
 
         } else {
-            Log_OC.wtf(TAG, "initFragments() called with invalid NULLs!");
+            Log_OC.e(TAG, "initFragments() called with invalid NULLs!");
             if (getAccount() == null) {
-                Log_OC.wtf(TAG, "\t account is NULL");
+                Log_OC.e(TAG, "\t account is NULL");
             }
             if (getFile() == null) {
-                Log_OC.wtf(TAG, "\t file is NULL");
+                Log_OC.e(TAG, "\t file is NULL");
             }
         }
     }
@@ -434,7 +434,7 @@ public class FileDisplayActivity extends HookActivity
         if (listOfFiles != null) {
             return (OCFileListFragment) listOfFiles;
         }
-        Log_OC.wtf(TAG, "Access to unexisting list of files fragment!!");
+        Log_OC.e(TAG, "Access to unexisting list of files fragment!!");
         return null;
     }
 

--- a/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -171,7 +171,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         if (listOfFiles != null) {
             return (OCFileListFragment)listOfFiles;
         }
-        Log_OC.wtf(TAG, "Access to unexisting list of files fragment!!");
+        Log_OC.e(TAG, "Access to unexisting list of files fragment!!");
         return null;
     }
 

--- a/src/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/com/owncloud/android/ui/activity/ShareActivity.java
@@ -117,7 +117,7 @@ public class ShareActivity extends FileActivity
             );
 
         } else {
-            Log_OC.wtf(TAG, "Unexpected intent " + intent.toString());
+            Log_OC.e(TAG, "Unexpected intent " + intent.toString());
         }
     }
 


### PR DESCRIPTION
bugfix based on oC's 1603 with adaption for the new drawer implementation.

> This will prevent crashing when running on a userdebug phone. Log#wtf
should only be used when the program can not go on because a critical
assertion fails. These all don't seem to meet that criteria.

> Fixes 1603

please check and merge @nextcloud/android 