### PR TITLE
Update to gradle:3.0.0-beta4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta3'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta4'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }


### PR DESCRIPTION
This fixes the latest, new lint warning which is due to ```'com.android.tools.build:gradle:3.0.0-beta4``` being released.

cc @tobiasKaminsky @mario 