### PR TITLE
Notifications: close snackbar when showing drawer

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -240,6 +240,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                     new Handler().post(pendingRunnable);
                     pendingRunnable = null;
                 }
+
+                closeDrawer();
             }
 
             /** Called when a drawer has settled in a completely open state. */


### PR DESCRIPTION
Before:
![2017-10-10-091358](https://user-images.githubusercontent.com/5836855/31373729-7658cf02-ad9b-11e7-8e8a-a6ddce2142e9.png)

After:
![2017-10-10-090836](https://user-images.githubusercontent.com/5836855/31373739-7d35e2b0-ad9b-11e7-8f6f-66108170e8fa.png)

With API >20 we could have used coordinatorLayout, but this prevents closing drawer on older APIs.
So I hide/show the snackbar on drawer opening/closing.
