### PR TITLE
prevent using destroyed activity

### DIFF
--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -539,10 +539,14 @@ public class DisplayUtils {
 
     public static void downloadIcon(Context context, String iconUrl, SimpleTarget imageView, int placeholder,
                                     int width, int height) {
-        if (iconUrl.endsWith(".svg")) {
-            downloadSVGIcon(context, iconUrl, imageView, placeholder, width, height);
-        } else {
-            downloadPNGIcon(context, iconUrl, imageView, placeholder);
+        try {
+            if (iconUrl.endsWith(".svg")) {
+                downloadSVGIcon(context, iconUrl, imageView, placeholder, width, height);
+            } else {
+                downloadPNGIcon(context, iconUrl, imageView, placeholder);
+            }
+        } catch (Exception e) {
+            Log_OC.d(TAG, "not setting image as activity is destroyed");
         }
     }
 


### PR DESCRIPTION
Glide refuses to work on a destroyed activity, catching Exception.
No need to handle it better as this happens on the old activity while rotation and a new one is already in place where Glide correctly shows/loads the icons.

Ref: #959 