### PR TITLE
Avoid toggling favourite for all selected files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -54,6 +54,7 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -546,26 +547,37 @@ public class FileOperationsHelper {
     }
 
     public void toggleFavorites(Collection<OCFile> files, boolean isFavorite){
+        List<OCFile> found = new ArrayList<>();
+        for(OCFile file : files){
+            if(file.isFavorite() == isFavorite){
+                found.add(file);
+            }
+        }
+
+        files.removeAll(found);
+
         for (OCFile file: files) {
             toggleFavorite(file, isFavorite);
         }
     }
 
     public void toggleFavorite(OCFile file, boolean isFavorite) {
-        file.setFavorite(isFavorite);
-        mFileActivity.getStorageManager().saveFile(file);
+        if (file.isFavorite() != isFavorite) {
+            file.setFavorite(isFavorite);
+            mFileActivity.getStorageManager().saveFile(file);
 
-        /// register the OCFile instance in the observer service to monitor local updates
-        Intent observedFileIntent = FileObserverService.makeObservedFileIntent(
-                mFileActivity,
-                file,
-                mFileActivity.getAccount(),
-                isFavorite);
-        mFileActivity.startService(observedFileIntent);
+            /// register the OCFile instance in the observer service to monitor local updates
+            Intent observedFileIntent = FileObserverService.makeObservedFileIntent(
+                    mFileActivity,
+                    file,
+                    mFileActivity.getAccount(),
+                    isFavorite);
+            mFileActivity.startService(observedFileIntent);
 
-        /// immediate content synchronization
-        if (file.isFavorite()) {
-            syncFile(file);
+            /// immediate content synchronization
+            if (file.isFavorite()) {
+                syncFile(file);
+            }
         }
     }
     

--- a/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -548,7 +548,7 @@ public class FileOperationsHelper {
 
     public void toggleFavorites(Collection<OCFile> files, boolean isFavorite){
         List<OCFile> alreadyRightStateList = new ArrayList<>();
-        for(OCFile file : files){
+        for(OCFile file : files) {
             if(file.isFavorite() == isFavorite) {
                 alreadyRightStateList.add(file);
             }

--- a/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -549,7 +549,7 @@ public class FileOperationsHelper {
     public void toggleFavorites(Collection<OCFile> files, boolean isFavorite){
         List<OCFile> alreadyRightStateList = new ArrayList<>();
         for(OCFile file : files){
-            if(file.isFavorite() == isFavorite){
+            if(file.isFavorite() == isFavorite) {
                 alreadyRightStateList.add(file);
             }
         }

--- a/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -547,14 +547,14 @@ public class FileOperationsHelper {
     }
 
     public void toggleFavorites(Collection<OCFile> files, boolean isFavorite){
-        List<OCFile> found = new ArrayList<>();
+        List<OCFile> alreadyRightStateList = new ArrayList<>();
         for(OCFile file : files){
             if(file.isFavorite() == isFavorite){
-                found.add(file);
+                alreadyRightStateList.add(file);
             }
         }
 
-        files.removeAll(found);
+        files.removeAll(alreadyRightStateList);
 
         for (OCFile file: files) {
             toggleFavorite(file, isFavorite);


### PR DESCRIPTION
We don't want to toggle favorite for files we know are already favorited. 
This simple change avoids this for both singular and multiple favorite
changes.

(And yes, there's some redundancy because toggleFavorite will do the required
check even if called  from toggleFavorites - but at least there are no redundant method
calls)

There are other problems in the way toggling a favorite is presented in the UI, but I'll leave
that to one of my future PRs.