### PR TITLE
minor layout optimization so the German "skip" (überspringen) fits in…

### DIFF
--- a/res/layout/whats_new_activity.xml
+++ b/res/layout/whats_new_activity.xml
@@ -60,6 +60,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|center_horizontal"
             android:layout_weight="1"
+            android:paddingRight="0dp"
+            android:paddingLeft="0dp"
             android:text="@string/whats_new_skip"/>
 
         <com.owncloud.android.ui.whatsnew.ProgressIndicator


### PR DESCRIPTION
… a single line

@tobiasKaminsky please review and merge. It is a very simple layout optimization to give some more space (no left/right padding) to the skip button on the what's new screen since "ÜBERSPRINGEN" would end up having a line break before the "N" so this PR gives the text as much space as possible.