### PR TITLE
round thumbnail size to power of 2: 384 => 256

### DIFF
--- a/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -286,7 +286,8 @@ public class ThumbnailsCacheManager {
         private int getThumbnailDimension(){
             // Converts dp to pixel
             Resources r = MainApp.getAppContext().getResources();
-            return Math.round(r.getDimension(R.dimen.file_icon_size_grid));
+            Double d = Math.pow(2,Math.floor(Math.log(r.getDimension(R.dimen.file_icon_size_grid))/Math.log(2)));
+            return d.intValue();
         }
 
         private Bitmap doOCFileInBackground() {


### PR DESCRIPTION
NC11 only supports thumbnails with power of 2: 128, 256, 512.
So if a mobile wants to have 384 this will result in 512px.
This PR rounds it down to power of 2: 384 => 256 instead of 512.