### PR TITLE
Prevent favorites from displaying twice

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1598,9 +1598,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                     mAdapter.notifyDataSetChanged();
                 }
             }
-        };
-
-        remoteOperationAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, true);
+        }.execute("");
     }
 
     private void setTitle(@StringRes final int title) {


### PR DESCRIPTION
Proposed fix for issue #1698 (also affects selecting "Photos" from Navigation Drawer)