### PR TITLE
don't reset approvals on push

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -18,7 +18,7 @@ group_defaults:
     approve_regex: '^(Approved|:shipit:|:\+1:|LGTM)'
     reject_regex: '^(Rejected|:-1:)'
   reset_on_push:
-    enabled: true
+    enabled: false
   reset_on_reopened:
     enabled: true
 


### PR DESCRIPTION
...since rebase/master merge happen right before merging to master and that resets the approval so nearly all the time we merge with admin permission. This way all checks will be green (most of the time).

This way we rely on trust that nobody introduces new changes (except merge/rebase) after a PR has been approved.

What do you think @mario @tobiasKaminsky 