### PR TITLE
Do not show warning on very first start of fresh installation

### DIFF
--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -43,11 +43,13 @@ import android.text.TextUtils;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.db.ProviderMeta;
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.ShareType;
+import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimeType;
 
@@ -689,6 +691,9 @@ public class FileContentProvider extends ContentProvider {
 
             // Create filesystem table
             createFileSystemTable(db);
+
+            PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
+                    .putBoolean(FileDisplayActivity.KEY_SHOW_ACCOUNT_WARNING, false).apply();
         }
 
         @Override

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -124,7 +124,7 @@ import static com.owncloud.android.db.PreferenceManager.getSortOrder;
 public class FileDisplayActivity extends HookActivity
         implements FileFragment.ContainerActivity,
         OnEnforceableRefreshListener, SortingOrderDialogFragment.OnSortingOrderListener {
-    private static final String KEY_SHOW_ACCOUNT_WARNING = "SHOW_ACCOUNT_WARNING";
+    public static final String KEY_SHOW_ACCOUNT_WARNING = "SHOW_ACCOUNT_WARNING";
 
     private SyncBroadcastReceiver mSyncBroadcastReceiver;
     private UploadFinishReceiver mUploadFinishReceiver;


### PR DESCRIPTION
The "account is corrupt" warning for RC version was also shown on fresh installations.

onCreate() in FileContentProvider is only called on very first start, so it is safe to put it in there.
I know this is a hack as has nothing to do with Database, but I hope it is fine as we can remove it on final 2.0 release?

P.s: In opposite to what we discussed @AndyScherzinger your very first idea was so much smoother and simpler that I had to use it ;-)