### PR TITLE
Fix saveFileWithParentNPE

### DIFF
--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -19,8 +19,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.owncloud.android"
-          android:versionCode="20000004"
-          android:versionName="2.0.0RC4">
+          android:versionCode="20000005"
+          android:versionName="2.0.0RC5">
 
     <application
         android:name=".MainApp"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -20,8 +20,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.owncloud.android"
-          android:versionCode="20000004"
-          android:versionName="2.0.0RC4">
+          android:versionCode="20000005"
+          android:versionName="2.0.0RC5">
 
     <uses-sdk
         android:minSdkVersion="14"

--- a/src/main/java/com/owncloud/android/operations/RemoteOperationFailedException.java
+++ b/src/main/java/com/owncloud/android/operations/RemoteOperationFailedException.java
@@ -1,0 +1,32 @@
+package com.owncloud.android.operations;
+
+/**
+ * RuntimeException for throwing errors of remote operation calls.
+ */
+public class RemoteOperationFailedException extends RuntimeException {
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the
+     *                {@link #getCause()} method).  (A <code>null</code> value
+     *                is permitted, and indicates that the cause is nonexistent
+     *                or unknown.)
+     */
+    public RemoteOperationFailedException(String message, Throwable cause) {
+        super(message + " / " + cause.getMessage(), cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     */
+    public RemoteOperationFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/modified/AndroidManifest.xml
+++ b/src/modified/AndroidManifest.xml
@@ -19,8 +19,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.owncloud.android"
-          android:versionCode="20000004"
-          android:versionName="2.0.0RC4">
+          android:versionCode="20000005"
+          android:versionName="2.0.0RC5">
 
     <application
         android:name=".MainApp"


### PR DESCRIPTION
fixes #1398 

Beware that we now skip entries where the parent retrieval from the server fails (like it is also done for e.g. shares).

cc @tobiasKaminsky @mario 