### PR TITLE
Centralize app's version code and name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ android {
 
         multiDexEnabled true
 
+        versionCode = 20000099
+        versionName = "2.0.0"
+
         // adapt structure from Eclipse to Gradle/Android Studio expectations;
         // see http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Configuring-the-Structure
 

--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -18,9 +18,7 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="com.owncloud.android"
-          android:versionCode="20000009"
-          android:versionName="2.0.0RC9">
+          package="com.owncloud.android">
 
     <application
         android:name=".MainApp"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -19,9 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.owncloud.android"
-          android:versionCode="20000009"
-          android:versionName="2.0.0RC9">
+          package="com.owncloud.android">
 
     <uses-sdk
         android:minSdkVersion="14"

--- a/src/modified/AndroidManifest.xml
+++ b/src/modified/AndroidManifest.xml
@@ -18,9 +18,7 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="com.owncloud.android"
-          android:versionCode="20000009"
-          android:versionName="2.0.0RC9">
+          package="com.owncloud.android">
 
     <application
         android:name=".MainApp"


### PR DESCRIPTION
Pure build config change (beware already set's it to 2.0.0 final) to only have exactly one location for all build flavors where the version code and name is set. Should thus not be merged before going for the 2.0.0 final release else the code and name need to be changed.

Also implies that #1627 has been merged (which should be part of 2.0.0RC9)