### PR TITLE
Lint: only upload new master on decrease of warning/error

### DIFF
--- a/scripts/lint/lint-up-wrapper.sh
+++ b/scripts/lint/lint-up-wrapper.sh
@@ -9,11 +9,12 @@
 
 ruby scripts/lint/lint-up.rb $1 $2 $3
 
-if [ $? -eq 0 ]; then
+returnValue=$?
+if [ $returnValue -eq 0 ]; then
     echo "New master at: https://nextcloud.kaminsky.me/index.php/s/tXwtChzyqMj6I8v"
     curl -u $4:$5 -X PUT https://nextcloud.kaminsky.me/remote.php/webdav/droneLogs/master.html --upload-file build/reports/lint/lint.html
     exit 0
-else
+elif [ $returnValue -eq 1 ]; then
     echo "New results at https://nextcloud.kaminsky.me/index.php/s/tXwtChzyqMj6I8v ->" $6.html
     curl -u $4:$5 -X PUT https://nextcloud.kaminsky.me/remote.php/webdav/droneLogs/$6.html --upload-file build/reports/lint/lint.html
     exit 1

--- a/scripts/lint/lint-up.rb
+++ b/scripts/lint/lint-up.rb
@@ -151,7 +151,7 @@ if  previous_results == true &&
     current_warning_count == previous_warning_count
 
     puts "SUCCESS: count stayed the same"
-    exit 0
+    exit 2
 end
 
 # either error count or warning count DECREASED


### PR DESCRIPTION
This way we avoid having the "same" master lint file uploaded over and over again.