### PR TITLE
Removing uploads from account when logout

### DIFF
--- a/androidTest/java/com/owncloud/android/datamodel/UploadStorageManagerTest.java
+++ b/androidTest/java/com/owncloud/android/datamodel/UploadStorageManagerTest.java
@@ -1,0 +1,74 @@
+package com.owncloud.android.datamodel;
+
+import android.accounts.Account;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.owncloud.android.db.OCUpload;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+/**
+ * Created by JARP on 6/7/17.
+ */
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class UploadStorageManagerTest {
+
+    private ContentResolver contentResolver;
+    private Context instrumentationCtx;
+    private Account [] Accounts;
+    private  UploadsStorageManager uploadsStorageManager;
+    @Before
+    public void setup() {
+        instrumentationCtx = InstrumentationRegistry.getTargetContext();
+        contentResolver = instrumentationCtx.getContentResolver();
+        uploadsStorageManager = new UploadsStorageManager(contentResolver,instrumentationCtx);
+        Accounts = new Account[]{ new Account("A","A"),new Account("B","B") };
+    }
+
+    @Test
+    public void testDeleteAllUploads() {
+        //Clean
+        for (Account account : Accounts) {
+            uploadsStorageManager.removeAccountUploads(account);
+        }
+        int accountRowsA = 3;
+        int accountRowsB = 4;
+        insertUploads(Accounts[0],accountRowsA);
+        insertUploads(Accounts[1],accountRowsB);
+
+        Assert.assertTrue("Expected 4 removed uploads files",uploadsStorageManager.removeAccountUploads(Accounts[1]) == 4 );
+    }
+
+    private void insertUploads(Account account, int rowsToInsert) {
+
+        for (int i = 0; i < rowsToInsert; i++) {
+            uploadsStorageManager.storeUpload(createUpload(account));
+        }
+    }
+
+    private OCUpload createUpload(Account acc) {
+        return new  OCUpload( File.separator + "LocalPath",
+                OCFile.PATH_SEPARATOR + "RemotePath",
+                acc.name);
+    }
+
+    @After
+    public void tearDown()
+    {
+        for (Account account : Accounts) {
+            uploadsStorageManager.removeAccountUploads(account);
+        }
+    }
+}

--- a/androidTest/java/com/owncloud/android/datamodel/UploadStorageManagerTest.java
+++ b/androidTest/java/com/owncloud/android/datamodel/UploadStorageManagerTest.java
@@ -25,16 +25,15 @@ import java.io.File;
 @SmallTest
 public class UploadStorageManagerTest {
 
-    private ContentResolver contentResolver;
-    private Context instrumentationCtx;
-    private Account [] Accounts;
-    private  UploadsStorageManager uploadsStorageManager;
+    private Account[] Accounts;
+    private UploadsStorageManager uploadsStorageManager;
+
     @Before
-    public void setup() {
-        instrumentationCtx = InstrumentationRegistry.getTargetContext();
-        contentResolver = instrumentationCtx.getContentResolver();
-        uploadsStorageManager = new UploadsStorageManager(contentResolver,instrumentationCtx);
-        Accounts = new Account[]{ new Account("A","A"),new Account("B","B") };
+    public void setUp() {
+        Context instrumentationCtx = InstrumentationRegistry.getTargetContext();
+        ContentResolver contentResolver = instrumentationCtx.getContentResolver();
+        uploadsStorageManager = new UploadsStorageManager(contentResolver, instrumentationCtx);
+        Accounts = new Account[]{new Account("A", "A"), new Account("B", "B")};
     }
 
     @Test
@@ -45,10 +44,10 @@ public class UploadStorageManagerTest {
         }
         int accountRowsA = 3;
         int accountRowsB = 4;
-        insertUploads(Accounts[0],accountRowsA);
-        insertUploads(Accounts[1],accountRowsB);
+        insertUploads(Accounts[0], accountRowsA);
+        insertUploads(Accounts[1], accountRowsB);
 
-        Assert.assertTrue("Expected 4 removed uploads files",uploadsStorageManager.removeAccountUploads(Accounts[1]) == 4 );
+        Assert.assertTrue("Expected 4 removed uploads files", uploadsStorageManager.removeAccountUploads(Accounts[1]) == 4);
     }
 
     private void insertUploads(Account account, int rowsToInsert) {
@@ -59,14 +58,13 @@ public class UploadStorageManagerTest {
     }
 
     private OCUpload createUpload(Account acc) {
-        return new  OCUpload( File.separator + "LocalPath",
+        return new OCUpload(File.separator + "LocalPath",
                 OCFile.PATH_SEPARATOR + "RemotePath",
                 acc.name);
     }
 
     @After
-    public void tearDown()
-    {
+    public void tearDown() {
         for (Account account : Accounts) {
             uploadsStorageManager.removeAccountUploads(account);
         }

--- a/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -605,4 +605,12 @@ public class UploadsStorageManager extends Observable {
         return result;
     }
 
+    public int removeAccountUploads(Account account) {
+        Log_OC.v(TAG, "Delete all uploads for account " + account.name);
+        return getDB().delete(
+                ProviderTableMeta.CONTENT_URI_UPLOADS,
+                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "=?",
+                new String[]{account.name});
+    }
+
 }

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -360,6 +360,7 @@ public class UserInfoActivity extends FileActivity {
                                     UploadsStorageManager uploadsStorageManager = new UploadsStorageManager(
                                             contentResolver, getActivity());
                                     uploadsStorageManager.cancelPendingAutoUploadJobsForAccount(account);
+                                    uploadsStorageManager.removeAccountUploads(account);
 
                                     // disable daily backup
                                     ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(


### PR DESCRIPTION
This PR will remove the uploads when the user logout from it´s account. Because when you login with another account you will see the previous uploaded file.

