### PR TITLE
PNG: remove fullscreen checkerboard background

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/res/layout/preview_image_fragment.xml
+++ b/res/layout/preview_image_fragment.xml
@@ -31,7 +31,8 @@
     android:id="@+id/top"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000">
+    android:background="#000000"
+    android:animateLayoutChanges="true">
 
     <ProgressBar
         android:id="@+id/progressWheel"
@@ -49,7 +50,8 @@
         android:layout_margin="@dimen/zero"
         android:layout_centerInParent="true"
         android:contentDescription="@string/preview_image_description"
-        android:src="@drawable/image_fail" />
+        android:src="@drawable/image_fail"
+        />
 
     <TextView
         android:id="@+id/message"

--- a/res/layout/preview_image_fragment.xml
+++ b/res/layout/preview_image_fragment.xml
@@ -31,10 +31,9 @@
     android:id="@+id/top"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000"
-    tools:context=".ui.fragment.PreviewImageFragment" >
+    android:background="#000000">
 
-    <ProgressBar 
+    <ProgressBar
         android:id="@+id/progressWheel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -45,13 +44,13 @@
 
     <third_parties.michaelOrtiz.TouchImageViewCustom
         android:id="@+id/image"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_margin="@dimen/zero"
         android:layout_centerInParent="true"
         android:contentDescription="@string/preview_image_description"
         android:src="@drawable/image_fail" />
-    
+
     <TextView
         android:id="@+id/message"
         android:layout_width="wrap_content"

--- a/res/layout/preview_image_fragment.xml
+++ b/res/layout/preview_image_fragment.xml
@@ -45,8 +45,8 @@
 
     <third_parties.michaelOrtiz.TouchImageViewCustom
         android:id="@+id/image"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_margin="@dimen/zero"
         android:layout_centerInParent="true"
         android:contentDescription="@string/preview_image_description"

--- a/src/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -463,6 +463,10 @@ public class PreviewImageActivity extends FileActivity implements
 
     }
 
+    public boolean getSystemUIVisible() {
+        return (mFullScreenAnchorView.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+    }
+
     @SuppressLint("InlinedApi")
     public void toggleFullScreen() {
 

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -150,17 +150,19 @@ public class PreviewImageFragment extends FileFragment {
         View view = inflater.inflate(R.layout.preview_image_fragment, container, false);
         mImageView = (TouchImageViewCustom) view.findViewById(R.id.image);
         mImageView.setVisibility(View.GONE);
-        mImageView.setOnClickListener(new OnClickListener() {
+
+        view.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 ((PreviewImageActivity) getActivity()).toggleFullScreen();
             }
-
         });
+
         mMessageView = (TextView)view.findViewById(R.id.message);
         mMessageView.setVisibility(View.GONE);
         mProgressWheel = (ProgressBar)view.findViewById(R.id.progressWheel);
         mProgressWheel.setVisibility(View.VISIBLE);
+
         return view;
     }
 
@@ -441,8 +443,10 @@ public class PreviewImageFragment extends FileFragment {
                             Log_OC.e(TAG, "File could not be loaded as a bitmap: " + storagePath);
                             break;
                         } else {
-                            // Rotate image, obeying exif tag.
-                            result = BitmapUtils.rotateImage(result, storagePath);
+                            if (ocFile.getFileName().endsWith("jpg") || ocFile.getFileName().endsWith("jpeg")) {
+                                // Rotate image, obeying exif tag.
+                                result = BitmapUtils.rotateImage(result, storagePath);
+                            }
                         }
 
                     } catch (OutOfMemoryError e) {
@@ -507,6 +511,7 @@ public class PreviewImageFragment extends FileFragment {
             if (imageView != null) {
                 Log_OC.d(TAG, "Showing image with resolution " + bitmap.getWidth() + "x" +
                         bitmap.getHeight());
+
 
                 if (result.ocFile.getMimetype().equalsIgnoreCase("image/png")) {
                     Drawable backrepeat = getResources().getDrawable(R.drawable.backrepeat);

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -81,7 +81,6 @@ public class PreviewImageFragment extends FileFragment {
     private TouchImageViewCustom mImageView;
     private TextView mMessageView;
     private ProgressBar mProgressWheel;
-    private RelativeLayout mRelativeLayout;
 
     public Bitmap mBitmap = null;
 
@@ -90,9 +89,6 @@ public class PreviewImageFragment extends FileFragment {
     private boolean mIgnoreFirstSavedState;
 
     private LoadBitmapTask mLoadBitmapTask = null;
-
-    private boolean weZoomedAlready;
-
 
     /**
      * Public factory method to create a new fragment that previews an image.

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -158,6 +158,13 @@ public class PreviewImageFragment extends FileFragment {
             }
         });
 
+        mImageView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ((PreviewImageActivity) getActivity()).toggleFullScreen();
+            }
+        });
+
         mMessageView = (TextView)view.findViewById(R.id.message);
         mMessageView.setVisibility(View.GONE);
         mProgressWheel = (ProgressBar)view.findViewById(R.id.progressWheel);

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -37,6 +37,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
@@ -75,6 +76,7 @@ public class PreviewImageFragment extends FileFragment {
     private TouchImageViewCustom mImageView;
     private TextView mMessageView;
     private ProgressBar mProgressWheel;
+    private RelativeLayout mRelativeLayout;
 
     public Bitmap mBitmap = null;
 
@@ -83,6 +85,8 @@ public class PreviewImageFragment extends FileFragment {
     private boolean mIgnoreFirstSavedState;
 
     private LoadBitmapTask mLoadBitmapTask = null;
+
+    private boolean weZoomedAlready;
 
 
     /**
@@ -149,7 +153,29 @@ public class PreviewImageFragment extends FileFragment {
         super.onCreateView(inflater, container, savedInstanceState);
         View view = inflater.inflate(R.layout.preview_image_fragment, container, false);
         mImageView = (TouchImageViewCustom) view.findViewById(R.id.image);
+        mRelativeLayout = (RelativeLayout) view.findViewById(R.id.top);
         mImageView.setVisibility(View.GONE);
+
+        mImageView.setOnTouchImageViewListener(new TouchImageViewCustom.OnTouchImageViewListener() {
+            @Override
+            public void onMove() {
+                if (!weZoomedAlready && mImageView.isZoomed()) {
+                    weZoomedAlready = true;
+                    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
+                            RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+                    layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+                    mImageView.setLayoutParams(layoutParams);
+                    mRelativeLayout.invalidate();
+                } else if (!mImageView.isZoomed()) {
+                    weZoomedAlready = false;
+                    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
+                            RelativeLayout.LayoutParams.WRAP_CONTENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
+                    layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+                    mImageView.setLayoutParams(layoutParams);
+                    mRelativeLayout.invalidate();
+                }
+            }
+        });
 
         view.setOnClickListener(new OnClickListener() {
             @Override

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -525,7 +525,6 @@ public class PreviewImageFragment extends FileFragment {
 
 
                 if (result.ocFile.getMimetype().equalsIgnoreCase("image/png")) {
-                    Drawable backrepeat = getResources().getDrawable(R.drawable.backrepeat);
                     Resources r = getResources();
                     Drawable[] layers = new Drawable[2];
                     layers[0] = r.getDrawable(R.drawable.backrepeat);

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -42,7 +42,6 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
@@ -154,7 +153,6 @@ public class PreviewImageFragment extends FileFragment {
         super.onCreateView(inflater, container, savedInstanceState);
         View view = inflater.inflate(R.layout.preview_image_fragment, container, false);
         mImageView = (TouchImageViewCustom) view.findViewById(R.id.image);
-        mRelativeLayout = (RelativeLayout) view.findViewById(R.id.top);
         mImageView.setVisibility(View.GONE);
 
         view.setOnClickListener(new OnClickListener() {

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -450,7 +450,7 @@ public class PreviewImageFragment extends FileFragment {
                             Log_OC.e(TAG, "File could not be loaded as a bitmap: " + storagePath);
                             break;
                         } else {
-                            if (ocFile.getFileName().endsWith("jpg") || ocFile.getFileName().endsWith("jpeg")) {
+                            if (ocFile.getFileName().endsWith(".jpg") || ocFile.getFileName().endsWith(".jpeg")) {
                                 // Rotate image, obeying exif tag.
                                 result = BitmapUtils.rotateImage(result, storagePath);
                             }

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -66,7 +66,7 @@ import third_parties.michaelOrtiz.TouchImageViewCustom;
  *
  * Trying to get an instance with a NULL {@link OCFile} will produce an
  * {@link IllegalStateException}.
- * 
+ *
  * If the {@link OCFile} passed is not downloaded, an {@link IllegalStateException} is generated on
  * instantiation too.
  */
@@ -113,13 +113,13 @@ public class PreviewImageFragment extends FileFragment {
     }
 
 
-    
+
     /**
      *  Creates an empty fragment for image previews.
-     * 
+     *
      *  MUST BE KEPT: the system uses it when tries to reinstantiate a fragment automatically
      *  (for instance, when the device is turned a aside).
-     * 
+     *
      *  DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful
      *  construction
      */
@@ -159,6 +159,7 @@ public class PreviewImageFragment extends FileFragment {
             @Override
             public void onClick(View v) {
                 ((PreviewImageActivity) getActivity()).toggleFullScreen();
+                toggleImageBackground();
             }
         });
 
@@ -166,6 +167,7 @@ public class PreviewImageFragment extends FileFragment {
             @Override
             public void onClick(View v) {
                 ((PreviewImageActivity) getActivity()).toggleFullScreen();
+                toggleImageBackground();
             }
         });
 
@@ -376,7 +378,7 @@ public class PreviewImageFragment extends FileFragment {
         finish();
     }
 
-    
+
     private class LoadBitmapTask extends AsyncTask<OCFile, Void, LoadImage> {
 
         /**
@@ -398,7 +400,7 @@ public class PreviewImageFragment extends FileFragment {
 
         /**
          * Weak reference to the target {@link ProgressBar} shown while the load is in progress.
-         * 
+         *
          * Using a weak reference will avoid memory leaks if the target ImageView is retired from
          * memory before the load finishes.
          */
@@ -525,18 +527,21 @@ public class PreviewImageFragment extends FileFragment {
 
 
                 if (result.ocFile.getMimetype().equalsIgnoreCase("image/png")) {
-                    Resources r = getResources();
-                    Drawable[] layers = new Drawable[2];
-                    layers[0] = r.getDrawable(R.drawable.backrepeat);
-                    Drawable d = new BitmapDrawable(getResources(), bitmap);
-                    layers[1] = d;
-                    LayerDrawable layerDrawable = new LayerDrawable(layers);
-                    layerDrawable.setLayerHeight(0, (int) convertDpToPixel(bitmap.getHeight(), getActivity()));
-                    layerDrawable.setLayerHeight(1, (int) convertDpToPixel(bitmap.getHeight(), getActivity()));
-                    layerDrawable.setLayerWidth(0, (int) convertDpToPixel(bitmap.getWidth(), getActivity()));
-                    layerDrawable.setLayerWidth(1, (int) convertDpToPixel(bitmap.getWidth(), getActivity()));
-                    imageView.setImageDrawable(layerDrawable);
-
+                    if (getResources() != null) {
+                        Resources r = getResources();
+                        Drawable[] layers = new Drawable[2];
+                        layers[0] = r.getDrawable(R.color.white);
+                        Drawable bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
+                        layers[1] = bitmapDrawable;
+                        LayerDrawable layerDrawable = new LayerDrawable(layers);
+                        layerDrawable.setLayerHeight(0, (int) convertDpToPixel(bitmap.getHeight(), getActivity()));
+                        layerDrawable.setLayerHeight(1, (int) convertDpToPixel(bitmap.getHeight(), getActivity()));
+                        layerDrawable.setLayerWidth(0, (int) convertDpToPixel(bitmap.getWidth(), getActivity()));
+                        layerDrawable.setLayerWidth(1, (int) convertDpToPixel(bitmap.getWidth(), getActivity()));
+                        imageView.setImageDrawable(layerDrawable);
+                    } else {
+                        imageView.setImageBitmap(bitmap);
+                    }
                 }
 
                 if (result.ocFile.getMimetype().equalsIgnoreCase("image/gif")) {
@@ -581,7 +586,7 @@ public class PreviewImageFragment extends FileFragment {
     /**
      * Helper method to test if an {@link OCFile} can be passed to a {@link PreviewImageFragment}
      * to be previewed.
-     * 
+     *
      * @param file      File to test if can be previewed.
      * @return          'True' if the file can be handled by the fragment.
      */
@@ -597,6 +602,30 @@ public class PreviewImageFragment extends FileFragment {
         Activity container = getActivity();
         container.finish();
     }
+
+    private void toggleImageBackground() {
+        if (getFile() != null && getFile().getMimetype().equalsIgnoreCase("image/png")) {
+            if (getActivity() != null && (getActivity() instanceof PreviewImageActivity)) {
+                PreviewImageActivity previewImageActivity = (PreviewImageActivity) getActivity();
+                if (getResources() != null) {
+                    LayerDrawable layerDrawable = (LayerDrawable)mImageView.getDrawable();
+                    Drawable layerOne;
+
+                    if (previewImageActivity.getSystemUIVisible()) {
+                        layerOne = getResources().getDrawable(R.color.white);
+                    } else {
+                        layerOne = getResources().getDrawable(R.drawable.backrepeat);
+                    }
+
+                    layerDrawable.setDrawableByLayerId(layerDrawable.getId(0), layerOne);
+
+                    mImageView.setImageDrawable(layerDrawable);
+                }
+            }
+        }
+    }
+
+
 
     private static float convertDpToPixel(float dp, Context context){
         Resources resources = context.getResources();

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -300,39 +300,39 @@ public class PreviewImageFragment extends FileFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.action_share_file: {
+            case R.id.action_share_file:
                 mContainerActivity.getFileOperationsHelper().showShareFile(getFile());
                 return true;
-            }
-            case R.id.action_open_file_with: {
+            
+            case R.id.action_open_file_with:
                 openFile();
                 return true;
-            }
-            case R.id.action_remove_file: {
+
+            case R.id.action_remove_file:
                 RemoveFilesDialogFragment dialog = RemoveFilesDialogFragment.newInstance(getFile());
                 dialog.show(getFragmentManager(), ConfirmationDialogFragment.FTAG_CONFIRMATION);
                 return true;
-            }
-            case R.id.action_see_details: {
+
+            case R.id.action_see_details:
                 seeDetails();
                 return true;
-            }
-            case R.id.action_send_file: {
+
+            case R.id.action_send_file:
                 mContainerActivity.getFileOperationsHelper().sendDownloadedFile(getFile());
                 return true;
-            }
-            case R.id.action_sync_file: {
+
+            case R.id.action_sync_file:
                 mContainerActivity.getFileOperationsHelper().syncFile(getFile());
                 return true;
-            }
-            case R.id.action_favorite_file: {
+
+            case R.id.action_favorite_file:
                 mContainerActivity.getFileOperationsHelper().toggleFavorite(getFile(), true);
                 return true;
-            }
-            case R.id.action_unfavorite_file: {
+
+            case R.id.action_unfavorite_file:
                 mContainerActivity.getFileOperationsHelper().toggleFavorite(getFile(), false);
                 return true;
-            }
+
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -1,21 +1,20 @@
 /**
- *   ownCloud Android client application
+ * ownCloud Android client application
  *
- *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
- *
- *   This program is free software: you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License version 2,
- *   as published by the Free Software Foundation.
- *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * @author David A. Velasco
+ * Copyright (C) 2015 ownCloud Inc.
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package com.owncloud.android.ui.preview;
 
@@ -103,7 +102,7 @@ public class PreviewImageFragment extends FileFragment {
      *                                  {@link FragmentStatePagerAdapter}
      *                                  ; TODO better solution
      */
-    public static PreviewImageFragment newInstance(OCFile imageFile, boolean ignoreFirstSavedState){
+    public static PreviewImageFragment newInstance(OCFile imageFile, boolean ignoreFirstSavedState) {
         PreviewImageFragment frag = new PreviewImageFragment();
         Bundle args = new Bundle();
         args.putParcelable(ARG_FILE, imageFile);
@@ -111,7 +110,6 @@ public class PreviewImageFragment extends FileFragment {
         frag.setArguments(args);
         return frag;
     }
-
 
 
     /**
@@ -135,9 +133,9 @@ public class PreviewImageFragment extends FileFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Bundle args = getArguments();
-        setFile((OCFile)args.getParcelable(ARG_FILE));
-            // TODO better in super, but needs to check ALL the class extending FileFragment;
-            // not right now
+        setFile((OCFile) args.getParcelable(ARG_FILE));
+        // TODO better in super, but needs to check ALL the class extending FileFragment;
+        // not right now
 
         mIgnoreFirstSavedState = args.getBoolean(ARG_IGNORE_FIRST);
         setHasOptionsMenu(true);
@@ -171,9 +169,9 @@ public class PreviewImageFragment extends FileFragment {
             }
         });
 
-        mMessageView = (TextView)view.findViewById(R.id.message);
+        mMessageView = (TextView) view.findViewById(R.id.message);
         mMessageView.setVisibility(View.GONE);
-        mProgressWheel = (ProgressBar)view.findViewById(R.id.progressWheel);
+        mProgressWheel = (ProgressBar) view.findViewById(R.id.progressWheel);
         mProgressWheel.setVisibility(View.VISIBLE);
 
         return view;
@@ -255,10 +253,10 @@ public class PreviewImageFragment extends FileFragment {
             setFile(mContainerActivity.getStorageManager().getFileById(getFile().getFileId()));
 
             FileMenuFilter mf = new FileMenuFilter(
-                getFile(),
-                mContainerActivity.getStorageManager().getAccount(),
-                mContainerActivity,
-                getActivity()
+                    getFile(),
+                    mContainerActivity.getStorageManager().getAccount(),
+                    mContainerActivity,
+                    getActivity()
             );
             mf.filter(menu);
         }
@@ -327,11 +325,11 @@ public class PreviewImageFragment extends FileFragment {
                 mContainerActivity.getFileOperationsHelper().syncFile(getFile());
                 return true;
             }
-            case R.id.action_favorite_file:{
+            case R.id.action_favorite_file: {
                 mContainerActivity.getFileOperationsHelper().toggleFavorite(getFile(), true);
                 return true;
             }
-            case R.id.action_unfavorite_file:{
+            case R.id.action_unfavorite_file: {
                 mContainerActivity.getFileOperationsHelper().toggleFavorite(getFile(), false);
                 return true;
             }
@@ -362,9 +360,9 @@ public class PreviewImageFragment extends FileFragment {
         if (mBitmap != null) {
             mBitmap.recycle();
             System.gc();
-                // putting this in onStop() is just the same; the fragment is always destroyed by
-                // {@link FragmentStatePagerAdapter} when the fragment in swiped further than the
-                // valid offscreen distance, and onStop() is never called before than that
+            // putting this in onStop() is just the same; the fragment is always destroyed by
+            // {@link FragmentStatePagerAdapter} when the fragment in swiped further than the
+            // valid offscreen distance, and onStop() is never called before than that
         }
         super.onDestroy();
     }
@@ -507,11 +505,10 @@ public class PreviewImageFragment extends FileFragment {
             hideProgressWheel();
             if (result.bitmap != null) {
                 showLoadedImage(result);
-            }
-            else {
+            } else {
                 showErrorMessage();
             }
-            if (result.bitmap != null && mBitmap != result.bitmap)  {
+            if (result.bitmap != null && mBitmap != result.bitmap) {
                 // unused bitmap, release it! (just in case)
                 result.bitmap.recycle();
             }
@@ -546,12 +543,12 @@ public class PreviewImageFragment extends FileFragment {
 
                 if (result.ocFile.getMimetype().equalsIgnoreCase("image/gif")) {
                     imageView.setGIFImageFromStoragePath(result.ocFile.getStoragePath());
-                } else if (!result.ocFile.getMimetype().equalsIgnoreCase("image/png")){
+                } else if (!result.ocFile.getMimetype().equalsIgnoreCase("image/png")) {
                     imageView.setImageBitmap(bitmap);
                 }
 
                 imageView.setVisibility(View.VISIBLE);
-                mBitmap  = bitmap;  // needs to be kept for recycling when not useful
+                mBitmap = bitmap;  // needs to be kept for recycling when not useful
             }
 
             final TextView messageView = mMessageViewRef.get();
@@ -604,33 +601,29 @@ public class PreviewImageFragment extends FileFragment {
     }
 
     private void toggleImageBackground() {
-        if (getFile() != null && getFile().getMimetype().equalsIgnoreCase("image/png")) {
-            if (getActivity() != null && (getActivity() instanceof PreviewImageActivity)) {
-                PreviewImageActivity previewImageActivity = (PreviewImageActivity) getActivity();
-                if (getResources() != null) {
-                    LayerDrawable layerDrawable = (LayerDrawable)mImageView.getDrawable();
-                    Drawable layerOne;
+        if (getFile() != null && getFile().getMimetype().equalsIgnoreCase("image/png") && getActivity() != null
+                && getActivity() instanceof PreviewImageActivity && getResources() != null) {
+            PreviewImageActivity previewImageActivity = (PreviewImageActivity) getActivity();
+            LayerDrawable layerDrawable = (LayerDrawable) mImageView.getDrawable();
+            Drawable layerOne;
 
-                    if (previewImageActivity.getSystemUIVisible()) {
-                        layerOne = getResources().getDrawable(R.color.white);
-                    } else {
-                        layerOne = getResources().getDrawable(R.drawable.backrepeat);
-                    }
-
-                    layerDrawable.setDrawableByLayerId(layerDrawable.getId(0), layerOne);
-
-                    mImageView.setImageDrawable(layerDrawable);
-                }
+            if (previewImageActivity.getSystemUIVisible()) {
+                layerOne = getResources().getDrawable(R.color.white);
+            } else {
+                layerOne = getResources().getDrawable(R.drawable.backrepeat);
             }
+
+            layerDrawable.setDrawableByLayerId(layerDrawable.getId(0), layerOne);
+
+            mImageView.setImageDrawable(layerDrawable);
         }
     }
 
 
-
-    private static float convertDpToPixel(float dp, Context context){
+    private static float convertDpToPixel(float dp, Context context) {
         Resources resources = context.getResources();
         DisplayMetrics metrics = resources.getDisplayMetrics();
-        float px = dp * ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+        float px = dp * ((float) metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
         return px;
     }
 
@@ -643,7 +636,7 @@ public class PreviewImageFragment extends FileFragment {
         private Bitmap bitmap;
         private OCFile ocFile;
 
-        public LoadImage(Bitmap bitmap, OCFile ocFile){
+        public LoadImage(Bitmap bitmap, OCFile ocFile) {
             this.bitmap = bitmap;
             this.ocFile = ocFile;
         }

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -531,10 +531,10 @@ public class PreviewImageFragment extends FileFragment {
                         Drawable bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
                         layers[1] = bitmapDrawable;
                         LayerDrawable layerDrawable = new LayerDrawable(layers);
-                        layerDrawable.setLayerHeight(0, (int) convertDpToPixel(bitmap.getHeight(), getActivity()));
-                        layerDrawable.setLayerHeight(1, (int) convertDpToPixel(bitmap.getHeight(), getActivity()));
-                        layerDrawable.setLayerWidth(0, (int) convertDpToPixel(bitmap.getWidth(), getActivity()));
-                        layerDrawable.setLayerWidth(1, (int) convertDpToPixel(bitmap.getWidth(), getActivity()));
+                        layerDrawable.setLayerHeight(0, convertDpToPixel(bitmap.getHeight(), getActivity()));
+                        layerDrawable.setLayerHeight(1, convertDpToPixel(bitmap.getHeight(), getActivity()));
+                        layerDrawable.setLayerWidth(0, convertDpToPixel(bitmap.getWidth(), getActivity()));
+                        layerDrawable.setLayerWidth(1, convertDpToPixel(bitmap.getWidth(), getActivity()));
                         imageView.setImageDrawable(layerDrawable);
                     } else {
                         imageView.setImageBitmap(bitmap);
@@ -620,10 +620,10 @@ public class PreviewImageFragment extends FileFragment {
     }
 
 
-    private static float convertDpToPixel(float dp, Context context) {
+    private static int convertDpToPixel(float dp, Context context) {
         Resources resources = context.getResources();
         DisplayMetrics metrics = resources.getDisplayMetrics();
-        float px = dp * ((float) metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+        int px = (int) (dp * ((float) metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT));
         return px;
     }
 

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -616,6 +616,7 @@ public class PreviewImageFragment extends FileFragment {
             layerDrawable.setDrawableByLayerId(layerDrawable.getId(0), layerOne);
 
             mImageView.setImageDrawable(layerDrawable);
+            mImageView.invalidate();
         }
     }
 

--- a/src/third_parties/michaelOrtiz/TouchImageViewCustom.java
+++ b/src/third_parties/michaelOrtiz/TouchImageViewCustom.java
@@ -10,8 +10,6 @@
 
 package third_parties.michaelOrtiz;
 
-import com.owncloud.android.ui.preview.ImageViewCustom;
-
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -36,6 +34,8 @@ import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.widget.OverScroller;
 import android.widget.Scroller;
+
+import com.owncloud.android.ui.preview.ImageViewCustom;
 
 /**
  * Extends Android ImageView to include pinch zooming, panning, fling and double tap zoom.


### PR DESCRIPTION
This PR fixes issue #456, and in addition, fixes a bug where we tried to fetch EXIF tags for PNG files that don't really have them.

I now toggle full screen on view click as well, because some images are too small and people might be having trouble clicking on them.
