### PR TITLE
Integration of pullapprove

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,3 +1,0 @@
-pattern = "(?i):shipit:|:\\+1:|LGTM"
-self_approval_off=true
-approvals = 1

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -40,4 +40,4 @@ groups:
     required: 1
     users:
       - jancborchardt 
-      - eppfel 
+      - eppfel

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,43 @@
+version: 2
+
+# General settings to apply
+always_pending:
+  title_regex: '(WIP|wip)'
+  labels:
+    - 1. to develop
+    - 2. developing
+  # custom message that will be used for the GitHub status
+  explanation: 'This PR is a work in progress...'
+
+# Group settings to apply to all groups by default, optionally being overridden later
+group_defaults:
+  author_approval:
+    ignored: true
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(Approved|:shipit:|:\+1:|LGTM)'
+    reject_regex: '^(Rejected|:-1:)'
+  reset_on_push:
+    enabled: true
+  reset_on_reopened:
+    enabled: true
+
+groups:
+  code-review:
+    required: 2
+    users:
+      - AndyScherzinger
+      - tobiasKaminsky
+      - mario
+      - przybylski 
+
+  design-review:
+    conditions:
+      labels:
+      - design
+    reset_on_push:
+      enabled: false
+    required: 1
+    users:
+      - jancborchardt 
+      - eppfel 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,0 @@
-AndyScherzinger
-przybylski
-tobiasKaminsky
-LukasReschke
-jancborchardt
-MorrisJobke


### PR DESCRIPTION
This is the PR for integration https://pullapprove.com

It demands:
* Any PR to be reviewed by at least 2 devs
* Any PR labeled with design to be reviewed by at least 1 designer (Jan, Felix)
* Approval can be approved via commenting: :shipit:, 👍, Approved or LGTM
* Pushes to the PR resets the review process for the code review
* Reopening of a PR resets the review process
* Authors can't approve their own PR