### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
+++ b/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
@@ -104,6 +104,9 @@ public class OCFileUnitTest {
         // Read the data from the parcel
         parcel.setDataPosition(0);
         OCFile fileReadFromParcel = OCFile.CREATOR.createFromParcel(parcel);
+		if (parcel != null) {
+			parcel.recycle();
+		}
 
         // Verify that the received data are correct
         assertThat(fileReadFromParcel.getRemotePath(), is(PATH));

--- a/src/com/owncloud/android/widgets/ActionEditText.java
+++ b/src/com/owncloud/android/widgets/ActionEditText.java
@@ -139,6 +139,9 @@ public class ActionEditText extends EditText {
                 0xff0000);
         badgeClickCallback = a
                 .getString(R.styleable.ActionEditText_onBadgeClick);
+		if (a != null) {
+			a.recycle();
+		}
     }
 
 }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis