### PR TITLE
Updated federated sharing edit options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     compile name: 'touch-image-view'
     compile 'com.android.support:multidex:1.0.1'
 
-    compile 'com.github.nextcloud:android-library:1.0.16'
+    compile 'com.github.nextcloud:android-library:check_for_unshareable_federated_shares-SNAPSHOT'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     compile name: 'touch-image-view'
     compile 'com.android.support:multidex:1.0.1'
 
-    compile 'com.github.nextcloud:android-library:check_for_unshareable_federated_shares-SNAPSHOT'
+    compile 'com.github.nextcloud:android-library:1.0.17'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -371,12 +371,16 @@ public class UploadFileOperation extends SyncOperation {
                 throw new OperationCancelledException();
             }
 
+            // Get the last modification date of the file from the file system
+            Long timeStampLong = originalFile.lastModified()/1000;
+            String timeStamp = timeStampLong.toString();
+
             /// perform the upload
             if ( mChunked &&
                     (new File(mFile.getStoragePath())).length() >
                             ChunkedUploadRemoteFileOperation.CHUNK_SIZE ) {
                 mUploadOperation = new ChunkedUploadRemoteFileOperation(mContext, mFile.getStoragePath(),
-                        mFile.getRemotePath(), mFile.getMimetype(), mFile.getEtagInConflict());
+                        mFile.getRemotePath(), mFile.getMimetype(), mFile.getEtagInConflict(), timeStamp);
             } else {
                 mUploadOperation = new UploadRemoteFileOperation(mFile.getStoragePath(),
                         mFile.getRemotePath(), mFile.getMimetype(), mFile.getEtagInConflict());

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -42,7 +42,6 @@ import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.UnshareOperation;
 import com.owncloud.android.operations.UpdateSharePermissionsOperation;
-import com.owncloud.android.providers.UsersAndGroupsSearchProvider;
 import com.owncloud.android.ui.dialog.ShareLinkToDialog;
 import com.owncloud.android.ui.fragment.EditShareFragment;
 import com.owncloud.android.ui.fragment.SearchShareesFragment;
@@ -51,6 +50,7 @@ import com.owncloud.android.ui.fragment.ShareFragmentListener;
 import com.owncloud.android.utils.ErrorMessageAdapter;
 import com.owncloud.android.utils.GetShareWithUsersAsyncTask;
 
+import org.nextcloud.providers.UsersAndGroupsSearchProvider;
 import java.util.ArrayList;
 
 
@@ -154,10 +154,12 @@ public class ShareActivity extends FileActivity
             return OCShare.READ_PERMISSION_FLAG;    // minimum permissions
 
         } else if (getFile().isFolder()) {
-            return (isFederated) ? OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER : OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER;
+            return (isFederated) ? OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9 :
+                    OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER;
 
         } else {    // isFile
-            return (isFederated) ? OCShare.FEDERATED_PERMISSIONS_FOR_FILE : OCShare.MAXIMUM_PERMISSIONS_FOR_FILE;
+            return (isFederated) ? OCShare.FEDERATED_PERMISSIONS_FOR_FILE_UP_TO_OC9 :
+                    OCShare.MAXIMUM_PERMISSIONS_FOR_FILE;
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -43,6 +43,7 @@ import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.UnshareOperation;
 import com.owncloud.android.operations.UpdateSharePermissionsOperation;
+import com.owncloud.android.providers.UsersAndGroupsSearchProvider;
 import com.owncloud.android.ui.dialog.ShareLinkToDialog;
 import com.owncloud.android.ui.fragment.EditShareFragment;
 import com.owncloud.android.ui.fragment.SearchShareesFragment;
@@ -51,9 +52,7 @@ import com.owncloud.android.ui.fragment.ShareFragmentListener;
 import com.owncloud.android.utils.ErrorMessageAdapter;
 import com.owncloud.android.utils.GetShareWithUsersAsyncTask;
 
-import org.nextcloud.providers.UsersAndGroupsSearchProvider;
 import java.util.ArrayList;
-
 
 /**
  * Activity for sharing files

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -38,6 +38,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
+import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.UnshareOperation;
@@ -153,13 +154,28 @@ public class ShareActivity extends FileActivity
         if (getFile().isSharedWithMe()) {
             return OCShare.READ_PERMISSION_FLAG;    // minimum permissions
 
-        } else if (getFile().isFolder()) {
-            return (isFederated) ? OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9 :
-                    OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER;
-
-        } else {    // isFile
-            return (isFederated) ? OCShare.FEDERATED_PERMISSIONS_FOR_FILE_UP_TO_OC9 :
-                    OCShare.MAXIMUM_PERMISSIONS_FOR_FILE;
+        } else if (isFederated) {
+            OwnCloudVersion serverVersion =
+                    com.owncloud.android.authentication.AccountUtils.getServerVersion(getAccount());
+            if (serverVersion != null && serverVersion.isNotReshareableFederatedSupported()) {
+                return (
+                        getFile().isFolder() ?
+                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_AFTER_OC9 :
+                                OCShare.FEDERATED_PERMISSIONS_FOR_FILE_AFTER_OC9
+                );
+            } else {
+                return (
+                        getFile().isFolder() ?
+                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9 :
+                                OCShare.FEDERATED_PERMISSIONS_FOR_FILE_UP_TO_OC9
+                );
+            }
+        } else {
+            return (
+                    getFile().isFolder() ?
+                            OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER :
+                            OCShare.MAXIMUM_PERMISSIONS_FOR_FILE
+            );
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -154,27 +154,18 @@ public class ShareActivity extends FileActivity
             return OCShare.READ_PERMISSION_FLAG;    // minimum permissions
 
         } else if (isFederated) {
-            OwnCloudVersion serverVersion =
-                    com.owncloud.android.authentication.AccountUtils.getServerVersion(getAccount());
+            OwnCloudVersion serverVersion = com.owncloud.android.authentication.AccountUtils.
+                    getServerVersion(getAccount());
             if (serverVersion != null && serverVersion.isNotReshareableFederatedSupported()) {
-                return (
-                        getFile().isFolder() ?
-                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_AFTER_OC9 :
-                                OCShare.FEDERATED_PERMISSIONS_FOR_FILE_AFTER_OC9
-                );
+                return (getFile().isFolder() ? OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_AFTER_OC9 :
+                        OCShare.FEDERATED_PERMISSIONS_FOR_FILE_AFTER_OC9);
             } else {
-                return (
-                        getFile().isFolder() ?
-                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9 :
-                                OCShare.FEDERATED_PERMISSIONS_FOR_FILE_UP_TO_OC9
-                );
+                return (getFile().isFolder() ? OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9 :
+                        OCShare.FEDERATED_PERMISSIONS_FOR_FILE_UP_TO_OC9);
             }
         } else {
-            return (
-                    getFile().isFolder() ?
-                            OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER :
-                            OCShare.MAXIMUM_PERMISSIONS_FOR_FILE
-            );
+            return (getFile().isFolder() ? OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER :
+                    OCShare.MAXIMUM_PERMISSIONS_FOR_FILE);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -43,7 +43,6 @@ import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.UnshareOperation;
 import com.owncloud.android.operations.UpdateSharePermissionsOperation;
-import com.owncloud.android.providers.UsersAndGroupsSearchProvider;
 import com.owncloud.android.ui.dialog.ShareLinkToDialog;
 import com.owncloud.android.ui.fragment.EditShareFragment;
 import com.owncloud.android.ui.fragment.SearchShareesFragment;
@@ -52,7 +51,9 @@ import com.owncloud.android.ui.fragment.ShareFragmentListener;
 import com.owncloud.android.utils.ErrorMessageAdapter;
 import com.owncloud.android.utils.GetShareWithUsersAsyncTask;
 
+import org.nextcloud.providers.UsersAndGroupsSearchProvider;
 import java.util.ArrayList;
+
 
 /**
  * Activity for sharing files

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -178,15 +178,15 @@ public class EditShareFragment extends Fragment {
                 // from checking when iOS is ready
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditCreateCheckBox);
                 compound.setChecked((sharePermissions & OCShare.CREATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditChangeCheckBox);
                 compound.setChecked((sharePermissions & OCShare.UPDATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditDeleteCheckBox);
                 compound.setChecked((sharePermissions & OCShare.DELETE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
             }
 
             setPermissionsListening(editShareView, true);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -174,19 +174,19 @@ public class EditShareFragment extends Fragment {
             boolean areEditOptionsAvailable = !isFederated || isNotReshareableFederatedSupported;
 
             if (mFile.isFolder() && areEditOptionsAvailable) {
-                /// TODO change areEditOptionsAvailable in order to delete !isFederated
+                /// TODO change areEditOptionsAllowed in order to delete !isFederated
                 // from checking when iOS is ready
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditCreateCheckBox);
                 compound.setChecked((sharePermissions & OCShare.CREATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditChangeCheckBox);
                 compound.setChecked((sharePermissions & OCShare.UPDATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditDeleteCheckBox);
                 compound.setChecked((sharePermissions & OCShare.DELETE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
             }
 
             setPermissionsListening(editShareView, true);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -69,6 +69,9 @@ public class EditShareFragment extends Fragment {
     /** File bound to mShare, received as a parameter in construction time */
     private OCFile mFile;
 
+    /** Account of the shared file, received as a parameter in construction time */
+    private Account mAccount;
+
     /** Listener for changes on privilege checkboxes */
     private CompoundButton.OnCheckedChangeListener mOnPrivilegeChangeListener;
     
@@ -101,7 +104,7 @@ public class EditShareFragment extends Fragment {
             mShare = getArguments().getParcelable(ARG_SHARE);
             mFile = getArguments().getParcelable(ARG_FILE);
             /* OC account holding the shared file, received as a parameter in construction time */
-            //Account mAccount = getArguments().getParcelable(ARG_ACCOUNT);
+            mAccount = getArguments().getParcelable(ARG_ACCOUNT);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -164,7 +164,7 @@ public class EditShareFragment extends Fragment {
             boolean areEditOptionsAvailable = !isFederated || isNotReshareableFederatedSupported;
 
             if (mFile.isFolder() && areEditOptionsAvailable) {
-                /// TODO change areEditOptionsAllowed in order to delete !isFederated
+                /// TODO change areEditOptionsAvailable in order to delete !isFederated
                 // from checking when iOS is ready
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditCreateCheckBox);
                 compound.setChecked((sharePermissions & OCShare.CREATE_PERMISSION_FLAG) > 0);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -174,7 +174,7 @@ public class EditShareFragment extends Fragment {
             boolean areEditOptionsAvailable = !isFederated || isNotReshareableFederatedSupported;
 
             if (mFile.isFolder() && areEditOptionsAvailable) {
-                /// TODO change areEditOptionsAllowed in order to delete !isFederated
+                /// TODO change areEditOptionsAvailable in order to delete !isFederated
                 // from checking when iOS is ready
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditCreateCheckBox);
                 compound.setChecked((sharePermissions & OCShare.CREATE_PERMISSION_FLAG) > 0);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -161,18 +161,22 @@ public class EditShareFragment extends Fragment {
             boolean canEdit = (sharePermissions & anyUpdatePermission) > 0;
             compound.setChecked(canEdit);
 
-            if (mFile.isFolder() && !isFederated) {
+            boolean areEditOptionsAvailable = !isFederated || isNotReshareableFederatedSupported;
+
+            if (mFile.isFolder() && areEditOptionsAvailable) {
+                /// TODO change areEditOptionsAllowed in order to delete !isFederated
+                // from checking when iOS is ready
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditCreateCheckBox);
                 compound.setChecked((sharePermissions & OCShare.CREATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility(canEdit ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditChangeCheckBox);
                 compound.setChecked((sharePermissions & OCShare.UPDATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility(canEdit ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditDeleteCheckBox);
                 compound.setChecked((sharePermissions & OCShare.DELETE_PERMISSION_FLAG) > 0);
-                compound.setVisibility(canEdit ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
             }
 
             setPermissionsListening(editShareView, true);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -33,6 +33,7 @@ import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -40,6 +41,7 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.SharePermissionsBuilder;
 import com.owncloud.android.lib.resources.shares.ShareType;
+import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.utils.AnalyticsUtils;
 
@@ -145,6 +147,11 @@ public class EditShareFragment extends Fragment {
 
             int sharePermissions = mShare.getPermissions();
             boolean isFederated = ShareType.FEDERATED.equals(mShare.getShareType());
+            OwnCloudVersion serverVersion = AccountUtils.getServerVersion(mAccount);
+            boolean isNotReshareableFederatedSupported = (
+                    serverVersion != null &&
+                            serverVersion.isNotReshareableFederatedSupported()
+            );
             CompoundButton compound;
 
             compound = (CompoundButton) editShareView.findViewById(R.id.canShareSwitch);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -168,15 +168,15 @@ public class EditShareFragment extends Fragment {
                 // from checking when iOS is ready
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditCreateCheckBox);
                 compound.setChecked((sharePermissions & OCShare.CREATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditChangeCheckBox);
                 compound.setChecked((sharePermissions & OCShare.UPDATE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
 
                 compound = (CompoundButton) editShareView.findViewById(R.id.canEditDeleteCheckBox);
                 compound.setChecked((sharePermissions & OCShare.DELETE_PERMISSION_FLAG) > 0);
-                compound.setVisibility((canEdit && areEditOptionsAvailable) ? View.VISIBLE : View.GONE);
+                compound.setVisibility((canEdit) ? View.VISIBLE : View.GONE);
             }
 
             setPermissionsListening(editShareView, true);

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -151,23 +151,19 @@ public class EditShareFragment extends Fragment {
             int sharePermissions = mShare.getPermissions();
             boolean isFederated = ShareType.FEDERATED.equals(mShare.getShareType());
             OwnCloudVersion serverVersion = AccountUtils.getServerVersion(mAccount);
-            boolean isNotReshareableFederatedSupported = (
-                    serverVersion != null &&
-                            serverVersion.isNotReshareableFederatedSupported()
-            );
-            CompoundButton compound;
+            boolean isNotReshareableFederatedSupported = (serverVersion != null &&
+                    serverVersion.isNotReshareableFederatedSupported());
 
-            compound = (CompoundButton) editShareView.findViewById(R.id.canShareSwitch);
-            if(isFederated) {
+            CompoundButton compound = (CompoundButton) editShareView.findViewById(R.id.canShareSwitch);
+
+            if (isFederated) {
                 compound.setVisibility(View.INVISIBLE);
             }
             compound.setChecked((sharePermissions & OCShare.SHARE_PERMISSION_FLAG) > 0);
 
             compound = (CompoundButton) editShareView.findViewById(R.id.canEditSwitch);
-            int anyUpdatePermission =
-                    OCShare.CREATE_PERMISSION_FLAG |
-                            OCShare.UPDATE_PERMISSION_FLAG |
-                            OCShare.DELETE_PERMISSION_FLAG;
+            int anyUpdatePermission = OCShare.CREATE_PERMISSION_FLAG | OCShare.UPDATE_PERMISSION_FLAG |
+                    OCShare.DELETE_PERMISSION_FLAG;
             boolean canEdit = (sharePermissions & anyUpdatePermission) > 0;
             compound.setChecked(canEdit);
 

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -478,9 +478,18 @@ public class FileOperationsHelper {
         if (hideFileListing) {
             updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS, OCShare.CREATE_PERMISSION_FLAG);
         } else {
-            updateShareIntent.
-                    putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
-                            OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9);
+            OwnCloudVersion serverVersion =
+                    com.owncloud.android.authentication.AccountUtils.getServerVersion(mFileActivity.getAccount());
+
+            if (serverVersion != null && serverVersion.isNotReshareableFederatedSupported()) {
+                updateShareIntent.
+                        putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
+                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_AFTER_OC9);
+            } else {
+                updateShareIntent.
+                        putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
+                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9);
+            }
         }
 
         queueShareIntent(updateShareIntent);

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -478,8 +478,7 @@ public class FileOperationsHelper {
         if (hideFileListing) {
             updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS, OCShare.CREATE_PERMISSION_FLAG);
         } else {
-            OwnCloudVersion serverVersion =
-                    com.owncloud.android.authentication.AccountUtils.getServerVersion(mFileActivity.getAccount());
+            OwnCloudVersion serverVersion = AccountUtils.getServerVersion(mFileActivity.getAccount());
 
             if (serverVersion != null && serverVersion.isNotReshareableFederatedSupported()) {
                 updateShareIntent.

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -478,7 +478,8 @@ public class FileOperationsHelper {
         if (hideFileListing) {
             updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS, OCShare.CREATE_PERMISSION_FLAG);
         } else {
-            OwnCloudVersion serverVersion = AccountUtils.getServerVersion(mFileActivity.getAccount());
+            OwnCloudVersion serverVersion =
+                    com.owncloud.android.authentication.AccountUtils.getServerVersion(mFileActivity.getAccount());
 
             if (serverVersion != null && serverVersion.isNotReshareableFederatedSupported()) {
                 updateShareIntent.

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -479,7 +479,8 @@ public class FileOperationsHelper {
             updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS, OCShare.CREATE_PERMISSION_FLAG);
         } else {
             updateShareIntent.
-                    putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS, OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER);
+                    putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
+                            OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9);
         }
 
         queueShareIntent(updateShareIntent);

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -29,7 +29,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.webkit.MimeTypeMap;
@@ -373,8 +372,8 @@ public class FileOperationsHelper {
      */
     public void showShareFile(OCFile file){
         Intent intent = new Intent(mFileActivity, ShareActivity.class);
-        intent.putExtra(mFileActivity.EXTRA_FILE, (Parcelable) file);
-        intent.putExtra(mFileActivity.EXTRA_ACCOUNT, mFileActivity.getAccount());
+        intent.putExtra(FileActivity.EXTRA_FILE, file);
+        intent.putExtra(FileActivity.EXTRA_ACCOUNT, mFileActivity.getAccount());
         mFileActivity.startActivity(intent);
 
     }
@@ -481,13 +480,11 @@ public class FileOperationsHelper {
             OwnCloudVersion serverVersion = AccountUtils.getServerVersion(mFileActivity.getAccount());
 
             if (serverVersion != null && serverVersion.isNotReshareableFederatedSupported()) {
-                updateShareIntent.
-                        putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
-                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_AFTER_OC9);
+                updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
+                        OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_AFTER_OC9);
             } else {
-                updateShareIntent.
-                        putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
-                                OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9);
+                updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS,
+                        OCShare.FEDERATED_PERMISSIONS_FOR_FOLDER_UP_TO_OC9);
             }
         }
 


### PR DESCRIPTION
Update federated sharing options checking if re-sharing is allowed.

Depends on https://github.com/nextcloud/android-library/pull/25 and feedback from @schiessle in which server version this is available (to be set in the library)