### PR TITLE
bugfix for empty folder display 

### DIFF
--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -327,7 +327,7 @@ public class FileStorageUtils {
             }
         });
 
-        File[] returnArray = new File[1];
+        File[] returnArray = new File[files.size()];
         return files.toArray(returnArray);
     }
 
@@ -386,7 +386,7 @@ public class FileStorageUtils {
             }
         });
 
-        File[] returnArray = new File[1];
+        File[] returnArray = new File[files.size()];
         return files.toArray(returnArray);
     }
 
@@ -436,7 +436,7 @@ public class FileStorageUtils {
             }
         });
 
-        File[] returnArray = new File[1];
+        File[] returnArray = new File[files.size()];
         return files.toArray(returnArray);
     }
     


### PR DESCRIPTION
Empty local folders now show an empty folder while before they would show the first parent folder as a child folder from which you navigated into an empty folder.

example:

* /EmptyFolder (empty)
* /EmptyFolder2 (empty)

Navigating into /EmptyFolder will then show you /EmptyFolder/EmptyFolder, navigate back up and navigate in /EmptyFolder2 will show you /EmptyFolder2/EmptyFolder

This has been reported in https://github.com/nextcloud/android/issues/221#issuecomment-243442544 and is fixed by this PR.

Please review @tobiasKaminsky @przybylski 

cc @nickvergessen @michalmiddleton