### PR TITLE
Prevent action bar title from being overwritten

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -156,7 +156,7 @@ public class FileDisplayActivity extends HookActivity
         SendShareDialog.SendShareDialogDownloader {
 
     public static final String RESTART = "RESTART";
- 
+
     private SyncBroadcastReceiver mSyncBroadcastReceiver;
     private UploadFinishReceiver mUploadFinishReceiver;
     private DownloadFinishReceiver mDownloadFinishReceiver;
@@ -368,7 +368,7 @@ public class FileDisplayActivity extends HookActivity
 
             if (MainApp.getVersionCode() > lastSeenVersion) {
                 OwnCloudVersion serverVersion = AccountUtils.getServerVersionForAccount(account, this);
-                
+
                 if (serverVersion == null) {
                     OCCapability capability = getCapabilities();
                     serverVersion = new OwnCloudVersion(capability.getVersionMayor() + VERSION_DOT +
@@ -736,7 +736,7 @@ public class FileDisplayActivity extends HookActivity
                     if (success) {
                         // update the file from database, for the local storage path
                         mWaitingToPreview = getStorageManager().getFileById(mWaitingToPreview.getFileId());
-                        
+
                         if (PreviewMediaFragment.canBePreviewed(mWaitingToPreview)) {
                             boolean streaming = AccountUtils.getServerVersionForAccount(getAccount(), this)
                                     .isMediaStreamingSupported();
@@ -1261,7 +1261,7 @@ public class FileDisplayActivity extends HookActivity
         } else {
             setDrawerMenuItemChecked(menuItemId);
         }
-        
+
         Log_OC.v(TAG, "onResume() end");
     }
 
@@ -2301,7 +2301,7 @@ public class FileDisplayActivity extends HookActivity
         } else {
             Log_OC.e(TAG, "Trying to send a NULL OCFile");
         }
-        
+
         mWaitingToSend = null;
     }
 
@@ -2492,9 +2492,23 @@ public class FileDisplayActivity extends HookActivity
         browseToRoot();
     }
 
+    public void setActionBarTitle(@StringRes final int title) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (getSupportActionBar() != null) {
+                    ThemeUtils.setColoredTitle(getSupportActionBar(), title, getBaseContext());
+                }
+            }
+        });
+    }
+
     @Override
     public void showFiles(boolean onDeviceOnly) {
         super.showFiles(onDeviceOnly);
+        if (onDeviceOnly) {
+            setActionBarTitle(R.string.drawer_item_on_device);
+        }
         getListOfFilesFragment().refreshDirectory();
     }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1443,6 +1443,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         remoteOperationAsyncTask = new AsyncTask() {
             @Override
             protected Object doInBackground(Object[] params) {
+                setTitle();
                 if (getContext() != null && !isCancelled()) {
                     RemoteOperationResult remoteOperationResult = remoteOperation.execute(currentAccount, getContext());
 

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -224,11 +224,16 @@ public final class ThemeUtils {
     public static String getDefaultDisplayNameForRootFolder(Context context) {
         OCCapability capability = getCapability(context);
 
-        if (capability.getServerName() == null || capability.getServerName().isEmpty()) {
-            return MainApp.getAppContext().getResources().getString(R.string.default_display_name_for_root_folder);
+        if (MainApp.isOnlyOnDevice()) {
+            return MainApp.getAppContext().getString(R.string.drawer_item_on_device);
         } else {
-            return capability.getServerName();
+            if (capability.getServerName() == null || capability.getServerName().isEmpty()) {
+                return MainApp.getAppContext().getResources().getString(R.string.default_display_name_for_root_folder);
+            } else {
+                return capability.getServerName();
+            }
         }
+
     }
 
     public static void setStatusBarColor(Activity activity, @ColorInt int color) {


### PR DESCRIPTION
Proposed fix for #1693 

Resolves #1693 

Setting the title within the AsyncTask to prevent the ToolbarActivity from overwriting the title with the default provider title. I did some testing and it seems to work fine since the setTitle function is being called to run on the UI thread.