### PR TITLE
Add numeric buttons on PassCodeActivity

### DIFF
--- a/res/anim/shake.xml
+++ b/res/anim/shake.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:interpolator="@anim/shake_interpolator"
+	android:duration="500"
+	android:fromXDelta="0.0"
+	android:toXDelta="5.0"
+	>
+</translate>

--- a/res/anim/shake_interpolator.xml
+++ b/res/anim/shake_interpolator.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><cycleInterpolator	xmlns:android="http://schemas.android.com/apk/res/android"	android:cycles="4.0"	></cycleInterpolator>

--- a/res/anim/shake_interpolator.xml
+++ b/res/anim/shake_interpolator.xml
@@ -1,1 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><cycleInterpolator	xmlns:android="http://schemas.android.com/apk/res/android"	android:cycles="6.0"	></cycleInterpolator>
+<?xml version="1.0" encoding="utf-8"?>
+<cycleInterpolator
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:cycles="6.0"
+	>
+</cycleInterpolator>

--- a/res/anim/shake_interpolator.xml
+++ b/res/anim/shake_interpolator.xml
@@ -1,1 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?><cycleInterpolator	xmlns:android="http://schemas.android.com/apk/res/android"	android:cycles="4.0"	></cycleInterpolator>
+<?xml version="1.0" encoding="utf-8"?><cycleInterpolator	xmlns:android="http://schemas.android.com/apk/res/android"	android:cycles="6.0"	></cycleInterpolator>

--- a/res/layout-land/passcodelock.xml
+++ b/res/layout-land/passcodelock.xml
@@ -47,38 +47,47 @@
         android:textSize="@dimen/two_line_secondary_text_size"
         />
 
-    <android.support.design.widget.TextInputLayout
-        android:id="@+id/passcode"
-        android:layout_width="fill_parent"
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:errorEnabled="true">
+        android:gravity="center">
 
-        <EditText
-            android:id="@+id/passcodeEditText"
-            android:focusable="true"
-            android:cursorVisible="true"
-            android:imeOptions="flagNoExtractUi"
-            android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:gravity="center"
-            android:layout_margin="10dp"
-            android:inputType="numberPassword"
-            android:digits="1234567890"
-            android:maxLength="4"
-            android:maxLines="1"
-            android:textIsSelectable="false"
-            android:longClickable="false">
-            <requestFocus/>
-        </EditText>
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/passcode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            android:layout_weight="10">
 
-    </android.support.design.widget.TextInputLayout>
+            <EditText
+                android:id="@+id/passcodeEditText"
+                android:focusable="true"
+                android:cursorVisible="true"
+                android:imeOptions="flagNoExtractUi"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:gravity="center"
+                android:layout_margin="10dp"
+                android:inputType="numberPassword"
+                android:digits="1234567890"
+                android:maxLength="4"
+                android:maxLines="1"
+                android:textIsSelectable="false"
+                android:longClickable="false">
+                <requestFocus/>
+            </EditText>
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/cancel"
-        android:theme="@style/Button.Primary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/common_cancel" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/cancel"
+            android:theme="@style/Button.Primary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/common_cancel"
+            android:layout_weight="1"/>
+    </LinearLayout>
 
     <LinearLayout
         android:orientation="vertical"

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -106,51 +106,51 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent">
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="1"
                         android:layout_width="60dip"
                         android:layout_height="match_parent"
+                        android:id="@+id/button1"
+                        android:layout_weight="1" />
+
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="2"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
                         android:id="@+id/button2"
                         android:layout_weight="1" />
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="3"
                         android:layout_width="60dip"
                         android:layout_height="60dip"
                         android:id="@+id/button3"
                         android:layout_weight="1" />
 
-                    <Button
-                        android:text="Button"
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" >
+
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="4"
                         android:layout_width="60dip"
-                        android:layout_height="60dip"
+                        android:layout_height="match_parent"
                         android:id="@+id/button4"
                         android:layout_weight="1" />
 
-                </TableRow>
-
-                <TableRow
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
-
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="5"
                         android:layout_width="60dip"
-                        android:layout_height="match_parent"
+                        android:layout_height="60dip"
                         android:id="@+id/button5"
                         android:layout_weight="1" />
-
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="6"
                         android:layout_width="60dip"
                         android:layout_height="60dip"
                         android:id="@+id/button6"
-                        android:layout_weight="1" />
-                    <Button
-                        android:text="Button"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button7"
                         android:layout_weight="1"/>
                 </TableRow>
 
@@ -158,25 +158,25 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" >
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="7"
                         android:layout_width="60dip"
                         android:layout_height="match_parent"
+                        android:id="@+id/button7"
+                        android:layout_weight="1"/>
+
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="8"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
                         android:id="@+id/button8"
                         android:layout_weight="1"/>
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="9"
                         android:layout_width="60dip"
                         android:layout_height="60dip"
                         android:id="@+id/button9"
-                        android:layout_weight="1"/>
-
-                    <Button
-                        android:text="Button"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button10"
                         android:layout_weight="1"/>
                 </TableRow>
 
@@ -184,25 +184,25 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" >
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="CLEAR"
                         android:layout_width="60dip"
                         android:layout_height="60dip"
-                        android:id="@+id/button8"
+                        android:id="@+id/clear"
                         android:layout_weight="1"/>
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="0"
                         android:layout_width="60dip"
                         android:layout_height="60dip"
-                        android:id="@+id/button9"
+                        android:id="@+id/button0"
                         android:layout_weight="1"/>
 
-                    <Button
-                        android:text="Button"
+                    <android.support.v7.widget.AppCompatButton
+                        android:text="BACK"
                         android:layout_width="60dip"
                         android:layout_height="60dip"
-                        android:id="@+id/button10"
+                        android:id="@+id/back"
                         android:layout_weight="1"/>
                 </TableRow>
 

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -18,7 +18,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:gravity="center_horizontal"
@@ -46,40 +47,30 @@
         android:textSize="@dimen/two_line_secondary_text_size"
          />
     
-    <LinearLayout
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/passcode"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:gravity="center_horizontal" >
+        >
 
         <EditText
-            android:id="@+id/txt0"
+            android:id="@+id/passcodeEditText"
             android:focusable="true"
-            style="@style/PassCodeStyle"
             android:cursorVisible="true"
             android:imeOptions="flagNoExtractUi"
-            ><requestFocus/></EditText>
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:hint="@string/prefs_passcode"
+            android:gravity="center"
+            android:layout_margin="10dp"
+            android:inputType="numberPassword"
+            android:digits="1234567890"
+            android:maxLength="4"
+            android:maxLines="1"
+            android:textIsSelectable="false"
+            android:longClickable="false"><requestFocus/></EditText>
 
-        <EditText
-            android:id="@+id/txt1"
-            style="@style/PassCodeStyle"
-            android:cursorVisible="true"
-            android:imeOptions="flagNoExtractUi"
-            />
-
-        <EditText
-            android:id="@+id/txt2"
-            style="@style/PassCodeStyle"
-            android:cursorVisible="true"
-            android:imeOptions="flagNoExtractUi"
-            />
-
-        <EditText
-            android:id="@+id/txt3"
-            style="@style/PassCodeStyle"
-            android:cursorVisible="true"
-            android:imeOptions="flagNoExtractUi"
-            />
-    </LinearLayout>
+    </android.support.design.widget.TextInputLayout>
 
     <android.support.v7.widget.AppCompatButton
         android:id="@+id/cancel"
@@ -96,7 +87,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <Button
+            <android.support.v7.widget.AppCompatButton
                 android:text="SoftKey"
                 android:layout_width="60dp"
                 android:layout_height="60dp"

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -18,6 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:gravity="center_horizontal"
@@ -86,5 +87,128 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/common_cancel" />
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TableRow
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent">
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="match_parent"
+                        android:id="@+id/button2"
+                        android:layout_weight="1" />
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button3"
+                        android:layout_weight="1" />
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button4"
+                        android:layout_weight="1" />
+
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" >
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="match_parent"
+                        android:id="@+id/button5"
+                        android:layout_weight="1" />
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button6"
+                        android:layout_weight="1" />
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button7"
+                        android:layout_weight="1"/>
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" >
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="match_parent"
+                        android:id="@+id/button8"
+                        android:layout_weight="1"/>
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button9"
+                        android:layout_weight="1"/>
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button10"
+                        android:layout_weight="1"/>
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" >
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button8"
+                        android:layout_weight="1"/>
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button9"
+                        android:layout_weight="1"/>
+
+                    <Button
+                        android:text="Button"
+                        android:layout_width="60dip"
+                        android:layout_height="60dip"
+                        android:id="@+id/button10"
+                        android:layout_weight="1"/>
+                </TableRow>
+
+            </TableLayout>
+        </LinearLayout>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -51,7 +51,7 @@
         android:id="@+id/passcode"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        >
+        app:errorEnabled="true">
 
         <EditText
             android:id="@+id/passcodeEditText"
@@ -60,7 +60,6 @@
             android:imeOptions="flagNoExtractUi"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="@string/prefs_passcode"
             android:gravity="center"
             android:layout_margin="10dp"
             android:inputType="numberPassword"
@@ -84,25 +83,13 @@
         android:layout_height="match_parent">
 
         <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <android.support.v7.widget.AppCompatButton
-                android:text="SoftKey"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
-                android:id="@+id/button_softkey"
-                android:elevation="0dp"/>
-        </TableRow>
-
-        <TableRow
             android:layout_width="wrap_content"
             android:layout_height="match_parent">
 
             <android.support.v7.widget.AppCompatButton
                 android:text="1"
                 android:layout_width="60dip"
-                android:layout_height="match_parent"
+                android:layout_height="60dip"
                 android:id="@+id/button1"
                 android:layout_weight="1" />
 
@@ -129,7 +116,7 @@
             <android.support.v7.widget.AppCompatButton
                 android:text="4"
                 android:layout_width="60dip"
-                android:layout_height="match_parent"
+                android:layout_height="60dip"
                 android:id="@+id/button4"
                 android:layout_weight="1" />
 
@@ -154,7 +141,7 @@
             <android.support.v7.widget.AppCompatButton
                 android:text="7"
                 android:layout_width="60dip"
-                android:layout_height="match_parent"
+                android:layout_height="60dip"
                 android:id="@+id/button7"
                 android:layout_weight="1"/>
 
@@ -192,7 +179,7 @@
                 android:layout_weight="1"/>
 
             <android.support.v7.widget.AppCompatButton
-                android:text="BACK"
+                android:text="BACK\nSoftKey"
                 android:layout_width="60dip"
                 android:layout_height="60dip"
                 android:id="@+id/back"

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -88,127 +88,126 @@
         android:layout_height="wrap_content"
         android:text="@string/common_cancel" />
 
-    <LinearLayout
-        android:orientation="vertical"
+    <TableLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <LinearLayout
-            android:orientation="horizontal"
+        <TableRow
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <TableLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+            <Button
+                android:text="SoftKey"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:id="@+id/button_softkey"
+                android:elevation="0dp"/>
+        </TableRow>
 
-                <TableRow
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent">
+        <TableRow
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent">
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="1"
-                        android:layout_width="60dip"
-                        android:layout_height="match_parent"
-                        android:id="@+id/button1"
-                        android:layout_weight="1" />
+            <android.support.v7.widget.AppCompatButton
+                android:text="1"
+                android:layout_width="60dip"
+                android:layout_height="match_parent"
+                android:id="@+id/button1"
+                android:layout_weight="1" />
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="2"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button2"
-                        android:layout_weight="1" />
+            <android.support.v7.widget.AppCompatButton
+                android:text="2"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button2"
+                android:layout_weight="1" />
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="3"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button3"
-                        android:layout_weight="1" />
+            <android.support.v7.widget.AppCompatButton
+                android:text="3"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button3"
+                android:layout_weight="1" />
 
-                </TableRow>
+        </TableRow>
 
-                <TableRow
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="4"
-                        android:layout_width="60dip"
-                        android:layout_height="match_parent"
-                        android:id="@+id/button4"
-                        android:layout_weight="1" />
+            <android.support.v7.widget.AppCompatButton
+                android:text="4"
+                android:layout_width="60dip"
+                android:layout_height="match_parent"
+                android:id="@+id/button4"
+                android:layout_weight="1" />
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="5"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button5"
-                        android:layout_weight="1" />
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="6"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button6"
-                        android:layout_weight="1"/>
-                </TableRow>
+            <android.support.v7.widget.AppCompatButton
+                android:text="5"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button5"
+                android:layout_weight="1" />
+            <android.support.v7.widget.AppCompatButton
+                android:text="6"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button6"
+                android:layout_weight="1"/>
+        </TableRow>
 
-                <TableRow
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="7"
-                        android:layout_width="60dip"
-                        android:layout_height="match_parent"
-                        android:id="@+id/button7"
-                        android:layout_weight="1"/>
+            <android.support.v7.widget.AppCompatButton
+                android:text="7"
+                android:layout_width="60dip"
+                android:layout_height="match_parent"
+                android:id="@+id/button7"
+                android:layout_weight="1"/>
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="8"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button8"
-                        android:layout_weight="1"/>
+            <android.support.v7.widget.AppCompatButton
+                android:text="8"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button8"
+                android:layout_weight="1"/>
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="9"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button9"
-                        android:layout_weight="1"/>
-                </TableRow>
+            <android.support.v7.widget.AppCompatButton
+                android:text="9"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button9"
+                android:layout_weight="1"/>
+        </TableRow>
 
-                <TableRow
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="CLEAR"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/clear"
-                        android:layout_weight="1"/>
+            <android.support.v7.widget.AppCompatButton
+                android:text="CLEAR"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/clear"
+                android:layout_weight="1"/>
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="0"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/button0"
-                        android:layout_weight="1"/>
+            <android.support.v7.widget.AppCompatButton
+                android:text="0"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/button0"
+                android:layout_weight="1"/>
 
-                    <android.support.v7.widget.AppCompatButton
-                        android:text="BACK"
-                        android:layout_width="60dip"
-                        android:layout_height="60dip"
-                        android:id="@+id/back"
-                        android:layout_weight="1"/>
-                </TableRow>
+            <android.support.v7.widget.AppCompatButton
+                android:text="BACK"
+                android:layout_width="60dip"
+                android:layout_height="60dip"
+                android:id="@+id/back"
+                android:layout_weight="1"/>
+        </TableRow>
 
-            </TableLayout>
-        </LinearLayout>
-
-    </LinearLayout>
+    </TableLayout>
 
 </LinearLayout>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -253,21 +253,7 @@
 		<item name="@android:windowEnterAnimation">@anim/pump_bottom</item>
 		<item name="@android:windowExitAnimation">@anim/disappear</item>
 	</style>
-	
-	<style name="PassCodeStyle">
-        <item name="android:layout_width">50dp</item>
-        <item name="android:layout_height">50dp</item>
-  		<item name="android:gravity">center</item>
-  		<item name="android:layout_margin">10dp</item>
-  		<item name="android:inputType">numberDecimal</item>
-  		<item name="android:numeric">decimal</item>
-		<item name="android:digits">1234567890</item>
-		<item name="android:maxLength">1</item>
-		<item name="android:password">true</item>
-		<item name="android:singleLine">true</item>
-  		    
-    </style>
-	
+
 	<style name="OAuthDialog" parent="style/Theme.AppCompat.Light.Dialog.Alert">
 		<item name="windowNoTitle">false</item>
 		<item name="colorAccent">@color/owncloud_blue_accent</item>

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -60,15 +60,16 @@ import static android.content.Context.INPUT_METHOD_SERVICE;
 
 
 class SoftKeyboardUtil {
-    public interface SoftKeyboardListener {
-        void onClose();
-    }
     private static final String TAG = SoftKeyboardUtil.class.getSimpleName();
 
     private AppCompatActivity mActivity;
     private boolean mIsSoftKeyboardOpened;
     private SoftKeyboardListener mSoftKeyboardListener;
     private int mHideCount;
+
+    public interface SoftKeyboardListener {
+        void onClose();
+    }
 
     private void setListenerToRootView() {
         View view = mActivity.findViewById(android.R.id.content).getRootView();

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -154,7 +154,6 @@ public class PassCodeActivity extends AppCompatActivity {
                 // will receive and confirm pass code value
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
                 mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
-                setCancelButtonEnabled(true);
 
                 View view = findViewById(android.R.id.content);
                 Snackbar
@@ -175,6 +174,7 @@ public class PassCodeActivity extends AppCompatActivity {
                 //the app was in the passcodeconfirmation
                 requestPassCodeConfirmation();
             }
+            setCancelButtonEnabled(true);
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
             /// pass code preference has just been disabled in Preferences;
@@ -299,7 +299,6 @@ public class PassCodeActivity extends AppCompatActivity {
             });
         } else {
             cancel.setVisibility(View.GONE);
-            cancel.setVisibility(View.INVISIBLE);
             cancel.setOnClickListener(null);
         }
     }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -24,6 +24,7 @@ package com.owncloud.android.ui.activity;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
@@ -33,6 +34,7 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
@@ -159,12 +161,39 @@ public class PassCodeActivity extends AppCompatActivity {
         }
 
         setTextListeners();
+        setListenerToRootView();
 
+        if (false) {
         if (mSoftkeyMode) {
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
         } else {
         	getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 		}
+        }
+
+        ((Button) findViewById(R.id.button_softkey)).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mSoftkeyMode = mSoftkeyMode == false ? true : false;
+                setSoftkeyMode();
+            }
+        });
+    }
+
+    private void setSoftkeyMode() {
+        if (mSoftkeyMode) {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+            for(int i=0;i< mButtonIDList.length; i++) {
+                Button b = (Button)findViewById(mButtonIDList[i]);
+                b.setVisibility(View.VISIBLE);
+            }
+        } else {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+            for(int i=0;i< mButtonIDList.length; i++) {
+                Button b = (Button)findViewById(mButtonIDList[i]);
+                b.setVisibility(View.INVISIBLE);
+            }
+        }
     }
 
 
@@ -574,4 +603,55 @@ public class PassCodeActivity extends AppCompatActivity {
             }
         }
 	}
+
+    boolean isOpened = false;
+
+    // http://www.it1me.com/it-answers?id=25216749&s=Template:TalbotCountyMD-NRHP-stub&ttl=SoftKeyboard+open+and+close+listener+in+an+activity+in+Android%3F
+    // http://stackoverflow.com/questions/25216749/softkeyboard-open-and-close-listener-in-an-activity-in-android
+    public void setListenerToRootView() {
+        View view = findViewById(android.R.id.content).getRootView();
+        view.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+
+            @Override
+            public void onGlobalLayout() {
+                // navigation bar height
+                int navigationBarHeight = 0;
+                int resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+                if (resourceId > 0) {
+                    navigationBarHeight = getResources().getDimensionPixelSize(resourceId);
+                }
+
+                // status bar height
+                int statusBarHeight = 0;
+                resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
+                if (resourceId > 0) {
+                    statusBarHeight = getResources().getDimensionPixelSize(resourceId);
+                }
+
+                // display window size for the app layout
+                Rect rect = new Rect();
+                getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
+
+                View view = findViewById(android.R.id.content).getRootView();
+                int h = view.getHeight();
+                // screen height - (user app height + status + nav) ..... if non-zero, then there is a soft keyboard
+                int keyboardHeight = h - (statusBarHeight + navigationBarHeight + rect.height());
+
+                if (keyboardHeight <= 0) {
+//                    onHideKeyboard();
+                    if (isOpened) {
+//                        goHome();
+                        mSoftkeyMode = false;
+                        setSoftkeyMode();
+                    }
+                    isOpened = false;
+                    int a = 0;
+                } else {
+                    isOpened = true;
+//                    onShowKeyboard(keyboardHeight);
+                    int b = 0;
+                }
+            }
+        });
+    }
 }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -26,6 +26,7 @@ import android.animation.ObjectAnimator;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
@@ -36,6 +37,7 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.View.OnLongClickListener;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.animation.Animation;
@@ -44,12 +46,8 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
-import com.owncloud.android.lib.common.utils.Log_OC;
-
-import java.util.Arrays;
 
 public class PassCodeActivity extends AppCompatActivity {
 
@@ -71,6 +69,10 @@ public class PassCodeActivity extends AppCompatActivity {
     public final static String PREFERENCE_PASSCODE_D3 = "PrefPinCode3";
     public final static String PREFERENCE_PASSCODE_D4 = "PrefPinCode4";
 
+    private boolean ENABLE_GO_HOME = true;
+    private boolean DEFAULT_SOFT_KEYBOARD_MODE = false;  // true=soft keyboard / false=buttons
+    private int GUARD_TIME = 3000;
+
     private Button mBCancel;
     private TextView mPassCodeHdr;
     private TextView mPassCodeHdrExplanation;
@@ -80,49 +82,40 @@ public class PassCodeActivity extends AppCompatActivity {
     private boolean mConfirmingPassCode = false;
     private static final String KEY_CONFIRMING_PASSCODE = "CONFIRMING_PASSCODE";
 
-    private boolean mBChange = true; // to control that only one blocks jump
-
-    private static final int mButtonIDList[] = {
-        R.id.button0,
-        R.id.button1,
-        R.id.button2,
-        R.id.button3,
-        R.id.button4,
-        R.id.button5,
-        R.id.button6,
-        R.id.button7,
-        R.id.button8,
-        R.id.button9,
-        R.id.clear,
-        R.id.back,
+    private static final int mButtonsIDList[] = {
+            R.id.button0,
+            R.id.button1,
+            R.id.button2,
+            R.id.button3,
+            R.id.button4,
+            R.id.button5,
+            R.id.button6,
+            R.id.button7,
+            R.id.button8,
+            R.id.button9,
+            R.id.clear,
+            R.id.back,
     };
-    private int mEditPos;
-    private boolean mSoftinputMode = true;
-    private Animation mAnimation;
+    private boolean mSoftKeyboardMode;
+    private boolean mIsSoftKeyboardOpend;
 
     /**
      * Initializes the activity.
-     *
+     * <p>
      * An intent with a valid ACTION is expected; if none is found, an
      * {@link IllegalArgumentException} will be thrown.
      *
-     * @param savedInstanceState    Previously saved state - irrelevant in this case
+     * @param savedInstanceState Previously saved state - irrelevant in this case
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.passcodelock);
 
-        mAnimation = AnimationUtils.loadAnimation(this, R.anim.shake);
         mBCancel = (Button) findViewById(R.id.cancel);
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
 
-        for(int i=0;i< mButtonIDList.length; i++) {
-            Button b = (Button)findViewById(mButtonIDList[i]);
-            b.setOnClickListener(new ButtonClicked(i));
-        }
-        
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             /// this is a pass code request; the user has to input the right value
             mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
@@ -134,10 +127,10 @@ public class PassCodeActivity extends AppCompatActivity {
                 mConfirmingPassCode = savedInstanceState.getBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE);
                 mPassCode = savedInstanceState.getString(PassCodeActivity.KEY_PASSCODE);
             }
-            if(mConfirmingPassCode){
+            if (mConfirmingPassCode) {
                 //the app was in the passcodeconfirmation
                 requestPassCodeConfirmation();
-            }else{
+            } else {
                 /// pass code preference has just been activated in Preferences;
                 // will receive and confirm pass code value
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
@@ -159,75 +152,76 @@ public class PassCodeActivity extends AppCompatActivity {
                     + TAG);
         }
 
-        setTextListeners();
+        setupPassCodeEditText();
+        mSoftKeyboardMode = DEFAULT_SOFT_KEYBOARD_MODE;
+        setupKeyboard();
         setListenerToRootView();
 
-        if (false) {
-            if (mSoftinputMode) {
-                getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-            } else {
-                getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-            }
+        if (mSoftKeyboardMode) {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+        } else {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
         }
+    }
 
-        ((Button) findViewById(R.id.button_softkey)).setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mSoftinputMode = mSoftinputMode == false ? true : false;
-                if (mSoftinputMode) {
-                    hideSoftKeyboard();
-//                    InputMethodManager imm = (InputMethodManager)getSystemService(
-//                        Context.INPUT_METHOD_SERVICE);
-//                    imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
-                    setSoftkeyVisibility(true);
-                } else {
-                    showSoftKeyboard();
-//                    InputMethodManager imm = (InputMethodManager)getSystemService(
-//                        Context.INPUT_METHOD_SERVICE);
-//                    imm.showSoftInput(mPassCodeEditTexts[0], 0);
-                    setSoftkeyVisibility(false);
+    private void setupKeyboard() {
+        if (mSoftKeyboardMode) {
+            showSoftKeyboard();
+            setButtonsVisibility(false);
+        } else {
+            hideSoftKeyboard();
+            setButtonsVisibility(true);
+        }
+    }
+
+    private void setButtonsVisibility(boolean visible) {
+        if (visible) {
+            for (int i = 0; i < mButtonsIDList.length; i++) {
+                Button b = (Button) findViewById(mButtonsIDList[i]);
+                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(b, "alpha", 0f, 1f);
+                objectAnimator.setDuration(300);
+                objectAnimator.start();
+                b.setClickable(true);
+                b.setOnClickListener(new ButtonClicked(i));
+                if (i == 11) {
+                    b.setLongClickable(true);
+                    b.setOnLongClickListener(new OnLongClickListener() {
+                        @Override
+                        public boolean onLongClick(View v) {
+                            mSoftKeyboardMode = !mSoftKeyboardMode;
+                            setupKeyboard();
+                            return true;
+                        }
+                    });
                 }
             }
-        });
-    }
-
-    private void setSoftkeyVisibility(boolean visible) {
-        if (visible) {
-            for(int i=0;i< mButtonIDList.length; i++) {
-                Button b = (Button)findViewById(mButtonIDList[i]);
-                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat( b, "alpha", 0f, 1f );
-                objectAnimator.setDuration( 3000 );
-                objectAnimator.start();
- //               objectAnimator.addListener();
-//                b.setVisibility(View.VISIBLE);
-                b.setClickable(true);
-            }
         } else {
-            for(int i=0;i< mButtonIDList.length; i++) {
-                Button b = (Button)findViewById(mButtonIDList[i]);
-                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat( b, "alpha", 1f, 0f );
-                objectAnimator.setDuration( 3000 );
+            for (int i = 0; i < mButtonsIDList.length; i++) {
+                Button b = (Button) findViewById(mButtonsIDList[i]);
+                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(b, "alpha", 1f, 0f);
+                objectAnimator.setDuration(300);
                 objectAnimator.start();
-                //b.setVisibility(View.INVISIBLE);
                 b.setClickable(false);
+                b.setOnClickListener(null);
+                b.setLongClickable(false);
+                b.setOnLongClickListener(null);
             }
         }
     }
-
 
     /**
      * Enables or disables the cancel button to allow the user interrupt the ACTION
      * requested to the activity.
      *
-     * @param enabled       'True' makes the cancel button available, 'false' hides it.
+     * @param enabled 'True' makes the cancel button available, 'false' hides it.
      */
-    protected void setCancelButtonEnabled(boolean enabled){
-        if(enabled){
+    protected void setCancelButtonEnabled(boolean enabled) {
+        if (enabled) {
             mBCancel.setVisibility(View.VISIBLE);
             mBCancel.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-//                    hideSoftKeyboard();
+                    hideSoftKeyboard();
                     finish();
                 }
             });
@@ -238,22 +232,20 @@ public class PassCodeActivity extends AppCompatActivity {
         }
     }
 
-
-    /**
-     * Binds the appropiate listeners to the input boxes receiving each digit of the pass code.
-     */
-    protected void setTextListeners() {
+    protected void setupPassCodeEditText() {
         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
         EditText et = til.getEditText();
-        et.setShowSoftInputOnFocus(false);      // TODO: API21  for disabling popup softkey when double clicked
+        if (Build.VERSION.SDK_INT >= 21) {
+            et.setShowSoftInputOnFocus(false);  // for disabling popup soft keyboard when double clicked
+        }
         et.requestFocus();
-        et.addTextChangedListener(new PassCodeDigitTextWatcher(false));
+        et.addTextChangedListener(new PassCodeDigitTextWatcher());
         mPassCodeEditText = et;
     }
 
     /**
      * Processes the pass code entered by the user just after the last digit was in.
-     *
+     * <p>
      * Takes into account the action requested to the activity, the currently saved pass code and
      * the previously typed pass code, if any.
      */
@@ -264,33 +256,8 @@ public class PassCodeActivity extends AppCompatActivity {
                 hideSoftKeyboard();
                 finish();
 
-            }  else {
-                final Handler handler = new Handler();
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        handler.post(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                try {
-                                    Thread.sleep(200);
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-
-                                mPassCodeEditText.startAnimation(mAnimation);
-
-//                                clearPasscode();
-                                showErrorAndRestart(R.string.pass_code_wrong, R.string.pass_code_enter_pass_code,
-                                        View.INVISIBLE);
-
-                            }
-                        });
-
-                    }
-                }).start();
+            } else {
+                passCodeWrong();
             }
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
@@ -301,8 +268,8 @@ public class PassCodeActivity extends AppCompatActivity {
                 hideSoftKeyboard();
                 finish();
             } else {
-                showErrorAndRestart(R.string.pass_code_wrong, R.string.pass_code_enter_pass_code,
-                        View.INVISIBLE);
+                mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
+                showErrorAndRestart(R.string.pass_code_wrong);
             }
 
         } else if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction())) {
@@ -315,20 +282,43 @@ public class PassCodeActivity extends AppCompatActivity {
                 savePassCodeAndExit();
 
             } else {
-                showErrorAndRestart(
-                        R.string.pass_code_mismatch, R.string.pass_code_configure_your_pass_code, View.VISIBLE
-                );
+                mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
+                showErrorAndRestart(R.string.pass_code_mismatch);
+                mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
+
             }
         }
+    }
+
+    private void passCodeWrong() {
+        if (!mSoftKeyboardMode) {
+            setButtonsVisibility(false);
+        }
+        Animation animation = AnimationUtils.loadAnimation(PassCodeActivity.this, R.anim.shake);
+        mPassCodeEditText.startAnimation(animation);
+        mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
+        showErrorAndRestart(R.string.pass_code_wrong);
+
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+                til.setError(null);
+                if (!mSoftKeyboardMode) {
+                    setButtonsVisibility(true);
+                }
+                clearBoxes();
+            }
+        }, GUARD_TIME);
     }
 
     private void hideSoftKeyboard() {
         View focusedView = getCurrentFocus();
         if (focusedView != null) {
             InputMethodManager inputMethodManager =
-                (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+                    (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
             inputMethodManager.hideSoftInputFromWindow(
-                focusedView.getWindowToken(), 0);
+                    focusedView.getWindowToken(), 0);
         }
     }
 
@@ -336,30 +326,24 @@ public class PassCodeActivity extends AppCompatActivity {
         View focusedView = getCurrentFocus();
         if (focusedView != null) {
             InputMethodManager inputMethodManager =
-                (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+                    (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
             inputMethodManager.showSoftInput(
-                focusedView, 0);
+                    focusedView, 0);
         }
     }
 
-    private void showErrorAndRestart(int errorMessage, int headerMessage,
-                                     int explanationVisibility) {
+    private void showErrorAndRestart(int errorMessage) {
         mPassCode = "";
         CharSequence errorSeq = getString(errorMessage);
-        Toast.makeText(this, errorSeq, Toast.LENGTH_LONG).show();
-        mPassCodeHdr.setText(headerMessage);                // TODO check if really needed
-        mPassCodeHdrExplanation.setVisibility(explanationVisibility); // TODO check if really needed
         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
         til.setError(errorSeq);
-//        clearBoxes();
     }
-
 
     /**
      * Ask to the user for retyping the pass code just entered before saving it as the current pass
      * code.
      */
-    protected void requestPassCodeConfirmation(){
+    protected void requestPassCodeConfirmation() {
         clearBoxes();
         mPassCodeHdr.setText(R.string.pass_code_reenter_your_pass_code);
         mPassCodeHdrExplanation.setVisibility(View.INVISIBLE);
@@ -369,11 +353,11 @@ public class PassCodeActivity extends AppCompatActivity {
     /**
      * Compares pass code entered by the user with the value currently saved in the app.
      *
-     * @return     'True' if entered pass code equals to the saved one.
+     * @return 'True' if entered pass code equals to the saved one.
      */
-    protected boolean checkPassCode(){
+    protected boolean checkPassCode() {
         SharedPreferences appPrefs = PreferenceManager
-            .getDefaultSharedPreferences(getApplicationContext());
+                .getDefaultSharedPreferences(getApplicationContext());
 
         String savedPassCode = "";
         savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D1, null);
@@ -389,9 +373,9 @@ public class PassCodeActivity extends AppCompatActivity {
      * Compares pass code retyped by the user in the input fields with the value entered just
      * before.
      *
-     * @return     'True' if retyped pass code equals to the entered before.
+     * @return 'True' if retyped pass code equals to the entered before.
      */
-    protected boolean confirmPassCode(){
+    protected boolean confirmPassCode() {
         mConfirmingPassCode = false;
 
         boolean result = mPassCode.equals(mPassCodeEditText.getText().toString());
@@ -409,9 +393,9 @@ public class PassCodeActivity extends AppCompatActivity {
      * Overrides click on the BACK arrow to correctly cancel ACTION_ENABLE or ACTION_DISABLE, while
      * preventing than ACTION_CHECK may be worked around.
      *
-     * @param keyCode       Key code of the key that triggered the down event.
-     * @param event         Event triggered.
-     * @return              'True' when the key event was processed by this method.
+     * @param keyCode Key code of the key that triggered the down event.
+     * @param event   Event triggered.
+     * @return 'True' when the key event was processed by this method.
      */
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
@@ -421,7 +405,9 @@ public class PassCodeActivity extends AppCompatActivity {
                 finish();
             }   // else, do nothing, but report that the key was consumed to stay alive
             else {
-//                goHome();		// TODO:
+                if (ENABLE_GO_HOME) {
+                    goHome();
+                }
             }
             return true;
         }
@@ -453,37 +439,11 @@ public class PassCodeActivity extends AppCompatActivity {
     }
 
     private class PassCodeDigitTextWatcher implements TextWatcher {
-
-        private int mIndex;
-        private boolean mLastOne = false;
-
-        /**
-         * Constructor
-         *
-         * @param index         Position in the pass code of the input field that will be bound to
-         *                      this watcher.
-         * @param lastOne       'True' means that watcher corresponds to the last position of the
-         *                      pass code.
-         */
-        public PassCodeDigitTextWatcher(boolean lastOne) {
-            mIndex = 0;
-            mLastOne  = lastOne;
-        }
-
-        /**
-         * Performs several actions when the user types a digit in an input field:
-         *  - saves the input digit to the state of the activity; this will allow retyping the
-         *    pass code to confirm it.
-         *  - moves the focus automatically to the next field
-         *  - for the last field, triggers the processing of the full pass code
-         *
-         * @param s     Changed text
-         */
         @Override
         public void afterTextChanged(Editable s) {
-            String passcode = mPassCodeEditText.getText().toString();
-            if (passcode.length() == 4) {
-                mPassCode = passcode;
+            String passCode = mPassCodeEditText.getText().toString();
+            if (passCode.length() == 4) {
+                mPassCode = passCode;
                 processFullPassCode();
             }
         }
@@ -507,37 +467,27 @@ public class PassCodeActivity extends AppCompatActivity {
             mIndex = index;
         }
 
-		public void onClick(View v) {
+        public void onClick(View v) {
             if (mIndex <= 9) {
                 // 0,1,2,...,8,9
                 int key = KeyEvent.KEYCODE_0 + mIndex;
                 mPassCodeEditText.dispatchKeyEvent(
-                    new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, key, 0));
+                        new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, key, 0));
                 mPassCodeEditText.dispatchKeyEvent(
-                    new KeyEvent(0, 0, KeyEvent.ACTION_UP, key, 0));
+                        new KeyEvent(0, 0, KeyEvent.ACTION_UP, key, 0));
             } else if (mIndex == 10) {
                 // clear
                 clearBoxes();
             } else {
                 // delete
-                if (false) {
-                    String passCode = mPassCodeEditText.getText().toString();
-                    passCode = passCode.substring(0, passCode.length() - 1);
-                    mPassCodeEditText.setText(passCode);
-                } else {
-                    mPassCodeEditText.dispatchKeyEvent(
+                mPassCodeEditText.dispatchKeyEvent(
                         new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL, 0));
-                    mPassCodeEditText.dispatchKeyEvent(
+                mPassCodeEditText.dispatchKeyEvent(
                         new KeyEvent(0, 0, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL, 0));
-                }
             }
         }
-	}
+    }
 
-    boolean isOpened = false;
-
-    // http://www.it1me.com/it-answers?id=25216749&s=Template:TalbotCountyMD-NRHP-stub&ttl=SoftKeyboard+open+and+close+listener+in+an+activity+in+Android%3F
-    // http://stackoverflow.com/questions/25216749/softkeyboard-open-and-close-listener-in-an-activity-in-android
     public void setListenerToRootView() {
         View view = findViewById(android.R.id.content).getRootView();
         view.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -568,18 +518,13 @@ public class PassCodeActivity extends AppCompatActivity {
                 int keyboardHeight = h - (statusBarHeight + navigationBarHeight + rect.height());
 
                 if (keyboardHeight <= 0) {
-//                    onHideKeyboard();
-                    if (isOpened) {
-//                        goHome();
-                        mSoftinputMode = true;
-                        setSoftkeyVisibility(true);
+                    if (mIsSoftKeyboardOpend) {
+                        mSoftKeyboardMode = false;
+                        setButtonsVisibility(true);
                     }
-                    isOpened = false;
-                    int a = 0;
+                    mIsSoftKeyboardOpend = false;
                 } else {
-                    isOpened = true;
-//                    onShowKeyboard(keyboardHeight);
-                    int b = 0;
+                    mIsSoftKeyboardOpend = true;
                 }
             }
         });

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -71,6 +71,7 @@ class SoftKeyboardUtil {
     private AppCompatActivity mActivity;
     private boolean mIsSoftKeyboardOpened;
     private SoftKeyboardListener mSoftKeyboardListener;
+    private int mHideCount;
 
     private void setListenerToRootView() {
         View view = mActivity.findViewById(android.R.id.content).getRootView();
@@ -105,8 +106,12 @@ class SoftKeyboardUtil {
 
                 if (softKeyboardHeight <= 0) {
                     if (mIsSoftKeyboardOpened) {
-                        // soft keyboard was closed (back key was pressed)
-                        mSoftKeyboardListener.onClose();
+                        // soft keyboard was closed
+                        if (mHideCount == 0) {
+                            // back key was pressed
+                            mSoftKeyboardListener.onClose();
+                        }
+                        mHideCount = 0;
                     }
                     mIsSoftKeyboardOpened = false;
                 } else {
@@ -122,23 +127,35 @@ class SoftKeyboardUtil {
         if (softKeyboardListener != null) {
             setListenerToRootView();
         }
+        mHideCount = 0;
     }
+
     public void initHidden() {
         mActivity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
     }
+
     public void initVisible() {
         mActivity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
     }
+
     public void show() {
+        mHideCount = 0;
         View focusedView = mActivity.getCurrentFocus();
         if (focusedView != null) {
             InputMethodManager imm = (InputMethodManager) mActivity.getSystemService(INPUT_METHOD_SERVICE);
             imm.showSoftInput(focusedView, 0);
         } else {
             Log_OC.i(TAG, "focusedView = null in show()");
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    show();
+                }
+            }, 10);
         }
     }
     public void hide() {
+        mHideCount++;
         View focusedView = mActivity.getCurrentFocus();
         if (focusedView != null) {
             InputMethodManager imm = (InputMethodManager) mActivity.getSystemService(INPUT_METHOD_SERVICE);
@@ -169,9 +186,9 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
     public final static String PREFERENCE_PASSCODE_D3 = "PrefPinCode3";
     public final static String PREFERENCE_PASSCODE_D4 = "PrefPinCode4";
 
-    private static final boolean ENABLE_GO_HOME = true;
-    private static final boolean INIT_SOFT_KEYBOARD_MODE = true;  // true=soft keyboard / false=buttons
-    private static final boolean ENABLE_SWITCH_SOFT_KEYBOARD = false;
+    private static final boolean ENABLE_GO_HOME = false;
+    private static final boolean INIT_SOFT_KEYBOARD_MODE = false;  // true=soft keyboard / false=buttons
+    private static final boolean ENABLE_SWITCH_SOFT_KEYBOARD = true;
     private static final int GUARD_TIME = 3000;    // (ms)
     private static final boolean ENABLE_SUFFLE_BUTTONS = false;
 
@@ -313,6 +330,12 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
         }
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        clearPassCodeEditText();
+    }
+
     private void setupKeyboard() {
         mShowButtonsWhenSoftKeyboardClose = true;
         if (mSoftKeyboardMode) {
@@ -355,11 +378,11 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
     private void animeAlpha(View view, boolean visible) {
         if (visible) {
             ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 0f, 1f);
-            objectAnimator.setDuration(300);
+            objectAnimator.setDuration(500);
             objectAnimator.start();
         } else {
             ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 1f, 0f);
-            objectAnimator.setDuration(300);
+            objectAnimator.setDuration(500);
             objectAnimator.start();
         }
     }
@@ -424,7 +447,6 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
             cancel.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    hideSoftKeyboard();
                     finish();
                 }
             });
@@ -438,6 +460,7 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
         EditText et = til.getEditText();
         et.setTextIsSelectable(false);     // TODO:no effect for double tap?
+        //et.setContextClickable(false);
         if (Build.VERSION.SDK_INT >= 21) {
             et.setShowSoftInputOnFocus(false);  // for disabling popup soft keyboard when double clicked
         }
@@ -474,21 +497,12 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             if (checkPassCode(passCode)) {
                 /// pass code accepted in request, user is allowed to access the app
-                hideSoftKeyboard();
                 finish();
 
             } else {
                 mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
-                passCodeWrong(R.string.pass_code_wrong);
-                new Handler().postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
-                        til.setError(null);
-                        setupKeyboard();
-                        clearPassCodeEditText();
-                    }
-                }, GUARD_TIME);
+                showErrorMessage(R.string.pass_code_wrong);
+                startGuard();
             }
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
@@ -496,21 +510,11 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
                 Intent resultIntent = new Intent();
                 resultIntent.putExtra(KEY_CHECK_RESULT, true);
                 setResult(RESULT_OK, resultIntent);
-                hideSoftKeyboard();
                 finish();
             } else {
                 mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
-                passCodeWrong(R.string.pass_code_wrong);
-                new Handler().postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        Intent resultIntent = new Intent();
-                        resultIntent.putExtra(KEY_CHECK_RESULT, true);
-                        setResult(RESULT_CANCELED, resultIntent);
-                        hideSoftKeyboard();
-                        finish();
-                    }
-                }, GUARD_TIME);
+                showErrorMessage(R.string.pass_code_wrong);
+                startGuard();
             }
 
         } else if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction())) {
@@ -529,35 +533,66 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
 
             } else {
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
-                passCodeWrong(R.string.pass_code_mismatch);
-                new Handler().postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
-                        til.setError(null);
-                        setupKeyboard();
-                        clearPassCodeEditText();
-                        mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
-                        mConfirmingPassCodeFlag = false;
-                    }
-                }, GUARD_TIME);
+                showErrorMessage(R.string.pass_code_mismatch);
+                startGuard();
             }
         }
     }
 
-    private void passCodeWrong(int errorMessage) {
-        if (!mSoftKeyboardMode) {
-            setButtonsVisibility(false);
-        } else {
-            hideSoftKeyboard();
-        }
-        Animation animation = AnimationUtils.loadAnimation(PassCodeActivity.this, R.anim.shake);
-        mPassCodeEditText.startAnimation(animation);
+    private void showErrorMessage(int errorMessage) {
         CharSequence errorSeq = getString(errorMessage);
         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
         til.setError(errorSeq);
     }
 
+    private void eraseErrorMessage() {
+        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+        til.setError(null);
+    }
+
+    private void startGuard() {
+        if (!mSoftKeyboardMode) {
+            setButtonsVisibility(false);
+        } else {
+            hideSoftKeyboard();
+        }
+//        mPassCodeEditText.setFocusable(false);
+        mPassCodeEditText.setClickable(false);
+        Animation animation = AnimationUtils.loadAnimation(PassCodeActivity.this, R.anim.shake);
+        mPassCodeEditText.startAnimation(animation);
+        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+        til.setPasswordVisibilityToggleEnabled(false);
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                endGuard();
+            }
+        }, GUARD_TIME);
+    }
+
+    private void endGuard() {
+//        mPassCodeEditText.setFocusable(true);     // TODO:
+        mPassCodeEditText.setClickable(true);
+        mPassCodeEditText.requestFocus();
+        eraseErrorMessage();
+        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+        til.setPasswordVisibilityToggleEnabled(true);
+        if (ACTION_CHECK.equals(getIntent().getAction())) {
+            setupKeyboard();
+            clearPassCodeEditText();
+        } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
+            Intent resultIntent = new Intent();
+            resultIntent.putExtra(KEY_CHECK_RESULT, true);
+            setResult(RESULT_CANCELED, resultIntent);
+            finish();
+        } else if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction())) {
+            setupKeyboard();
+            clearPassCodeEditText();
+            mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
+            mConfirmingPassCodeFlag = false;
+        }
+    }
+            
     private void hideSoftKeyboard() {
         mShowButtonsWhenSoftKeyboardClose = false;
         mSoftKeyboard.hide();
@@ -616,8 +651,7 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
             if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction()) ||
                     ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
                 finish();
-            }   // else, do nothing, but report that the key was consumed to stay alive
-            else {
+            } else {
                 if (ENABLE_GO_HOME) {
                     goHome();
                 }
@@ -672,6 +706,7 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
         }
     }
 
+    // when softKeyboard close
     @Override
     public void onClose()
     {
@@ -681,7 +716,18 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
                 setButtonsVisibility(true);
             }
         } else {
-            processFullPassCode("miss");	// TODO:
+            if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction()) ||
+                    ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
+                // same as cancel button
+                finish();
+            } else {
+                if (ENABLE_GO_HOME) {
+                    goHome();
+                } else {
+                    showErrorMessage(R.string.pass_code_enter_pass_code);
+                    startGuard();
+                }
+            }
         }
     }
 }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -30,6 +30,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.support.design.widget.Snackbar;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
@@ -78,8 +79,8 @@ public class PassCodeActivity extends AppCompatActivity {
     private TextView mPassCodeHdrExplanation;
     private EditText mPassCodeEditText;
 
-    private String mPassCode;
-    private boolean mConfirmingPassCode = false;
+    private String mConfirmingPassCode;
+    private boolean mConfirmingPassCodeFlag = false;
     private static final String KEY_CONFIRMING_PASSCODE = "CONFIRMING_PASSCODE";
 
     private static final int mButtonsIDList[] = {
@@ -124,10 +125,10 @@ public class PassCodeActivity extends AppCompatActivity {
 
         } else if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction())) {
             if (savedInstanceState != null) {
-                mConfirmingPassCode = savedInstanceState.getBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE);
-                mPassCode = savedInstanceState.getString(PassCodeActivity.KEY_PASSCODE);
+                mConfirmingPassCodeFlag = savedInstanceState.getBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE);
+                mConfirmingPassCode = savedInstanceState.getString(PassCodeActivity.KEY_PASSCODE);
             }
-            if (mConfirmingPassCode) {
+            if (mConfirmingPassCodeFlag) {
                 //the app was in the passcodeconfirmation
                 requestPassCodeConfirmation();
             } else {
@@ -138,6 +139,21 @@ public class PassCodeActivity extends AppCompatActivity {
                 // TODO choose a header, check iOS
                 mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
                 setCancelButtonEnabled(true);
+
+                View view = findViewById(android.R.id.content);
+                Snackbar
+                    .make(view, getString(R.string.pass_code_configure_your_pass_code_explanation), Snackbar.LENGTH_LONG)
+                    .setAction("Cancel", new OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                Intent resultIntent = new Intent();
+                                resultIntent.putExtra(KEY_CHECK_RESULT, true);
+                                setResult(RESULT_CANCELED, resultIntent);
+                                hideSoftKeyboard();
+                                finish();
+                            }
+                    })
+                    .show();
             }
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
@@ -239,7 +255,25 @@ public class PassCodeActivity extends AppCompatActivity {
             et.setShowSoftInputOnFocus(false);  // for disabling popup soft keyboard when double clicked
         }
         et.requestFocus();
-        et.addTextChangedListener(new PassCodeDigitTextWatcher());
+        et.addTextChangedListener(new TextWatcher(){
+            @Override
+            public void afterTextChanged(Editable s) {
+                String passCode = mPassCodeEditText.getText().toString();
+                if (passCode.length() == 4) {
+                    processFullPassCode(passCode);
+                }
+            }
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                // nothing to do
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                // nothing to do
+            }
+        });
         mPassCodeEditText = et;
     }
 
@@ -249,19 +283,31 @@ public class PassCodeActivity extends AppCompatActivity {
      * Takes into account the action requested to the activity, the currently saved pass code and
      * the previously typed pass code, if any.
      */
-    private void processFullPassCode() {
+    private void processFullPassCode(String passCode) {
         if (ACTION_CHECK.equals(getIntent().getAction())) {
-            if (checkPassCode()) {
+            if (checkPassCode(passCode)) {
                 /// pass code accepted in request, user is allowed to access the app
                 hideSoftKeyboard();
                 finish();
 
             } else {
-                passCodeWrong();
+                mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
+                passCodeWrong(R.string.pass_code_wrong);
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+                        til.setError(null);
+                        if (!mSoftKeyboardMode) {
+                            setButtonsVisibility(true);
+                        }
+                        clearPassCodeEditText();
+                    }
+                }, GUARD_TIME);
             }
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
-            if (checkPassCode()) {
+            if (checkPassCode(passCode)) {
                 Intent resultIntent = new Intent();
                 resultIntent.putExtra(KEY_CHECK_RESULT, true);
                 setResult(RESULT_OK, resultIntent);
@@ -269,47 +315,63 @@ public class PassCodeActivity extends AppCompatActivity {
                 finish();
             } else {
                 mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
-                showErrorAndRestart(R.string.pass_code_wrong);
+                passCodeWrong(R.string.pass_code_wrong);
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        Intent resultIntent = new Intent();
+                        resultIntent.putExtra(KEY_CHECK_RESULT, true);
+                        setResult(RESULT_CANCELED, resultIntent);
+                        hideSoftKeyboard();
+                        finish();
+                    }
+                }, GUARD_TIME);
             }
 
         } else if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction())) {
             /// enabling pass code
-            if (!mConfirmingPassCode) {
+            if (!mConfirmingPassCodeFlag) {
                 requestPassCodeConfirmation();
+                mConfirmingPassCodeFlag = true;
+                mConfirmingPassCode = passCode;
 
-            } else if (confirmPassCode()) {
+            } else if (mConfirmingPassCode.equals(passCode)) {
                 /// confirmed: user typed the same pass code twice
-                savePassCodeAndExit();
+                Intent resultIntent = new Intent();
+                resultIntent.putExtra(KEY_PASSCODE, mConfirmingPassCode);
+                setResult(RESULT_OK, resultIntent);
+                finish();
 
             } else {
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
-                showErrorAndRestart(R.string.pass_code_mismatch);
-                mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
-
+                mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
+                passCodeWrong(R.string.pass_code_mismatch);
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+                        til.setError(null);
+                        if (!mSoftKeyboardMode) {
+                            setButtonsVisibility(true);
+                        }
+                        clearPassCodeEditText();
+                        mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
+                        mConfirmingPassCodeFlag = false;
+                    }
+                }, GUARD_TIME);
             }
         }
     }
 
-    private void passCodeWrong() {
+    private void passCodeWrong(int errorMessage) {
         if (!mSoftKeyboardMode) {
             setButtonsVisibility(false);
         }
         Animation animation = AnimationUtils.loadAnimation(PassCodeActivity.this, R.anim.shake);
         mPassCodeEditText.startAnimation(animation);
-        mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
-        showErrorAndRestart(R.string.pass_code_wrong);
-
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
-                til.setError(null);
-                if (!mSoftKeyboardMode) {
-                    setButtonsVisibility(true);
-                }
-                clearBoxes();
-            }
-        }, GUARD_TIME);
+        CharSequence errorSeq = getString(errorMessage);
+        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+        til.setError(errorSeq);
     }
 
     private void hideSoftKeyboard() {
@@ -332,22 +394,14 @@ public class PassCodeActivity extends AppCompatActivity {
         }
     }
 
-    private void showErrorAndRestart(int errorMessage) {
-        mPassCode = "";
-        CharSequence errorSeq = getString(errorMessage);
-        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
-        til.setError(errorSeq);
-    }
-
     /**
      * Ask to the user for retyping the pass code just entered before saving it as the current pass
      * code.
      */
     protected void requestPassCodeConfirmation() {
-        clearBoxes();
+        clearPassCodeEditText();
         mPassCodeHdr.setText(R.string.pass_code_reenter_your_pass_code);
         mPassCodeHdrExplanation.setVisibility(View.INVISIBLE);
-        mConfirmingPassCode = true;
     }
 
     /**
@@ -355,7 +409,7 @@ public class PassCodeActivity extends AppCompatActivity {
      *
      * @return 'True' if entered pass code equals to the saved one.
      */
-    protected boolean checkPassCode() {
+    protected boolean checkPassCode(String passCode) {
         SharedPreferences appPrefs = PreferenceManager
                 .getDefaultSharedPreferences(getApplicationContext());
 
@@ -365,27 +419,13 @@ public class PassCodeActivity extends AppCompatActivity {
         savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D3, null);
         savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D4, null);
 
-        boolean result = mPassCode.equals(savedPassCode);
-        return result;
-    }
-
-    /**
-     * Compares pass code retyped by the user in the input fields with the value entered just
-     * before.
-     *
-     * @return 'True' if retyped pass code equals to the entered before.
-     */
-    protected boolean confirmPassCode() {
-        mConfirmingPassCode = false;
-
-        boolean result = mPassCode.equals(mPassCodeEditText.getText().toString());
-        return result;
+        return passCode.equals(savedPassCode);
     }
 
     /**
      * Sets the input fields to empty strings and puts the focus on the first one.
      */
-    protected void clearBoxes() {
+    protected void clearPassCodeEditText() {
         mPassCodeEditText.setText("");
     }
 
@@ -421,42 +461,11 @@ public class PassCodeActivity extends AppCompatActivity {
         startActivity(homeIntent);
     }
 
-    /**
-     * Saves the pass code input by the user as the current pass code.
-     */
-    protected void savePassCodeAndExit() {
-        Intent resultIntent = new Intent();
-        resultIntent.putExtra(KEY_PASSCODE, mPassCode);
-        setResult(RESULT_OK, resultIntent);
-        finish();
-    }
-
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE, mConfirmingPassCode);
-        outState.putString(PassCodeActivity.KEY_PASSCODE, mPassCode);
-    }
-
-    private class PassCodeDigitTextWatcher implements TextWatcher {
-        @Override
-        public void afterTextChanged(Editable s) {
-            String passCode = mPassCodeEditText.getText().toString();
-            if (passCode.length() == 4) {
-                mPassCode = passCode;
-                processFullPassCode();
-            }
-        }
-
-        @Override
-        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            // nothing to do
-        }
-
-        @Override
-        public void onTextChanged(CharSequence s, int start, int before, int count) {
-            // nothing to do
-        }
+        outState.putBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE, mConfirmingPassCodeFlag);
+        outState.putString(PassCodeActivity.KEY_PASSCODE, mConfirmingPassCode);
     }
 
     private class ButtonClicked implements OnClickListener {
@@ -477,7 +486,7 @@ public class PassCodeActivity extends AppCompatActivity {
                         new KeyEvent(0, 0, KeyEvent.ACTION_UP, key, 0));
             } else if (mIndex == 10) {
                 // clear
-                clearBoxes();
+                clearPassCodeEditText();
             } else {
                 // delete
                 mPassCodeEditText.dispatchKeyEvent(
@@ -491,7 +500,6 @@ public class PassCodeActivity extends AppCompatActivity {
     public void setListenerToRootView() {
         View view = findViewById(android.R.id.content).getRootView();
         view.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-
             @Override
             public void onGlobalLayout() {
                 // navigation bar height
@@ -511,14 +519,18 @@ public class PassCodeActivity extends AppCompatActivity {
                 // display window size for the app layout
                 Rect rect = new Rect();
                 getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
+                int appHeight = rect.height();
 
+                // screen height
                 View view = findViewById(android.R.id.content).getRootView();
-                int h = view.getHeight();
-                // screen height - (user app height + status + nav) ..... if non-zero, then there is a soft keyboard
-                int keyboardHeight = h - (statusBarHeight + navigationBarHeight + rect.height());
+                int screenHeight = view.getHeight();
 
-                if (keyboardHeight <= 0) {
+                // soft keyboard height
+                int softKeyboardHeight = screenHeight - (statusBarHeight + navigationBarHeight + appHeight);
+
+                if (softKeyboardHeight <= 0) {
                     if (mIsSoftKeyboardOpend) {
+                        // soft keyboard was closed (back key was pressed)
                         mSoftKeyboardMode = false;
                         setButtonsVisibility(true);
                     }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -22,6 +22,7 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -39,6 +40,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
+import android.view.ViewAnimationUtils;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.animation.Animation;
@@ -49,6 +51,8 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+
+import java.util.Random;
 
 public class PassCodeActivity extends AppCompatActivity {
 
@@ -72,9 +76,10 @@ public class PassCodeActivity extends AppCompatActivity {
 
     private boolean ENABLE_GO_HOME = true;
     private boolean DEFAULT_SOFT_KEYBOARD_MODE = false;  // true=soft keyboard / false=buttons
+    private boolean ENABLE_SWITCH_SOFT_KEYBOARD = true;
     private int GUARD_TIME = 3000;
+    private boolean ENABLE_SWAP_BUTTON = false;
 
-    private Button mBCancel;
     private TextView mPassCodeHdr;
     private TextView mPassCodeHdrExplanation;
     private EditText mPassCodeEditText;
@@ -97,8 +102,11 @@ public class PassCodeActivity extends AppCompatActivity {
             R.id.clear,
             R.id.back,
     };
+    private Button[] mButtonsList = new Button[12];
+    private int mButtonVisibilityPrev = 0;       // 0=unknown/1=visible/2=invisible
     private boolean mSoftKeyboardMode;
-    private boolean mIsSoftKeyboardOpend;
+    private boolean mIsSoftKeyboardOpened;
+    private boolean mShowButtonsWhenSoftKeyboardClose = true;
 
     /**
      * Initializes the activity.
@@ -113,9 +121,22 @@ public class PassCodeActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.passcodelock);
 
-        mBCancel = (Button) findViewById(R.id.cancel);
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
+        for (int i = 0; i < mButtonsIDList.length; i++) {
+            mButtonsList[i] = (Button) findViewById(mButtonsIDList[i]);
+        }
+        if (ENABLE_SWAP_BUTTON) {
+            Random r = new Random();
+            int n = r.nextInt(100);
+            for (int i = 0; i < n; i++) {
+                int x = r.nextInt(10);
+                int y = r.nextInt(10);
+                Button t = mButtonsList[x];
+                mButtonsList[x] = mButtonsList[y];
+                mButtonsList[y] = t;
+            }
+        }
 
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             /// this is a pass code request; the user has to input the right value
@@ -128,22 +149,18 @@ public class PassCodeActivity extends AppCompatActivity {
                 mConfirmingPassCodeFlag = savedInstanceState.getBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE);
                 mConfirmingPassCode = savedInstanceState.getString(PassCodeActivity.KEY_PASSCODE);
             }
-            if (mConfirmingPassCodeFlag) {
-                //the app was in the passcodeconfirmation
-                requestPassCodeConfirmation();
-            } else {
+            if (!mConfirmingPassCodeFlag) {
                 /// pass code preference has just been activated in Preferences;
                 // will receive and confirm pass code value
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
-                //mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
-                // TODO choose a header, check iOS
                 mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
                 setCancelButtonEnabled(true);
 
                 View view = findViewById(android.R.id.content);
                 Snackbar
-                    .make(view, getString(R.string.pass_code_configure_your_pass_code_explanation), Snackbar.LENGTH_LONG)
-                    .setAction("Cancel", new OnClickListener() {
+                        .make(view, getString(R.string.pass_code_configure_your_pass_code_explanation),
+                                Snackbar.LENGTH_LONG)
+                        .setAction("Cancel", new OnClickListener() {
                             @Override
                             public void onClick(View v) {
                                 Intent resultIntent = new Intent();
@@ -152,8 +169,11 @@ public class PassCodeActivity extends AppCompatActivity {
                                 hideSoftKeyboard();
                                 finish();
                             }
-                    })
-                    .show();
+                        })
+                        .show();
+            } else {
+                //the app was in the passcodeconfirmation
+                requestPassCodeConfirmation();
             }
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
@@ -171,6 +191,7 @@ public class PassCodeActivity extends AppCompatActivity {
         setupPassCodeEditText();
         mSoftKeyboardMode = DEFAULT_SOFT_KEYBOARD_MODE;
         setupKeyboard();
+
         setListenerToRootView();
 
         if (mSoftKeyboardMode) {
@@ -181,6 +202,7 @@ public class PassCodeActivity extends AppCompatActivity {
     }
 
     private void setupKeyboard() {
+        mShowButtonsWhenSoftKeyboardClose = true;
         if (mSoftKeyboardMode) {
             showSoftKeyboard();
             setButtonsVisibility(false);
@@ -190,16 +212,50 @@ public class PassCodeActivity extends AppCompatActivity {
         }
     }
 
-    private void setButtonsVisibility(boolean visible) {
+    private void animeCircle(View myView, boolean visible) {
         if (visible) {
-            for (int i = 0; i < mButtonsIDList.length; i++) {
-                Button b = (Button) findViewById(mButtonsIDList[i]);
-                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(b, "alpha", 0f, 1f);
-                objectAnimator.setDuration(300);
-                objectAnimator.start();
+            int cx = (myView.getLeft() + myView.getRight()) / 2;
+            int cy = (myView.getTop() + myView.getBottom()) / 2;
+            int finalRadius = Math.max(myView.getWidth(), myView.getHeight());
+            Animator anim =
+                ViewAnimationUtils.createCircularReveal(myView, cx, cy, 0, finalRadius);
+            anim.start();
+        } else {
+            int cx = (myView.getLeft() + myView.getRight()) / 2;
+            int cy = (myView.getTop() + myView.getBottom()) / 2;
+            int initialRadius = myView.getWidth();
+            Animator anim =
+                ViewAnimationUtils.createCircularReveal(myView, cx, cy, initialRadius, 0);
+            anim.start();
+        }
+    }
+
+    private void animeAlpha(View view, boolean visible) {
+        if (visible) {
+            ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 0f, 1f);
+            objectAnimator.setDuration(300);
+            objectAnimator.start();
+        } else {
+            ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 1f, 0f);
+            objectAnimator.setDuration(300);
+            objectAnimator.start();
+        }
+    }
+
+    private void buttonAnime(Button b, boolean visible) {
+        animeAlpha(b, visible);
+//        animeCircle(b, visible);
+    }
+    
+    private void setButtonsVisibility(boolean visible) {
+        if (visible && mButtonVisibilityPrev != 1) {
+            mButtonVisibilityPrev = 1;
+            for (int i = 0; i < mButtonsList.length; i++) {
+                Button b = mButtonsList[i];
+                buttonAnime(b, visible);
                 b.setClickable(true);
-                b.setOnClickListener(new ButtonClicked(i));
-                if (i == 11) {
+                b.setOnClickListener(new ButtonClicked(mPassCodeEditText, i));
+                if (i == 11 && ENABLE_SWITCH_SOFT_KEYBOARD) {
                     b.setLongClickable(true);
                     b.setOnLongClickListener(new OnLongClickListener() {
                         @Override
@@ -211,12 +267,11 @@ public class PassCodeActivity extends AppCompatActivity {
                     });
                 }
             }
-        } else {
-            for (int i = 0; i < mButtonsIDList.length; i++) {
-                Button b = (Button) findViewById(mButtonsIDList[i]);
-                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(b, "alpha", 1f, 0f);
-                objectAnimator.setDuration(300);
-                objectAnimator.start();
+        } else if (!visible && mButtonVisibilityPrev != 2) {
+            mButtonVisibilityPrev = 2;
+            for (int i = 0; i < mButtonsList.length; i++) {
+                Button b = mButtonsList[i];
+                buttonAnime(b, visible);
                 b.setClickable(false);
                 b.setOnClickListener(null);
                 b.setLongClickable(false);
@@ -232,9 +287,10 @@ public class PassCodeActivity extends AppCompatActivity {
      * @param enabled 'True' makes the cancel button available, 'false' hides it.
      */
     protected void setCancelButtonEnabled(boolean enabled) {
+        Button cancel = (Button) findViewById(R.id.cancel);
         if (enabled) {
-            mBCancel.setVisibility(View.VISIBLE);
-            mBCancel.setOnClickListener(new OnClickListener() {
+            cancel.setVisibility(View.VISIBLE);
+            cancel.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     hideSoftKeyboard();
@@ -242,15 +298,16 @@ public class PassCodeActivity extends AppCompatActivity {
                 }
             });
         } else {
-            mBCancel.setVisibility(View.GONE);
-            mBCancel.setVisibility(View.INVISIBLE);
-            mBCancel.setOnClickListener(null);
+            cancel.setVisibility(View.GONE);
+            cancel.setVisibility(View.INVISIBLE);
+            cancel.setOnClickListener(null);
         }
     }
 
     protected void setupPassCodeEditText() {
         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
         EditText et = til.getEditText();
+        et.setTextIsSelectable(false);     // TODO:no effect for double tap?
         if (Build.VERSION.SDK_INT >= 21) {
             et.setShowSoftInputOnFocus(false);  // for disabling popup soft keyboard when double clicked
         }
@@ -298,9 +355,7 @@ public class PassCodeActivity extends AppCompatActivity {
                     public void run() {
                         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
                         til.setError(null);
-                        if (!mSoftKeyboardMode) {
-                            setButtonsVisibility(true);
-                        }
+                        setupKeyboard();
                         clearPassCodeEditText();
                     }
                 }, GUARD_TIME);
@@ -344,16 +399,13 @@ public class PassCodeActivity extends AppCompatActivity {
 
             } else {
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
-                mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
                 passCodeWrong(R.string.pass_code_mismatch);
                 new Handler().postDelayed(new Runnable() {
                     @Override
                     public void run() {
                         TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
                         til.setError(null);
-                        if (!mSoftKeyboardMode) {
-                            setButtonsVisibility(true);
-                        }
+                        setupKeyboard();
                         clearPassCodeEditText();
                         mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
                         mConfirmingPassCodeFlag = false;
@@ -366,6 +418,8 @@ public class PassCodeActivity extends AppCompatActivity {
     private void passCodeWrong(int errorMessage) {
         if (!mSoftKeyboardMode) {
             setButtonsVisibility(false);
+        } else {
+            hideSoftKeyboard();
         }
         Animation animation = AnimationUtils.loadAnimation(PassCodeActivity.this, R.anim.shake);
         mPassCodeEditText.startAnimation(animation);
@@ -377,6 +431,7 @@ public class PassCodeActivity extends AppCompatActivity {
     private void hideSoftKeyboard() {
         View focusedView = getCurrentFocus();
         if (focusedView != null) {
+            mShowButtonsWhenSoftKeyboardClose = false;
             InputMethodManager inputMethodManager =
                     (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
             inputMethodManager.hideSoftInputFromWindow(
@@ -471,8 +526,10 @@ public class PassCodeActivity extends AppCompatActivity {
     private class ButtonClicked implements OnClickListener {
 
         private int mIndex;
+        private EditText mEditText;
 
-        public ButtonClicked(int index) {
+        public ButtonClicked(EditText editText, int index) {
+            mEditText = editText;
             mIndex = index;
         }
 
@@ -480,18 +537,18 @@ public class PassCodeActivity extends AppCompatActivity {
             if (mIndex <= 9) {
                 // 0,1,2,...,8,9
                 int key = KeyEvent.KEYCODE_0 + mIndex;
-                mPassCodeEditText.dispatchKeyEvent(
+                mEditText.dispatchKeyEvent(
                         new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, key, 0));
-                mPassCodeEditText.dispatchKeyEvent(
+                mEditText.dispatchKeyEvent(
                         new KeyEvent(0, 0, KeyEvent.ACTION_UP, key, 0));
             } else if (mIndex == 10) {
                 // clear
-                clearPassCodeEditText();
+                mEditText.setText("");
             } else {
                 // delete
-                mPassCodeEditText.dispatchKeyEvent(
+                mEditText.dispatchKeyEvent(
                         new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL, 0));
-                mPassCodeEditText.dispatchKeyEvent(
+                mEditText.dispatchKeyEvent(
                         new KeyEvent(0, 0, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL, 0));
             }
         }
@@ -529,14 +586,20 @@ public class PassCodeActivity extends AppCompatActivity {
                 int softKeyboardHeight = screenHeight - (statusBarHeight + navigationBarHeight + appHeight);
 
                 if (softKeyboardHeight <= 0) {
-                    if (mIsSoftKeyboardOpend) {
+                    if (mIsSoftKeyboardOpened) {
                         // soft keyboard was closed (back key was pressed)
-                        mSoftKeyboardMode = false;
-                        setButtonsVisibility(true);
+                        if (ENABLE_SWITCH_SOFT_KEYBOARD) {
+                            if (mShowButtonsWhenSoftKeyboardClose) {
+                                mSoftKeyboardMode = false;
+                                setButtonsVisibility(true);
+                            }
+                        } else {
+                            processFullPassCode("miss");
+                        }
                     }
-                    mIsSoftKeyboardOpend = false;
+                    mIsSoftKeyboardOpened = false;
                 } else {
-                    mIsSoftKeyboardOpend = true;
+                    mIsSoftKeyboardOpened = true;
                 }
             }
         });

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -53,12 +53,103 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.lib.common.utils.Log_OC;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class PassCodeActivity extends AppCompatActivity {
+import static android.content.Context.INPUT_METHOD_SERVICE;
+
+
+class SoftKeyboardUtil {
+    public interface SoftKeyboardListener {
+        void onClose();
+    }
+    private static final String TAG = SoftKeyboardUtil.class.getSimpleName();
+
+    private AppCompatActivity mActivity;
+    private boolean mIsSoftKeyboardOpened;
+    private SoftKeyboardListener mSoftKeyboardListener;
+
+    private void setListenerToRootView() {
+        View view = mActivity.findViewById(android.R.id.content).getRootView();
+        view.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                // navigation bar height
+                int navigationBarHeight = 0;
+                int resourceId = mActivity.getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+                if (resourceId > 0) {
+                    navigationBarHeight = mActivity.getResources().getDimensionPixelSize(resourceId);
+                }
+
+                // status bar height
+                int statusBarHeight = 0;
+                resourceId = mActivity.getResources().getIdentifier("status_bar_height", "dimen", "android");
+                if (resourceId > 0) {
+                    statusBarHeight = mActivity.getResources().getDimensionPixelSize(resourceId);
+                }
+
+                // display window size for the app layout
+                Rect rect = new Rect();
+                mActivity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
+                int appHeight = rect.height();
+
+                // screen height
+                View view = mActivity.findViewById(android.R.id.content).getRootView();
+                int screenHeight = view.getHeight();
+
+                // soft keyboard height
+                int softKeyboardHeight = screenHeight - (statusBarHeight + navigationBarHeight + appHeight);
+
+                if (softKeyboardHeight <= 0) {
+                    if (mIsSoftKeyboardOpened) {
+                        // soft keyboard was closed (back key was pressed)
+                        mSoftKeyboardListener.onClose();
+                    }
+                    mIsSoftKeyboardOpened = false;
+                } else {
+                    mIsSoftKeyboardOpened = true;
+                }
+            }
+        });
+    }
+
+    public SoftKeyboardUtil(AppCompatActivity activity, SoftKeyboardListener softKeyboardListener) {
+        mActivity = activity;
+        mSoftKeyboardListener = softKeyboardListener;
+        if (softKeyboardListener != null) {
+            setListenerToRootView();
+        }
+    }
+    public void initHidden() {
+        mActivity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+    }
+    public void initVisible() {
+        mActivity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+    }
+    public void show() {
+        View focusedView = mActivity.getCurrentFocus();
+        if (focusedView != null) {
+            InputMethodManager imm = (InputMethodManager) mActivity.getSystemService(INPUT_METHOD_SERVICE);
+            imm.showSoftInput(focusedView, 0);
+        } else {
+            Log_OC.i(TAG, "focusedView = null in show()");
+        }
+    }
+    public void hide() {
+        View focusedView = mActivity.getCurrentFocus();
+        if (focusedView != null) {
+            InputMethodManager imm = (InputMethodManager) mActivity.getSystemService(INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(focusedView.getWindowToken(), 0);
+        } else {
+            Log_OC.i(TAG, "focusedView = null in hide()");
+        }
+    }
+}
+
+public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardUtil.SoftKeyboardListener {
 
     private static final String TAG = PassCodeActivity.class.getSimpleName();
 
@@ -78,11 +169,11 @@ public class PassCodeActivity extends AppCompatActivity {
     public final static String PREFERENCE_PASSCODE_D3 = "PrefPinCode3";
     public final static String PREFERENCE_PASSCODE_D4 = "PrefPinCode4";
 
-    private boolean ENABLE_GO_HOME = true;
-    private boolean DEFAULT_SOFT_KEYBOARD_MODE = false;  // true=soft keyboard / false=buttons
-    private boolean ENABLE_SWITCH_SOFT_KEYBOARD = false;
-    private int GUARD_TIME = 3000;
-    private boolean ENABLE_SUFFLE_BUTTONS = false;
+    private static final boolean ENABLE_GO_HOME = true;
+    private static final boolean INIT_SOFT_KEYBOARD_MODE = true;  // true=soft keyboard / false=buttons
+    private static final boolean ENABLE_SWITCH_SOFT_KEYBOARD = false;
+    private static final int GUARD_TIME = 3000;    // (ms)
+    private static final boolean ENABLE_SUFFLE_BUTTONS = false;
 
     private TextView mPassCodeHdr;
     private TextView mPassCodeHdrExplanation;
@@ -107,40 +198,40 @@ public class PassCodeActivity extends AppCompatActivity {
             R.id.back,
     };
     private static final String mButtonsMainStr[] = {
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "Clear",
-        "Back"
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "Clear",
+            "Back"
     };
-    private static final String mButtonsSubStr[] = {
-        "",
-        "",
-        "abc",
-        "def",
-        "ghi",
-        "jkl",
-        "mno",
-        "pqrs",
-        "tuv",
-        "wxyz",
-        "",
-        "softkey..."
+    private static String mButtonsSubStr[] = {
+            "",
+            "",
+            "abc",
+            "def",
+            "ghi",
+            "jkl",
+            "mno",
+            "pqrs",
+            "tuv",
+            "wxyz",
+            "",
+            "softkey..."
     };
     private Integer[] mButtonsIDListShuffle = new Integer[12];
     private AppCompatButton[] mButtonsList = new AppCompatButton[12];
     private int mButtonVisibilityPrev = 0;       // 0=unknown/1=visible/2=invisible
     private boolean mSoftKeyboardMode;
-    private boolean mIsSoftKeyboardOpened;
     private boolean mShowButtonsWhenSoftKeyboardClose = true;
-
+    private SoftKeyboardUtil mSoftKeyboard;
+    
     /**
      * Initializes the activity.
      * <p>
@@ -208,16 +299,17 @@ public class PassCodeActivity extends AppCompatActivity {
                     + TAG);
         }
 
+        if (!ENABLE_SWITCH_SOFT_KEYBOARD) {
+            mButtonsSubStr[11] = "";
+        }
         setupPassCodeEditText();
-        mSoftKeyboardMode = DEFAULT_SOFT_KEYBOARD_MODE;
+        mSoftKeyboardMode = INIT_SOFT_KEYBOARD_MODE;
+        mSoftKeyboard = new SoftKeyboardUtil(this, this);
         setupKeyboard();
-
-        setListenerToRootView();
-
         if (mSoftKeyboardMode) {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+            mSoftKeyboard.initVisible();
         } else {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+            mSoftKeyboard.initHidden();
         }
     }
 
@@ -467,24 +559,12 @@ public class PassCodeActivity extends AppCompatActivity {
     }
 
     private void hideSoftKeyboard() {
-        View focusedView = getCurrentFocus();
-        if (focusedView != null) {
-            mShowButtonsWhenSoftKeyboardClose = false;
-            InputMethodManager inputMethodManager =
-                    (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
-            inputMethodManager.hideSoftInputFromWindow(
-                    focusedView.getWindowToken(), 0);
-        }
+        mShowButtonsWhenSoftKeyboardClose = false;
+        mSoftKeyboard.hide();
     }
 
     private void showSoftKeyboard() {
-        View focusedView = getCurrentFocus();
-        if (focusedView != null) {
-            InputMethodManager inputMethodManager =
-                    (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
-            inputMethodManager.showSoftInput(
-                    focusedView, 0);
-        }
+        mSoftKeyboard.show();
     }
 
     /**
@@ -592,54 +672,16 @@ public class PassCodeActivity extends AppCompatActivity {
         }
     }
 
-    public void setListenerToRootView() {
-        View view = findViewById(android.R.id.content).getRootView();
-        view.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-            @Override
-            public void onGlobalLayout() {
-                // navigation bar height
-                int navigationBarHeight = 0;
-                int resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
-                if (resourceId > 0) {
-                    navigationBarHeight = getResources().getDimensionPixelSize(resourceId);
-                }
-
-                // status bar height
-                int statusBarHeight = 0;
-                resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-                if (resourceId > 0) {
-                    statusBarHeight = getResources().getDimensionPixelSize(resourceId);
-                }
-
-                // display window size for the app layout
-                Rect rect = new Rect();
-                getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
-                int appHeight = rect.height();
-
-                // screen height
-                View view = findViewById(android.R.id.content).getRootView();
-                int screenHeight = view.getHeight();
-
-                // soft keyboard height
-                int softKeyboardHeight = screenHeight - (statusBarHeight + navigationBarHeight + appHeight);
-
-                if (softKeyboardHeight <= 0) {
-                    if (mIsSoftKeyboardOpened) {
-                        // soft keyboard was closed (back key was pressed)
-                        if (ENABLE_SWITCH_SOFT_KEYBOARD) {
-                            if (mShowButtonsWhenSoftKeyboardClose) {
-                                mSoftKeyboardMode = false;
-                                setButtonsVisibility(true);
-                            }
-                        } else {
-                            processFullPassCode("miss");
-                        }
-                    }
-                    mIsSoftKeyboardOpened = false;
-                } else {
-                    mIsSoftKeyboardOpened = true;
-                }
+    @Override
+    public void onClose()
+    {
+        if (ENABLE_SWITCH_SOFT_KEYBOARD) {
+            if (mShowButtonsWhenSoftKeyboardClose) {
+                mSoftKeyboardMode = false;
+                setButtonsVisibility(true);
             }
-        });
+        } else {
+            processFullPassCode("miss");	// TODO:
+        }
     }
 }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -34,7 +34,9 @@ import android.preference.PreferenceManager;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.AppCompatButton;
 import android.text.Editable;
+import android.text.Html;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
@@ -52,7 +54,9 @@ import android.widget.TextView;
 
 import com.owncloud.android.R;
 
-import java.util.Random;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class PassCodeActivity extends AppCompatActivity {
 
@@ -76,9 +80,9 @@ public class PassCodeActivity extends AppCompatActivity {
 
     private boolean ENABLE_GO_HOME = true;
     private boolean DEFAULT_SOFT_KEYBOARD_MODE = false;  // true=soft keyboard / false=buttons
-    private boolean ENABLE_SWITCH_SOFT_KEYBOARD = true;
+    private boolean ENABLE_SWITCH_SOFT_KEYBOARD = false;
     private int GUARD_TIME = 3000;
-    private boolean ENABLE_SWAP_BUTTON = false;
+    private boolean ENABLE_SUFFLE_BUTTONS = false;
 
     private TextView mPassCodeHdr;
     private TextView mPassCodeHdrExplanation;
@@ -102,7 +106,36 @@ public class PassCodeActivity extends AppCompatActivity {
             R.id.clear,
             R.id.back,
     };
-    private Button[] mButtonsList = new Button[12];
+    private static final String mButtonsMainStr[] = {
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "Clear",
+        "Back"
+    };
+    private static final String mButtonsSubStr[] = {
+        "",
+        "",
+        "abc",
+        "def",
+        "ghi",
+        "jkl",
+        "mno",
+        "pqrs",
+        "tuv",
+        "wxyz",
+        "",
+        "softkey..."
+    };
+    private Integer[] mButtonsIDListShuffle = new Integer[12];
+    private AppCompatButton[] mButtonsList = new AppCompatButton[12];
     private int mButtonVisibilityPrev = 0;       // 0=unknown/1=visible/2=invisible
     private boolean mSoftKeyboardMode;
     private boolean mIsSoftKeyboardOpened;
@@ -123,20 +156,7 @@ public class PassCodeActivity extends AppCompatActivity {
 
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
-        for (int i = 0; i < mButtonsIDList.length; i++) {
-            mButtonsList[i] = (Button) findViewById(mButtonsIDList[i]);
-        }
-        if (ENABLE_SWAP_BUTTON) {
-            Random r = new Random();
-            int n = r.nextInt(100);
-            for (int i = 0; i < n; i++) {
-                int x = r.nextInt(10);
-                int y = r.nextInt(10);
-                Button t = mButtonsList[x];
-                mButtonsList[x] = mButtonsList[y];
-                mButtonsList[y] = t;
-            }
-        }
+        setupButtons();
 
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             /// this is a pass code request; the user has to input the right value
@@ -212,6 +232,16 @@ public class PassCodeActivity extends AppCompatActivity {
         }
     }
 
+    private void setupButtons() {
+        for (int i = 0; i < mButtonsIDList.length; i++) {
+            mButtonsIDListShuffle[i] = i;
+        }
+        for (int i = 0; i < mButtonsIDList.length; i++) {
+            mButtonsList[i] = (AppCompatButton) findViewById(mButtonsIDList[i]);
+            mButtonsList[i].setAllCaps(false);
+        }
+    }
+
     private void animeCircle(View myView, boolean visible) {
         if (visible) {
             int cx = (myView.getLeft() + myView.getRight()) / 2;
@@ -250,12 +280,21 @@ public class PassCodeActivity extends AppCompatActivity {
     private void setButtonsVisibility(boolean visible) {
         if (visible && mButtonVisibilityPrev != 1) {
             mButtonVisibilityPrev = 1;
+            if (ENABLE_SUFFLE_BUTTONS) {
+                List<Integer> list = Arrays.asList(mButtonsIDListShuffle);
+                Collections.shuffle(list);
+                mButtonsIDListShuffle = (Integer[]) list.toArray(new Integer[list.size()]);
+            }
             for (int i = 0; i < mButtonsList.length; i++) {
                 Button b = mButtonsList[i];
+                int j = ENABLE_SUFFLE_BUTTONS ? mButtonsIDListShuffle[i] : i;
                 buttonAnime(b, visible);
                 b.setClickable(true);
-                b.setOnClickListener(new ButtonClicked(mPassCodeEditText, i));
-                if (i == 11 && ENABLE_SWITCH_SOFT_KEYBOARD) {
+                String s = String.format("<big>%s</big><br/><font color=\"grey\"><small>%s</small></font>",
+                                         mButtonsMainStr[j], mButtonsSubStr[j]);
+                b.setText(Html.fromHtml(s));
+                b.setOnClickListener(new ButtonClicked(mPassCodeEditText, j));
+                if (j == 11 && ENABLE_SWITCH_SOFT_KEYBOARD) {
                     b.setLongClickable(true);
                     b.setOnLongClickListener(new OnLongClickListener() {
                         @Override

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -22,6 +22,7 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Rect;
@@ -100,7 +101,7 @@ public class PassCodeActivity extends AppCompatActivity {
         R.id.txt2,
         R.id.txt3,
     };
-    private boolean mSoftkeyMode = true;
+    private boolean mSoftinputMode = true;
 
     /**
      * Initializes the activity.
@@ -164,7 +165,7 @@ public class PassCodeActivity extends AppCompatActivity {
         setListenerToRootView();
 
         if (false) {
-        if (mSoftkeyMode) {
+        if (mSoftinputMode) {
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
         } else {
         	getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
@@ -174,21 +175,31 @@ public class PassCodeActivity extends AppCompatActivity {
         ((Button) findViewById(R.id.button_softkey)).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                mSoftkeyMode = mSoftkeyMode == false ? true : false;
-                setSoftkeyMode();
+                mSoftinputMode = mSoftinputMode == false ? true : false;
+                if (mSoftinputMode) {
+                    hideSoftKeyboard();
+//                    InputMethodManager imm = (InputMethodManager)getSystemService(
+//                        Context.INPUT_METHOD_SERVICE);
+//                    imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+                    setSoftkeyVisibility(true);
+                } else {
+                    showSoftKeyboard();
+//                    InputMethodManager imm = (InputMethodManager)getSystemService(
+//                        Context.INPUT_METHOD_SERVICE);
+//                    imm.showSoftInput(mPassCodeEditTexts[0], 0);
+                    setSoftkeyVisibility(false);
+                }
             }
         });
     }
 
-    private void setSoftkeyMode() {
-        if (mSoftkeyMode) {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+    private void setSoftkeyVisibility(boolean visible) {
+        if (visible) {
             for(int i=0;i< mButtonIDList.length; i++) {
                 Button b = (Button)findViewById(mButtonIDList[i]);
                 b.setVisibility(View.VISIBLE);
             }
         } else {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
             for(int i=0;i< mButtonIDList.length; i++) {
                 Button b = (Button)findViewById(mButtonIDList[i]);
                 b.setVisibility(View.INVISIBLE);
@@ -302,6 +313,16 @@ public class PassCodeActivity extends AppCompatActivity {
                 (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
             inputMethodManager.hideSoftInputFromWindow(
                 focusedView.getWindowToken(), 0);
+        }
+    }
+
+    private void showSoftKeyboard() {
+        View focusedView = getCurrentFocus();
+        if (focusedView != null) {
+            InputMethodManager inputMethodManager =
+                (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+            inputMethodManager.showSoftInput(
+                focusedView, 0);
         }
     }
 
@@ -641,8 +662,8 @@ public class PassCodeActivity extends AppCompatActivity {
 //                    onHideKeyboard();
                     if (isOpened) {
 //                        goHome();
-                        mSoftkeyMode = false;
-                        setSoftkeyMode();
+                        mSoftinputMode = true;
+                        setSoftkeyVisibility(true);
                     }
                     isOpened = false;
                     int a = 0;

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -22,12 +22,10 @@
  */
 package com.owncloud.android.ui.activity;
 
-import java.util.Arrays;
-
 import android.content.Intent;
-
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
@@ -45,6 +43,8 @@ import android.widget.Toast;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
+import java.util.Arrays;
+
 public class PassCodeActivity extends AppCompatActivity {
 
     private static final String TAG = PassCodeActivity.class.getSimpleName();
@@ -53,7 +53,7 @@ public class PassCodeActivity extends AppCompatActivity {
     public final static String ACTION_CHECK_WITH_RESULT = "ACTION_CHECK_WITH_RESULT";
     public final static String ACTION_CHECK = "ACTION_CHECK";
 
-    public final static String KEY_PASSCODE  = "KEY_PASSCODE";
+    public final static String KEY_PASSCODE = "KEY_PASSCODE";
     public final static String KEY_CHECK_RESULT = "KEY_CHECK_RESULT";
 
     // NOTE: PREFERENCE_SET_PASSCODE must have the same value as preferences.xml-->android:key for passcode preference
@@ -77,7 +77,7 @@ public class PassCodeActivity extends AppCompatActivity {
 
     private boolean mBChange = true; // to control that only one blocks jump
 
-    private int mButtonIDList[] = {
+    private static final int mButtonIDList[] = {
         R.id.button0,
         R.id.button1,
         R.id.button2,
@@ -92,6 +92,13 @@ public class PassCodeActivity extends AppCompatActivity {
         R.id.back,
     };
     private int mEditPos;
+    private static final int mPassCodeEditTextIDList[] = {
+        R.id.txt0,
+        R.id.txt1,
+        R.id.txt2,
+        R.id.txt3,
+    };
+    private boolean mSoftkeyMode = true;
 
     /**
      * Initializes the activity.
@@ -109,19 +116,6 @@ public class PassCodeActivity extends AppCompatActivity {
         mBCancel = (Button) findViewById(R.id.cancel);
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
-        mPassCodeEditTexts[0] = (EditText) findViewById(R.id.txt0);
-        mPassCodeEditTexts[0].setTextIsSelectable(false);
-//        getWindow().setSoftInputMode(
-//                android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
-        mPassCodeEditTexts[1] = (EditText) findViewById(R.id.txt1);
-        mPassCodeEditTexts[1].setTextIsSelectable(false);
-        mPassCodeEditTexts[2] = (EditText) findViewById(R.id.txt2);
-        mPassCodeEditTexts[2].setTextIsSelectable(false);
-        mPassCodeEditTexts[3] = (EditText) findViewById(R.id.txt3);
-        mPassCodeEditTexts[3].setTextIsSelectable(false);
-
-        mPassCodeEditTexts[0].requestFocus();
-        mEditPos = 0;
 
         for(int i=0;i< mButtonIDList.length; i++) {
             Button b = (Button)findViewById(mButtonIDList[i]);
@@ -164,9 +158,13 @@ public class PassCodeActivity extends AppCompatActivity {
                     + TAG);
         }
 
-        this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-
         setTextListeners();
+
+        if (mSoftkeyMode) {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+        } else {
+        	getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+		}
     }
 
 
@@ -198,95 +196,28 @@ public class PassCodeActivity extends AppCompatActivity {
      * Binds the appropiate listeners to the input boxes receiving each digit of the pass code.
      */
     protected void setTextListeners() {
-    
-         ///  First input field
-        mPassCodeEditTexts[0].addTextChangedListener(new PassCodeDigitTextWatcher(0, false));
-        mPassCodeEditTexts[0].setOnFocusChangeListener(new FocusChecker(0));
-
-
-        /*------------------------------------------------
-         *  SECOND BOX 
-         -------------------------------------------------*/
-        mPassCodeEditTexts[1].addTextChangedListener(new PassCodeDigitTextWatcher(1, false));
-
-        mPassCodeEditTexts[1].setOnKeyListener(new View.OnKeyListener() {
-
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (keyCode == KeyEvent.KEYCODE_DEL && mBChange) {  // TODO WIP: event should be
-                // used to control what's exactly happening with DEL, not any custom field...
-                    mPassCodeEditTexts[0].setText("");
-                    mPassCodeEditTexts[0].requestFocus();
-                    if (!mConfirmingPassCode) {
-                        mPassCodeDigits[0] = "";
-                    }
-                    mBChange = false;
-
-                } else if (!mBChange) {
-                    mBChange = true;
-                }
-                return false;
+        for (int i = 0; i < mPassCodeEditTextIDList.length; i++) {
+            EditText et = (EditText) findViewById(mPassCodeEditTextIDList[i]);
+            et.setTextIsSelectable(false);
+            et.setShowSoftInputOnFocus(false);      // TODO: API21  for disabling popup softkey when double clicked
+            et.setLongClickable(false);
+            if (i == 0) {
+//                et.setFocusable(true);
+//                et.setFocusableInTouchMode(true);
+                et.setClickable(true);
+                et.requestFocus();
+                mEditPos = i;
+            } else {
+//                et.setFocusable(false);
+//                et.setFocusableInTouchMode(false);
+                et.setClickable(false);
             }
-        });
-        mPassCodeEditTexts[1].setOnFocusChangeListener(new FocusChecker(1));
-
-        
-        
-        /*------------------------------------------------
-         *  THIRD BOX
-         -------------------------------------------------*/
-        mPassCodeEditTexts[2].addTextChangedListener(new PassCodeDigitTextWatcher(2, false));
-
-        mPassCodeEditTexts[2].setOnKeyListener(new View.OnKeyListener() {
-
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (keyCode == KeyEvent.KEYCODE_DEL && mBChange) {
-                    mPassCodeEditTexts[1].requestFocus();
-                    if (!mConfirmingPassCode) {
-                        mPassCodeDigits[1] = "";
-                    }
-                    mPassCodeEditTexts[1].setText("");
-                    mBChange = false;
-
-                } else if (!mBChange) {
-                    mBChange = true;
-
-                }
-                return false;
-            }
-        });
-
-        mPassCodeEditTexts[2].setOnFocusChangeListener(new FocusChecker(2));
-
-
-        /*------------------------------------------------
-         *  FOURTH BOX
-         -------------------------------------------------*/
-        mPassCodeEditTexts[3].addTextChangedListener(new PassCodeDigitTextWatcher(3, true));
-
-        mPassCodeEditTexts[3].setOnKeyListener(new View.OnKeyListener() {
-
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (keyCode == KeyEvent.KEYCODE_DEL && mBChange) {
-                    mPassCodeEditTexts[2].requestFocus();
-                    if (!mConfirmingPassCode) {
-                        mPassCodeDigits[2] = "";
-                    }
-                    mPassCodeEditTexts[2].setText("");
-                    mBChange = false;
-
-                } else if (!mBChange) {
-                    mBChange = true;
-                }
-                return false;
-            }
-        });
-
-        mPassCodeEditTexts[3].setOnFocusChangeListener(new FocusChecker(3));
+            et.addTextChangedListener(new PassCodeDigitTextWatcher(i, i == 3 ? true : false));
+            et.setOnFocusChangeListener(new FocusChecker(i));
+            et.setOnKeyListener(new KeyListener(i));
+            mPassCodeEditTexts[i] = et;
+        }
     } // end setTextListener
-
 
     /**
      * Processes the pass code entered by the user just after the last digit was in.
@@ -409,9 +340,10 @@ public class PassCodeActivity extends AppCompatActivity {
     /**
      * Sets the input fields to empty strings and puts the focus on the first one.
      */
-    protected void clearBoxes(){
-        for (int i=0; i < mPassCodeEditTexts.length; i++) {
+    protected void clearBoxes() {
+        for (int i = 0; i < mPassCodeEditTexts.length; i++) {
             mPassCodeEditTexts[i].setText("");
+            mPassCodeEditTexts[i].setClickable(i == 0 ? true : false);
         }
         mPassCodeEditTexts[0].requestFocus();
         mEditPos = 0;
@@ -426,14 +358,13 @@ public class PassCodeActivity extends AppCompatActivity {
      * @return              'True' when the key event was processed by this method.
      */
     @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event){
-        if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount()== 0){
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
             if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction()) ||
                     ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
                 finish();
             }   // else, do nothing, but report that the key was consumed to stay alive
-            else
-            {
+            else {
 //                goHome();		// TODO:
             }
             return true;
@@ -469,6 +400,59 @@ public class PassCodeActivity extends AppCompatActivity {
         outState.putStringArray(PassCodeActivity.KEY_PASSCODE_DIGITS, mPassCodeDigits);
     }
 
+    private class KeyListener implements View.OnKeyListener {
+
+        private int mIndex;
+
+        public KeyListener(int index) {
+            mIndex = index;
+        }
+        
+        @Override
+        public boolean onKey(View v, int keyCode, KeyEvent event) {
+            if (event.getAction() == KeyEvent.ACTION_DOWN &&
+                event.getRepeatCount() == 0)
+            {
+                if (KeyEvent.KEYCODE_0 <= keyCode && keyCode <= KeyEvent.KEYCODE_9) {
+                    String keyStr = String.format("%d", keyCode - KeyEvent.KEYCODE_0);
+                    mEditPos = mIndex;
+                    mPassCodeEditTexts[mIndex].setText(keyStr);
+                    if (!mConfirmingPassCode) {
+                        mPassCodeDigits[mIndex] = keyStr;
+                    }
+                    if (mIndex == 3) {
+                        new Handler().postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                processFullPassCode();
+                            }
+                        }, 3000);
+                    } else {
+                        mEditPos = mIndex + 1;
+                        mPassCodeEditTexts[mEditPos].requestFocus();
+                    }
+                }
+                else if (keyCode == KeyEvent.KEYCODE_DEL) {       // TODO WIP: event should be
+                    // used to control what's exactly happening with DEL, not any custom field...
+                    if (mIndex > 0) {
+                        mEditPos = mIndex - 1;
+                        mPassCodeEditTexts[mEditPos].setText("");
+                        mPassCodeEditTexts[mEditPos].requestFocus();
+                        if (!mConfirmingPassCode) {
+                            mPassCodeDigits[mEditPos] = "";
+                        }
+                    }
+                }
+                mBChange = false;
+
+            } else if (!mBChange) {
+                mBChange = true;
+            }
+            return false;
+        }
+    }
+
+	// TODO: delete this class
     private class PassCodeDigitTextWatcher implements TextWatcher {
 
         private int mIndex = -1;
@@ -485,12 +469,6 @@ public class PassCodeActivity extends AppCompatActivity {
         public PassCodeDigitTextWatcher(int index, boolean lastOne) {
             mIndex = index;
             mLastOne  = lastOne;
-            if (mIndex < 0) {
-                throw new IllegalArgumentException(
-                        "Invalid index in " + PassCodeDigitTextWatcher.class.getSimpleName() +
-                                " constructor"
-                );
-            }
         }
 
         private int next() {
@@ -508,19 +486,7 @@ public class PassCodeActivity extends AppCompatActivity {
          */
         @Override
         public void afterTextChanged(Editable s) {
-            if (s.length() > 0) {
-                if (!mConfirmingPassCode) {
-                    mPassCodeDigits[mIndex] = mPassCodeEditTexts[mIndex].getText().toString();
-                }
-                mPassCodeEditTexts[next()].requestFocus();
-
-                if (mLastOne) {
-                    processFullPassCode();
-                }
-
-            } else {
-                Log_OC.d(TAG, "Text box " + mIndex + " was cleaned");
-            }
+            // nothing to do
         }
 
         @Override
@@ -532,7 +498,6 @@ public class PassCodeActivity extends AppCompatActivity {
         public void onTextChanged(CharSequence s, int start, int before, int count) {
             // nothing to do
         }
-
     }
 
 	private class FocusChecker implements View.OnFocusChangeListener {
@@ -545,17 +510,19 @@ public class PassCodeActivity extends AppCompatActivity {
             
         @Override
         public void onFocusChange(View v, boolean hasFocus) {
+            Log_OC.d(TAG, String.format("Text box[%d] focus %s", mIndex, hasFocus ? "get" : "lost"));
             if (hasFocus) {
-                int i;
                 mEditPos = mIndex;
-                for (i=0;i<mIndex;i++) {
+                for (int i = 0; i < mEditPos; i++) {
                     if (mPassCodeEditTexts[i].getText().toString().equals("")) {
-                        mPassCodeEditTexts[i].requestFocus();
+                        mEditPos = i;
+                        mPassCodeEditTexts[mEditPos].requestFocus();
                         break;
                     }
                 }
-                for(int j=i;j<4;j++) {
-                    mPassCodeEditTexts[j].setText("");
+                for (int i = mEditPos; i < 4; i++) {
+                    mPassCodeEditTexts[i].setText("");
+                    mPassCodeEditTexts[i].setClickable(false);
                 }
             }
         }
@@ -570,35 +537,41 @@ public class PassCodeActivity extends AppCompatActivity {
         }
 
 		public void onClick(View v) {
+            if (mIndex <= 9) {
+                // 0,1,2,...,8,9
+                String keyStr = String.format("%d", mIndex);
+                Log_OC.d(TAG, String.format("Text box[%d] = %s", mEditPos, keyStr));
+                mPassCodeEditTexts[mEditPos].setText(keyStr);
+                if (!mConfirmingPassCode) {
+                    mPassCodeDigits[mEditPos] = keyStr;
+                }
+                if (mEditPos == 3) {
+                    new Handler().postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            processFullPassCode();
 
-			Button button = (Button) v;
-
-            if (mIndex < 9) {
-                String s;
-                s = String.format("%d", mIndex);
-                mPassCodeEditTexts[mEditPos].setText(s);
-                mEditPos++;
+                        }
+                    }, 3000);
+                } else {
+                    mPassCodeEditTexts[mEditPos].setClickable(true);
+                    mEditPos++;
+                    mPassCodeEditTexts[mEditPos].requestFocus();
+                }
             } else if (mIndex == 10) {
                 // clear
                 clearBoxes();
             } else {
                 // delete
                 if (mEditPos > 0) {
-                    for (int i=mEditPos ; i < 4 ; i++) {
-                        mPassCodeEditTexts[i].setText("");
-                    }
                     mEditPos--;
+                    for (int i = mEditPos; i < 4; i++) {
+                        mPassCodeEditTexts[i].setText("");
+                        mPassCodeEditTexts[i].setClickable(false);
+                    }
                     mPassCodeEditTexts[mEditPos].requestFocus();
                 }
             }
-
-            {
-                String s;
-                s = String.format("key %d", mIndex);
-                Toast toast = Toast.makeText(PassCodeActivity.this, s, Toast.LENGTH_SHORT);
-                toast.show();
-            }
-
         }
 	}
 }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -22,13 +22,14 @@
  */
 package com.owncloud.android.ui.activity;
 
-import android.content.Context;
+import android.animation.ObjectAnimator;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -37,6 +38,8 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
@@ -71,10 +74,9 @@ public class PassCodeActivity extends AppCompatActivity {
     private Button mBCancel;
     private TextView mPassCodeHdr;
     private TextView mPassCodeHdrExplanation;
-    private EditText[] mPassCodeEditTexts = new EditText[4];
+    private EditText mPassCodeEditText;
 
-    private String [] mPassCodeDigits = {"","","",""};
-    private static final String KEY_PASSCODE_DIGITS = "PASSCODE_DIGITS";
+    private String mPassCode;
     private boolean mConfirmingPassCode = false;
     private static final String KEY_CONFIRMING_PASSCODE = "CONFIRMING_PASSCODE";
 
@@ -95,13 +97,8 @@ public class PassCodeActivity extends AppCompatActivity {
         R.id.back,
     };
     private int mEditPos;
-    private static final int mPassCodeEditTextIDList[] = {
-        R.id.txt0,
-        R.id.txt1,
-        R.id.txt2,
-        R.id.txt3,
-    };
     private boolean mSoftinputMode = true;
+    private Animation mAnimation;
 
     /**
      * Initializes the activity.
@@ -115,7 +112,8 @@ public class PassCodeActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.passcodelock);
-        
+
+        mAnimation = AnimationUtils.loadAnimation(this, R.anim.shake);
         mBCancel = (Button) findViewById(R.id.cancel);
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
@@ -134,7 +132,7 @@ public class PassCodeActivity extends AppCompatActivity {
         } else if (ACTION_REQUEST_WITH_RESULT.equals(getIntent().getAction())) {
             if (savedInstanceState != null) {
                 mConfirmingPassCode = savedInstanceState.getBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE);
-                mPassCodeDigits = savedInstanceState.getStringArray(PassCodeActivity.KEY_PASSCODE_DIGITS);
+                mPassCode = savedInstanceState.getString(PassCodeActivity.KEY_PASSCODE);
             }
             if(mConfirmingPassCode){
                 //the app was in the passcodeconfirmation
@@ -165,11 +163,11 @@ public class PassCodeActivity extends AppCompatActivity {
         setListenerToRootView();
 
         if (false) {
-        if (mSoftinputMode) {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-        } else {
-        	getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-		}
+            if (mSoftinputMode) {
+                getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+            } else {
+                getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+            }
         }
 
         ((Button) findViewById(R.id.button_softkey)).setOnClickListener(new OnClickListener() {
@@ -197,12 +195,21 @@ public class PassCodeActivity extends AppCompatActivity {
         if (visible) {
             for(int i=0;i< mButtonIDList.length; i++) {
                 Button b = (Button)findViewById(mButtonIDList[i]);
-                b.setVisibility(View.VISIBLE);
+                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat( b, "alpha", 0f, 1f );
+                objectAnimator.setDuration( 3000 );
+                objectAnimator.start();
+ //               objectAnimator.addListener();
+//                b.setVisibility(View.VISIBLE);
+                b.setClickable(true);
             }
         } else {
             for(int i=0;i< mButtonIDList.length; i++) {
                 Button b = (Button)findViewById(mButtonIDList[i]);
-                b.setVisibility(View.INVISIBLE);
+                ObjectAnimator objectAnimator = ObjectAnimator.ofFloat( b, "alpha", 1f, 0f );
+                objectAnimator.setDuration( 3000 );
+                objectAnimator.start();
+                //b.setVisibility(View.INVISIBLE);
+                b.setClickable(false);
             }
         }
     }
@@ -236,28 +243,13 @@ public class PassCodeActivity extends AppCompatActivity {
      * Binds the appropiate listeners to the input boxes receiving each digit of the pass code.
      */
     protected void setTextListeners() {
-        for (int i = 0; i < mPassCodeEditTextIDList.length; i++) {
-            EditText et = (EditText) findViewById(mPassCodeEditTextIDList[i]);
-            et.setTextIsSelectable(false);
-            et.setShowSoftInputOnFocus(false);      // TODO: API21  for disabling popup softkey when double clicked
-            et.setLongClickable(false);
-            if (i == 0) {
-//                et.setFocusable(true);
-//                et.setFocusableInTouchMode(true);
-                et.setClickable(true);
-                et.requestFocus();
-                mEditPos = i;
-            } else {
-//                et.setFocusable(false);
-//                et.setFocusableInTouchMode(false);
-                et.setClickable(false);
-            }
-            et.addTextChangedListener(new PassCodeDigitTextWatcher(i, i == 3 ? true : false));
-            et.setOnFocusChangeListener(new FocusChecker(i));
-            et.setOnKeyListener(new KeyListener(i));
-            mPassCodeEditTexts[i] = et;
-        }
-    } // end setTextListener
+        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+        EditText et = til.getEditText();
+        et.setShowSoftInputOnFocus(false);      // TODO: API21  for disabling popup softkey when double clicked
+        et.requestFocus();
+        et.addTextChangedListener(new PassCodeDigitTextWatcher(false));
+        mPassCodeEditText = et;
+    }
 
     /**
      * Processes the pass code entered by the user just after the last digit was in.
@@ -273,8 +265,32 @@ public class PassCodeActivity extends AppCompatActivity {
                 finish();
 
             }  else {
-                showErrorAndRestart(R.string.pass_code_wrong, R.string.pass_code_enter_pass_code,
-                        View.INVISIBLE);
+                final Handler handler = new Handler();
+                new Thread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        handler.post(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                try {
+                                    Thread.sleep(200);
+                                } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                                }
+
+                                mPassCodeEditText.startAnimation(mAnimation);
+
+//                                clearPasscode();
+                                showErrorAndRestart(R.string.pass_code_wrong, R.string.pass_code_enter_pass_code,
+                                        View.INVISIBLE);
+
+                            }
+                        });
+
+                    }
+                }).start();
             }
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
@@ -328,12 +344,14 @@ public class PassCodeActivity extends AppCompatActivity {
 
     private void showErrorAndRestart(int errorMessage, int headerMessage,
                                      int explanationVisibility) {
-        Arrays.fill(mPassCodeDigits, null);
+        mPassCode = "";
         CharSequence errorSeq = getString(errorMessage);
         Toast.makeText(this, errorSeq, Toast.LENGTH_LONG).show();
         mPassCodeHdr.setText(headerMessage);                // TODO check if really needed
         mPassCodeHdrExplanation.setVisibility(explanationVisibility); // TODO check if really needed
-        clearBoxes();
+        TextInputLayout til = (TextInputLayout) findViewById(R.id.passcode);
+        til.setError(errorSeq);
+//        clearBoxes();
     }
 
 
@@ -357,17 +375,13 @@ public class PassCodeActivity extends AppCompatActivity {
         SharedPreferences appPrefs = PreferenceManager
             .getDefaultSharedPreferences(getApplicationContext());
 
-        String savedPassCodeDigits[] = new String[4];
-        savedPassCodeDigits[0] = appPrefs.getString(PREFERENCE_PASSCODE_D1, null);
-        savedPassCodeDigits[1] = appPrefs.getString(PREFERENCE_PASSCODE_D2, null);
-        savedPassCodeDigits[2] = appPrefs.getString(PREFERENCE_PASSCODE_D3, null);
-        savedPassCodeDigits[3] = appPrefs.getString(PREFERENCE_PASSCODE_D4, null);
+        String savedPassCode = "";
+        savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D1, null);
+        savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D2, null);
+        savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D3, null);
+        savedPassCode += appPrefs.getString(PREFERENCE_PASSCODE_D4, null);
 
-        boolean result = true;
-        for (int i = 0; i < mPassCodeDigits.length && result; i++) {
-            result = (mPassCodeDigits[i] != null) &&
-                    mPassCodeDigits[i].equals(savedPassCodeDigits[i]);
-        }
+        boolean result = mPassCode.equals(savedPassCode);
         return result;
     }
 
@@ -380,10 +394,7 @@ public class PassCodeActivity extends AppCompatActivity {
     protected boolean confirmPassCode(){
         mConfirmingPassCode = false;
 
-        boolean result = true;
-        for (int i = 0; i < mPassCodeEditTexts.length && result; i++) {
-            result = ((mPassCodeEditTexts[i].getText().toString()).equals(mPassCodeDigits[i]));
-        }
+        boolean result = mPassCode.equals(mPassCodeEditText.getText().toString());
         return result;
     }
 
@@ -391,12 +402,7 @@ public class PassCodeActivity extends AppCompatActivity {
      * Sets the input fields to empty strings and puts the focus on the first one.
      */
     protected void clearBoxes() {
-        for (int i = 0; i < mPassCodeEditTexts.length; i++) {
-            mPassCodeEditTexts[i].setText("");
-            mPassCodeEditTexts[i].setClickable(i == 0 ? true : false);
-        }
-        mPassCodeEditTexts[0].requestFocus();
-        mEditPos = 0;
+        mPassCodeEditText.setText("");
     }
 
     /**
@@ -434,78 +440,21 @@ public class PassCodeActivity extends AppCompatActivity {
      */
     protected void savePassCodeAndExit() {
         Intent resultIntent = new Intent();
-        resultIntent.putExtra(KEY_PASSCODE,
-                mPassCodeDigits[0] + mPassCodeDigits[1] + mPassCodeDigits[2] + mPassCodeDigits[3]);
-
+        resultIntent.putExtra(KEY_PASSCODE, mPassCode);
         setResult(RESULT_OK, resultIntent);
-
         finish();
     }
-
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(PassCodeActivity.KEY_CONFIRMING_PASSCODE, mConfirmingPassCode);
-        outState.putStringArray(PassCodeActivity.KEY_PASSCODE_DIGITS, mPassCodeDigits);
+        outState.putString(PassCodeActivity.KEY_PASSCODE, mPassCode);
     }
 
-    private class KeyListener implements View.OnKeyListener {
-
-        private int mIndex;
-
-        public KeyListener(int index) {
-            mIndex = index;
-        }
-        
-        @Override
-        public boolean onKey(View v, int keyCode, KeyEvent event) {
-            if (event.getAction() == KeyEvent.ACTION_DOWN &&
-                event.getRepeatCount() == 0)
-            {
-                if (KeyEvent.KEYCODE_0 <= keyCode && keyCode <= KeyEvent.KEYCODE_9) {
-                    String keyStr = String.format("%d", keyCode - KeyEvent.KEYCODE_0);
-                    mEditPos = mIndex;
-                    mPassCodeEditTexts[mIndex].setText(keyStr);
-                    if (!mConfirmingPassCode) {
-                        mPassCodeDigits[mIndex] = keyStr;
-                    }
-                    if (mIndex == 3) {
-                        new Handler().postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                processFullPassCode();
-                            }
-                        }, 3000);
-                    } else {
-                        mEditPos = mIndex + 1;
-                        mPassCodeEditTexts[mEditPos].requestFocus();
-                    }
-                }
-                else if (keyCode == KeyEvent.KEYCODE_DEL) {       // TODO WIP: event should be
-                    // used to control what's exactly happening with DEL, not any custom field...
-                    if (mIndex > 0) {
-                        mEditPos = mIndex - 1;
-                        mPassCodeEditTexts[mEditPos].setText("");
-                        mPassCodeEditTexts[mEditPos].requestFocus();
-                        if (!mConfirmingPassCode) {
-                            mPassCodeDigits[mEditPos] = "";
-                        }
-                    }
-                }
-                mBChange = false;
-
-            } else if (!mBChange) {
-                mBChange = true;
-            }
-            return false;
-        }
-    }
-
-	// TODO: delete this class
     private class PassCodeDigitTextWatcher implements TextWatcher {
 
-        private int mIndex = -1;
+        private int mIndex;
         private boolean mLastOne = false;
 
         /**
@@ -516,13 +465,9 @@ public class PassCodeActivity extends AppCompatActivity {
          * @param lastOne       'True' means that watcher corresponds to the last position of the
          *                      pass code.
          */
-        public PassCodeDigitTextWatcher(int index, boolean lastOne) {
-            mIndex = index;
+        public PassCodeDigitTextWatcher(boolean lastOne) {
+            mIndex = 0;
             mLastOne  = lastOne;
-        }
-
-        private int next() {
-            return mLastOne ? 0 : mIndex + 1;
         }
 
         /**
@@ -536,7 +481,11 @@ public class PassCodeActivity extends AppCompatActivity {
          */
         @Override
         public void afterTextChanged(Editable s) {
-            // nothing to do
+            String passcode = mPassCodeEditText.getText().toString();
+            if (passcode.length() == 4) {
+                mPassCode = passcode;
+                processFullPassCode();
+            }
         }
 
         @Override
@@ -547,34 +496,6 @@ public class PassCodeActivity extends AppCompatActivity {
         @Override
         public void onTextChanged(CharSequence s, int start, int before, int count) {
             // nothing to do
-        }
-    }
-
-	private class FocusChecker implements View.OnFocusChangeListener {
-
-        private int mIndex;
-
-        public FocusChecker(int index) {
-            mIndex = index;
-        }
-            
-        @Override
-        public void onFocusChange(View v, boolean hasFocus) {
-            Log_OC.d(TAG, String.format("Text box[%d] focus %s", mIndex, hasFocus ? "get" : "lost"));
-            if (hasFocus) {
-                mEditPos = mIndex;
-                for (int i = 0; i < mEditPos; i++) {
-                    if (mPassCodeEditTexts[i].getText().toString().equals("")) {
-                        mEditPos = i;
-                        mPassCodeEditTexts[mEditPos].requestFocus();
-                        break;
-                    }
-                }
-                for (int i = mEditPos; i < 4; i++) {
-                    mPassCodeEditTexts[i].setText("");
-                    mPassCodeEditTexts[i].setClickable(false);
-                }
-            }
         }
     }
 
@@ -589,37 +510,25 @@ public class PassCodeActivity extends AppCompatActivity {
 		public void onClick(View v) {
             if (mIndex <= 9) {
                 // 0,1,2,...,8,9
-                String keyStr = String.format("%d", mIndex);
-                Log_OC.d(TAG, String.format("Text box[%d] = %s", mEditPos, keyStr));
-                mPassCodeEditTexts[mEditPos].setText(keyStr);
-                if (!mConfirmingPassCode) {
-                    mPassCodeDigits[mEditPos] = keyStr;
-                }
-                if (mEditPos == 3) {
-                    new Handler().postDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            processFullPassCode();
-
-                        }
-                    }, 3000);
-                } else {
-                    mPassCodeEditTexts[mEditPos].setClickable(true);
-                    mEditPos++;
-                    mPassCodeEditTexts[mEditPos].requestFocus();
-                }
+                int key = KeyEvent.KEYCODE_0 + mIndex;
+                mPassCodeEditText.dispatchKeyEvent(
+                    new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, key, 0));
+                mPassCodeEditText.dispatchKeyEvent(
+                    new KeyEvent(0, 0, KeyEvent.ACTION_UP, key, 0));
             } else if (mIndex == 10) {
                 // clear
                 clearBoxes();
             } else {
                 // delete
-                if (mEditPos > 0) {
-                    mEditPos--;
-                    for (int i = mEditPos; i < 4; i++) {
-                        mPassCodeEditTexts[i].setText("");
-                        mPassCodeEditTexts[i].setClickable(false);
-                    }
-                    mPassCodeEditTexts[mEditPos].requestFocus();
+                if (false) {
+                    String passCode = mPassCodeEditText.getText().toString();
+                    passCode = passCode.substring(0, passCode.length() - 1);
+                    mPassCodeEditText.setText(passCode);
+                } else {
+                    mPassCodeEditText.dispatchKeyEvent(
+                        new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL, 0));
+                    mPassCodeEditText.dispatchKeyEvent(
+                        new KeyEvent(0, 0, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL, 0));
                 }
             }
         }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -35,6 +35,7 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
@@ -76,6 +77,21 @@ public class PassCodeActivity extends AppCompatActivity {
 
     private boolean mBChange = true; // to control that only one blocks jump
 
+    private int mButtonIDList[] = {
+        R.id.button0,
+        R.id.button1,
+        R.id.button2,
+        R.id.button3,
+        R.id.button4,
+        R.id.button5,
+        R.id.button6,
+        R.id.button7,
+        R.id.button8,
+        R.id.button9,
+        R.id.clear,
+        R.id.back,
+    };
+    private int mEditPos;
 
     /**
      * Initializes the activity.
@@ -85,6 +101,7 @@ public class PassCodeActivity extends AppCompatActivity {
      *
      * @param savedInstanceState    Previously saved state - irrelevant in this case
      */
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.passcodelock);
@@ -93,13 +110,24 @@ public class PassCodeActivity extends AppCompatActivity {
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
         mPassCodeEditTexts[0] = (EditText) findViewById(R.id.txt0);
-        mPassCodeEditTexts[0].requestFocus();
-        getWindow().setSoftInputMode(
-                android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        mPassCodeEditTexts[0].setTextIsSelectable(false);
+//        getWindow().setSoftInputMode(
+//                android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         mPassCodeEditTexts[1] = (EditText) findViewById(R.id.txt1);
+        mPassCodeEditTexts[1].setTextIsSelectable(false);
         mPassCodeEditTexts[2] = (EditText) findViewById(R.id.txt2);
+        mPassCodeEditTexts[2].setTextIsSelectable(false);
         mPassCodeEditTexts[3] = (EditText) findViewById(R.id.txt3);
+        mPassCodeEditTexts[3].setTextIsSelectable(false);
 
+        mPassCodeEditTexts[0].requestFocus();
+        mEditPos = 0;
+
+        for(int i=0;i< mButtonIDList.length; i++) {
+            Button b = (Button)findViewById(mButtonIDList[i]);
+            b.setOnClickListener(new ButtonClicked(i));
+        }
+        
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             /// this is a pass code request; the user has to input the right value
             mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
@@ -136,6 +164,8 @@ public class PassCodeActivity extends AppCompatActivity {
                     + TAG);
         }
 
+        this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+
         setTextListeners();
     }
 
@@ -152,6 +182,7 @@ public class PassCodeActivity extends AppCompatActivity {
             mBCancel.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
+//                    hideSoftKeyboard();
                     finish();
                 }
             });
@@ -170,6 +201,7 @@ public class PassCodeActivity extends AppCompatActivity {
     
          ///  First input field
         mPassCodeEditTexts[0].addTextChangedListener(new PassCodeDigitTextWatcher(0, false));
+        mPassCodeEditTexts[0].setOnFocusChangeListener(new FocusChecker(0));
 
 
         /*------------------------------------------------
@@ -196,19 +228,8 @@ public class PassCodeActivity extends AppCompatActivity {
                 return false;
             }
         });
+        mPassCodeEditTexts[1].setOnFocusChangeListener(new FocusChecker(1));
 
-        mPassCodeEditTexts[1].setOnFocusChangeListener(new View.OnFocusChangeListener() {
-
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                /// TODO WIP: should take advantage of hasFocus to reduce processing
-                if (mPassCodeEditTexts[0].getText().toString().equals("")) {  // TODO WIP validation
-                // could be done in a global way, with a single OnFocusChangeListener for all the
-                // input fields
-                    mPassCodeEditTexts[0].requestFocus();
-                }
-            }
-        });
         
         
         /*------------------------------------------------
@@ -236,17 +257,7 @@ public class PassCodeActivity extends AppCompatActivity {
             }
         });
 
-        mPassCodeEditTexts[2].setOnFocusChangeListener(new View.OnFocusChangeListener() {
-
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if (mPassCodeEditTexts[0].getText().toString().equals("")) {
-                    mPassCodeEditTexts[0].requestFocus();
-                } else if (mPassCodeEditTexts[1].getText().toString().equals("")) {
-                    mPassCodeEditTexts[1].requestFocus();
-                }
-            }
-        });
+        mPassCodeEditTexts[2].setOnFocusChangeListener(new FocusChecker(2));
 
 
         /*------------------------------------------------
@@ -273,22 +284,7 @@ public class PassCodeActivity extends AppCompatActivity {
             }
         });
 
-        mPassCodeEditTexts[3].setOnFocusChangeListener(new View.OnFocusChangeListener() {
-
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-
-                if (mPassCodeEditTexts[0].getText().toString().equals("")) {
-                    mPassCodeEditTexts[0].requestFocus();
-                } else if (mPassCodeEditTexts[1].getText().toString().equals("")) {
-                    mPassCodeEditTexts[1].requestFocus();
-                } else if (mPassCodeEditTexts[2].getText().toString().equals("")) {
-                    mPassCodeEditTexts[2].requestFocus();
-                }
-
-            }
-        });
-
+        mPassCodeEditTexts[3].setOnFocusChangeListener(new FocusChecker(3));
     } // end setTextListener
 
 
@@ -345,9 +341,7 @@ public class PassCodeActivity extends AppCompatActivity {
             InputMethodManager inputMethodManager =
                 (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
             inputMethodManager.hideSoftInputFromWindow(
-                focusedView.getWindowToken(),
-                0
-            );
+                focusedView.getWindowToken(), 0);
         }
     }
 
@@ -420,6 +414,7 @@ public class PassCodeActivity extends AppCompatActivity {
             mPassCodeEditTexts[i].setText("");
         }
         mPassCodeEditTexts[0].requestFocus();
+        mEditPos = 0;
     }
 
     /**
@@ -437,9 +432,20 @@ public class PassCodeActivity extends AppCompatActivity {
                     ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
                 finish();
             }   // else, do nothing, but report that the key was consumed to stay alive
+            else
+            {
+//                goHome();		// TODO:
+            }
             return true;
         }
         return super.onKeyDown(keyCode, event);
+    }
+
+    private void goHome() {
+        Intent homeIntent = new Intent(Intent.ACTION_MAIN);
+        homeIntent.addCategory(Intent.CATEGORY_HOME);
+        homeIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(homeIntent);
     }
 
     /**
@@ -529,4 +535,70 @@ public class PassCodeActivity extends AppCompatActivity {
 
     }
 
+	private class FocusChecker implements View.OnFocusChangeListener {
+
+        private int mIndex;
+
+        public FocusChecker(int index) {
+            mIndex = index;
+        }
+            
+        @Override
+        public void onFocusChange(View v, boolean hasFocus) {
+            if (hasFocus) {
+                int i;
+                mEditPos = mIndex;
+                for (i=0;i<mIndex;i++) {
+                    if (mPassCodeEditTexts[i].getText().toString().equals("")) {
+                        mPassCodeEditTexts[i].requestFocus();
+                        break;
+                    }
+                }
+                for(int j=i;j<4;j++) {
+                    mPassCodeEditTexts[j].setText("");
+                }
+            }
+        }
+    }
+
+    private class ButtonClicked implements OnClickListener {
+
+        private int mIndex;
+
+        public ButtonClicked(int index) {
+            mIndex = index;
+        }
+
+		public void onClick(View v) {
+
+			Button button = (Button) v;
+
+            if (mIndex < 9) {
+                String s;
+                s = String.format("%d", mIndex);
+                mPassCodeEditTexts[mEditPos].setText(s);
+                mEditPos++;
+            } else if (mIndex == 10) {
+                // clear
+                clearBoxes();
+            } else {
+                // delete
+                if (mEditPos > 0) {
+                    for (int i=mEditPos ; i < 4 ; i++) {
+                        mPassCodeEditTexts[i].setText("");
+                    }
+                    mEditPos--;
+                    mPassCodeEditTexts[mEditPos].requestFocus();
+                }
+            }
+
+            {
+                String s;
+                s = String.format("key %d", mIndex);
+                Toast toast = Toast.makeText(PassCodeActivity.this, s, Toast.LENGTH_SHORT);
+                toast.show();
+            }
+
+        }
+	}
 }

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -22,7 +22,6 @@
  */
 package com.owncloud.android.ui.activity;
 
-import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -42,13 +41,11 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
-import android.view.ViewAnimationUtils;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -242,13 +239,14 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
             "",
             "softkey..."
     };
+    private static final String mButtonFormat = "<big>%s</big><br/><font color=\"grey\"><small>%s</small></font>";
     private Integer[] mButtonsIDListShuffle = new Integer[12];
     private AppCompatButton[] mButtonsList = new AppCompatButton[12];
-    private int mButtonVisibilityPrev = 0;       // 0=unknown/1=visible/2=invisible
+    private int mButtonVisibilityPrev = 0;       // 0=startup/1=visible/2=invisible
     private boolean mSoftKeyboardMode;
     private boolean mShowButtonsWhenSoftKeyboardClose = true;
     private SoftKeyboardUtil mSoftKeyboard;
-    
+
     /**
      * Initializes the activity.
      * <p>
@@ -265,7 +263,14 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
         mPassCodeHdr = (TextView) findViewById(R.id.header);
         mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
         setupButtons();
+        setupPassCodeEditText();
+        mSoftKeyboardMode = INIT_SOFT_KEYBOARD_MODE;
+        mSoftKeyboard = new SoftKeyboardUtil(this, this);
+        if (!ENABLE_SWITCH_SOFT_KEYBOARD) {
+            mButtonsSubStr[11] = "";
+        }
 
+        boolean needKeyboardSetup = true;
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             /// this is a pass code request; the user has to input the right value
             mPassCodeHdr.setText(R.string.pass_code_enter_pass_code);
@@ -283,18 +288,26 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
                 mPassCodeHdr.setText(R.string.pass_code_configure_your_pass_code);
                 mPassCodeHdrExplanation.setVisibility(View.VISIBLE);
 
+                if (mSoftKeyboardMode) {
+                    needKeyboardSetup = false;
+                    setButtonsVisibility(false);
+                }
                 View view = findViewById(android.R.id.content);
                 Snackbar
-                        .make(view, getString(R.string.pass_code_configure_your_pass_code_explanation),
+                        .make(view, R.string.pass_code_configure_your_pass_code_explanation,
                                 Snackbar.LENGTH_LONG)
-                        .setAction("Cancel", new OnClickListener() {
+                        .setAction(R.string.common_ok, new OnClickListener() {
                             @Override
                             public void onClick(View v) {
-                                Intent resultIntent = new Intent();
-                                resultIntent.putExtra(KEY_CHECK_RESULT, true);
-                                setResult(RESULT_CANCELED, resultIntent);
-                                hideSoftKeyboard();
-                                finish();
+                                // nothing to do
+                            }
+                        })
+                        .setCallback(new Snackbar.Callback() {
+                            @Override
+                            public void onDismissed(Snackbar snackbar, int event) {
+                                if (mSoftKeyboardMode) {
+                                    setupKeyboard();
+                                }
                             }
                         })
                         .show();
@@ -316,17 +329,13 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
                     + TAG);
         }
 
-        if (!ENABLE_SWITCH_SOFT_KEYBOARD) {
-            mButtonsSubStr[11] = "";
-        }
-        setupPassCodeEditText();
-        mSoftKeyboardMode = INIT_SOFT_KEYBOARD_MODE;
-        mSoftKeyboard = new SoftKeyboardUtil(this, this);
-        setupKeyboard();
-        if (mSoftKeyboardMode) {
-            mSoftKeyboard.initVisible();
-        } else {
-            mSoftKeyboard.initHidden();
+        if (needKeyboardSetup) {
+            setupKeyboard();
+            if (mSoftKeyboardMode) {
+                mSoftKeyboard.initVisible();
+            } else {
+                mSoftKeyboard.initHidden();
+            }
         }
     }
 
@@ -357,56 +366,32 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
         }
     }
 
-    private void animeCircle(View myView, boolean visible) {
+    private void buttonAnimation(View view, boolean visible, int duration) {
+        ObjectAnimator objectAnimator;
         if (visible) {
-            int cx = (myView.getLeft() + myView.getRight()) / 2;
-            int cy = (myView.getTop() + myView.getBottom()) / 2;
-            int finalRadius = Math.max(myView.getWidth(), myView.getHeight());
-            Animator anim =
-                ViewAnimationUtils.createCircularReveal(myView, cx, cy, 0, finalRadius);
-            anim.start();
+            objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 0f, 1f);
         } else {
-            int cx = (myView.getLeft() + myView.getRight()) / 2;
-            int cy = (myView.getTop() + myView.getBottom()) / 2;
-            int initialRadius = myView.getWidth();
-            Animator anim =
-                ViewAnimationUtils.createCircularReveal(myView, cx, cy, initialRadius, 0);
-            anim.start();
+            objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 1f, 0f);
         }
+        objectAnimator.setDuration(duration);
+        objectAnimator.start();
     }
 
-    private void animeAlpha(View view, boolean visible) {
-        if (visible) {
-            ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 0f, 1f);
-            objectAnimator.setDuration(500);
-            objectAnimator.start();
-        } else {
-            ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(view, "alpha", 1f, 0f);
-            objectAnimator.setDuration(500);
-            objectAnimator.start();
-        }
-    }
-
-    private void buttonAnime(Button b, boolean visible) {
-        animeAlpha(b, visible);
-//        animeCircle(b, visible);
-    }
-    
     private void setButtonsVisibility(boolean visible) {
+        int duration = mButtonVisibilityPrev == 0 ? 0 : 500;
         if (visible && mButtonVisibilityPrev != 1) {
             mButtonVisibilityPrev = 1;
             if (ENABLE_SUFFLE_BUTTONS) {
                 List<Integer> list = Arrays.asList(mButtonsIDListShuffle);
                 Collections.shuffle(list);
-                mButtonsIDListShuffle = (Integer[]) list.toArray(new Integer[list.size()]);
+                mButtonsIDListShuffle = list.toArray(new Integer[list.size()]);
             }
             for (int i = 0; i < mButtonsList.length; i++) {
-                Button b = mButtonsList[i];
+                AppCompatButton b = mButtonsList[i];
                 int j = ENABLE_SUFFLE_BUTTONS ? mButtonsIDListShuffle[i] : i;
-                buttonAnime(b, visible);
+                buttonAnimation(b, true, duration);
                 b.setClickable(true);
-                String s = String.format("<big>%s</big><br/><font color=\"grey\"><small>%s</small></font>",
-                                         mButtonsMainStr[j], mButtonsSubStr[j]);
+                String s = String.format(mButtonFormat, mButtonsMainStr[j], mButtonsSubStr[j]);
                 b.setText(Html.fromHtml(s));
                 b.setOnClickListener(new ButtonClicked(mPassCodeEditText, j));
                 if (j == 11 && ENABLE_SWITCH_SOFT_KEYBOARD) {
@@ -423,9 +408,8 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
             }
         } else if (!visible && mButtonVisibilityPrev != 2) {
             mButtonVisibilityPrev = 2;
-            for (int i = 0; i < mButtonsList.length; i++) {
-                Button b = mButtonsList[i];
-                buttonAnime(b, visible);
+            for (AppCompatButton b: mButtonsList) {
+                buttonAnimation(b, false, duration);
                 b.setClickable(false);
                 b.setOnClickListener(null);
                 b.setLongClickable(false);
@@ -441,7 +425,7 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
      * @param enabled 'True' makes the cancel button available, 'false' hides it.
      */
     protected void setCancelButtonEnabled(boolean enabled) {
-        Button cancel = (Button) findViewById(R.id.cancel);
+        AppCompatButton cancel = (AppCompatButton) findViewById(R.id.cancel);
         if (enabled) {
             cancel.setVisibility(View.VISIBLE);
             cancel.setOnClickListener(new OnClickListener() {
@@ -592,7 +576,7 @@ public class PassCodeActivity extends AppCompatActivity implements SoftKeyboardU
             mConfirmingPassCodeFlag = false;
         }
     }
-            
+
     private void hideSoftKeyboard() {
         mShowButtonsWhenSoftKeyboardClose = false;
         mSoftKeyboard.hide();


### PR DESCRIPTION
- Implimenting new numeric buttons for input passcode.
  - Soft Keyboard is need for passcode.
    But Soft Keyboard disappear sometimes.
	Then I tried add buttons.
  - But I think now Soft Keyboard always appear.
  - New button's design is not cool.
	('2 abc','3 def',...,Clear icon,Back icon and ...)
  - Do you think that the numeric buttons are necessary?
  - You can switch Soft Keyboard when Back is longClicked

- I add guard time when passcode is not match
  - against Brute-force attack :)
  - and add small animation :)
  - Do you think that time is increase(3sec->6sec->12sec->...)?

- I tried implimenting snackbar instead of mPassCodeHdrExplanation.
  - It is simple. But too simple notification?
  - If snackbar is enought, We can delete mPassCodeHdrExplanation.
  - If snackbar is not enought, I Will delete snackbar.

- Replace four EditTexts to TextInputLayout.
  - TextInputLayout is easy to handle KEYCODE_DEL and Soft Keyboard.
  - I think Soft Keyboard is normal Soft Keyboard (like built-in soft keyboard)
    or Password input keyboard (like Keepass2Android)
  - Use TextInputLayout#setError() instead of toast()

- I add goHome() when ACTION_CHECK.equals(getIntent().getAction())
