### PR TITLE
Webviews: better error handling 

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -126,6 +126,7 @@ import com.owncloud.android.utils.AnalyticsUtils;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.ErrorMessageAdapter;
 
+import java.io.InputStream;
 import java.net.URLDecoder;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
@@ -412,7 +413,13 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
                 progressBar.setVisibility(View.GONE);
                 mLoginWebView.setVisibility(View.VISIBLE);
-                mLoginWebView.loadData(DisplayUtils.getData(getResources().openRawResource(R.raw.custom_error)),"text/html; charset=UTF-8", null);
+
+                InputStream resources = getResources().openRawResource(R.raw.custom_error);
+                String customError = DisplayUtils.getData(resources);
+
+                if (!customError.isEmpty()) {
+                    mLoginWebView.loadData(customError, "text/html; charset=UTF-8", null);
+                }
             }
         });
 

--- a/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
@@ -37,6 +37,8 @@ import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.DisplayUtils;
 
+import java.io.InputStream;
+
 /**
  * This activity shows an URL as a web view
  */
@@ -122,8 +124,12 @@ public class ExternalSiteWebView extends FileActivity {
 
         webview.setWebViewClient(new WebViewClient() {
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-                webview.loadData(DisplayUtils.getData(getResources().openRawResource(R.raw.custom_error)),
-                        "text/html; charset=UTF-8", null);
+                InputStream resources = getResources().openRawResource(R.raw.custom_error);
+                String customError = DisplayUtils.getData(resources);
+
+                if (!customError.isEmpty()) {
+                    webview.loadData(customError, "text/html; charset=UTF-8", null);
+                }
             }
         });
 

--- a/src/main/res/raw/custom_error.html
+++ b/src/main/res/raw/custom_error.html
@@ -1,4 +1,0 @@
-<html>
-<h1>Sorry</h1>
-Modified
-</html>


### PR DESCRIPTION
Fixes #1619 

If custom_error is empty simply show error page, otherwise show custom error html page

![2017-10-27-135251](https://user-images.githubusercontent.com/5836855/32102948-b72c0be4-bb1e-11e7-89d7-c6bda9b354f2.png)
