### PR TITLE
propose instant image/video upload make use of file's last modified time

### DIFF
--- a/src/main/java/com/owncloud/android/files/InstantUploadBroadcastReceiver.java
+++ b/src/main/java/com/owncloud/android/files/InstantUploadBroadcastReceiver.java
@@ -87,7 +87,9 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         String file_path = null;
         String file_name = null;
         String mime_type = null;
-        long date_taken = 0;
+        // comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
+        //long date_taken = 0; // deprecated by Angus on 20170425
+        long date_modified = 0; // created by Angus on 20170425 // date_modified as variable identifier is more appropriate
 
         Log_OC.i(TAG, "New photo received");
 
@@ -121,7 +123,11 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         file_path = c.getString(c.getColumnIndex(Images.Media.DATA));
         file_name = c.getString(c.getColumnIndex(Images.Media.DISPLAY_NAME));
         mime_type = c.getString(c.getColumnIndex(Images.Media.MIME_TYPE));
-        date_taken = System.currentTimeMillis();
+        // comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
+        //date_taken = System.currentTimeMillis(); // deprecated by Angus on 20170425 // date_taken != system current time as of triggering upload
+        date_modified = c.getLong(c.getColumnIndex(Images.Media.DATE_MODIFIED)) * 1000; // created by Angus on 20170425 // date_modified as variable identifier is more appropriate // Images.Media.DATE_MODIFIED is in second, hence should be converted to millisecond by * 1000
+        // there are other viable options of constants (e.g. DATE_MODIFIED, DATE_TAKEN or DATE_ADDED) seemingly better suiting the attribute in terms of "file's datetime timestamp" than using System.currentTimeMillis()
+        
         c.close();
 
         if (file_path.equals(lastUploadedPhotoPath)) {
@@ -145,7 +151,9 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
                 context,
                 account,
                 file_path,
-                FileStorageUtils.getInstantUploadFilePath(uploadPath, file_name, date_taken, subfolderByDate),
+                // comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
+                //FileStorageUtils.getInstantUploadFilePath(uploadPath, file_name, date_taken, subfolderByDate),
+                FileStorageUtils.getInstantUploadFilePath(uploadPath, file_name, date_modified, subfolderByDate), // edited by Angus on 20170425
                 behaviour,
                 mime_type,
                 true,           // create parent folder if not existent
@@ -175,7 +183,9 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         String file_path = null;
         String file_name = null;
         String mime_type = null;
-        long date_taken = 0;
+        // comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
+        //long date_taken = 0; // deprecated by Angus on 20170425
+        long date_modified = 0; // created by Angus on 20170425 // date_modified as variable identifier is more appropriate
 
         Log_OC.i(TAG, "New video received");
 
@@ -200,8 +210,12 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         file_path = c.getString(c.getColumnIndex(Video.Media.DATA));
         file_name = c.getString(c.getColumnIndex(Video.Media.DISPLAY_NAME));
         mime_type = c.getString(c.getColumnIndex(Video.Media.MIME_TYPE));
+        date_modified = c.getLong(c.getColumnIndex(Video.Media.DATE_MODIFIED)) * 1000; // created by Angus on 20170425 // date_modified as variable identifier is more appropriate // Images.Media.DATE_MODIFIED is in second, hence should be converted to millisecond by * 1000
+        // there are other viable options of constants (e.g. DATE_MODIFIED, DATE_TAKEN or DATE_ADDED) seemingly better suiting the attribute in terms of "file's datetime timestamp" than using System.currentTimeMillis()
+        
         c.close();
-        date_taken = System.currentTimeMillis();
+        // comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
+        //date_taken = System.currentTimeMillis(); // deprecated by Angus on 20170425 // date_taken != system current time as of triggering upload
         Log_OC.d(TAG, file_path + "");
 
         int behaviour = getUploadBehaviour(context);
@@ -210,7 +224,9 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
                 context,
                 account,
                 file_path,
-                FileStorageUtils.getInstantVideoUploadFilePath(context, file_name, date_taken),
+                // comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
+                //FileStorageUtils.getInstantVideoUploadFilePath(context, file_name, date_taken),
+                FileStorageUtils.getInstantVideoUploadFilePath(context, file_name, date_modified), // edited by Angus on 20170425
                 behaviour,
                 mime_type,
                 true,           // create parent folder if not existent


### PR DESCRIPTION
Propose instant image/video upload make use of file's last modified time rather than datetime as of upload trigger

Summary:
the changes is to respect and retain an image/video file's last modified time (i.e. mtime) of itself.

Description:
Uses of System.currentTimeMillis() as of upload triggered are not guaranteeing the truth of last modification datetime about users' uploaded data.

Uses of Media.DATE_MODIFIED are seemingly more appropriate for the usage.

==========
For example:
Consider that 
1. USER_A captured a screenshot at 2017-04-25 1800HKT, a photo at 2017-04-25 1900HKT, a video at 2017-04-25 2000HKT
2. USER_A then connected the android phone to a stable WiFi network at 2017-04-26 1200HKT, which enables Nextcloud android app to trigger those pending auto-upload/backup jobs

==========
Currently unexpected result:
USER_A will be told by Nextcloud that the uploaded files are all last modified on/at 2017-04-26 1200HKT

==========
Expected result:
Nextcloud should tell users an exact truth about last modification time of an uploaded file.

e.g.:
USER_A should be told by Nextcloud that the uploaded screenshot is last modified on/at 2017-04-25 1800HKT, the uploaded photo is last modified on/at 2017-04-25 1900HKT, the uploaded video is last modified on/at 2017-04-25 2000HKT.

==========
Other discussions:
1. comments are polluting the clean code but I temporarily write down comments to explain my changes for sack of facilitating others to review my changes. pls remove it after reviews if feeling uncomfortable.
2. File Upload Datetime Timestamp is also considerably important information for users to get an understanding about their uploaded file when users revisit their files. For file_upload_datetime_timestamp, uses of System.currentTimeMillis() (as of file upload trigger/completion at client/server) would be suitable to the usage. Should it be considered to be implemented in a planned future? Besides, considered that, file upload is async task, where a progress of file upload could be taking a lengthly upload duration, say probably an hour long for big video file over a slow network, take file upload completion timestamp at server as reference for file_upload_datetime_timestamp may be considerably more logical to usage? I think that could be discussed.


Thanks for your attentions!