### PR TITLE
Hide select and deselect all on preview and details fragments, fix #1574

### DIFF
--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -87,9 +87,10 @@ public class FileMenuFilter {
      * Filters out the file actions available in the passed {@link Menu} taken into account
      * the state of the {@link OCFile} held by the filter.
      *
-     * @param menu              Options or context menu to filter.
+     * @param menu                  Options or context menu to filter.
+     * @param inSingleFileFragment  True if this is not listing, but single file fragment, like preview or details.
      */
-    public void filter(Menu menu) {
+    public void filter(Menu menu, boolean inSingleFileFragment) {
         if (mFiles == null || mFiles.size() <= 0) {
             hideAll(menu);
 
@@ -97,7 +98,7 @@ public class FileMenuFilter {
             List<Integer> toShow = new ArrayList<>();
             List<Integer> toHide = new ArrayList<>();
 
-            filter(toShow, toHide);
+            filter(toShow, toHide, inSingleFileFragment);
 
             MenuItem item;
             for (int i : toShow) {
@@ -132,10 +133,11 @@ public class FileMenuFilter {
      *
      * Decides what actions must be shown and hidden.
      *
-     * @param toShow            List to save the options that must be shown in the menu.
-     * @param toHide            List to save the options that must be shown in the menu.
+     * @param toShow                List to save the options that must be shown in the menu.
+     * @param toHide                List to save the options that must be shown in the menu.
+     * @param inSingleFileFragment  True if this is not listing, but single file fragment, like preview or details.
      */
-    private void filter(List<Integer> toShow, List<Integer> toHide) {
+    private void filter(List<Integer> toShow, List<Integer> toHide, boolean inSingleFileFragment) {
         boolean synchronizing = anyFileSynchronizing();
 
         /// decision is taken for each possible action on a file in the menu
@@ -174,25 +176,34 @@ public class FileMenuFilter {
         }
 
         // SELECT ALL
-        // Show only if at least one item isn't selected.
-        if (mFiles.size() >= mNumberOfAllFiles) {
-            toHide.add(R.id.action_select_all);
+        if (!inSingleFileFragment) {
+            // Show only if at least one item isn't selected.
+            if (mFiles.size() >= mNumberOfAllFiles) {
+                toHide.add(R.id.action_select_all_action_menu);
+            } else {
+                toShow.add(R.id.action_select_all_action_menu);
+            }
         } else {
-            toShow.add(R.id.action_select_all);
+            // Always hide in single file fragments
+            toHide.add(R.id.action_select_all_action_menu);
         }
 
         // DESELECT ALL
-        // Show only if at least one item is selected.
-        if (mFiles.isEmpty()) {
-            toHide.add(R.id.action_deselect_all);
-        } else {
-            toShow.add(R.id.action_deselect_all);
+        if (!inSingleFileFragment) {
+            // Show only if at least one item is selected.
+            if (mFiles.isEmpty()) {
+                toHide.add(R.id.action_deselect_all_action_menu);
+            } else {
+                toShow.add(R.id.action_deselect_all_action_menu);
+            }
+        }else {
+            // Always hide in single file fragments
+            toHide.add(R.id.action_deselect_all_action_menu);
         }
 
         // OPEN WITH (different to preview!)
         if (!isSingleFile() || !anyFileDown() || synchronizing) {
             toHide.add(R.id.action_open_file_with);
-
         } else {
             toShow.add(R.id.action_open_file_with);
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -229,6 +229,13 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         }
 
         // additional restriction for this fragment
+        item = menu.findItem(R.id.action_select_all);
+        if (item != null) {
+            item.setVisible(false);
+            item.setEnabled(false);
+        }
+
+        // additional restriction for this fragment
         item = menu.findItem(R.id.action_move);
         if (item != null) {
             item.setVisible(false);

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -218,7 +218,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                 mContainerActivity,
                 getActivity()
             );
-            mf.filter(menu);
+            mf.filter(menu, true);
         }
 
         // additional restriction for this fragment 

--- a/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -141,7 +141,7 @@ public class LocalFileListFragment extends ExtendedListFragment {
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         if (mContainerActivity.isFolderPickerMode()) {
-            menu.removeItem(R.id.action_select_all);
+            menu.removeItem(R.id.action_select_all_action_menu);
             menu.removeItem(R.id.action_search);
         } else {
             super.onCreateOptionsMenu(menu, inflater);

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -634,7 +634,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                     mContainerActivity,
                     getActivity()
             );
-            mf.filter(menu);
+            mf.filter(menu, false);
             return true;
         }
 
@@ -1006,11 +1006,11 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                 getActivity().startActivityForResult(action, FileDisplayActivity.REQUEST_CODE__COPY_FILES);
                 return true;
             }
-            case R.id.action_select_all: {
+            case R.id.action_select_all_action_menu: {
                 selectAllFiles(true);
                 return true;
             }
-            case R.id.action_deselect_all: {
+            case R.id.action_deselect_all_action_menu: {
                 selectAllFiles(false);
                 return true;
             }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -297,6 +297,13 @@ public class PreviewImageFragment extends FileFragment {
         }
 
         // additional restriction for this fragment
+        item = menu.findItem(R.id.action_select_all);
+        if (item != null) {
+            item.setVisible(false);
+            item.setEnabled(false);
+        }
+
+        // additional restriction for this fragment
         item = menu.findItem(R.id.action_move);
         if (item != null) {
             item.setVisible(false);

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -277,7 +277,7 @@ public class PreviewImageFragment extends FileFragment {
                     mContainerActivity,
                     getActivity()
             );
-            mf.filter(menu);
+            mf.filter(menu, true);
         }
 
         // additional restriction for this fragment 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -389,6 +389,13 @@ public class PreviewMediaFragment extends FileFragment implements
         }
 
         // additional restriction for this fragment
+        item = menu.findItem(R.id.action_select_all);
+        if (item != null) {
+            item.setVisible(false);
+            item.setEnabled(false);
+        }
+
+        // additional restriction for this fragment
         item = menu.findItem(R.id.action_move);
         if (item != null) {
             item.setVisible(false);

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -377,7 +377,7 @@ public class PreviewMediaFragment extends FileFragment implements
                 mContainerActivity,
                 getActivity()
             );
-            mf.filter(menu);
+            mf.filter(menu, true);
         }
 
         // additional restriction for this fragment 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -287,7 +287,7 @@ public class PreviewTextFragment extends FileFragment {
                     mContainerActivity,
                     getActivity()
             );
-            mf.filter(menu);
+            mf.filter(menu, true);
         }
 
         // additional restriction for this fragment

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -298,6 +298,13 @@ public class PreviewTextFragment extends FileFragment {
         }
 
         // additional restriction for this fragment
+        item = menu.findItem(R.id.action_select_all);
+        if (item != null) {
+            item.setVisible(false);
+            item.setEnabled(false);
+        }
+
+        // additional restriction for this fragment
         item = menu.findItem(R.id.action_move);
         if (item != null) {
             item.setVisible(false);

--- a/src/main/res/menu/file_actions_menu.xml
+++ b/src/main/res/menu/file_actions_menu.xml
@@ -77,13 +77,13 @@
         android:showAsAction="never"
         android:orderInCategory="1" />
     <item
-        android:id="@+id/action_select_all"
+        android:id="@+id/action_select_all_action_menu"
         android:title="@string/select_all"
         app:showAsAction="never"
         android:showAsAction="never"
         android:orderInCategory="1" />
     <item
-        android:id="@+id/action_deselect_all"
+        android:id="@+id/action_deselect_all_action_menu"
         android:title="@string/deselect_all"
         app:showAsAction="never"
         android:showAsAction="never"


### PR DESCRIPTION
resolves #1574

This change makes select/deselect menu items invisible on fragments where they should be invisible. To do this, first was needed to "split" two different "select all" actions into different ones, so they are not overlapped. For that, one of them was changed from "action_select_all" to "action_select_all_action_menu". Second, in method filter() that decides which menu items are visible, "inSingleFileFragment" bool is pushed. This is how we decide are we under some listing, or showing single file (either details or any preview fragment).