### PR TITLE
fix removing of local only folder

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -519,7 +519,7 @@ public class FileDataStorageManager {
 
 
     public boolean removeFolder(OCFile folder, boolean removeDBData, boolean removeLocalContent) {
-        boolean success = false;
+        boolean success = true;
         if (folder != null && folder.isFolder()) {
             if (removeDBData && folder.getFileId() != -1) {
                 success = removeFolderInDb(folder);
@@ -527,6 +527,8 @@ public class FileDataStorageManager {
             if (removeLocalContent && success) {
                 success = removeLocalFolder(folder);
             }
+        } else {
+            success = false;
         }
 
         return success;


### PR DESCRIPTION
Ref: https://github.com/nextcloud/android/issues/1189

Previous change was introduced so that if ocFile == null --> return false, so added this explicitly.