### PR TITLE
align app version code/name throughout builds (1.4.3)

### DIFF
--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -19,8 +19,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.owncloud.android"
-          android:versionCode="10040299"
-          android:versionName="1.4.2">
+          android:versionCode="10040399"
+          android:versionName="1.4.3">
 
     <application
         android:name=".MainApp"

--- a/src/modified/AndroidManifest.xml
+++ b/src/modified/AndroidManifest.xml
@@ -19,8 +19,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.owncloud.android"
-          android:versionCode="10040299"
-          android:versionName="1.4.2">
+          android:versionCode="10040399"
+          android:versionName="1.4.3">
 
     <application
         android:name=".MainApp"


### PR DESCRIPTION
drone builds fail if version code isn't aligned in builds