### PR TITLE
Use correct array of options

### DIFF
--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -32,4 +32,9 @@
 		<item>@string/menu_item_sort_by_date</item>
 		<item>@string/menu_item_sort_by_size</item>
 	</string-array>
+
+	<string-array name="menu_items_sort_by_options_local" translatable="false">
+		<item>@string/menu_item_sort_by_name</item>
+		<item>@string/menu_item_sort_by_date</item>
+	</string-array>
 </resources>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -32,9 +32,4 @@
 		<item>@string/menu_item_sort_by_date</item>
 		<item>@string/menu_item_sort_by_size</item>
 	</string-array>
-
-	<string-array name="menu_items_sort_by_options_local" translatable="false">
-		<item>@string/menu_item_sort_by_name</item>
-		<item>@string/menu_item_sort_by_date</item>
-	</string-array>
 </resources>

--- a/src/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -30,7 +30,6 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -210,7 +209,7 @@ public class UploadFilesActivity extends FileActivity implements
 
                 AlertDialog.Builder builder = new AlertDialog.Builder(this);
                 builder.setTitle(R.string.actionbar_sort_title)
-                        .setSingleChoiceItems(R.array.actionbar_sortby, sortOrder ,
+                        .setSingleChoiceItems(R.array.menu_items_sort_by_options_local, sortOrder,
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int which) {
                                         switch (which){

--- a/src/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -107,8 +107,7 @@ public class UploadFilesActivity extends FileActivity implements
         /// USER INTERFACE
             
         // Drop-down navigation 
-        mDirectories = new CustomArrayAdapter<String>(this,
-                R.layout.support_simple_spinner_dropdown_item);
+        mDirectories = new CustomArrayAdapter<>(this, R.layout.support_simple_spinner_dropdown_item);
         File currDir = mCurrentDir;
         while(currDir != null && currDir.getParentFile() != null) {
             mDirectories.add(currDir.getName());
@@ -119,8 +118,7 @@ public class UploadFilesActivity extends FileActivity implements
         // Inflate and set the layout view
         setContentView(R.layout.upload_files_layout);
 
-        mFileListFragment = (LocalFileListFragment)
-                getSupportFragmentManager().findFragmentById(R.id.local_files_list);
+        mFileListFragment = (LocalFileListFragment) getSupportFragmentManager().findFragmentById(R.id.local_files_list);
         
         
         // Set input controllers
@@ -209,7 +207,7 @@ public class UploadFilesActivity extends FileActivity implements
 
                 AlertDialog.Builder builder = new AlertDialog.Builder(this);
                 builder.setTitle(R.string.actionbar_sort_title)
-                        .setSingleChoiceItems(R.array.menu_items_sort_by_options_local, sortOrder,
+                        .setSingleChoiceItems(R.array.menu_items_sort_by_options, sortOrder,
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int which) {
                                         switch (which){
@@ -218,6 +216,9 @@ public class UploadFilesActivity extends FileActivity implements
                                                 break;
                                             case 1:
                                                 mFileListFragment.sortByDate(false);
+                                                break;
+                                            case 2:
+                                                mFileListFragment.sortBySize(false);
                                                 break;
                                         }
 

--- a/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -61,7 +61,6 @@ import java.util.Observer;
 /**
  * This Adapter populates a ListView with following types of uploads: pending,
  * active, completed. Filtering possible.
- *
  */
 public class ExpandableUploadListAdapter extends BaseExpandableListAdapter implements Observer {
 

--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -24,7 +24,6 @@ import android.accounts.Account;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.webkit.MimeTypeMap;
 
@@ -331,13 +330,14 @@ public class FileStorageUtils {
     public static File[] sortLocalFilesBySize(File[] filesArray) {
         final int multiplier = mSortAscending ? 1 : -1;
 
-        List<File> files = new ArrayList<File>(Arrays.asList(filesArray));
+        List<File> files = new ArrayList<>(Arrays.asList(filesArray));
 
         Collections.sort(files, new Comparator<File>() {
             public int compare(File o1, File o2) {
                 if (o1.isDirectory() && o2.isDirectory()) {
-                    Long obj1 = getFolderSize(o1);
-                    return multiplier * obj1.compareTo(getFolderSize(o2));
+                    // Long obj1 = getFolderSize(o1);
+                    // return multiplier * obj1.compareTo(getFolderSize(o2));
+                    return o1.getPath().toLowerCase().compareTo(o2.getPath().toLowerCase());
                 } else if (o1.isDirectory()) {
                     return -1;
                 } else if (o2.isDirectory()) {


### PR DESCRIPTION
Resolves: #336

> android app crashes when trying to sort a directory of photos to upload

@tobiasKaminsky please review - This is a work in progress since imho the implementation is broken for a simply reason. OCFIleList and LocalFileList both use the same preference for the sorting choice. So if you choose BySize in the main screen and then open upload via the FAB it'll load "by Size" and will try to sort this way. Unfortunately the local file sorting by size also sorts folders, by recursively calculating their size which takes around one minute on my phone... So imho we either need to 
- remove folders from the local file sorting as in sort by size with folders on top sorted alphabetically or
- split the sorting choice into two preferences and don't offer sorting by size at all.

What do you think @tobiasKaminsky - I vote for ignore folders during size sorting (locally)
