### PR TITLE
Fix spelling error in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ For _stable_ and _release candidate_ the version name follows the [semantic vers
 * 2 digits for beta code as in release candidates starting at '01'
 * 2 digits for hot fix code
 * 3 digits for minor version code
-* n digits for mayor version code
+* n digits for major version code
 
 ![Version code schema](https://cloud.githubusercontent.com/assets/1315170/15992040/e4e05442-30c2-11e6-88e2-84e77fa1653d.png)
 
@@ -171,14 +171,14 @@ To get an idea which PRs and issues will be part of the next release simply chec
 Stable releases are based on the git [master](https://github.com/nextcloud/android).
 
 1. Bump the version name and version code in the [AndroidManifest.xml](https://github.com/nextcloud/android/blob/master/AndroidManifest.xml), see chapter 'Version Name and number'.
-2. Create a [release/tag](https://github.com/nextcloud/android/releases) in git. Tag name following the naming schema: ```stable-Mayor.Minor.Hotfix``` (e.g. stable-1.2.0) naming the version number following the [semantic versioning schema](http://semver.org/)
+2. Create a [release/tag](https://github.com/nextcloud/android/releases) in git. Tag name following the naming schema: ```stable-Major.Minor.Hotfix``` (e.g. stable-1.2.0) naming the version number following the [semantic versioning schema](http://semver.org/)
 
 
 ### Release Candidate Release
 Release Candidate releases are based on the git [master](https://github.com/nextcloud/android) and are done between stable releases.
 
 1. Bump the version name and version code in the [AndroidManifest.xml](https://github.com/nextcloud/android/blob/master/AndroidManifest.xml), see below the version name and code concept.
-2. Create a [release/tag](https://github.com/nextcloud/android/releases) in git. Tag name following the naming schema: ```rc-Mayor.Minor.Hotfix-betaIncrement``` (e.g. rc-1.2.0-12) naming the version number following the [semantic versioning schema](http://semver.org/)
+2. Create a [release/tag](https://github.com/nextcloud/android/releases) in git. Tag name following the naming schema: ```rc-Major.Minor.Hotfix-betaIncrement``` (e.g. rc-1.2.0-12) naming the version number following the [semantic versioning schema](http://semver.org/)
 
 
 ###Development Beta Release

--- a/src/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1880,7 +1880,7 @@ public class FileDataStorageManager {
         // Prepare capabilities data
         ContentValues cv = new ContentValues();
         cv.put(ProviderTableMeta.CAPABILITIES_ACCOUNT_NAME, mAccount.name);
-        cv.put(ProviderTableMeta.CAPABILITIES_VERSION_MAYOR, capability.getVersionMayor());
+        cv.put(ProviderTableMeta.CAPABILITIES_VERSION_MAJOR, capability.getVersionMajor());
         cv.put(ProviderTableMeta.CAPABILITIES_VERSION_MINOR, capability.getVersionMinor());
         cv.put(ProviderTableMeta.CAPABILITIES_VERSION_MICRO, capability.getVersionMicro());
         cv.put(ProviderTableMeta.CAPABILITIES_VERSION_STRING, capability.getVersionString());
@@ -2010,8 +2010,8 @@ public class FileDataStorageManager {
             capability.setId(c.getLong(c.getColumnIndex(ProviderTableMeta._ID)));
             capability.setAccountName(c.getString(c
                     .getColumnIndex(ProviderTableMeta.CAPABILITIES_ACCOUNT_NAME)));
-            capability.setVersionMayor(c.getInt(c
-                    .getColumnIndex(ProviderTableMeta.CAPABILITIES_VERSION_MAYOR)));
+            capability.setVersionMajor(c.getInt(c
+                    .getColumnIndex(ProviderTableMeta.CAPABILITIES_VERSION_MAJOR)));
             capability.setVersionMinor(c.getInt(c
                     .getColumnIndex(ProviderTableMeta.CAPABILITIES_VERSION_MINOR)));
             capability.setVersionMicro(c.getInt(c

--- a/src/com/owncloud/android/db/ProviderMeta.java
+++ b/src/com/owncloud/android/db/ProviderMeta.java
@@ -107,7 +107,7 @@ public class ProviderMeta {
 
         // Columns of capabilities table
         public static final String CAPABILITIES_ACCOUNT_NAME = "account";
-        public static final String CAPABILITIES_VERSION_MAYOR = "version_mayor";
+        public static final String CAPABILITIES_VERSION_MAJOR = "version_major";
         public static final String CAPABILITIES_VERSION_MINOR = "version_minor";
         public static final String CAPABILITIES_VERSION_MICRO = "version_micro";
         public static final String CAPABILITIES_VERSION_STRING = "version_string";

--- a/src/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/com/owncloud/android/providers/FileContentProvider.java
@@ -846,7 +846,7 @@ public class FileContentProvider extends ContentProvider {
         db.execSQL("CREATE TABLE " + ProviderTableMeta.CAPABILITIES_TABLE_NAME + "("
                 + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
                 + ProviderTableMeta.CAPABILITIES_ACCOUNT_NAME + " TEXT, "
-                + ProviderTableMeta.CAPABILITIES_VERSION_MAYOR + " INTEGER, "
+                + ProviderTableMeta.CAPABILITIES_VERSION_MAJOR + " INTEGER, "
                 + ProviderTableMeta.CAPABILITIES_VERSION_MINOR + " INTEGER, "
                 + ProviderTableMeta.CAPABILITIES_VERSION_MICRO + " INTEGER, "
                 + ProviderTableMeta.CAPABILITIES_VERSION_STRING + " TEXT, "


### PR DESCRIPTION
I believe that there are english spelling errors in both the sources and documentation: The word "Mayor" should probably be spelled "Major".

This pull request addresses this english spelling inconsistency.