### PR TITLE
prevent NPE if trying to store grid preference for favorites/shared

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1199,9 +1199,12 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                 GRID_IS_PREFERED_PREFERENCE, Context.MODE_PRIVATE
         );
 
-        SharedPreferences.Editor editor = setting.edit();
-        editor.putBoolean(String.valueOf(mFile.getFileId()), setGrid);
-        editor.apply();
+        // can be in case of favorites, shared
+        if (mFile != null) {
+            SharedPreferences.Editor editor = setting.edit();
+            editor.putBoolean(String.valueOf(mFile.getFileId()), setGrid);
+            editor.apply();
+        }
     }
 
     private void unsetAllMenuItems(final boolean unsetDrawer) {


### PR DESCRIPTION
If in favorites/shared and "switch to grid" it crashes as it tries to store preference for this mFile.
Instead now do nothing.

To think of, if we want to store the preference for these searches...?