### PR TITLE
Display quota if configured/available in navigation drawer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     /// dependencies for app building
     compile name: 'touch-image-view'
 
-    compile 'com.github.nextcloud:android-library:1.0.2'
+    compile 'com.github.nextcloud:android-library:1.0.4'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     /// dependencies for app building
     compile name: 'touch-image-view'
 
-    compile 'com.github.nextcloud:android-library:1.0.4'
+    compile 'com.github.nextcloud:android-library:1.0.6'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/res/layout/drawer.xml
+++ b/res/layout/drawer.xml
@@ -35,7 +35,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:background="#F5F5F5"
             android:clickable="false"
             android:orientation="vertical"
             android:paddingBottom="@dimen/standard_half_padding"

--- a/res/layout/drawer.xml
+++ b/res/layout/drawer.xml
@@ -35,6 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
+            android:background="@color/white"
             android:clickable="false"
             android:orientation="vertical"
             android:paddingBottom="@dimen/standard_half_padding"

--- a/res/layout/drawer.xml
+++ b/res/layout/drawer.xml
@@ -24,9 +24,43 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
+        android:layout_weight="1"
         android:fitsSystemWindows="true"
-        app:theme="@style/NavigationView_ItemTextAppearance"
         app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer_menu"/>
+        app:menu="@menu/drawer_menu"
+        app:theme="@style/NavigationView_ItemTextAppearance">
+
+        <LinearLayout
+            android:id="@+id/drawer_quota"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:background="#F5F5F5"
+            android:clickable="false"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/standard_half_padding"
+            android:paddingLeft="@dimen/standard_padding"
+            android:paddingRight="@dimen/standard_padding"
+            android:paddingTop="@dimen/standard_half_padding"
+            android:visibility="gone">
+
+            <ProgressBar
+                android:id="@+id/drawer_quota_ProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="false"
+                android:indeterminateOnly="false"
+                android:text="@string/drawer_quota"
+                />
+
+            <TextView
+                android:id="@+id/drawer_quota_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/drawer_quota"/>
+        </LinearLayout>
+
+    </android.support.design.widget.NavigationView>
 
 </merge>

--- a/res/menu/drawer_menu.xml
+++ b/res/menu/drawer_menu.xml
@@ -67,4 +67,15 @@
             android:icon="@drawable/ic_settings"
             android:title="@string/actionbar_settings"/>
     </group>
+
+    <!--
+      dummy group/element as a workaround to see
+      the whole menu in case of quota being displayed
+    -->
+    <group>
+        <item
+            android:enabled="false"
+            android:orderInCategory="200"
+            android:title=""/>
+    </group>
 </menu>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -52,4 +52,10 @@
     <!-- special transparent action bar colors for image preview -->
     <color name="owncloud_blue_transparent">#201D2D44</color>
     <color name="owncloud_blue_dark_transparent">#40162233</color>
+
+    <!-- level colors for info notifications/visualisations -->
+    <color name="infolevel_info">@color/color_accent</color>
+    <color name="infolevel_warning">#fdd835</color>
+    <color name="infolevel_critical">#e57373</color>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="drawer_item_on_device">On device</string>
     <string name="drawer_item_settings">Settings</string>
     <string name="drawer_item_uploads_list">Uploads</string>
+    <string name="drawer_quota">%1$s%2$s of %3$s%4$s used</string>
 	<string name="drawer_close">Close</string>
     <string name="drawer_open">Open</string>
     <string name="prefs_category_general">General</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="drawer_item_on_device">On device</string>
     <string name="drawer_item_settings">Settings</string>
     <string name="drawer_item_uploads_list">Uploads</string>
-    <string name="drawer_quota">%1$s%2$s of %3$s%4$s used</string>
+    <string name="drawer_quota">%1$s of %2$s used</string>
 	<string name="drawer_close">Close</string>
     <string name="drawer_open">Open</string>
     <string name="prefs_category_general">General</string>

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -553,8 +553,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
 
         mQuotaTextView.setText(String.format(
                 getString(R.string.drawer_quota),
-                DisplayUtils.bytesToHumanReadable(usedSpace),
-                DisplayUtils.bytesToHumanReadable(totalSpace)));
+                DisplayUtils.quotaBytesToHumanReadable(usedSpace),
+                DisplayUtils.quotaBytesToHumanReadable(totalSpace)));
 
         showQuota(true);
     }

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -149,35 +149,22 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
 
         mNavigationView = (NavigationView) findViewById(R.id.nav_view);
         if (mNavigationView != null) {
-            mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toogle);
-            mAccountChooserToggle.setImageResource(R.drawable.ic_down);
-            mIsAccountChooserActive = false;
-            mAccountMiddleAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_middle);
-            mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
+            setupDrawerHeader();
 
-            // on pre lollipop the light theme adds a black tint to icons with white coloring
-            // ruining the generic avatars, so tinting for icons is deactivated pre lollipop
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                mNavigationView.setItemIconTintList(null);
-            }
+            setupDrawerMenu(mNavigationView);
 
-            setupDrawerContent(mNavigationView);
-
-            findNavigationViewChildById(R.id.drawer_active_user)
-                    .setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            toggleAccountList();
-                        }
-                    });
-
-            // Quota UI elements
-            mQuotaView = (LinearLayout) findViewById(R.id.drawer_quota);
-            mQuotaProgressBar = (ProgressBar) findViewById(R.id.drawer_quota_ProgressBar);
-            mQuotaTextView = (TextView) findViewById(R.id.drawer_quota_text);
-            DisplayUtils.colorPreLollipopHorizontalProgressBar(mQuotaProgressBar);
+            setupQuotaElement();
         }
 
+        setupDrawerToggle();
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+
+    /**
+     * initializes and sets up the drawer toggle.
+     */
+    private void setupDrawerToggle() {
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
 
             /** Called when a drawer has settled in a completely closed state. */
@@ -201,7 +188,35 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
         // Set the drawer toggle as the DrawerListener
         mDrawerLayout.setDrawerListener(mDrawerToggle);
         mDrawerToggle.setDrawerIndicatorEnabled(true);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+
+    /**
+     * initializes and sets up the drawer header.
+     */
+    private void setupDrawerHeader() {
+        mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toogle);
+        mAccountChooserToggle.setImageResource(R.drawable.ic_down);
+        mIsAccountChooserActive = false;
+        mAccountMiddleAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_middle);
+        mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
+
+        findNavigationViewChildById(R.id.drawer_active_user)
+                .setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        toggleAccountList();
+                    }
+                });
+    }
+
+    /**
+     * setup quota elements of the drawer.
+     */
+    private void setupQuotaElement() {
+        mQuotaView = (LinearLayout) findViewById(R.id.drawer_quota);
+        mQuotaProgressBar = (ProgressBar) findViewById(R.id.drawer_quota_ProgressBar);
+        mQuotaTextView = (TextView) findViewById(R.id.drawer_quota_text);
+        DisplayUtils.colorPreLollipopHorizontalProgressBar(mQuotaProgressBar);
     }
 
     /**
@@ -209,7 +224,14 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
      *
      * @param navigationView the drawers navigation view
      */
-    protected void setupDrawerContent(NavigationView navigationView) {
+    protected void setupDrawerMenu(NavigationView navigationView) {
+        // on pre lollipop the light theme adds a black tint to icons with white coloring
+        // ruining the generic avatars, so tinting for icons is deactivated pre lollipop
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            navigationView.setItemIconTintList(null);
+        }
+
+        // setup actions for drawer menu items
         navigationView.setNavigationItemSelectedListener(
                 new NavigationView.OnNavigationItemSelectedListener() {
                     @Override
@@ -259,9 +281,9 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
 
         // handle correct state
         if (mIsAccountChooserActive) {
-            mNavigationView.getMenu().setGroupVisible(R.id.drawer_menu_accounts, true);
+            navigationView.getMenu().setGroupVisible(R.id.drawer_menu_accounts, true);
         } else {
-            mNavigationView.getMenu().setGroupVisible(R.id.drawer_menu_accounts, false);
+            navigationView.getMenu().setGroupVisible(R.id.drawer_menu_accounts, false);
         }
     }
 
@@ -464,7 +486,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                     findNavigationViewChildById(R.id.drawer_current_account));
 
             // check and show quota info if available
-            getUserQuota();
+            getAndDisplayUserQuota();
         }
     }
 
@@ -543,7 +565,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
     /**
      * Retrieves and shows the user quota if available
      */
-    private void getUserQuota() {
+    private void getAndDisplayUserQuota() {
         // set user space information
         Thread t = new Thread(new Runnable() {
             public void run() {

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -38,6 +38,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.owncloud.android.MainApp;
@@ -120,6 +122,9 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
      * accounts for the (max) three displayed accounts in the drawer header.
      */
     private Account[] mAvatars = new Account[3];
+    private LinearLayout mQuotaView;
+    private ProgressBar mQuotaProgressBar;
+    private TextView mQuotaTextView;
 
     /**
      * Initializes the drawer, its content and highlights the menu item with the given id.
@@ -144,9 +149,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
             mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toogle);
             mAccountChooserToggle.setImageResource(R.drawable.ic_down);
             mIsAccountChooserActive = false;
-
-            mAccountMiddleAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_middle);
-            mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
+            mAccountMiddleAccountAvatar = (ImageView) findViewById(R.id.drawer_account_middle);
+            mAccountEndAccountAvatar = (ImageView) findViewById(R.id.drawer_account_end);
 
             // on pre lollipop the light theme adds a black tint to icons with white coloring
             // ruining the generic avatars, so tinting for icons is deactivated pre lollipop
@@ -163,6 +167,12 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                             toggleAccountList();
                         }
                     });
+
+            // Quota UI elements
+            mQuotaView = (LinearLayout) findNavigationViewChildById(R.id.drawer_quota);
+            mQuotaProgressBar = (ProgressBar) findNavigationViewChildById(R.id.drawer_quota_ProgressBar);
+            mQuotaTextView = (TextView) findNavigationViewChildById(R.id.drawer_quota_text);
+            DisplayUtils.colorPreLollipopHorizontalProgressBar(mQuotaProgressBar);
         }
 
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
@@ -475,6 +485,39 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 mNavigationView.getMenu().setGroupVisible(R.id.drawer_menu_standard, true);
             }
         }
+    }
+
+    /**
+     * shows or hides the quota UI elements.
+     *
+     * @param showQuota show/hide quota information
+     */
+    private void showQuota(boolean showQuota) {
+        if (showQuota) {
+            mQuotaView.setVisibility(View.VISIBLE);
+        } else {
+            mQuotaView.setVisibility(View.GONE);
+        }
+    }
+
+    /**
+     * configured the quota to be displayed.
+     *
+     * @param usedSpace the used space
+     * @param totalSpace the total space
+     * @param percent the percentage of space already used
+     */
+    private void setQuotaInformation(long usedSpace, long totalSpace, Double percent) {
+        int progress = (int) Math.ceil(percent);
+        mQuotaProgressBar.setProgress(progress);
+        mQuotaTextView.setText(String.format(
+                getString(R.string.drawer_quota),
+                DisplayUtils.bytesToHumanReadable(usedSpace),
+                DisplayUtils.bytesToHumanReadable(totalSpace)));
+
+        // TODO Think about coloring of the progressbar at certain thresholds
+
+        showQuota(true);
     }
 
     /**

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -149,8 +149,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
             mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toogle);
             mAccountChooserToggle.setImageResource(R.drawable.ic_down);
             mIsAccountChooserActive = false;
-            mAccountMiddleAccountAvatar = (ImageView) findViewById(R.id.drawer_account_middle);
-            mAccountEndAccountAvatar = (ImageView) findViewById(R.id.drawer_account_end);
+            mAccountMiddleAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_middle);
+            mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
 
             // on pre lollipop the light theme adds a black tint to icons with white coloring
             // ruining the generic avatars, so tinting for icons is deactivated pre lollipop
@@ -169,9 +169,9 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                     });
 
             // Quota UI elements
-            mQuotaView = (LinearLayout) findNavigationViewChildById(R.id.drawer_quota);
-            mQuotaProgressBar = (ProgressBar) findNavigationViewChildById(R.id.drawer_quota_ProgressBar);
-            mQuotaTextView = (TextView) findNavigationViewChildById(R.id.drawer_quota_text);
+            mQuotaView = (LinearLayout) findViewById(R.id.drawer_quota);
+            mQuotaProgressBar = (ProgressBar) findViewById(R.id.drawer_quota_ProgressBar);
+            mQuotaTextView = (TextView) findViewById(R.id.drawer_quota_text);
             DisplayUtils.colorPreLollipopHorizontalProgressBar(mQuotaProgressBar);
         }
 

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -125,8 +125,20 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
      * accounts for the (max) three displayed accounts in the drawer header.
      */
     private Account[] mAvatars = new Account[3];
+
+    /**
+     * container layout of the quota view.
+     */
     private LinearLayout mQuotaView;
+
+    /**
+     * progress bar of the quota view.
+     */
     private ProgressBar mQuotaProgressBar;
+
+    /**
+     * text view of the quota view.
+     */
     private TextView mQuotaTextView;
 
     /**
@@ -537,12 +549,12 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
      */
     private void setQuotaInformation(long usedSpace, long totalSpace, int relative) {
         mQuotaProgressBar.setProgress(relative);
+        DisplayUtils.colorHorizontalProgressBar(mQuotaProgressBar, DisplayUtils.getRelativeInfoColor(this, relative));
+
         mQuotaTextView.setText(String.format(
                 getString(R.string.drawer_quota),
                 DisplayUtils.bytesToHumanReadable(usedSpace),
                 DisplayUtils.bytesToHumanReadable(totalSpace)));
-
-        // TODO Think about coloring of the progressbar at certain thresholds
 
         showQuota(true);
     }

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -553,8 +553,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
 
         mQuotaTextView.setText(String.format(
                 getString(R.string.drawer_quota),
-                DisplayUtils.quotaBytesToHumanReadable(usedSpace),
-                DisplayUtils.quotaBytesToHumanReadable(totalSpace)));
+                DisplayUtils.bytesToHumanReadable(usedSpace),
+                DisplayUtils.bytesToHumanReadable(totalSpace)));
 
         showQuota(true);
     }

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -587,19 +587,33 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                         AccountUtils.getCurrentOwnCloudAccount(DrawerActivity.this), DrawerActivity.this);
 
                 if (result.isSuccess() && result.getData() != null) {
-                    RemoteGetUserQuotaOperation.Quota quota = (RemoteGetUserQuotaOperation.Quota) result.getData().get
-                            (0);
+                    final RemoteGetUserQuotaOperation.Quota quota =
+                            (RemoteGetUserQuotaOperation.Quota) result.getData().get(0);
 
                     final long used = quota.getUsed();
                     final long total = quota.getTotal();
                     final int relative = (int) Math.ceil(quota.getRelative());
+                    final long quotaValue = quota.getQuota();
 
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            if (mQuotaView != null) {
-                                setQuotaInformation(used,total,relative);
+                            if (quotaValue > 0
+                                    || quotaValue == RemoteGetUserQuotaOperation.QUOTA_LIMIT_INFO_NOT_AVAILABLE) {
+                                /**
+                                 * show quota in case
+                                 * it is available and calculated (> 0) or
+                                 * in case of legacy servers (==QUOTA_LIMIT_INFO_NOT_AVAILABLE)
+                                 */
+                                setQuotaInformation(used, total, relative);
                             } else {
+                                /**
+                                 * quotaValue < 0 means special cases like
+                                 * {@link RemoteGetUserQuotaOperation.SPACE_NOT_COMPUTED},
+                                 * {@link RemoteGetUserQuotaOperation.SPACE_UNKNOWN} or
+                                 * {@link RemoteGetUserQuotaOperation.SPACE_UNLIMITED}
+                                 * thus don't display any quota information.
+                                 */
                                 showQuota(false);
                             }
                         }

--- a/src/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/com/owncloud/android/utils/DisplayUtils.java
@@ -67,6 +67,7 @@ public class DisplayUtils {
 
     private static final String[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
     private static final int[] sizeScales = { 0, 0, 1, 1, 1, 2, 2, 2, 2 };
+    private static final int[] quotaSizeScales = { 0, 0, 0, 1, 1, 2, 2, 2, 2 };
     public static final int RELATIVE_THRESHOLD_WARNING = 90;
     public static final int RELATIVE_THRESHOLD_CRITICAL = 95;
 
@@ -95,18 +96,48 @@ public class DisplayUtils {
      * </ul>
      *
      * @param bytes Input file size
-     * @return Like something readable like "12 MB"
+     * @return something readable like "12 MB"
      */
     public static String bytesToHumanReadable(long bytes) {
+        return bytesToHumanReadable(bytes, sizeScales, sizeSuffixes);
+    }
+
+    /**
+     * Converts the file size in bytes to human readable output.
+     * <ul>
+     *     <li>appends a size suffix, e.g. B, KB, MB etc.</li>
+     *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
+     * </ul>
+     *
+     * @param bytes Input file size
+     * @return something readable like "12 MB"
+     */
+    public static String quotaBytesToHumanReadable(long bytes) {
+        return bytesToHumanReadable(bytes, quotaSizeScales, sizeSuffixes);
+    }
+
+    /**
+     * Converts the file size in bytes to human readable output.
+     * <ul>
+     *     <li>appends a size suffix, e.g. B, KB, MB etc.</li>
+     *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
+     * </ul>
+     *
+     * @param bytes        Input file size
+     * @param sizeScales   scales for the different size units
+     * @param sizeSuffixes suffixes for the different size units
+     * @return something readable like "12 MB"
+     */
+    private static String bytesToHumanReadable(long bytes, int[] sizeScales, String[] sizeSuffixes) {
         double result = bytes;
-        int attachedSuff = 0;
-        while (result > 1024 && attachedSuff < sizeSuffixes.length) {
+        int suffixIndex = 0;
+        while (result > 1024 && suffixIndex < sizeSuffixes.length) {
             result /= 1024.;
-            attachedSuff++;
+            suffixIndex++;
         }
 
         return new BigDecimal(result).setScale(
-                sizeScales[attachedSuff], BigDecimal.ROUND_HALF_UP) + " " + sizeSuffixes[attachedSuff];
+                sizeScales[suffixIndex], BigDecimal.ROUND_HALF_UP) + " " + sizeSuffixes[suffixIndex];
     }
 
     /**

--- a/src/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/com/owncloud/android/utils/DisplayUtils.java
@@ -64,16 +64,16 @@ import java.util.Map;
  */
 public class DisplayUtils {
     private static final String TAG = DisplayUtils.class.getSimpleName();
-    
-    private static final String OWNCLOUD_APP_NAME = "ownCloud";
-    
+
     private static final String[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
     private static final int[] sizeScales = { 0, 0, 1, 1, 1, 2, 2, 2, 2 };
+    public static final int RELATIVE_THRESHOLD_WARNING = 90;
+    public static final int RELATIVE_THRESHOLD_CRITICAL = 95;
 
     private static Map<String, String> mimeType2HumanReadable;
 
     static {
-        mimeType2HumanReadable = new HashMap<String, String>();
+        mimeType2HumanReadable = new HashMap<>();
         // images
         mimeType2HumanReadable.put("image/jpeg", "JPEG image");
         mimeType2HumanReadable.put("image/jpg", "JPEG image");
@@ -155,9 +155,9 @@ public class DisplayUtils {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
             // Find host name after '//' or '@'
             int hostStart = 0;
-            if  (urlNoDots.indexOf("//") != -1) {
+            if (urlNoDots.contains("//")) {
                 hostStart = url.indexOf("//") + "//".length();
-            } else if (url.indexOf("@") != -1) {
+            } else if (url.contains("@")) {
                 hostStart = url.indexOf("@") + "@".length();
             }
 
@@ -207,17 +207,33 @@ public class DisplayUtils {
                 DateUtils.WEEK_IN_MILLIS, 0);
     }
 
-    @SuppressWarnings("deprecation")
-    public static CharSequence getRelativeDateTimeString (
-            Context c, long time, long minResolution, long transitionResolution, int flags
-            ){
-        
+    /**
+     * determines the info level color based on certain thresholds
+     * {@link #RELATIVE_THRESHOLD_WARNING} and {@link #RELATIVE_THRESHOLD_CRITICAL}.
+     *
+     * @param context  the app's context
+     * @param relative relative value for which the info level color should be looked up
+     * @return info level color
+     */
+    public static int getRelativeInfoColor(Context context, int relative) {
+        if (relative < RELATIVE_THRESHOLD_WARNING) {
+            return context.getResources().getColor(R.color.infolevel_info);
+        } else if (relative >= RELATIVE_THRESHOLD_WARNING && relative < RELATIVE_THRESHOLD_CRITICAL) {
+            return context.getResources().getColor(R.color.infolevel_warning);
+        } else {
+            return context.getResources().getColor(R.color.infolevel_critical);
+        }
+    }
+
+    public static CharSequence getRelativeDateTimeString(
+            Context c, long time, long minResolution, long transitionResolution, int flags) {
+
         CharSequence dateString = "";
-        
+
         // in Future
-        if (time > System.currentTimeMillis()){
+        if (time > System.currentTimeMillis()) {
             return DisplayUtils.unixTimeToHumanReadable(time);
-        } 
+        }
         // < 60 seconds -> seconds ago
         else if ((System.currentTimeMillis() - time) < 60 * 1000) {
             return c.getString(R.string.file_list_seconds_ago);
@@ -238,8 +254,9 @@ public class DisplayUtils {
     }
 
     /**
-     * Update the passed path removing the last "/" if it is not the root folder
-     * @param path
+     * Update the passed path removing the last "/" if it is not the root folder.
+     *
+     * @param path the path to be trimmed
      */
     public static String getPathWithoutLastSlash(String path) {
 
@@ -250,12 +267,11 @@ public class DisplayUtils {
         return path;
     }
 
-
     /**
-     * Gets the screen size in pixels in a backwards compatible way
+     * Gets the screen size in pixels in a backwards compatible way.
      *
-     * @param caller        Activity calling; needed to get access to the {@link android.view.WindowManager}
-     * @return              Size in pixels of the screen, or default {@link Point} if caller is null
+     * @param caller Activity calling; needed to get access to the {@link android.view.WindowManager}
+     * @return Size in pixels of the screen, or default {@link Point} if caller is null
      */
     public static Point getScreenSize(Activity caller) {
         Point size = new Point();
@@ -277,7 +293,18 @@ public class DisplayUtils {
      */
     public static void colorPreLollipopHorizontalProgressBar(ProgressBar progressBar) {
         if (progressBar != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            int color = progressBar.getResources().getColor(R.color.color_accent);
+            colorHorizontalProgressBar(progressBar, progressBar.getResources().getColor(R.color.color_accent));
+        }
+    }
+
+    /**
+     * sets the coloring of the given progress bar to color_accent.
+     *
+     * @param progressBar the progress bar to be colored
+     * @param color       the color to be used
+     */
+    public static void colorHorizontalProgressBar(ProgressBar progressBar, @ColorInt int color) {
+        if (progressBar != null) {
             progressBar.getIndeterminateDrawable().setColorFilter(color, PorterDuff.Mode.SRC_IN);
             progressBar.getProgressDrawable().setColorFilter(color, PorterDuff.Mode.SRC_IN);
         }
@@ -315,7 +342,7 @@ public class DisplayUtils {
      * Sets the color of the status bar to {@code color} on devices with OS version lollipop or higher.
      *
      * @param fragmentActivity fragment activity
-     * @param color the color
+     * @param color            the color
      */
     public static void colorStatusBar(FragmentActivity fragmentActivity, @ColorInt int color) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -326,11 +353,11 @@ public class DisplayUtils {
     /**
      * Sets the color of the progressbar to {@code color} within the given toolbar.
      *
-     * @param activity the toolbar activity instance
+     * @param activity         the toolbar activity instance
      * @param progressBarColor the color to be used for the toolbar's progress bar
      */
     public static void colorToolbarProgressBar(FragmentActivity activity, int progressBarColor) {
-        if(activity instanceof ToolbarActivity) {
+        if (activity instanceof ToolbarActivity) {
             ((ToolbarActivity) activity).setProgressBarBackgroundColor(progressBarColor);
         }
     }

--- a/src/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/com/owncloud/android/utils/DisplayUtils.java
@@ -1,23 +1,25 @@
 /**
- *   ownCloud Android client application
+ *   Nextcloud Android client application
  *
+ *   @author Andy Scherzinger
  *   @author Bartek Przybylski
  *   @author David A. Velasco
  *   Copyright (C) 2011  Bartek Przybylski
  *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 Andy Scherzinger
  *
- *   This program is free software: you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License version 2,
- *   as published by the Free Software Foundation.
+ *   This program is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ *   License as published by the Free Software Foundation; either
+ *   version 3 of the License, or any later version.
  *
  *   This program is distributed in the hope that it will be useful,
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU General Public License for more details.
+ *   GNU AFFERO GENERAL PUBLIC LICENSE for more details.
  *
- *   You should have received a copy of the GNU General Public License
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *   You should have received a copy of the GNU Affero General Public
+ *   License along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package com.owncloud.android.utils;
@@ -37,7 +39,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.text.format.DateUtils;
-import android.view.Display;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.SeekBar;
@@ -60,16 +61,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A helper class for some string operations.
+ * A helper class for UI/display related operations.
  */
 public class DisplayUtils {
     private static final String TAG = DisplayUtils.class.getSimpleName();
 
     private static final String[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
     private static final int[] sizeScales = { 0, 0, 1, 1, 1, 2, 2, 2, 2 };
-    private static final int[] quotaSizeScales = { 0, 0, 0, 1, 1, 2, 2, 2, 2 };
     public static final int RELATIVE_THRESHOLD_WARNING = 90;
     public static final int RELATIVE_THRESHOLD_CRITICAL = 95;
+    public static final String MIME_TYPE_UNKNOWN = "Unknown type";
 
     private static Map<String, String> mimeType2HumanReadable;
 
@@ -95,40 +96,10 @@ public class DisplayUtils {
      *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
      * </ul>
      *
-     * @param bytes Input file size
+     * @param bytes        Input file size
      * @return something readable like "12 MB"
      */
     public static String bytesToHumanReadable(long bytes) {
-        return bytesToHumanReadable(bytes, sizeScales, sizeSuffixes);
-    }
-
-    /**
-     * Converts the file size in bytes to human readable output.
-     * <ul>
-     *     <li>appends a size suffix, e.g. B, KB, MB etc.</li>
-     *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
-     * </ul>
-     *
-     * @param bytes Input file size
-     * @return something readable like "12 MB"
-     */
-    public static String quotaBytesToHumanReadable(long bytes) {
-        return bytesToHumanReadable(bytes, quotaSizeScales, sizeSuffixes);
-    }
-
-    /**
-     * Converts the file size in bytes to human readable output.
-     * <ul>
-     *     <li>appends a size suffix, e.g. B, KB, MB etc.</li>
-     *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
-     * </ul>
-     *
-     * @param bytes        Input file size
-     * @param sizeScales   scales for the different size units
-     * @param sizeSuffixes suffixes for the different size units
-     * @return something readable like "12 MB"
-     */
-    private static String bytesToHumanReadable(long bytes, int[] sizeScales, String[] sizeSuffixes) {
         double result = bytes;
         int suffixIndex = 0;
         while (result > 1024 && suffixIndex < sizeSuffixes.length) {
@@ -145,7 +116,7 @@ public class DisplayUtils {
      * like "JPG image".
      * 
      * @param mimetype MIME type to convert
-     * @return A human friendly version of the MIME type
+     * @return A human friendly version of the MIME type, {@link #MIME_TYPE_UNKNOWN} if it can't be converted
      */
     public static String convertMIMEtoPrettyPrint(String mimetype) {
         if (mimeType2HumanReadable.containsKey(mimetype)) {
@@ -153,11 +124,12 @@ public class DisplayUtils {
         }
         if (mimetype.split("/").length >= 2)
             return mimetype.split("/")[1].toUpperCase() + " file";
-        return "Unknown type";
+        return MIME_TYPE_UNKNOWN;
     }
 
     /**
      * Converts Unix time to human readable format
+     *
      * @param milliseconds that have passed since 01/01/1970
      * @return The human readable time for the users locale
      */
@@ -169,6 +141,7 @@ public class DisplayUtils {
     
     /**
      * Converts an internationalized domain name (IDN) in an URL to and from ASCII/Unicode.
+     *
      * @param url the URL where the domain name should be converted
      * @param toASCII if true converts from Unicode to ASCII, if false converts from ASCII to Unicode
      * @return the URL containing the converted domain name
@@ -299,7 +272,7 @@ public class DisplayUtils {
     }
 
     /**
-     * Gets the screen size in pixels in a backwards compatible way.
+     * Gets the screen size in pixels.
      *
      * @param caller Activity calling; needed to get access to the {@link android.view.WindowManager}
      * @return Size in pixels of the screen, or default {@link Point} if caller is null
@@ -307,12 +280,7 @@ public class DisplayUtils {
     public static Point getScreenSize(Activity caller) {
         Point size = new Point();
         if (caller != null) {
-            Display display = caller.getWindowManager().getDefaultDisplay();
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB_MR2) {
-                display.getSize(size);
-            } else {
-                size.set(display.getWidth(), display.getHeight());
-            }
+            caller.getWindowManager().getDefaultDisplay().getSize(size);
         }
         return size;
     }
@@ -359,9 +327,9 @@ public class DisplayUtils {
     }
 
     /**
-     * set the owncloud standard colors for the snackbar.
+     * set the Nextcloud standard colors for the snackbar.
      *
-     * @param context the context relevant for setting the color according to the context's theme
+     * @param context  the context relevant for setting the color according to the context's theme
      * @param snackbar the snackbar to be colored
      */
     public static void colorSnackbar(Context context, Snackbar snackbar) {


### PR DESCRIPTION
for initial discussion please see #195 

Open issue:
* quota string formatting. For now I went with ```%1$s of %2$s used``` which could re-use the given formatter for (might need some work or a slightly different string) so %1$s and %2$s would be the sizes with the units calculated like the one in the file lists e.g. "1MB of 3,0GB used", another idea (like dropbox) would be to mix: "10% of 3,0GB used" - both have their advantages and disadvantages.

DONE
* coloring of the progress bar: "just blue" or turning yellow-ish and red-ish when hitting certain thresholds like 85% and 95%? And if so which yellow/red colors should be used.

As a sidenote, for now I had to add a "invisible" menu item for the bottom padding since I cannot customize the layouting of the menu-list itself which is imho okay until AppCompat provides more options to customize the drawer itself.

cc @tobiasKaminsky for further development and @jancborchardt regarding the quota string/format and colors to be used.

![device-2016-08-08-172117](https://cloud.githubusercontent.com/assets/1315170/17485902/5bb47df2-5d8f-11e6-9a46-0d0eb3e84ddb.png)
