### PR TITLE
UX: Enhance sharing when resharing is forbidden

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -24,6 +24,7 @@ package com.owncloud.android.ui.fragment;
 import android.accounts.Account;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.widget.SwitchCompat;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -312,8 +313,16 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_send_share_file: {
-                mContainerActivity.getFileOperationsHelper().sendShareFile(getFile(),
+                if(getFile().isSharedWithMe() && !getFile().canReshare()){
+                    Snackbar.make(getView(),
+                            R.string.resharing_is_not_allowed,
+                            Snackbar.LENGTH_LONG
+                    )
+                            .show();
+                } else {
+                    mContainerActivity.getFileOperationsHelper().sendShareFile(getFile(),
                         (FileDisplayActivity) mContainerActivity);
+                }
                 return true;
             }
             case R.id.action_open_file_with: {

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -944,8 +944,8 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             OCFile singleFile = checkedFiles.get(0);
             switch (menuId) {
                 case R.id.action_send_share_file: {
-                    mContainerActivity.getFileOperationsHelper().sendShareFile(singleFile,
-                            (FileDisplayActivity) mContainerActivity);
+                        mContainerActivity.getFileOperationsHelper().sendShareFile(singleFile,
+                    (FileDisplayActivity) mContainerActivity);
                     return true;
                 }
                 case R.id.action_open_file_with: {

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -422,8 +422,16 @@ public class PreviewImageFragment extends FileFragment {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_send_share_file:
-                mContainerActivity.getFileOperationsHelper().sendShareFile(getFile(),
+                if(getFile().isSharedWithMe() && !getFile().canReshare()){
+                    Snackbar.make(getView(),
+                            R.string.resharing_is_not_allowed,
+                            Snackbar.LENGTH_LONG
+                    )
+                            .show();
+                } else {
+                    mContainerActivity.getFileOperationsHelper().sendShareFile(getFile(),
                         (FileDisplayActivity) mContainerActivity);
+                }
                 return true;
 
             case R.id.action_open_file_with:

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -38,6 +38,7 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -38,7 +38,6 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
-import android.support.design.widget.Snackbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -189,13 +188,13 @@ public class PreviewMediaFragment extends FileFragment implements
 
         mView = inflater.inflate(R.layout.file_preview, container, false);
 
-        mPreviewContainer = (RelativeLayout) mView.findViewById(R.id.file_preview_container);
-        mImagePreview = (ImageView) mView.findViewById(R.id.image_preview);
-        mVideoPreview = (VideoView) mView.findViewById(R.id.video_preview);
+        mPreviewContainer = mView.findViewById(R.id.file_preview_container);
+        mImagePreview = mView.findViewById(R.id.image_preview);
+        mVideoPreview = mView.findViewById(R.id.video_preview);
         mVideoPreview.setOnTouchListener(this);
 
-        mMediaController = (MediaControlView) mView.findViewById(R.id.media_controller);
-        mMultiView = (RelativeLayout) mView.findViewById(R.id.multi_view);
+        mMediaController = mView.findViewById(R.id.media_controller);
+        mMultiView = mView.findViewById(R.id.multi_view);
 
         setupMultiView(mView);
         setMultiListLoadingMessage();
@@ -204,11 +203,11 @@ public class PreviewMediaFragment extends FileFragment implements
 
 
     protected void setupMultiView(View view) {
-        mMultiListContainer = (LinearLayout) view.findViewById(R.id.empty_list_view);
-        mMultiListMessage = (TextView) view.findViewById(R.id.empty_list_view_text);
-        mMultiListHeadline = (TextView) view.findViewById(R.id.empty_list_view_headline);
-        mMultiListIcon = (ImageView) view.findViewById(R.id.empty_list_icon);
-        mMultiListProgress = (ProgressBar) view.findViewById(R.id.empty_list_progress);
+        mMultiListContainer = view.findViewById(R.id.empty_list_view);
+        mMultiListMessage = view.findViewById(R.id.empty_list_view_text);
+        mMultiListHeadline = view.findViewById(R.id.empty_list_view_headline);
+        mMultiListIcon = view.findViewById(R.id.empty_list_icon);
+        mMultiListProgress = view.findViewById(R.id.empty_list_progress);
     }
 
     private void setMultiListLoadingMessage() {

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -22,6 +22,7 @@ package com.owncloud.android.ui.preview;
 import android.accounts.Account;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -382,8 +383,16 @@ public class PreviewTextFragment extends FileFragment {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_send_share_file: {
-                mContainerActivity.getFileOperationsHelper().sendShareFile(getFile(),
+                if(getFile().isSharedWithMe() && !getFile().canReshare()){
+                    Snackbar.make(getView(),
+                            R.string.resharing_is_not_allowed,
+                            Snackbar.LENGTH_LONG
+                    )
+                            .show();
+                } else {
+                    mContainerActivity.getFileOperationsHelper().sendShareFile(getFile(),
                         (FileDisplayActivity) mContainerActivity);
+                }
                 return true;
             }
             case R.id.action_open_file_with: {


### PR DESCRIPTION
Pull request for #1176.

Restored Sharing menu for the reshared file.
Warning is showed when resharing isn't allowed.