### PR TITLE
AutoUpload: default to "keep file in original folder"

### DIFF
--- a/src/main/java/com/owncloud/android/services/AutoUploadJob.java
+++ b/src/main/java/com/owncloud/android/services/AutoUploadJob.java
@@ -52,7 +52,7 @@ public class AutoUploadJob extends Job {
         final String filePath = bundle.getString(LOCAL_PATH, "");
         final String remotePath = bundle.getString(REMOTE_PATH, "");
         final Account account = AccountUtils.getOwnCloudAccountByName(context, bundle.getString(ACCOUNT, ""));
-        final Integer uploadBehaviour = bundle.getInt(UPLOAD_BEHAVIOUR, -1);
+        final Integer uploadBehaviour = bundle.getInt(UPLOAD_BEHAVIOUR, FileUploader.LOCAL_BEHAVIOUR_FORGET);
 
 
         File file = new File(filePath);

--- a/src/main/java/com/owncloud/android/ui/activity/FolderSyncActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderSyncActivity.java
@@ -45,12 +45,13 @@ import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.SyncedFolder;
 import com.owncloud.android.datamodel.SyncedFolderDisplayItem;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
+import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.ui.adapter.FolderSyncAdapter;
 import com.owncloud.android.ui.decoration.MediaGridItemDecoration;
 import com.owncloud.android.ui.dialog.SyncedFolderPreferencesDialogFragment;
 import com.owncloud.android.ui.dialog.parcel.SyncedFolderParcelable;
-import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.AnalyticsUtils;
+import com.owncloud.android.utils.DisplayUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -303,7 +304,7 @@ public class FolderSyncActivity extends FileActivity implements FolderSyncAdapte
                 false,
                 false,
                 AccountUtils.getCurrentOwnCloudAccount(this).name,
-                0,
+                FileUploader.LOCAL_BEHAVIOUR_FORGET,
                 false,
                 mediaFolder.filePaths,
                 mediaFolder.folderName,


### PR DESCRIPTION
Ref: #911 

The default, if you enable a synced folder but do not choose any upload behaviour was "0", which then lead to a green "downloaded sign" but no file available.
The default now is "keep in folder" which is in sync with the UI.