### PR TITLE
Recognize maintenance mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ repositories {
     }
 }
 
+
 android {
     lintOptions {
         abortOnError true

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     compile name: 'touch-image-view'
     compile 'com.android.support:multidex:1.0.1'
 
-    compile 'com.github.nextcloud:android-library:1.0.15'
+    compile 'com.github.nextcloud:android-library:recognizeMaintenanceMode-SNAPSHOT'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     compile name: 'touch-image-view'
     compile 'com.android.support:multidex:1.0.1'
 
-    compile 'com.github.nextcloud:android-library:recognizeMaintenanceMode-SNAPSHOT'
+    compile 'com.github.nextcloud:android-library:1.0.16'
     compile "com.android.support:support-v4:${supportLibraryVersion}"
     compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1545,19 +1545,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         }
     }
 
-    private void updateStatusIconFailUserName(int statusText) {
-        mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = statusText;
-    }
-
     private void updateStatusIconFailUserName(int failedStatusText){
         mAuthStatusIcon = R.drawable.ic_alert;
         mAuthStatusText = failedStatusText;
-    }
-
-    private void updateFailedAuthStatusIconAndText(int failedStatusText){
-        mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = statusText;
     }
 
     private void updateServerStatusIconNoRegularAuth() {

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1454,7 +1454,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = R.string.auth_redirect_non_secure_connection_title;
                 break;
             case MAINTENANCE_MODE:
-                mServerStatusText = R.string.maintenance_mode;
+                mServerStatusText = R.string.auth_maintenance_mode;
                 break;
             default:
                 mServerStatusText = 0;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1454,7 +1454,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = R.string.auth_redirect_non_secure_connection_title;
                 break;
             case MAINTENANCE_MODE:
-                mServerStatusText = R.string.auth_maintenance_mode;
+                mServerStatusText = R.string.maintenance_mode;
                 break;
             default:
                 mServerStatusText = 0;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1545,6 +1545,10 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         }
     }
 
+    private void updateStatusIconFailUserName(int statusText) {
+        mAuthStatusIcon = R.drawable.ic_alert;
+        mAuthStatusText = statusText;
+    }
 
     private void updateStatusIconFailUserName(int failedStatusText){
         mAuthStatusIcon = R.drawable.ic_alert;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1546,9 +1546,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     }
 
 
-    private void updateFailedAuthStatusIconAndText(int failedStatusText){
+    private void updateStatusIconFailUserName(int statusText){
         mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = failedStatusText;
+        mAuthStatusText = statusText;
     }
 
     private void updateServerStatusIconNoRegularAuth() {

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1545,6 +1545,10 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         }
     }
 
+    private void updateStatusIconFailUserName(int statusText) {
+        mAuthStatusIcon = R.drawable.ic_alert;
+        mAuthStatusText = statusText;
+    }
 
     private void updateFailedAuthStatusIconAndText(int failedStatusText){
         mAuthStatusIcon = R.drawable.ic_alert;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1453,7 +1453,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = R.string.auth_redirect_non_secure_connection_title;
                 break;
             case MAINTENANCE_MODE:
-                mServerStatusText = R.string.maintenance_mode;
+                mServerStatusText = R.string.auth_maintenance_mode;
                 break;
             default:
                 mServerStatusText = 0;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1453,7 +1453,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = R.string.auth_redirect_non_secure_connection_title;
                 break;
             case MAINTENANCE_MODE:
-                mServerStatusText = R.string.auth_maintenance_mode;
+                mServerStatusText = R.string.maintenance_mode;
                 break;
             default:
                 mServerStatusText = 0;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1252,7 +1252,8 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             }
         } else {
             if (!webViewLoginMethod) {
-                updateStatusIconFailUserName();
+                int statusText = result.getCode() == ResultCode.MAINTENANCE_MODE ? R.string.maintenance_mode : R.string.auth_fail_get_user_name;
+                updateStatusIconFailUserName(statusText);
                 showAuthStatus();
             }
             Log_OC.e(TAG, "Access to user name failed: " + result.getLogMessage());
@@ -1545,9 +1546,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     }
 
 
-    private void updateStatusIconFailUserName() {
+    private void updateStatusIconFailUserName(int statusText){
         mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = R.string.auth_fail_get_user_name;
+        mAuthStatusText = statusText;
     }
 
     private void updateServerStatusIconNoRegularAuth() {

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1545,9 +1545,10 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         }
     }
 
-    private void updateStatusIconFailUserName(int statusText) {
+
+    private void updateStatusIconFailUserName(int failedStatusText){
         mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = statusText;
+        mAuthStatusText = failedStatusText;
     }
 
     private void updateFailedAuthStatusIconAndText(int failedStatusText){

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1546,9 +1546,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     }
 
 
-    private void updateStatusIconFailUserName(int statusText){
+    private void updateFailedAuthStatusIconAndText(int failedStatusText){
         mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = statusText;
+        mAuthStatusText = failedStatusText;
     }
 
     private void updateServerStatusIconNoRegularAuth() {

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1452,6 +1452,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusIcon = R.drawable.ic_lock_open_white;
                 mServerStatusText = R.string.auth_redirect_non_secure_connection_title;
                 break;
+            case MAINTENANCE_MODE:
+                mServerStatusText = R.string.maintenance_mode;
+                break;
             default:
                 mServerStatusText = 0;
                 mServerStatusIcon = 0;

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1553,7 +1553,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
     private void updateFailedAuthStatusIconAndText(int failedStatusText){
         mAuthStatusIcon = R.drawable.ic_alert;
-        mAuthStatusText = failedStatusText;
+        mAuthStatusText = statusText;
     }
 
     private void updateServerStatusIconNoRegularAuth() {

--- a/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -35,6 +35,7 @@ public enum UploadResult {
     DELAYED_FOR_WIFI(9),
     SERVICE_INTERRUPTED(10),
     DELAYED_FOR_CHARGING(11);
+    MAINTENANCE_MODE(12);
 
     private final int value;
 
@@ -74,6 +75,8 @@ public enum UploadResult {
                 return SERVICE_INTERRUPTED;
             case 11:
                 return DELAYED_FOR_CHARGING;
+            case 12:
+                return MAINTENANCE_MODE;
         }
         return null;
     }
@@ -115,6 +118,8 @@ public enum UploadResult {
                     return FILE_ERROR;
                 }
                 return UNKNOWN;
+            case MAINTENANCE_MODE:
+                return MAINTENANCE_MODE;
             default:
                 return UNKNOWN;
         }

--- a/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -36,6 +36,7 @@ public enum UploadResult {
     SERVICE_INTERRUPTED(10),
     DELAYED_FOR_CHARGING(11),
     MAINTENANCE_MODE(12);
+    MAINTENANCE_MODE(12);
 
     private final int value;
 

--- a/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -36,7 +36,6 @@ public enum UploadResult {
     SERVICE_INTERRUPTED(10),
     DELAYED_FOR_CHARGING(11),
     MAINTENANCE_MODE(12);
-    MAINTENANCE_MODE(12);
 
     private final int value;
 

--- a/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -34,7 +34,7 @@ public enum UploadResult {
     FILE_NOT_FOUND(8),
     DELAYED_FOR_WIFI(9),
     SERVICE_INTERRUPTED(10),
-    DELAYED_FOR_CHARGING(11);
+    DELAYED_FOR_CHARGING(11),
     MAINTENANCE_MODE(12);
 
     private final int value;

--- a/src/main/java/com/owncloud/android/operations/UnshareOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UnshareOperation.java
@@ -89,8 +89,8 @@ public class UnshareOperation extends SyncOperation {
 
                 getStorageManager().saveFile(file);
                 getStorageManager().removeShare(share);
-                
-            } else if (!existsFile(client, file.getRemotePath())) {
+
+            } else if (!existsFile(client, file.getRemotePath()) && result.getCode() != ResultCode.MAINTENANCE_MODE) {
                 // unshare failed because file was deleted before
                 getStorageManager().removeFile(file, true, true);
             }

--- a/src/main/java/com/owncloud/android/operations/UnshareOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UnshareOperation.java
@@ -90,7 +90,7 @@ public class UnshareOperation extends SyncOperation {
                 getStorageManager().saveFile(file);
                 getStorageManager().removeShare(share);
 
-            } else if (!existsFile(client, file.getRemotePath()) && result.getCode() != ResultCode.MAINTENANCE_MODE) {
+            } else if (result.getCode() != ResultCode.MAINTENANCE_MODE && !existsFile(client, file.getRemotePath())) {
                 // unshare failed because file was deleted before
                 getStorageManager().removeFile(file, true, true);
             }

--- a/src/main/java/com/owncloud/android/operations/UnshareOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UnshareOperation.java
@@ -90,7 +90,7 @@ public class UnshareOperation extends SyncOperation {
                 getStorageManager().saveFile(file);
                 getStorageManager().removeShare(share);
 
-            } else if (result.getCode() != ResultCode.MAINTENANCE_MODE && !existsFile(client, file.getRemotePath())) {
+            } else if (!existsFile(client, file.getRemotePath()) && result.getCode() != ResultCode.MAINTENANCE_MODE) {
                 // unshare failed because file was deleted before
                 getStorageManager().removeFile(file, true, true);
             }

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -323,6 +323,7 @@ public class UploadFileOperation extends SyncOperation {
             remoteParentPath = remoteParentPath.endsWith(OCFile.PATH_SEPARATOR) ?
                     remoteParentPath : remoteParentPath + OCFile.PATH_SEPARATOR;
             result = grantFolderExistence(remoteParentPath, client);
+
             if (!result.isSuccess()) {
 
                 return result;

--- a/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -266,15 +266,18 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
                 // the thread may die before, an exception will occur, and the message will be left on the screen
                 // until the app dies
 
-                Toast.makeText(
-                        getContext().getApplicationContext(),
-                        ErrorMessageAdapter.getErrorCauseMessage(
-                                result,
-                                null,
-                                getContext().getResources()
-                        ),
-                        Toast.LENGTH_SHORT
-                ).show();
+                // Edited: this toast message has no sense. If operation is being passed as null to getErrorCauseMessage(),
+                // the returned message is always null and therefore an empty toast is shown. Pending to review and change/delete
+
+//                Toast.makeText(
+//                        getContext().getApplicationContext(),
+//                        ErrorMessageAdapter.getErrorCauseMessage(
+//                                result,
+//                                null,
+//                                getContext().getResources()
+//                        ),
+//                        Toast.LENGTH_SHORT
+//                ).show();
             }
         });
     }

--- a/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -266,18 +266,15 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
                 // the thread may die before, an exception will occur, and the message will be left on the screen
                 // until the app dies
 
-                // Edited: this toast message has no sense. If operation is being passed as null to getErrorCauseMessage(),
-                // the returned message is always null and therefore an empty toast is shown. Pending to review and change/delete
-
-//                Toast.makeText(
-//                        getContext().getApplicationContext(),
-//                        ErrorMessageAdapter.getErrorCauseMessage(
-//                                result,
-//                                null,
-//                                getContext().getResources()
-//                        ),
-//                        Toast.LENGTH_SHORT
-//                ).show();
+                Toast.makeText(
+                        getContext().getApplicationContext(),
+                        ErrorMessageAdapter.getErrorCauseMessage(
+                                result,
+                                null,
+                                getContext().getResources()
+                        ),
+                        Toast.LENGTH_SHORT
+                ).show();
             }
         });
     }

--- a/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -265,15 +265,19 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
                 // The Toast must be shown in the main thread to grant that will be hidden correctly; otherwise
                 // the thread may die before, an exception will occur, and the message will be left on the screen
                 // until the app dies
-                Toast.makeText(
-                        getContext().getApplicationContext(),
-                        ErrorMessageAdapter.getErrorCauseMessage(
-                                result,
-                                null,
-                                getContext().getResources()
-                        ),
-                        Toast.LENGTH_SHORT
-                ).show();
+
+                // Edited: this toast message has no sense. If operation is being passed as null to getErrorCauseMessage(),
+                // the returned message is always null and therefore an empty toast is shown. Pending to review and change/delete
+
+//                Toast.makeText(
+//                        getContext().getApplicationContext(),
+//                        ErrorMessageAdapter.getErrorCauseMessage(
+//                                result,
+//                                null,
+//                                getContext().getResources()
+//                        ),
+//                        Toast.LENGTH_SHORT
+//                ).show();
             }
         });
     }

--- a/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -514,6 +514,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
      * @return              Text describing the status of the given upload.
      */
     private String getStatusText(OCUpload upload) {
+
         String status;
         switch (upload.getUploadStatus()) {
 
@@ -595,6 +596,9 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                     case UPLOADED:
                         // should not get here ; status should be UPLOAD_SUCCESS
                         status =  mParentActivity.getString(R.string.uploads_view_upload_status_succeeded);
+                        break;
+                    case MAINTENANCE_MODE:
+                        status = mParentActivity.getString(R.string.maintenance_mode);
                         break;
                     default:
                         status = "Naughty devs added a new fail result but no description for the user";

--- a/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
+++ b/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
@@ -74,6 +74,4 @@ public class NotificationUtils {
         }, delayInMillis); 
     
     }
-    
-
 }

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -191,6 +191,9 @@ public class ErrorMessageAdapter {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.share_link_forbidden_permissions));
 
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
+
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.share_link_file_error);
@@ -208,6 +211,9 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.unshare_link_forbidden_permissions));
+
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -227,6 +233,9 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.update_link_forbidden_permissions));
+
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -250,6 +259,9 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
+
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.move_file_error);
@@ -263,6 +275,9 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = String.format(res.getString(R.string.sync_current_folder_was_removed),
                             folderPathName);
+
+                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -284,6 +299,9 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.FORBIDDEN) {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.forbidden_permissions_copy));
+                
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -85,6 +85,9 @@ public class ErrorMessageAdapter {
                 } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
+                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
+
                 } else {
                     message = String.format(
                             res.getString(R.string.uploader_upload_failed_content_single),

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -85,7 +85,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {
                     message = String.format(
@@ -106,7 +106,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
                 }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                        message = res.getString(R.string.maintenance_mode);
+                        message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {
                     message = String.format(
@@ -126,7 +126,7 @@ public class ErrorMessageAdapter {
                             res.getString(R.string.forbidden_permissions_delete));
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -149,7 +149,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
@@ -172,7 +172,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
@@ -193,7 +193,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.share_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -214,7 +214,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -236,7 +236,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.update_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -261,7 +261,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -278,7 +278,7 @@ public class ErrorMessageAdapter {
                             folderPathName);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -302,7 +302,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.forbidden_permissions_copy));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -177,6 +177,7 @@ public class ErrorMessageAdapter {
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
             }
+
         } else if (operation instanceof CreateShareViaLinkOperation ||
                 operation instanceof CreateShareWithShareeOperation) {
 
@@ -190,6 +191,9 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.share_link_forbidden_permissions));
+
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -209,6 +213,9 @@ public class ErrorMessageAdapter {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
+
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.unshare_link_file_error);
@@ -227,6 +234,9 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.update_link_forbidden_permissions));
+
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -250,10 +260,14 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
+
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.move_file_error);
             }
+
         } else if (operation instanceof SynchronizeFolderOperation) {
 
             if (!result.isSuccess()) {
@@ -263,15 +277,20 @@ public class ErrorMessageAdapter {
                     message = String.format(res.getString(R.string.sync_current_folder_was_removed),
                             folderPathName);
 
+                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
+
                 } else {    // Generic error
                     // Show a Message, operation finished without success
                     message = String.format(res.getString(R.string.sync_folder_failed_content),
                             folderPathName);
                 }
             }
+
         } else if (operation instanceof CopyFileOperation) {
             if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                 message = res.getString(R.string.copy_file_not_found);
+
             } else if (result.getCode() == ResultCode.INVALID_COPY_INTO_DESCENDANT) {
                 message = res.getString(R.string.copy_file_invalid_into_descendent);
 
@@ -281,6 +300,9 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.FORBIDDEN) {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.forbidden_permissions_copy));
+                
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -106,6 +106,9 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
+                }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                        message = res.getString(R.string.maintenance_mode);
+
                 } else {
                     message = String.format(
                             res.getString(R.string.downloader_download_failed_content), new File(
@@ -122,6 +125,9 @@ public class ErrorMessageAdapter {
                     // Error --> No permissions
                     message = String.format(res.getString(R.string.forbidden_permissions),
                             res.getString(R.string.forbidden_permissions_delete));
+                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
+
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
                 }
@@ -142,6 +148,9 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
+
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
             }
@@ -161,6 +170,10 @@ public class ErrorMessageAdapter {
 
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
+
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
+
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
             }

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -125,6 +125,7 @@ public class ErrorMessageAdapter {
                     // Error --> No permissions
                     message = String.format(res.getString(R.string.forbidden_permissions),
                             res.getString(R.string.forbidden_permissions_delete));
+
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
                     message = res.getString(R.string.maintenance_mode);
 
@@ -300,7 +301,7 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.FORBIDDEN) {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.forbidden_permissions_copy));
-                
+
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
                 message = res.getString(R.string.maintenance_mode);
 

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -124,6 +124,7 @@ public class ErrorMessageAdapter {
                     // Error --> No permissions
                     message = String.format(res.getString(R.string.forbidden_permissions),
                             res.getString(R.string.forbidden_permissions_delete));
+
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
                     message = res.getString(R.string.maintenance_mode);
 
@@ -299,7 +300,7 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.FORBIDDEN) {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.forbidden_permissions_copy));
-                
+
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
                 message = res.getString(R.string.maintenance_mode);
 

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -30,7 +30,6 @@ import com.owncloud.android.operations.CreateFolderOperation;
 import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.CreateShareWithShareeOperation;
 import com.owncloud.android.operations.DownloadFileOperation;
-import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.MoveFileOperation;
 import com.owncloud.android.operations.RemoveFileOperation;
 import com.owncloud.android.operations.RenameFileOperation;

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -105,6 +105,9 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
+                }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                        message = res.getString(R.string.maintenance_mode);
+
                 } else {
                     message = String.format(
                             res.getString(R.string.downloader_download_failed_content), new File(
@@ -121,6 +124,8 @@ public class ErrorMessageAdapter {
                     // Error --> No permissions
                     message = String.format(res.getString(R.string.forbidden_permissions),
                             res.getString(R.string.forbidden_permissions_delete));
+                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -142,6 +147,9 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
+
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
             }
@@ -161,6 +169,9 @@ public class ErrorMessageAdapter {
 
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
+
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
 
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -85,7 +85,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = String.format(
@@ -106,7 +106,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
                 }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                        message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = String.format(
@@ -126,7 +126,7 @@ public class ErrorMessageAdapter {
                             res.getString(R.string.forbidden_permissions_delete));
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -149,7 +149,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
@@ -172,7 +172,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
@@ -193,7 +193,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.share_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -214,7 +214,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -236,7 +236,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.update_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -261,7 +261,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -278,7 +278,7 @@ public class ErrorMessageAdapter {
                             folderPathName);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -302,7 +302,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.forbidden_permissions_copy));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -313,9 +313,6 @@ public class ErrorMessageAdapter {
         return code == ResultCode.WRONG_CONNECTION ||
                 code == ResultCode.TIMEOUT ||
                 code == ResultCode.HOST_NOT_AVAILABLE ||
-                code == ResultCode.MAINTENANCE_MODE) {
-            return true;
-        } else
-            return false;
+                code == ResultCode.MAINTENANCE_MODE;
     }
 }

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -58,8 +58,8 @@ public class ErrorMessageAdapter {
 
         String message = null;
 
-        if (!result.isSuccess() && isNetworkError(result.getCode())) {
-            message = getErrorMessage(result, res);
+        if (!result.isSuccess() && isCommonError(result.getCode())) {
+            message = getCommonErrorMessage(result, res);
 
         } else if (operation instanceof UploadFileOperation) {
 
@@ -86,9 +86,6 @@ public class ErrorMessageAdapter {
                 } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
-
                 } else {
                     message = String.format(
                             res.getString(R.string.uploader_upload_failed_content_single),
@@ -107,9 +104,6 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
-                }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
-
                 } else {
                     message = String.format(
                             res.getString(R.string.downloader_download_failed_content), new File(
@@ -126,9 +120,6 @@ public class ErrorMessageAdapter {
                     // Error --> No permissions
                     message = String.format(res.getString(R.string.forbidden_permissions),
                             res.getString(R.string.forbidden_permissions_delete));
-
-                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -150,9 +141,6 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
             }
@@ -173,9 +161,6 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
             }
@@ -193,9 +178,6 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.share_link_forbidden_permissions));
-
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -215,9 +197,6 @@ public class ErrorMessageAdapter {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.unshare_link_file_error);
@@ -236,9 +215,6 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.update_link_forbidden_permissions));
-
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -262,9 +238,6 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.move_file_error);
@@ -278,9 +251,6 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = String.format(res.getString(R.string.sync_current_folder_was_removed),
                             folderPathName);
-
-                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -303,23 +273,16 @@ public class ErrorMessageAdapter {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.forbidden_permissions_copy));
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.copy_file_error);
-            }
-        } else if (operation instanceof GetSharesForFileOperation) {
-            if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
             }
         }
 
         return message;
     }
 
-    private static String getErrorMessage(RemoteOperationResult result, Resources res) {
+    private static String getCommonErrorMessage(RemoteOperationResult result, Resources res) {
 
         String message = null;
 
@@ -339,15 +302,21 @@ public class ErrorMessageAdapter {
 
             } else if (result.getCode() == ResultCode.HOST_NOT_AVAILABLE) {
                 message = res.getString(R.string.network_host_not_available);
+            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
             }
         }
 
         return message;
     }
 
-    private static boolean isNetworkError(RemoteOperationResult.ResultCode code) {
+    private static boolean isCommonError(RemoteOperationResult.ResultCode code) {
         return code == ResultCode.WRONG_CONNECTION ||
                 code == ResultCode.TIMEOUT ||
-                code == ResultCode.HOST_NOT_AVAILABLE;
+                code == ResultCode.HOST_NOT_AVAILABLE ||
+                code == ResultCode.MAINTENANCE_MODE) {
+            return true;
+        } else
+            return false;
     }
 }

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -86,7 +86,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {
                     message = String.format(
@@ -107,7 +107,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
                 }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                        message = res.getString(R.string.maintenance_mode);
+                        message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {
                     message = String.format(
@@ -127,7 +127,7 @@ public class ErrorMessageAdapter {
                             res.getString(R.string.forbidden_permissions_delete));
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -150,7 +150,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
@@ -173,7 +173,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
@@ -194,7 +194,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.share_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -215,7 +215,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -237,7 +237,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.update_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -262,7 +262,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -279,7 +279,7 @@ public class ErrorMessageAdapter {
                             folderPathName);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
+                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -303,7 +303,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.forbidden_permissions_copy));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
+                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
 
             } else {    // Generic error
                 // Show a Message, operation finished without success

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -31,6 +31,7 @@ import com.owncloud.android.operations.CreateFolderOperation;
 import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.CreateShareWithShareeOperation;
 import com.owncloud.android.operations.DownloadFileOperation;
+import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.MoveFileOperation;
 import com.owncloud.android.operations.RemoveFileOperation;
 import com.owncloud.android.operations.RenameFileOperation;
@@ -308,6 +309,10 @@ public class ErrorMessageAdapter {
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.copy_file_error);
+            }
+        } else if (operation instanceof GetSharesForFileOperation) {
+            if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
             }
         }
 

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -86,7 +86,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = String.format(
@@ -107,7 +107,7 @@ public class ErrorMessageAdapter {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
                 }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                        message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = String.format(
@@ -127,7 +127,7 @@ public class ErrorMessageAdapter {
                             res.getString(R.string.forbidden_permissions_delete));
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -150,7 +150,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
@@ -173,7 +173,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
@@ -194,7 +194,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.share_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -215,7 +215,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -237,7 +237,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.update_link_forbidden_permissions));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -262,7 +262,7 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -279,7 +279,7 @@ public class ErrorMessageAdapter {
                             folderPathName);
 
                 } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                    message = res.getString(R.string.maintenance_mode);
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -303,7 +303,7 @@ public class ErrorMessageAdapter {
                         res.getString(R.string.forbidden_permissions_copy));
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = String.format(res.getString(R.string.maintenance_mode), res.getString(R.string.app_name));
+                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -85,9 +85,6 @@ public class ErrorMessageAdapter {
                 } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
-
                 } else {
                     message = String.format(
                             res.getString(R.string.uploader_upload_failed_content_single),
@@ -106,9 +103,6 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = res.getString(R.string.downloader_download_file_not_found);
 
-                }  else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
-
                 } else {
                     message = String.format(
                             res.getString(R.string.downloader_download_failed_content), new File(
@@ -125,9 +119,6 @@ public class ErrorMessageAdapter {
                     // Error --> No permissions
                     message = String.format(res.getString(R.string.forbidden_permissions),
                             res.getString(R.string.forbidden_permissions_delete));
-
-                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
 
                 } else {
                     message = res.getString(R.string.remove_fail_msg);
@@ -149,9 +140,6 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {
                 message = res.getString(R.string.rename_server_fail_msg);
             }
@@ -172,9 +160,6 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {
                 message = res.getString(R.string.create_dir_fail_msg);
             }
@@ -192,9 +177,6 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.share_link_forbidden_permissions));
-
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -214,9 +196,6 @@ public class ErrorMessageAdapter {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.unshare_link_forbidden_permissions));
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.unshare_link_file_error);
@@ -235,9 +214,6 @@ public class ErrorMessageAdapter {
                 // Error --> No permissions
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.update_link_forbidden_permissions));
-
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
 
             } else {    // Generic error
                 // Show a Message, operation finished without success
@@ -261,9 +237,6 @@ public class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                 message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.move_file_error);
@@ -277,9 +250,6 @@ public class ErrorMessageAdapter {
                 if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                     message = String.format(res.getString(R.string.sync_current_folder_was_removed),
                             folderPathName);
-
-                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                    message = res.getString(R.string.maintenance_mode);
 
                 } else {    // Generic error
                     // Show a Message, operation finished without success
@@ -302,16 +272,9 @@ public class ErrorMessageAdapter {
                 message = String.format(res.getString(R.string.forbidden_permissions),
                         res.getString(R.string.forbidden_permissions_copy));
 
-            } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
-
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.copy_file_error);
-            }
-        } else if (operation instanceof GetSharesForFileOperation) {
-            if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                message = res.getString(R.string.maintenance_mode);
             }
         }
 
@@ -350,6 +313,9 @@ public class ErrorMessageAdapter {
         return code == ResultCode.WRONG_CONNECTION ||
                 code == ResultCode.TIMEOUT ||
                 code == ResultCode.HOST_NOT_AVAILABLE ||
-                code == ResultCode.MAINTENANCE_MODE;
+                code == ResultCode.MAINTENANCE_MODE) {
+            return true;
+        } else
+            return false;
     }
 }

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -84,6 +84,9 @@ public class ErrorMessageAdapter {
                 } else if (result.getCode() == ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER) {
                     message = res.getString(R.string.filename_forbidden_charaters_from_server);
 
+                } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                    message = res.getString(R.string.maintenance_mode);
+
                 } else {
                     message = String.format(
                             res.getString(R.string.uploader_upload_failed_content_single),

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -30,6 +30,7 @@ import com.owncloud.android.operations.CreateFolderOperation;
 import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.CreateShareWithShareeOperation;
 import com.owncloud.android.operations.DownloadFileOperation;
+import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.MoveFileOperation;
 import com.owncloud.android.operations.RemoveFileOperation;
 import com.owncloud.android.operations.RenameFileOperation;
@@ -307,6 +308,10 @@ public class ErrorMessageAdapter {
             } else {    // Generic error
                 // Show a Message, operation finished without success
                 message = res.getString(R.string.copy_file_error);
+            }
+        } else if (operation instanceof GetSharesForFileOperation) {
+            if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
+                message = res.getString(R.string.maintenance_mode);
             }
         }
 

--- a/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 package com.owncloud.android.utils;
 
 import android.content.res.Resources;
@@ -314,9 +313,6 @@ public class ErrorMessageAdapter {
         return code == ResultCode.WRONG_CONNECTION ||
                 code == ResultCode.TIMEOUT ||
                 code == ResultCode.HOST_NOT_AVAILABLE ||
-                code == ResultCode.MAINTENANCE_MODE) {
-            return true;
-        } else
-            return false;
+                code == ResultCode.MAINTENANCE_MODE;
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -543,7 +543,7 @@
     <string name="local_file_not_found_toast">File not found in local file system</string>
     <string name="confirmation_remove_files_alert">Do you really want to remove the selected items?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to remove the selected items and their contents?</string>
-    <string name="maintenance_mode">This ownCloud server is in maintenance mode, please try again later.</string>
+    <string name="maintenance_mode">This %1$s server is in maintenance mode, please try again later.</string>
 
     <string name="uploads_view_upload_status_waiting_for_charging">Awaiting charge</string>
     <string name="actionbar_search">Search</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -276,7 +276,6 @@
 	<string name="auth_fail_get_user_name">Your server is not returning a correct user ID, please contact an administrator</string>
 	<string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
     <string name="auth_account_does_not_exist">Account does not exist on the device yet</string>
-    <string name="auth_maintenance_mode">The server is in maintenance mode, please try again later.</string>
 
 
     <string name="favorite">Set as available offline</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -543,7 +543,7 @@
     <string name="local_file_not_found_toast">File not found in local file system</string>
     <string name="confirmation_remove_files_alert">Do you really want to remove the selected items?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to remove the selected items and their contents?</string>
-    <string name="maintenance_mode">This Owncloud instance is in maintenance mode, so it may take a while.</string>
+    <string name="maintenance_mode">This Owncloud instance is in maintenance mode, please try again later or contact your system administrator.</string>
 
     <string name="uploads_view_upload_status_waiting_for_charging">Awaiting charge</string>
     <string name="actionbar_search">Search</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
 	<string name="auth_fail_get_user_name">Your server is not returning a correct user ID, please contact an administrator</string>
 	<string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
     <string name="auth_account_does_not_exist">Account does not exist on the device yet</string>
+    <string name="auth_maintenance_mode">The server is in maintenance mode, please try again later.</string>
 
 
     <string name="favorite">Set as available offline</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -276,7 +276,6 @@
 	<string name="auth_fail_get_user_name">Your server is not returning a correct user ID, please contact an administrator</string>
 	<string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
     <string name="auth_account_does_not_exist">Account does not exist on the device yet</string>
-    <string name="auth_maintenance_mode">The server is in maintenance mode, please try again later.</string>
 
 
     <string name="favorite">Set as available offline</string>
@@ -545,7 +544,7 @@
     <string name="local_file_not_found_toast">File not found in local file system</string>
     <string name="confirmation_remove_files_alert">Do you really want to remove the selected items?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to remove the selected items and their contents?</string>
-    <string name="maintenance_mode">This %1$s server is in maintenance mode, please try again later.</string>
+    <string name="maintenance_mode">Server in maintenance mode</string>
 
     <string name="uploads_view_upload_status_waiting_for_charging">Awaiting charge</string>
     <string name="actionbar_search">Search</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -543,7 +543,7 @@
     <string name="local_file_not_found_toast">File not found in local file system</string>
     <string name="confirmation_remove_files_alert">Do you really want to remove the selected items?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to remove the selected items and their contents?</string>
-    <string name="maintenance_mode">This Owncloud instance is in maintenance mode, please try again later or contact your system administrator.</string>
+    <string name="maintenance_mode">This ownCloud server is in maintenance mode, please try again later.</string>
 
     <string name="uploads_view_upload_status_waiting_for_charging">Awaiting charge</string>
     <string name="actionbar_search">Search</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -543,6 +543,8 @@
     <string name="local_file_not_found_toast">File not found in local file system</string>
     <string name="confirmation_remove_files_alert">Do you really want to remove the selected items?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to remove the selected items and their contents?</string>
+    <string name="maintenance_mode">This Owncloud instance is in maintenance mode, so it may take a while.</string>
+
     <string name="uploads_view_upload_status_waiting_for_charging">Awaiting charge</string>
     <string name="actionbar_search">Search</string>
     <string name="files_drop_not_supported">This is a Nextcloud feature, please update.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -276,7 +276,9 @@
 	<string name="auth_fail_get_user_name">Your server is not returning a correct user ID, please contact an administrator</string>
 	<string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
     <string name="auth_account_does_not_exist">Account does not exist on the device yet</string>
-    
+    <string name="auth_maintenance_mode">The server is in maintenance mode, please try again later.</string>
+
+
     <string name="favorite">Set as available offline</string>
     <string name="unfavorite">Unset as available offline</string>
     <string name="favorite_real">Set as favorite</string>


### PR DESCRIPTION
basically a cherry pick for oC issue 1722 solution via oC 1864

Requires https://github.com/nextcloud/android-library/ v1.0.16

___
### Steps to reproduce
1. Switch Nextcloud server into maintenance mode
### Expected behaviour

The Android client should inform the user that the server currently in maintenance mode or unreachable.
### Actual behaviour

The client shows no message and displays folders as empty
### Affected software versions

All

<!--
## If you have suggestions of enhancements
--> 
### Tell us what could be improved:

Have the client display a notification when the server is unavailable (HTTP 503)

oC Testcases: https://github.com/owncloud/QA/blob/6462425acd0f7d555a8ff1a5858fee5661925ee8/Mobile/Android/Templates/Release_2.3.0/1864-maintenance_mode.md