### PR TITLE
Show info messages for push

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     /// dependencies for app building
     implementation name: 'touch-image-view'
     implementation 'com.android.support:multidex:1.0.2'
-    compile 'com.github.nextcloud:android-library:1.0.30'
+    compile 'com.github.nextcloud:android-library:pushWarning-SNAPSHOT'
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     /// dependencies for app building
     implementation name: 'touch-image-view'
     implementation 'com.android.support:multidex:1.0.2'
-    compile 'com.github.nextcloud:android-library:pushWarning-SNAPSHOT'
+    compile 'com.github.nextcloud:android-library:1.0.31'
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -247,6 +247,10 @@ public class PushUtils {
                                     arbitraryDataProvider.storeOrUpdateKeyValue(account.name, KEY_PUSH,
                                             gson.toJson(pushArbitraryData));
                                 }
+                            } else if (remoteOperationResult.getCode() ==
+                                    RemoteOperationResult.ResultCode.ACCOUNT_USES_OLD_LOGIN) {
+                                arbitraryDataProvider.storeOrUpdateKeyValue(account.name,
+                                        AccountUtils.ACCOUNT_USES_OLD_LOGIN, "true");
                             }
                         } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
                             Log_OC.d(TAG, "Failed to find an account");

--- a/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -248,9 +248,9 @@ public class PushUtils {
                                             gson.toJson(pushArbitraryData));
                                 }
                             } else if (remoteOperationResult.getCode() ==
-                                    RemoteOperationResult.ResultCode.ACCOUNT_USES_OLD_LOGIN) {
+                                    RemoteOperationResult.ResultCode.ACCOUNT_USES_STANDARD_PASSWORD) {
                                 arbitraryDataProvider.storeOrUpdateKeyValue(account.name,
-                                        AccountUtils.ACCOUNT_USES_OLD_LOGIN, "true");
+                                        AccountUtils.ACCOUNT_USES_STANDARD_PASSWORD, "true");
                             }
                         } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
                             Log_OC.d(TAG, "Failed to find an account");

--- a/src/main/java/com/owncloud/android/authentication/AccountUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountUtils.java
@@ -52,7 +52,7 @@ public class AccountUtils {
 
     public static final int ACCOUNT_VERSION = 1;
     public static final int ACCOUNT_VERSION_WITH_PROPER_ID = 2;
-    public static final String ACCOUNT_USES_OLD_LOGIN = "ACCOUNT_USES_OLD_LOGIN";
+    public static final String ACCOUNT_USES_STANDARD_PASSWORD = "ACCOUNT_USES_STANDARD_PASSWORD";
 
     /**
      * Can be used to get the currently selected ownCloud {@link Account} in the

--- a/src/main/java/com/owncloud/android/authentication/AccountUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountUtils.java
@@ -52,6 +52,7 @@ public class AccountUtils {
 
     public static final int ACCOUNT_VERSION = 1;
     public static final int ACCOUNT_VERSION_WITH_PROPER_ID = 2;
+    public static final String ACCOUNT_USES_OLD_LOGIN = "ACCOUNT_USES_OLD_LOGIN";
 
     /**
      * Can be used to get the currently selected ownCloud {@link Account} in the

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -30,6 +30,7 @@ import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.design.widget.BottomNavigationView;
+import android.support.design.widget.Snackbar;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
@@ -44,6 +45,7 @@ import android.widget.TextView;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
+import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
@@ -55,6 +57,7 @@ import com.owncloud.android.lib.resources.notifications.models.Notification;
 import com.owncloud.android.ui.adapter.NotificationListAdapter;
 import com.owncloud.android.utils.AnalyticsUtils;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PushUtils;
 import com.owncloud.android.utils.ThemeUtils;
 
 import java.io.IOException;
@@ -139,6 +142,23 @@ public class NotificationsActivity extends FileActivity {
 
             }
         });
+
+        Context context = getApplicationContext();
+        String pushUrl = context.getResources().getString(R.string.push_server_url);
+
+        if (pushUrl.isEmpty()) {
+            Snackbar.make(emptyContentContainer, R.string.push_notifications_not_implemented,
+                    Snackbar.LENGTH_INDEFINITE).show();
+        } else {
+            Account account = AccountUtils.getCurrentOwnCloudAccount(context);
+            ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
+            String pushValue = arbitraryDataProvider.getValue(account.name, PushUtils.KEY_PUSH);
+
+            if (pushValue == null || pushValue.isEmpty()) {
+                Snackbar.make(emptyContentContainer, R.string.push_notifications_old_login,
+                        Snackbar.LENGTH_INDEFINITE).show();
+            }
+        }
 
         setupContent();
     }

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -154,7 +154,7 @@ public class NotificationsActivity extends FileActivity {
             ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
 
             boolean usesOldLogin = arbitraryDataProvider.getBooleanValue(account.name,
-                    AccountUtils.ACCOUNT_USES_OLD_LOGIN);
+                    AccountUtils.ACCOUNT_USES_STANDARD_PASSWORD);
 
             if (usesOldLogin) {
                 Snackbar.make(emptyContentContainer, R.string.push_notifications_old_login,

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -152,11 +152,20 @@ public class NotificationsActivity extends FileActivity {
         } else {
             Account account = AccountUtils.getCurrentOwnCloudAccount(context);
             ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
-            String pushValue = arbitraryDataProvider.getValue(account.name, PushUtils.KEY_PUSH);
 
-            if (pushValue == null || pushValue.isEmpty()) {
+            boolean usesOldLogin = arbitraryDataProvider.getBooleanValue(account.name,
+                    AccountUtils.ACCOUNT_USES_OLD_LOGIN);
+
+            if (usesOldLogin) {
                 Snackbar.make(emptyContentContainer, R.string.push_notifications_old_login,
                         Snackbar.LENGTH_INDEFINITE).show();
+            } else {
+                String pushValue = arbitraryDataProvider.getValue(account.name, PushUtils.KEY_PUSH);
+
+                if (pushValue == null || pushValue.isEmpty()) {
+                    Snackbar.make(emptyContentContainer, R.string.push_notifications_temp_error,
+                            Snackbar.LENGTH_INDEFINITE).show();
+                }
             }
         }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -707,5 +707,5 @@
     <string name="prefs_license">License</string>
     <string name="prefs_gpl_v2" translatable="false">GNU General Public License, version 2</string>
     <string name="push_notifications_not_implemented">Push notifications disabled due to dependencies on proprietary Google Play services.</string>
-    <string name="push_notifications_old_login">Push notifications not possible due to outdated login session. Please consider recreating your account.</string>
+    <string name="push_notifications_old_login">No push notifications due to outdated login session. Please consider re-adding your account.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -706,6 +706,6 @@
     <string name="prefs_sourcecode">Get source code</string>
     <string name="prefs_license">License</string>
     <string name="prefs_gpl_v2" translatable="false">GNU General Public License, version 2</string>
-    <string name="push_notifications_not_implemented">For this version push notification were disabled due to dependencies on proprietary Google play services.</string>
-    <string name="push_notifications_old_login">Push notifications not possible due to old login method. Please consider to re-create your account.</string>
+    <string name="push_notifications_not_implemented">Push notifications disabled due to dependencies on proprietary Google Play services.</string>
+    <string name="push_notifications_old_login">Push notifications not possible due to outdated login session. Please consider recreating your account.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -706,4 +706,6 @@
     <string name="prefs_sourcecode">Get source code</string>
     <string name="prefs_license">License</string>
     <string name="prefs_gpl_v2" translatable="false">GNU General Public License, version 2</string>
+    <string name="push_notifications_not_implemented">For this version push notification were disabled due to dependencies on proprietary Google play services.</string>
+    <string name="push_notifications_old_login">Push notifications not possible due to old login method. Please consider to re-create your account.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -708,4 +708,5 @@
     <string name="prefs_gpl_v2" translatable="false">GNU General Public License, version 2</string>
     <string name="push_notifications_not_implemented">Push notifications disabled due to dependencies on proprietary Google Play services.</string>
     <string name="push_notifications_old_login">No push notifications due to outdated login session. Please consider re-adding your account.</string>
+    <string name="push_notifications_temp_error">Push notifications currently not available.</string>
 </resources>


### PR DESCRIPTION
Show warnings if
- no push possible (fdroid)
- push possible, but old login

I hope my idea is correct to use the push url / push return from google server.

Do we use polling, e.g. 1x / minute for fdroid, if this is possible? If not, then I will open up a new issue for 2.1.

resolves #1519 

Old login: 
![2017-09-20-091204](https://user-images.githubusercontent.com/5836855/30631443-8350d7b6-9de4-11e7-82ce-0d315e7fad37.png)

Fdroid (thanks to Björn for helping with wording ;-) ): 
![2017-09-20-091006](https://user-images.githubusercontent.com/5836855/30631448-86a35ea2-9de4-11e7-9a67-c466ad28b916.png)
