### PR TITLE
Nc lib update to 1.0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     /// dependencies for app building
     compile name: 'touch-image-view'
 
-    compile 'com.github.nextcloud:android-library:1.0.8'
+    compile 'com.github.nextcloud:android-library:1.0.9'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'


### PR DESCRIPTION
update Nc android lib to version 1.0.9 to fix #376 

lib fix has been pushed to beta and will thus be shipped whenever the next beta release is done / beta-lib dependency is refreshed during build.

@tobiasKaminsky to be decided if this should be fixed in 1.4.0 or if we wait for the result of the next beta relase and postpone it to 1.4.1.