### PR TITLE
Fix DavDroid integration (append necessary addition to mURI)

### DIFF
--- a/src/com/owncloud/android/authentication/AccountUtils.java
+++ b/src/com/owncloud/android/authentication/AccountUtils.java
@@ -40,6 +40,7 @@ public class AccountUtils {
     private static final String TAG = AccountUtils.class.getSimpleName();
 
     public static final String WEBDAV_PATH_4_0_AND_LATER = "/remote.php/webdav";
+    public static final String DAV_PATH = "/remote.php/dav";
     private static final String ODAV_PATH = "/remote.php/odav";
     private static final String SAML_SSO_PATH = "/remote.php/webdav";
     public static final String STATUS_PATH = "/status.php";

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -476,9 +476,7 @@ public class Preferences extends PreferenceActivity
         if (getPackageManager().resolveActivity(davDroidLoginIntent, 0) != null) {
             // arguments
             if (mUri != null) {
-                davDroidLoginIntent.putExtra("url", mUri.toString()
-                        + AccountUtils.getWebdavPath(AccountUtils.getServerVersion(account), MainApp.getAuthTokenType())
-                        );
+                davDroidLoginIntent.putExtra("url", mUri.toString() + AccountUtils.DAV_PATH);
             }
             davDroidLoginIntent.putExtra("username", AccountUtils.getAccountUsername(account.name));
             //loginIntent.putExtra("password", "...");

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -476,7 +476,7 @@ public class Preferences extends PreferenceActivity
         if (getPackageManager().resolveActivity(davDroidLoginIntent, 0) != null) {
             // arguments
             if (mUri != null) {
-                davDroidLoginIntent.putExtra("url", mUri.toString());
+                davDroidLoginIntent.putExtra("url", mUri.toString() + "/remote.php/dav");
             }
             davDroidLoginIntent.putExtra("username", AccountUtils.getAccountUsername(account.name));
             //loginIntent.putExtra("password", "...");

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -476,7 +476,9 @@ public class Preferences extends PreferenceActivity
         if (getPackageManager().resolveActivity(davDroidLoginIntent, 0) != null) {
             // arguments
             if (mUri != null) {
-                davDroidLoginIntent.putExtra("url", mUri.toString() + "/remote.php/dav");
+                davDroidLoginIntent.putExtra("url", mUri.toString()
+                        + AccountUtils.getWebdavPath(AccountUtils.getServerVersion(account), MainApp.getAuthTokenType())
+                        );
             }
             davDroidLoginIntent.putExtra("username", AccountUtils.getAccountUsername(account.name));
             //loginIntent.putExtra("password", "...");


### PR DESCRIPTION
DavDroid integration doesn't work as is, because the mURI isn't actually what DavDroid needs. I've appended "/remote.php/dav", as that is the URI necessary for DavDroid to successfully find the share.