### PR TITLE
NPE if pending uploads exists on account removal

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AccountUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountUtils.java
@@ -25,6 +25,7 @@ import android.accounts.AccountManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
@@ -61,7 +62,8 @@ public class AccountUtils {
      *                      {@link Account} available, if valid (still registered in the system as ownCloud 
      *                      account). If none is available and valid, returns null.
      */
-    public static Account getCurrentOwnCloudAccount(Context context) {
+    public static @Nullable
+    Account getCurrentOwnCloudAccount(Context context) {
         Account[] ocAccounts = getAccounts(context);
         Account defaultAccount = null;
 

--- a/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * ownCloud Android client application
  *
  * @author LukeOwncloud
@@ -374,18 +374,21 @@ public class UploadsStorageManager extends Observable {
     public OCUpload[] getCurrentAndPendingUploadsForCurrentAccount() {
         Account account = AccountUtils.getCurrentOwnCloudAccount(mContext);
 
-        OCUpload[] uploads = getUploads(
-                ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
-                        " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT + "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                        " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT + "==" + UploadResult.LOCK_FAILED.getValue() +
-                        " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                        "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                        " AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
-                new String[]{account.name}
-        );
-
-        return uploads;
-
+        if (account != null) {
+            return getUploads(
+                    ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
+                            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                            "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                            "==" + UploadResult.LOCK_FAILED.getValue() +
+                            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                            "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                            " AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
+                    new String[]{account.name}
+            );
+        } else {
+            return new OCUpload[0];
+        }
     }
 
     /**
@@ -400,8 +403,12 @@ public class UploadsStorageManager extends Observable {
     public OCUpload[] getFinishedUploadsForCurrentAccount() {
         Account account = AccountUtils.getCurrentOwnCloudAccount(mContext);
 
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
-                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", new String[]{account.name});
+        if (account != null) {
+            return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
+                    ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", new String[]{account.name});
+        } else {
+            return new OCUpload[0];
+        }
     }
 
     /**
@@ -415,16 +422,20 @@ public class UploadsStorageManager extends Observable {
     public OCUpload[] getFailedButNotDelayedUploadsForCurrentAccount() {
         Account account = AccountUtils.getCurrentOwnCloudAccount(mContext);
 
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                        AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
-                new String[]{account.name}
-        );
+        if (account != null) {
+            return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                            AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
+                    new String[]{account.name}
+            );
+        } else {
+            return new OCUpload[0];
+        }
     }
 
     /**
@@ -449,19 +460,22 @@ public class UploadsStorageManager extends Observable {
     public long clearFailedButNotDelayedUploads() {
         Account account = AccountUtils.getCurrentOwnCloudAccount(mContext);
 
-        long result = getDB().delete(
-                ProviderTableMeta.CONTENT_URI_UPLOADS,
-                ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
-                new String[]{account.name}
-        );
+        long result = 0;
+        if (account != null) {
+            result = getDB().delete(
+                    ProviderTableMeta.CONTENT_URI_UPLOADS,
+                    ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
+                    new String[]{account.name}
+            );
+        }
 
         Log_OC.d(TAG, "delete all failed uploads but those delayed for Wifi");
         if (result > 0) {
@@ -473,11 +487,14 @@ public class UploadsStorageManager extends Observable {
     public long clearSuccessfulUploads() {
         Account account = AccountUtils.getCurrentOwnCloudAccount(mContext);
 
-        long result = getDB().delete(
-                ProviderTableMeta.CONTENT_URI_UPLOADS,
-                ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value  + AND +
-                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", new String[]{account.name}
-        );
+        long result = 0;
+        if (account != null) {
+            result = getDB().delete(
+                    ProviderTableMeta.CONTENT_URI_UPLOADS,
+                    ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
+                            ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", new String[]{account.name}
+            );
+        }
 
         Log_OC.d(TAG, "delete all successful uploads");
         if (result > 0) {
@@ -489,23 +506,25 @@ public class UploadsStorageManager extends Observable {
     public long clearAllFinishedButNotDelayedUploads() {
         Account account = AccountUtils.getCurrentOwnCloudAccount(mContext);
 
-        String[] whereArgs = new String[3];
-        whereArgs[0] = String.valueOf(UploadStatus.UPLOAD_SUCCEEDED.value);
-        whereArgs[1] = String.valueOf(UploadStatus.UPLOAD_FAILED.value);
-        whereArgs[2] = account.name;
-        long result = getDB().delete(
-                ProviderTableMeta.CONTENT_URI_UPLOADS,
-                ProviderTableMeta.UPLOADS_STATUS + "=? OR " + ProviderTableMeta.UPLOADS_STATUS + "=?" +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                        AND +
-                        ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
-                whereArgs
-        );
+        long result = 0;
+        if (account != null) {
+            String[] whereArgs = new String[3];
+            whereArgs[0] = String.valueOf(UploadStatus.UPLOAD_SUCCEEDED.value);
+            whereArgs[1] = String.valueOf(UploadStatus.UPLOAD_FAILED.value);
+            whereArgs[2] = account.name;
+            result = getDB().delete(
+                    ProviderTableMeta.CONTENT_URI_UPLOADS,
+                    ProviderTableMeta.UPLOADS_STATUS + "=? OR " + ProviderTableMeta.UPLOADS_STATUS + "=?" +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                            AND +
+                            ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", whereArgs
+            );
+        }
 
         Log_OC.d(TAG, "delete all finished uploads");
         if (result > 0) {
@@ -520,7 +539,7 @@ public class UploadsStorageManager extends Observable {
      */
     public void updateDatabaseUploadResult(RemoteOperationResult uploadResult, UploadFileOperation upload) {
         // result: success or fail notification
-        Log_OC.d(TAG, "updateDataseUploadResult uploadResult: " + uploadResult + " upload: " + upload);
+        Log_OC.d(TAG, "updateDatabaseUploadResult uploadResult: " + uploadResult + " upload: " + upload);
 
         if (uploadResult.isCancelled()) {
             removeUpload(


### PR DESCRIPTION
Steps that triggered NPE:
- have pending uploads
- remove last existing account

-> NPE in getCurrentAndPendingUploadsForCurrentAccount() and other due to null in
AccountUtils.getCurrentOwnCloudAccount(mContext)

I changed the function to 
public static @Nullable Account getCurrentOwnCloudAccount(Context context)

now the IDE warns if one access a potentially nullable variable. Very useful!