### PR TITLE
HOTFIX: Ignore oauth for now and use always basic auth

### DIFF
--- a/src/main/java/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
+++ b/src/main/java/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
@@ -98,11 +98,8 @@ public class DetectAuthenticationMethodOperation extends RemoteOperation {
         // analyze response  
         if (result.getHttpCode() == HttpStatus.SC_UNAUTHORIZED) {
             String authRequest = ((result.getAuthenticateHeader()).trim()).toLowerCase();
-            if (authRequest.startsWith("basic")) {
+            if (authRequest.startsWith("basic") || authRequest.startsWith("bearer")) {
                 authMethod = AuthenticationMethod.BASIC_HTTP_AUTH;
-                
-            } else if (authRequest.startsWith("bearer")) {
-                authMethod = AuthenticationMethod.BEARER_TOKEN;
             }
             // else - fall back to UNKNOWN
                     


### PR DESCRIPTION
Otherwise new users cannot login into nc12 for the very first time.