### PR TITLE
Prevent NPE in FingerprintActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FingerprintActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FingerprintActivity.java
@@ -166,7 +166,9 @@ public class FingerprintActivity extends AppCompatActivity {
     @Override
     public void onStop(){
         super.onStop();
-        cancellationSignal.cancel();
+        if(cancellationSignal != null) {
+            cancellationSignal.cancel();
+        }
     }
 
     /**


### PR DESCRIPTION
resolves #1403 - check for null since the cancellationSignal is null if the device doesn't have a secure keyguard or no matching algorithm