### PR TITLE
On receiving untrusted ssl cert, test if it was previously accepted user

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -408,7 +408,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                         handler.cancel();
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    Log_OC.e(TAG, "Cert could not be verified");
                 }
             }
 

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -52,6 +52,7 @@ import android.content.pm.ActivityInfo;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.net.http.SslCertificate;
 import android.net.http.SslError;
 import android.os.Build;
 import android.os.Bundle;
@@ -100,6 +101,7 @@ import com.owncloud.android.lib.common.accounts.AccountTypeUtils;
 import com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException;
 import com.owncloud.android.lib.common.accounts.AccountUtils.Constants;
 import com.owncloud.android.lib.common.network.CertificateCombinedException;
+import com.owncloud.android.lib.common.network.NetworkUtils;
 import com.owncloud.android.lib.common.operations.OnRemoteOperationListener;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -121,6 +123,10 @@ import com.owncloud.android.ui.dialog.SslUntrustedCertDialog.OnSslUntrustedCertL
 import com.owncloud.android.utils.AnalyticsUtils;
 import com.owncloud.android.utils.DisplayUtils;
 
+import java.io.ByteArrayInputStream;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
@@ -391,12 +397,42 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mLoginWebView.setVisibility(View.VISIBLE);
             }
 
+            @Override
+            public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+                Certificate cert = getX509Certificate(error.getCertificate());
+
+                try {
+                    if (cert != null && NetworkUtils.isCertInKnownServersStore(cert, getApplicationContext())) {
+                        handler.proceed();
+                    } else {
+                        handler.cancel();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
                 progressBar.setVisibility(View.GONE);
                 mLoginWebView.setVisibility(View.VISIBLE);
                 mLoginWebView.loadData(DisplayUtils.getData(getResources().openRawResource(R.raw.custom_error)),"text/html; charset=UTF-8", null);
             }
         });
+    }
+
+    private Certificate getX509Certificate(SslCertificate sslCertificate) {
+        Bundle bundle = SslCertificate.saveState(sslCertificate);
+        byte[] bytes = bundle.getByteArray("x509-certificate");
+        if (bytes == null) {
+            return null;
+        } else {
+            try {
+                CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+                return certFactory.generateCertificate(new ByteArrayInputStream(bytes));
+            } catch (CertificateException e) {
+                return null;
+            }
+        }
     }
 
     private void parseAndLoginFromWebView(String dataString) {


### PR DESCRIPTION
When trying to connect to an untrusted server we show a dialog with cert infos.
If the user accepts the untrusted cert it will get stored. 
New weblogin flow now tests if the cert has been accepted.