### PR TITLE
Cancel pending thumbnail tasks

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -92,6 +92,8 @@ public class FileListListAdapter extends BaseAdapter {
     private OCFile currentDirectory;
     private static final String TAG = FileListListAdapter.class.getSimpleName();
 
+    private ArrayList<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks = new ArrayList<>();
+
     public FileListListAdapter(
             boolean justFolders,
             Context context,
@@ -375,8 +377,7 @@ public class FileListListAdapter extends BaseAdapter {
                             try {
                                 final ThumbnailsCacheManager.ThumbnailGenerationTask task =
                                         new ThumbnailsCacheManager.ThumbnailGenerationTask(
-                                                fileIcon, mStorageManager, mAccount
-                                        );
+                                                fileIcon, mStorageManager, mAccount, asyncTasks);
 
                                 if (thumbnail == null) {
                                     if (MimeTypeUtil.isVideo(file)) {
@@ -392,6 +393,7 @@ public class FileListListAdapter extends BaseAdapter {
                                                 task
                                         );
                                 fileIcon.setImageDrawable(asyncDrawable);
+                                asyncTasks.add(task);
                                 task.execute(file);
                             } catch (IllegalArgumentException e) {
                                 Log_OC.d(TAG, "ThumbnailGenerationTask : " + e.getMessage());
@@ -709,6 +711,20 @@ public class FileListListAdapter extends BaseAdapter {
             }
         }
         return ret;
+    }
+
+    public void cancelAllPendingTasks() {
+        for (ThumbnailsCacheManager.ThumbnailGenerationTask task : asyncTasks) {
+            if (task != null) {
+                task.cancel(true);
+                if (task.getGetMethod() != null) {
+                    Log_OC.d(TAG, "cancel: abort get method directly");
+                    task.getGetMethod().abort();
+                }
+            }
+        }
+
+        asyncTasks.clear();
     }
 
 }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -278,6 +278,14 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
         super.onDetach();
     }
 
+    @Override
+    public void onPause() {
+        super.onPause();
+        mAdapter.cancelAllPendingTasks();
+    }
+
+
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -32,6 +32,7 @@ import android.graphics.drawable.PictureDrawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Process;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -442,6 +443,9 @@ public class PreviewImageFragment extends FileFragment {
 
         @Override
         protected LoadImage doInBackground(OCFile... params) {
+            Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_BACKGROUND +
+                    android.os.Process.THREAD_PRIORITY_MORE_FAVORABLE);
+
             Bitmap bitmapResult = null;
             Drawable drawableResult = null;
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -1,18 +1,18 @@
-/**
+/*
  * ownCloud Android client application
  *
  * @author David A. Velasco
  * Copyright (C) 2015 ownCloud Inc.
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -443,8 +443,7 @@ public class PreviewImageFragment extends FileFragment {
 
         @Override
         protected LoadImage doInBackground(OCFile... params) {
-            Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_BACKGROUND +
-                    android.os.Process.THREAD_PRIORITY_MORE_FAVORABLE);
+            Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND + Process.THREAD_PRIORITY_MORE_FAVORABLE);
 
             Bitmap bitmapResult = null;
             Drawable drawableResult = null;


### PR DESCRIPTION
- set priority of image processing to higher value
- cancel all pending async tasks when leaving FDA: needs to be done by get.abort() as this is a blocking command and needs to be accessed directly

Ref: #955