### PR TITLE
1089_sharing_with_password_rule: don't ask for authentification when …

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -40,7 +40,6 @@ import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.authentication.AuthenticatorActivity;
-import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.services.FileDownloader;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
@@ -56,6 +55,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCode;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.operations.CreateShareViaLinkOperation;
 import com.owncloud.android.operations.CreateShareWithShareeOperation;
 import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.operations.SynchronizeFileOperation;
@@ -302,7 +302,7 @@ public abstract class FileActivity extends DrawerActivity
 
         dismissLoadingDialog();
 
-        if (!result.isSuccess() && (
+        if (!result.isSuccess() && ! (operation instanceof CreateShareViaLinkOperation) && (
                 result.getCode() == ResultCode.UNAUTHORIZED ||
                 (result.isException() && result.getException() instanceof AuthenticatorException)
                 )) {

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -347,13 +347,14 @@ public class ShareActivity extends FileActivity
             chooserDialog.show(getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
 
         } else {
-            // Detect Failure (403) --> maybe needs password
+            // Detect Failure (403) or Unauthorized (401) --> maybe needs password
             String password = operation.getPassword();
-            if (result.getCode() == RemoteOperationResult.ResultCode.SHARE_FORBIDDEN    &&
-                    (password == null || password.length() == 0)                        &&
-                    getCapabilities().getFilesSharingPublicEnabled().isUnknown()) {
+            if (((result.getCode() == RemoteOperationResult.ResultCode.SHARE_FORBIDDEN      &&
+                    (password == null || password.length() == 0)                            &&
+                    getCapabilities().getFilesSharingPublicEnabled().isUnknown())           ||
+                    result.getCode() == RemoteOperationResult.ResultCode.UNAUTHORIZED)   ) {
                     // Was tried without password, but not sure that it's optional.
-
+                Toast.makeText(this,"Please enter a valid password",Toast.LENGTH_SHORT).show();
                 // Try with password before giving up; see also ShareFileFragment#OnShareViaLinkListener
                 ShareFileFragment shareFileFragment = getShareFileFragment();
                 if (shareFileFragment != null

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@
     <string name="update_link_file_error">An error occurred while trying to update the share</string>
     <string name="share_link_password_title">Enter a password</string>
     <string name="share_link_empty_password">You must enter a password</string>
+    <string name="share_link_invalid_password">Password does not meet length requirements</string>
 
     <string name="activity_chooser_send_file_title">Send</string>
 


### PR DESCRIPTION
FileActivity.java: 
filter when operation is an instance of CreateShareViaLinkOperation before asking for creditentials.

ShareActivity.java:
adding this case to the condition that ask again for a correct password


strings.xml:
adding a string that describe the problem. By default (only value for now) "Password does not meet length requirements"