### PR TITLE
descend into folder after creating it in uploader

### DIFF
--- a/src/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/src/com/owncloud/android/operations/CreateFolderOperation.java
@@ -121,4 +121,8 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
             Log_OC.d(TAG, "Create directory " + mRemotePath + " in Database");
         }
     }
+
+    public String getRemotePath() {
+        return mRemotePath;
+    }
 }

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -611,6 +611,9 @@ public class ReceiveExternalFilesActivity extends FileActivity
     private void onCreateFolderOperationFinish(CreateFolderOperation operation,
                                                RemoteOperationResult result) {
         if (result.isSuccess()) {
+            String remotePath = operation.getRemotePath().substring(0, operation.getRemotePath().length() - 1);
+            String newFolder = remotePath.substring(remotePath.lastIndexOf("/") + 1);
+            mParents.push(newFolder);
             populateDirectoryList();
         } else {
             try {


### PR DESCRIPTION
revived PR by @tobiasKaminsky see oC 1045 and oC 1010 for initial discussion

>When the user creates a new directory in the upload pane, the app should automatically descend into that directory.

cc @przybylski @jancborchardt 