### PR TITLE
CookieManager.getInstance() can throw an Exception without saying so

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -69,6 +69,7 @@ import android.text.Editable;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.AndroidRuntimeException;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -345,13 +346,17 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     }
 
     private void deleteCookies() {
-        CookieSyncManager.createInstance(this);
-        CookieManager cookieManager = CookieManager.getInstance();
+        try {
+            CookieSyncManager.createInstance(this);
+            CookieManager cookieManager = CookieManager.getInstance();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            cookieManager.removeAllCookies(null);
-        } else {
-            cookieManager.removeAllCookie();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                cookieManager.removeAllCookies(null);
+            } else {
+                cookieManager.removeAllCookie();
+            }
+        } catch (AndroidRuntimeException e) {
+            Log_OC.e(TAG, e.getMessage());
         }
     }
 


### PR DESCRIPTION
Ref: #1340 

If cookies cannot removed maybe the same credentials are used if an user tries to use the new weblogin flow for the same server.