### PR TITLE
Restart weblogin flow if auth failed

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -124,6 +124,7 @@ import com.owncloud.android.ui.dialog.SslUntrustedCertDialog.OnSslUntrustedCertL
 import com.owncloud.android.utils.AnalyticsUtils;
 import com.owncloud.android.utils.DisplayUtils;
 
+import java.net.URLDecoder;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
@@ -495,11 +496,14 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
         for (String value : values) {
             if (value.startsWith("user" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR)) {
-                loginUrlInfo.username = value.substring(("user" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR).length());
+                loginUrlInfo.username = URLDecoder.decode(
+                        value.substring(("user" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR).length()));
             } else if (value.startsWith("password" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR)) {
-                loginUrlInfo.password = value.substring(("password" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR).length());
+                loginUrlInfo.password = URLDecoder.decode(
+                        value.substring(("password" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR).length()));
             } else if (value.startsWith("server" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR)) {
-                loginUrlInfo.serverAddress = value.substring(("server" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR).length());
+                loginUrlInfo.serverAddress = URLDecoder.decode(
+                        value.substring(("server" + LOGIN_URL_DATA_KEY_VALUE_SEPARATOR).length()));
             } else {
                 // error illegal URL element detected
                 throw new IllegalArgumentException("Illegal magic login URL element detected: " + value);

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -59,6 +59,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
@@ -1791,7 +1792,17 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             if (!webViewLoginMethod) {
                 updateAuthStatusIconAndText(result);
                 showAuthStatus();
+            } else {
+                mLoginWebView = (WebView) findViewById(R.id.login_webview);
+                initWebViewLogin(mServerInfo.mBaseUrl);
             }
+            // reset webview
+            webViewPassword = null;
+            webViewUser = null;
+            deleteCookies();
+
+            Snackbar.make(mLoginWebView, getString(R.string.auth_access_failed) + ": " + result.getLogMessage(),
+                    Snackbar.LENGTH_LONG).show();
             Log_OC.d(TAG, "Access failed: " + result.getLogMessage());
         }
     }

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -418,7 +418,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             @Override
             public void run() {
                 Snackbar.make(mLoginWebView, "Go back to old login method", Snackbar.LENGTH_INDEFINITE)
-                        .setAction("BACK", new View.OnClickListener() {
+                        .setAction(R.string.fallback_weblogin_back, new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {
                                 mLoginWebView.setVisibility(View.INVISIBLE);

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -417,7 +417,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
-                Snackbar.make(mLoginWebView, "Go back to old login method", Snackbar.LENGTH_INDEFINITE)
+                Snackbar.make(mLoginWebView, R.string.fallback_weblogin_text, Snackbar.LENGTH_INDEFINITE)
                         .setAction(R.string.fallback_weblogin_back, new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -264,7 +264,7 @@
 	<string name="auth_fail_get_user_name">Your server is not returning a correct user ID, please contact an administrator</string>
 	<string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
     <string name="auth_account_does_not_exist">Account does not exist on the device yet</string>
-
+    <string name="auth_access_failed">Access failed</string>
 
     <string name="favorite">Set as available offline</string>
     <string name="unfavorite">Unset as available offline</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -694,4 +694,5 @@
     <string name="whats_new_fingerprint_title">Unlock with fingerprint</string>
     <string name="whats_new_fingerprint_content">Use your fingerprint to unlock the app</string>
     <string name="fallback_weblogin_back">BACK</string>
+    <string name="fallback_weblogin_text">Go back to old login method</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -693,4 +693,5 @@
     <string name="resharing_is_not_allowed">Resharing is not allowed</string>
     <string name="whats_new_fingerprint_title">Unlock with fingerprint</string>
     <string name="whats_new_fingerprint_content">Use your fingerprint to unlock the app</string>
+    <string name="fallback_weblogin_back">BACK</string>
 </resources>


### PR DESCRIPTION
Otherwise we have an endless spinning loading dialog.
Discovered while debugging #1373: the existenceCheck failed and thus the loading dialog was not hidden.

Update: Cause of #1373 was the missing proper decoding of username/password which we get from new login flow.

Resolves #1373