### PR TITLE
Fix for #448. Rotation change in FolderPicker caused app crash.

### DIFF
--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -120,6 +120,7 @@ public class OCFileListFragment extends ExtendedListFragment {
         mSystemBarColor = getResources().getColor(R.color.primary_dark);
         mProgressBarActionModeColor = getResources().getColor(R.color.action_mode_background);
         mProgressBarColor = getResources().getColor(R.color.primary);
+        mMultiChoiceModeListener = new MultiChoiceModeListener();
     }
 
     /**
@@ -529,7 +530,6 @@ public class OCFileListFragment extends ExtendedListFragment {
      */
     private void setChoiceModeAsMultipleModal(Bundle savedInstanceState) {
         setChoiceMode(ListView.CHOICE_MODE_MULTIPLE_MODAL);
-        mMultiChoiceModeListener = new MultiChoiceModeListener();
         if (savedInstanceState != null) {
             mMultiChoiceModeListener.loadStateFrom(savedInstanceState);
         }


### PR DESCRIPTION
The <tt>onSaveInstanceState</tt> method may be called right after <tt>onCreate</tt>, before <tt>onCreateView</tt> is called. This caused a npe, since the <tt>mMultiChoiceModeListener</tt> was not yet initialized. 