### PR TITLE
Restore display of remote folder size

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="common_loading">Loading &#8230;</string>
     <string name="common_unknown">unknown</string>
     <string name="common_error_unknown">Unknown error</string>
+    <string name="common_pending">Pending</string>
     <string name="about_title">About</string>
     <string name="change_password">Change password</string>
     <string name="delete_account">Remove account</string>

--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -36,7 +36,6 @@ import android.widget.BaseAdapter;
 import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.ListAdapter;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
@@ -195,11 +194,6 @@ public class FileListListAdapter extends BaseAdapter implements FilterableListAd
                     fileSizeSeparatorV.setVisibility(View.VISIBLE);
                     fileSizeV.setVisibility(View.VISIBLE);
                     fileSizeV.setText(DisplayUtils.bytesToHumanReadable(file.getFileLength()));
-
-                    if (file.isFolder()) {
-                        fileSizeSeparatorV.setVisibility(View.GONE);
-                        fileSizeV.setVisibility(View.GONE);
-                    }
 
                 case GRID_ITEM:
                     // filename

--- a/src/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/com/owncloud/android/utils/DisplayUtils.java
@@ -96,19 +96,24 @@ public class DisplayUtils {
      *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
      * </ul>
      *
-     * @param bytes        Input file size
-     * @return something readable like "12 MB"
+     * @param bytes Input file size
+     * @return something readable like "12 MB", {@link com.owncloud.android.R.string#common_pending} for negative
+     * byte values
      */
     public static String bytesToHumanReadable(long bytes) {
-        double result = bytes;
-        int suffixIndex = 0;
-        while (result > 1024 && suffixIndex < sizeSuffixes.length) {
-            result /= 1024.;
-            suffixIndex++;
-        }
+        if (bytes < 0) {
+            return MainApp.getAppContext().getString(R.string.common_pending);
+        } else {
+            double result = bytes;
+            int suffixIndex = 0;
+            while (result > 1024 && suffixIndex < sizeSuffixes.length) {
+                result /= 1024.;
+                suffixIndex++;
+            }
 
-        return new BigDecimal(result).setScale(
-                sizeScales[suffixIndex], BigDecimal.ROUND_HALF_UP) + " " + sizeSuffixes[suffixIndex];
+            return new BigDecimal(result).setScale(
+                    sizeScales[suffixIndex], BigDecimal.ROUND_HALF_UP) + " " + sizeSuffixes[suffixIndex];
+        }
     }
 
     /**


### PR DESCRIPTION
see comment on #123 - https://github.com/nextcloud/android/pull/123#issuecomment-241051015
At some point the display seems to have been lost after the release of it (1.2.0). 
So this PR restores it (https://github.com/nextcloud/android/pull/235/commits/ad673921ebd6221bfbbeee75736f2340b10c66e7#diff-af208ce61778201d6e0fadf55ea46469L199) and also adds the display of "Pending" like the web app for remote folder sizes not yet known (federated shares calculate this but not instantly) (https://github.com/nextcloud/android/pull/235/files#diff-36e882c1d5231f769f0209395ecf63c4R104). The display of "Pending" corresponds with the server part of handling this size display situations for federated shares (web view).