### PR TITLE
Fix Snackbar on wrong login with old server

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1811,20 +1811,21 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             }
 
         } else {    // authorization fail due to client side - probably wrong credentials
-            if (!webViewLoginMethod) {
-                updateAuthStatusIconAndText(result);
-                showAuthStatus();
-            } else {
+            if (webViewLoginMethod) {
                 mLoginWebView = (WebView) findViewById(R.id.login_webview);
                 initWebViewLogin(mServerInfo.mBaseUrl);
+
+                Snackbar.make(mLoginWebView, getString(R.string.auth_access_failed) + ": " + result.getLogMessage(),
+                        Snackbar.LENGTH_LONG).show();
+            } else {
+                updateAuthStatusIconAndText(result);
+                showAuthStatus();
             }
             // reset webview
             webViewPassword = null;
             webViewUser = null;
             deleteCookies();
 
-            Snackbar.make(mLoginWebView, getString(R.string.auth_access_failed) + ": " + result.getLogMessage(),
-                    Snackbar.LENGTH_LONG).show();
             Log_OC.d(TAG, "Access failed: " + result.getLogMessage());
         }
     }


### PR DESCRIPTION
- switch if branch for easier readability
- show snackbar only for webview (for old login there is a decent error warning)

fixes:
```
java.lang.IllegalArgumentException: No suitable parent found from the given view. Please provide a valid view.
	at android.support.design.widget.Snackbar.make(Snackbar.java:137)
	at com.owncloud.android.authentication.AuthenticatorActivity.onAuthenticatorTaskCallback(AuthenticatorActivity.java:1826)
	at com.owncloud.android.authentication.AuthenticatorAsyncTask.onPostExecute(AuthenticatorAsyncTask.java:102)
	at com.owncloud.android.authentication.AuthenticatorAsyncTask.onPostExecute(AuthenticatorAsyncTask.java:41)
	at android.os.AsyncTask.finish(AsyncTask.java:660)
	at android.os.AsyncTask.-wrap1(AsyncTask.java)
	at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:677)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6776)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1520)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1410)
```
