### PR TITLE
Fix NPE in virtuals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,6 +209,8 @@ dependencies {
     annotationProcessor 'org.parceler:parceler:1.1.6'
     implementation 'com.github.bumptech.glide:glide:3.7.0'
     implementation 'com.caverock:androidsvg:1.2.1'
+    implementation "com.android.support:support-annotations:${supportLibraryVersion}"
+
     /// dependencies for local unit tests
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'
@@ -217,8 +219,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:rules:1.0.0'
     // Android JUnit Runner
     androidTestImplementation 'com.android.support.test:runner:1.0.0'
-    // Android Annotation Support
-    androidTestImplementation "com.android.support:support-annotations:${supportLibraryVersion}"
+
     // Espresso core
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
     // UIAutomator - for cross-app UI tests, and to grant screen is turned on in Espresso tests

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -33,6 +33,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.RemoteException;
 import android.provider.MediaStore;
+import android.support.annotation.Nullable;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta;
@@ -921,6 +922,7 @@ public class FileDataStorageManager {
         return c;
     }
 
+    @Nullable
     private OCFile createFileInstanceFromVirtual(Cursor c) {
         OCFile file = null;
         if (c != null) {
@@ -2148,16 +2150,18 @@ public class FileDataStorageManager {
         if (c != null && c.moveToFirst()) {
             do {
                 OCFile child = createFileInstanceFromVirtual(c);
-                ocFiles.add(child);
+
+                if (child != null) {
+                    ocFiles.add(child);
+                }
             } while (c.moveToNext());
             c.close();
         }
 
         if (onlyImages) {
-            OCFile current = null;
             Vector<OCFile> temp = new Vector<>();
             for (int i=0; i < ocFiles.size(); i++) {
-                current = ocFiles.get(i);
+                OCFile current = ocFiles.get(i);
                 if (MimeTypeUtil.isImage(current)) {
                     temp.add(current);
                 }

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -2159,9 +2159,10 @@ public class FileDataStorageManager {
         }
 
         if (onlyImages) {
+            OCFile current;
             Vector<OCFile> temp = new Vector<>();
             for (int i=0; i < ocFiles.size(); i++) {
-                OCFile current = ocFiles.get(i);
+                current = ocFiles.get(i);
                 if (MimeTypeUtil.isImage(current)) {
                     temp.add(current);
                 }


### PR DESCRIPTION
fix #1442

- use nullable
- only add non-null object to list

I do not understand why there can be a null while reading from database, but as createFileInstanceFromVirtual() can return null, it is always safer to handle this properly.