### PR TITLE
Upload: count uploads

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -90,6 +90,10 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             return name;
         }
 
+        public int getGroupItemCount() {
+            return items == null ? 0 : items.length;
+        }
+
         public Comparator<OCUpload> comparator = new Comparator<OCUpload>() {
 
             @Override
@@ -702,7 +706,8 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             convertView = inflaInflater.inflate(R.layout.upload_list_group, null);
         }
         TextView tv = (TextView) convertView.findViewById(R.id.uploadListGroupName);
-        tv.setText(group.getGroupName());
+        tv.setText(String.format(mParentActivity.getString(R.string.uploads_view_group_header),
+                group.getGroupName(), group.getGroupItemCount()));
         return convertView;
     }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="uploads_view_upload_status_unknown_fail">Unknown error</string>
     <string name="uploads_view_upload_status_waiting_for_wifi">Waiting for wifi connectivity</string>
     <string name="uploads_view_later_waiting_to_upload">Waiting to upload</string>
+    <string name="uploads_view_group_header" translatable="false">%1$s (%2$d)</string>
     <string name="downloader_download_in_progress_ticker">Downloading &#8230;</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>
     <string name="downloader_download_succeeded_ticker">Download succeeded</string>


### PR DESCRIPTION
original issue for item count in upload list group header is oC/1692 by @tobiasKaminsky  

> For pending, failed, etc. there should be the count shown: failed (5)

![device-2017-04-17-192215](https://cloud.githubusercontent.com/assets/1315170/25097225/ea6ad728-23a3-11e7-9d6e-9e90e23b28a8.png)

cc @mario 

