### PR TITLE
Avatar cache

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -599,7 +599,12 @@ public class ThumbnailsCacheManager {
                 if (this == avatarWorkerTask
                         && listener.shouldCallGeneratedCallback(mUsername, mCallContext)) {
                         listener.avatarGenerated(new BitmapDrawable(bitmap), mCallContext);
-                    }
+
+                    ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(
+                            MainApp.getAppContext().getContentResolver());
+                    arbitraryDataProvider.storeOrUpdateKeyValue(mAccount.name, "avatar_timestamp",
+                            Long.toString(System.currentTimeMillis()));
+                }
             }
         }
 

--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -48,6 +48,7 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.adapter.DiskLruImageCache;
 import com.owncloud.android.utils.BitmapUtils;
+import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.DisplayUtils.AvatarGenerationListener;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
@@ -602,7 +603,7 @@ public class ThumbnailsCacheManager {
 
                     ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(
                             MainApp.getAppContext().getContentResolver());
-                    arbitraryDataProvider.storeOrUpdateKeyValue(mAccount.name, "avatar_timestamp",
+                    arbitraryDataProvider.storeOrUpdateKeyValue(mAccount.name, DisplayUtils.AVATAR_TIMESTAMP,
                             Long.toString(System.currentTimeMillis()));
                 }
             }

--- a/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
+++ b/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
@@ -39,6 +39,7 @@ import com.owncloud.android.datamodel.SyncedFolder;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.UploadsStorageManager;
 import com.owncloud.android.ui.events.AccountRemovedEvent;
+import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.FilesSyncHelper;
 
@@ -84,7 +85,7 @@ public class AccountRemovalJob extends Job implements AccountManagerCallback<Boo
             // remove pending account removal
             ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(context.getContentResolver());
             arbitraryDataProvider.deleteKeyForAccount(account.name, PENDING_FOR_REMOVAL);
-            arbitraryDataProvider.deleteKeyForAccount(account.name, "avatar_timestamp");
+            arbitraryDataProvider.deleteKeyForAccount(account.name, DisplayUtils.AVATAR_TIMESTAMP);
 
             // remove synced folders set for account
             SyncedFolderProvider syncedFolderProvider = new SyncedFolderProvider(context.getContentResolver());

--- a/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
+++ b/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
@@ -84,6 +84,7 @@ public class AccountRemovalJob extends Job implements AccountManagerCallback<Boo
             // remove pending account removal
             ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(context.getContentResolver());
             arbitraryDataProvider.deleteKeyForAccount(account.name, PENDING_FOR_REMOVAL);
+            arbitraryDataProvider.deleteKeyForAccount(account.name, "avatar_timestamp");
 
             // remove synced folders set for account
             SyncedFolderProvider syncedFolderProvider = new SyncedFolderProvider(context.getContentResolver());

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -93,20 +93,16 @@ import java.util.Set;
  * A helper class for UI/display related operations.
  */
 public class DisplayUtils {
+    public static final String AVATAR_TIMESTAMP = "avatar_timestamp";
     private static final String TAG = DisplayUtils.class.getSimpleName();
-
     private static final String[] sizeSuffixes = {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
     private static final int[] sizeScales = {0, 0, 1, 1, 1, 2, 2, 2, 2};
     private static final int RELATIVE_THRESHOLD_WARNING = 90;
     private static final int RELATIVE_THRESHOLD_CRITICAL = 95;
     private static final String MIME_TYPE_UNKNOWN = "Unknown type";
-
     private static final String HTTP_PROTOCOLL = "http://";
     private static final String HTTPS_PROTOCOLL = "https://";
     private static final String TWITTER_HANDLE_PREFIX = "@";
-
-    public static final String AVATAR_TIMESTAMP = "avatar_timestamp";
-
     private static Map<String, String> mimeType2HumanReadable;
 
     static {
@@ -127,8 +123,8 @@ public class DisplayUtils {
     /**
      * Converts the file size in bytes to human readable output.
      * <ul>
-     *     <li>appends a size suffix, e.g. B, KB, MB etc.</li>
-     *     <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
+     * <li>appends a size suffix, e.g. B, KB, MB etc.</li>
+     * <li>rounds the size based on the suffix to 0,1 or 2 decimals</li>
      * </ul>
      *
      * @param bytes Input file size
@@ -223,7 +219,7 @@ public class DisplayUtils {
     /**
      * Converts an internationalized domain name (IDN) in an URL to and from ASCII/Unicode.
      *
-     * @param url the URL where the domain name should be converted
+     * @param url     the URL where the domain name should be converted
      * @param toASCII if true converts from Unicode to ASCII, if false converts from ASCII to Unicode
      * @return the URL containing the converted domain name
      */
@@ -258,9 +254,9 @@ public class DisplayUtils {
     /**
      * creates the display string for an account.
      *
-     * @param context the actual activity
-     * @param savedAccount the actual, saved account
-     * @param accountName the account name
+     * @param context        the actual activity
+     * @param savedAccount   the actual, saved account
+     * @param accountName    the account name
      * @param fallbackString String to be used in case of an error
      * @return the display string for the given account data
      */
@@ -293,7 +289,7 @@ public class DisplayUtils {
     /**
      * calculates the relative time string based on the given modificaion timestamp.
      *
-     * @param context the app's context
+     * @param context               the app's context
      * @param modificationTimestamp the UNIX timestamp of the file modification time.
      * @return a relative time string
      */
@@ -395,7 +391,7 @@ public class DisplayUtils {
         }
 
         SpannableStringBuilder sb = new SpannableStringBuilder(text);
-        if(spanText == null) {
+        if (spanText == null) {
             return sb;
         }
 
@@ -408,12 +404,6 @@ public class DisplayUtils {
         int end = start + spanText.length();
         sb.setSpan(style, start, end, Spannable.SPAN_INCLUSIVE_INCLUSIVE);
         return sb;
-    }
-
-    public interface AvatarGenerationListener {
-        void avatarGenerated(Drawable avatarDrawable, Object callContext);
-
-        boolean shouldCallGeneratedCallback(String tag, Object callContext);
     }
 
     /**
@@ -440,12 +430,11 @@ public class DisplayUtils {
             boolean twentyFourHoursPassed = false;
             long avatarTimestamp;
 
-            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, AVATAR_TIMESTAMP)) != -1) {
-                if (System.currentTimeMillis() >= avatarTimestamp + 24 * 60 * 60 * 1000) {
-                    twentyFourHoursPassed = true;
-                }
-
+            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, AVATAR_TIMESTAMP)) != -1 &&
+                    (System.currentTimeMillis() >= avatarTimestamp + 24 * 60 * 60 * 1000)) {
+                twentyFourHoursPassed = true;
             }
+
 
             if (thumbnail != null && !twentyFourHoursPassed) {
                 listener.avatarGenerated(
@@ -601,11 +590,10 @@ public class DisplayUtils {
         }
     }
 
-
     /**
      * Get String data from a InputStream
      *
-     * @param inputStream        The File InputStream
+     * @param inputStream The File InputStream
      */
     public static String getData(InputStream inputStream) {
 
@@ -621,5 +609,12 @@ public class DisplayUtils {
             Log_OC.e(TAG, e.getMessage());
         }
         return text.toString();
+    }
+
+
+    public interface AvatarGenerationListener {
+        void avatarGenerated(Drawable avatarDrawable, Object callContext);
+
+        boolean shouldCallGeneratedCallback(String tag, Object callContext);
     }
 }

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -421,21 +421,20 @@ public class DisplayUtils {
                 ((View) callContext).setContentDescription(account.name);
             }
 
-            // Thumbnail in Cache?
-            Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache("a_" + account.name);
 
             ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(
                     MainApp.getAppContext().getContentResolver());
 
-            boolean twentyFourHoursPassed = false;
             long avatarTimestamp;
+            boolean twentyFourHoursPassed = false;
 
-            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, AVATAR_TIMESTAMP)) != -1 &&
+            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, AVATAR_TIMESTAMP)) == -1 ||
                     (System.currentTimeMillis() >= avatarTimestamp + 24 * 60 * 60 * 1000)) {
                 twentyFourHoursPassed = true;
-                ThumbnailsCacheManager.removeBitmapFromDiskCache("a_" + account.name);
             }
 
+            // Thumbnail in Cache?
+            Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache("a_" + account.name);
 
             if (thumbnail != null && !twentyFourHoursPassed) {
                 listener.avatarGenerated(
@@ -445,7 +444,8 @@ public class DisplayUtils {
                 // generate new avatar
                 if (ThumbnailsCacheManager.cancelPotentialAvatarWork(account.name, callContext)) {
                     final ThumbnailsCacheManager.AvatarGenerationTask task =
-                            new ThumbnailsCacheManager.AvatarGenerationTask(listener, callContext, storageManager, account);
+                            new ThumbnailsCacheManager.AvatarGenerationTask(listener, callContext, storageManager, account,
+                                    twentyFourHoursPassed);
                     if (thumbnail == null) {
                         try {
                             listener.avatarGenerated(TextDrawable.createAvatar(account.name, avatarRadius), callContext);

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -433,6 +433,7 @@ public class DisplayUtils {
             if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, AVATAR_TIMESTAMP)) != -1 &&
                     (System.currentTimeMillis() >= avatarTimestamp + 24 * 60 * 60 * 1000)) {
                 twentyFourHoursPassed = true;
+                ThumbnailsCacheManager.removeBitmapFromDiskCache("a_" + account.name);
             }
 
 

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -105,6 +105,8 @@ public class DisplayUtils {
     private static final String HTTPS_PROTOCOLL = "https://";
     private static final String TWITTER_HANDLE_PREFIX = "@";
 
+    public static final String AVATAR_TIMESTAMP = "avatar_timestamp";
+
     private static Map<String, String> mimeType2HumanReadable;
 
     static {
@@ -438,7 +440,7 @@ public class DisplayUtils {
             boolean twentyFourHoursPassed = false;
             long avatarTimestamp;
 
-            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, "avatar_timestamp")) != -1) {
+            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, AVATAR_TIMESTAMP)) != -1) {
                 if (System.currentTimeMillis() >= avatarTimestamp + 24 * 60 * 60 * 1000) {
                     twentyFourHoursPassed = true;
                 }

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -57,6 +57,7 @@ import com.caverock.androidsvg.SVG;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
+import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
@@ -431,7 +432,20 @@ public class DisplayUtils {
             // Thumbnail in Cache?
             Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache("a_" + account.name);
 
-            if (thumbnail != null) {
+            ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(
+                    MainApp.getAppContext().getContentResolver());
+
+            boolean twentyFourHoursPassed = false;
+            long avatarTimestamp;
+
+            if ((avatarTimestamp = arbitraryDataProvider.getLongValue(account, "avatar_timestamp")) != -1) {
+                if (System.currentTimeMillis() >= avatarTimestamp + 24 * 60 * 60 * 1000) {
+                    twentyFourHoursPassed = true;
+                }
+
+            }
+
+            if (thumbnail != null && !twentyFourHoursPassed) {
                 listener.avatarGenerated(
                         BitmapUtils.bitmapToCircularBitmapDrawable(MainApp.getAppContext().getResources(), thumbnail),
                         callContext);


### PR DESCRIPTION
This is a temporary solution to improve how we handle avatars. Basically, it'll refresh them every 24 hours if you are in the app.

Long term solution - etags! yay!

Untested did not even compile, but I trust it works :P

If there are Codacy complaints (I already see one, but it complains without a reason *shrug*), please fix it.
Signed-off-by: Mario Danic <mario@lovelyhq.com>