### PR TITLE
No thumbnail for non-files

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -199,8 +199,10 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
 
                 for (RichObject richObject : activity.getRichSubjectElement().getRichObjectList()) {
-                    ImageView imageView = createThumbnail(richObject);
-                    activityViewHolder.list.addView(imageView);
+                    if (richObject.getPath() != null) {
+                        ImageView imageView = createThumbnail(richObject);
+                        activityViewHolder.list.addView(imageView);
+                    }
                 }
 
             } else {


### PR DESCRIPTION
Quick fix for #1307 

Follow up should be to use `previews` from the API response instead.
Will try to do that too:
https://github.com/nextcloud/activity/blob/master/docs/endpoint-v2.md#activity-element

