### PR TITLE
Do nothing if sharee already exists

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -51,6 +51,8 @@ import com.owncloud.android.ui.fragment.ShareFragmentListener;
 import com.owncloud.android.utils.ErrorMessageAdapter;
 import com.owncloud.android.utils.GetShareWithUsersAsyncTask;
 
+import java.util.ArrayList;
+
 
 /**
  * Activity for sharing files
@@ -111,10 +113,19 @@ public class ShareActivity extends FileActivity
             Uri data = intent.getData();
             String dataString = intent.getDataString();
             String shareWith = dataString.substring(dataString.lastIndexOf('/') + 1);
-            doShareWith(
-                    shareWith,
-                    data.getAuthority()
-            );
+
+            ArrayList<String> shareeNames = new ArrayList<>();
+            for (OCShare share : getStorageManager().getSharesWithForAFile(getFile().getRemotePath(), getAccount().name)) {
+                shareeNames.add(share.getShareWith());
+            }
+
+            if (!shareeNames.contains(shareWith)) {
+
+                doShareWith(
+                        shareWith,
+                        data.getAuthority()
+                );
+            }
 
         } else {
             Log_OC.e(TAG, "Unexpected intent " + intent.toString());


### PR DESCRIPTION
This is merely a workaround as I do not figured out how to do it better:
The current approach shows all sharees, but if a sharee already exists a click on its name simply does nothing.

Better/right approach: Filter the sharee suggestion list from existing sharees.
Please feel free to replace this PR with the better approach.

But now it solves #730, which is an improvement ;-)