### PR TITLE
Check if background string is empty

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -298,7 +298,7 @@ public class UserInfoActivity extends FileActivity {
                             .error(R.drawable.background)
                             .crossFade()
                             .into(target);
-                } else {
+                } else if (!background.isEmpty()) {
                     // plain color
                     int color = Color.parseColor(background);
                     appBar.setBackgroundColor(color);


### PR DESCRIPTION
Background string is by default empty, so if capability is not parsed correctly it leads to a crashing user info activity.
Fallback is the default image.

Ref: https://github.com/nextcloud/android/issues/1339