### PR TITLE
Use given empty list icon if it should not be tinted

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -772,6 +772,8 @@ public class ExtendedListFragment extends Fragment
 
                     if (tintIcon) {
                         mEmptyListIcon.setImageDrawable(ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor()));
+                    } else {
+                        mEmptyListIcon.setImageResource(icon);
                     }
 
                     mEmptyListIcon.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Bugfix to bring back the non tinted icons which at the moment would not display but show the blue folder icon simply because that is set by default in the layout itself. This fixes empty lists that show non-tinted icons like the fav-star, search-icon etc. basically any icon that is not a folder icon (which is tinted and will override the default icon):

![device-2017-09-13-192410](https://user-images.githubusercontent.com/1315170/30391346-500b78a0-98b9-11e7-8847-8f78d3fca4b9.png)

cc @mario @tobiasKaminsky 
