### PR TITLE
Codacy: remove unused code

### DIFF
--- a/src/main/java/com/owncloud/android/features/FeatureList.java
+++ b/src/main/java/com/owncloud/android/features/FeatureList.java
@@ -1,4 +1,4 @@
-/**
+/*
  *   Nextcloud Android client application
  *
  *   @author Bartosz Przybylski
@@ -27,11 +27,9 @@ import android.os.Parcelable;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
-import com.owncloud.android.lib.common.utils.Log_OC;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * @author Bartosz Przybylski
@@ -175,16 +173,5 @@ public class FeatureList {
                         return new FeatureItem[size];
                     }
                 };
-    }
-
-    private static int versionCodeFromString(String version) {
-        String v[] = version.split(Pattern.quote("."));
-        if (v.length != 3) {
-            Log_OC.e("FeatureList", "Version string is incorrect " + version);
-            return 0;
-        }
-        return Integer.parseInt(v[0])*(int)(10e6) +
-                Integer.parseInt(v[1])*(int)(10e3) +
-                Integer.parseInt(v[2])*100;
     }
 }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -187,17 +187,15 @@ public class PreviewImageActivity extends FileActivity implements
         if (operation instanceof RemoveFileOperation) {
             finish();
         } else if (operation instanceof SynchronizeFileOperation) {
-            onSynchronizeFileOperationFinish((SynchronizeFileOperation) operation, result);
+            onSynchronizeFileOperationFinish(result);
 
         }
     }
     
-    private void onSynchronizeFileOperationFinish(SynchronizeFileOperation operation,
-                                                  RemoteOperationResult result) {
+    private void onSynchronizeFileOperationFinish(RemoteOperationResult result) {
         if (result.isSuccess()) {
             supportInvalidateOptionsMenu();
         }
-
     }
 
     @Override


### PR DESCRIPTION
removing unused code to get rid of the last two remaining codacy issues for unused code.

@mario @tobiasKaminsky I didn't assign it to any milestone since I leave it to you to either merge it for 2.0.0 or postpone it to a future release. Since it is simply removing dead code it should imho be safe to merge at any time.