### PR TITLE
Nightly only: remove gcm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     compile 'com.getbase:floatingactionbutton:1.10.1'
     compile 'com.google.code.findbugs:annotations:2.0.1'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile 'com.google.android.gms:play-services:10.2.0'
     compile 'com.github.evernote:android-job:v1.1.7'
 
     /// dependencies for local unit tests

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="file_list_empty_headline_search">No results in this folder</string>
     <string name="file_list_empty_search">Try looking in another folder?</string>
     <string name="upload_list_empty_headline">No uploads available</string>
-    <string name="upload_list_empty_text">Upload some content or activate instant upload!\nPlease note that currently all pending uploads are removed on reboot!</string>
+    <string name="upload_list_empty_text">Upload some content or activate instant upload!\nPlease note that currently on nightly all pending uploads are removed on reboot!</string>
     <string name="file_list_folder">folder</string>
     <string name="file_list_folders">folders</string>
     <string name="file_list_file">file</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="file_list_empty_headline_search">No results in this folder</string>
     <string name="file_list_empty_search">Try looking in another folder?</string>
     <string name="upload_list_empty_headline">No uploads available</string>
-    <string name="upload_list_empty_text">Upload some content or activate instant upload!</string>
+    <string name="upload_list_empty_text">Upload some content or activate instant upload!\nPlease note that currently all pending uploads are removed on reboot!</string>
     <string name="file_list_folder">folder</string>
     <string name="file_list_folders">folders</string>
     <string name="file_list_file">file</string>

--- a/src/com/owncloud/android/services/ShutdownReceiver.java
+++ b/src/com/owncloud/android/services/ShutdownReceiver.java
@@ -24,6 +24,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.evernote.android.job.JobManager;
 import com.owncloud.android.MainApp;
 
 /**
@@ -35,6 +36,9 @@ public class ShutdownReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, final Intent intent) {
         if (MainApp.getSyncedFolderObserverService() != null) {
             MainApp.getSyncedFolderObserverService().onDestroy();
+
+            // as without GCM pending uploads are uploaded more than once try to cancel them
+            JobManager.instance().cancelAll();
         }
     }
 }


### PR DESCRIPTION
To get nightly working again on fdroid, I have removed GCM and all pending uploads will be deleted on reboot.
