### PR TITLE
Use text-color and element-color whenever possible (>=NC13)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ android {
 dependencies {
     /// dependencies for app building
     implementation 'com.android.support:multidex:1.0.2'
-    compile 'com.github.nextcloud:android-library:1.0.31'
+    compile 'com.github.nextcloud:android-library:themingWhite-SNAPSHOT'
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1926,6 +1926,8 @@ public class FileDataStorageManager {
         cv.put(ProviderTableMeta.CAPABILITIES_EXTERNAL_LINKS, capability.getExternalLinks().getValue());
         cv.put(ProviderTableMeta.CAPABILITIES_SERVER_NAME, capability.getServerName());
         cv.put(ProviderTableMeta.CAPABILITIES_SERVER_COLOR, capability.getServerColor());
+        cv.put(ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR, capability.getServerTextColor());
+        cv.put(ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR, capability.getServerElementColor());
         cv.put(ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL, capability.getServerBackground());
         cv.put(ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN, capability.getServerSlogan());
 
@@ -2069,6 +2071,10 @@ public class FileDataStorageManager {
                     .getColumnIndex(ProviderTableMeta.CAPABILITIES_EXTERNAL_LINKS))));
             capability.setServerName(c.getString(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_NAME)));
             capability.setServerColor(c.getString(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_COLOR)));
+            capability.setServerTextColor(
+                    c.getString(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR)));
+            capability.setServerElementColor(
+                    c.getString(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR)));
             capability.setServerBackground(c.getString(c.getColumnIndex(
                     ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL)));
             capability.setServerSlogan(c.getString(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN)));

--- a/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -32,7 +32,7 @@ import com.owncloud.android.MainApp;
 public class ProviderMeta {
 
     public static final String DB_NAME = "filelist";
-    public static final int DB_VERSION = 24;
+    public static final int DB_VERSION = 25;
 
     private ProviderMeta() {
     }
@@ -153,6 +153,8 @@ public class ProviderMeta {
         public static final String CAPABILITIES_EXTERNAL_LINKS = "external_links";
         public static final String CAPABILITIES_SERVER_NAME = "server_name";
         public static final String CAPABILITIES_SERVER_COLOR = "server_color";
+        public static final String CAPABILITIES_SERVER_TEXT_COLOR = "server_text_color";
+        public static final String CAPABILITIES_SERVER_ELEMENT_COLOR = "server_element_color";
         public static final String CAPABILITIES_SERVER_BACKGROUND_URL = "background_url";
         public static final String CAPABILITIES_SERVER_SLOGAN = "server_slogan";
 

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -1152,6 +1152,27 @@ public class FileContentProvider extends ContentProvider {
             if (!upgraded) {
                 Log_OC.i(SQL, String.format(Locale.ENGLISH, UPGRADE_VERSION_MSG, oldVersion, newVersion));
             }
+
+            if (oldVersion < 25 && newVersion >= 25) {
+                Log_OC.i(SQL, "Entering in the #25 Adding text and element color to capabilities");
+                db.beginTransaction();
+                try {
+                    db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                            ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + " TEXT ");
+
+                    db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                            ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + " TEXT ");
+
+                    upgraded = true;
+                    db.setTransactionSuccessful();
+                } finally {
+                    db.endTransaction();
+                }
+            }
+
+            if (!upgraded) {
+                Log_OC.i(SQL, String.format(Locale.ENGLISH, UPGRADE_VERSION_MSG, oldVersion, newVersion));
+            }
         }
 
         @Override
@@ -1252,6 +1273,8 @@ public class FileContentProvider extends ContentProvider {
                 + ProviderTableMeta.CAPABILITIES_EXTERNAL_LINKS + INTEGER  // boolean
                 + ProviderTableMeta.CAPABILITIES_SERVER_NAME + TEXT
                 + ProviderTableMeta.CAPABILITIES_SERVER_COLOR + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + TEXT
                 + ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN + TEXT
                 + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL + " TEXT );");
     }

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -919,10 +919,10 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 }
             }
 
-            int darkColor = ThemeUtils.primaryDarkColor();
-            ThemeUtils.tintDrawable(item.getIcon(), darkColor);
+            int elementColor = ThemeUtils.elementColor();
+            ThemeUtils.tintDrawable(item.getIcon(), elementColor);
 
-            String colorHex = ThemeUtils.colorToHexString(darkColor);
+            String colorHex = ThemeUtils.colorToHexString(elementColor);
             item.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + item.getTitle() + "</font>"));
 
             mCheckedMenuItem = menuItemId;

--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -150,7 +150,7 @@ public class MimeTypeUtil {
             drawableId = R.drawable.folder;
         }
 
-        return ThemeUtils.tintDrawable(drawableId, ThemeUtils.primaryColor(account));
+        return ThemeUtils.tintDrawable(drawableId, ThemeUtils.elementColor(account));
     }
 
     public static Drawable getDefaultFolderIcon() {

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -103,6 +103,34 @@ public class ThemeUtils {
         }
     }
 
+    public static int elementColor() {
+        return elementColor(null);
+    }
+
+    public static int elementColor(Account account) {
+        OCCapability capability = getCapability(account);
+
+        try {
+            return Color.parseColor(capability.getServerElementColor());
+        } catch (Exception e) {
+            int primaryColor;
+
+            try {
+                primaryColor = Color.parseColor(capability.getServerColor());
+            } catch (Exception e1) {
+                primaryColor = MainApp.getAppContext().getResources().getColor(R.color.primary);
+            }
+
+            float[] hsl = colorToHSL(primaryColor);
+
+            if (hsl[2] > 0.8) {
+                return MainApp.getAppContext().getResources().getColor(R.color.elementFallbackColor);
+            } else {
+                return primaryColor;
+            }
+        }
+    }
+
     public static boolean themingEnabled() {
         return getCapability().getServerColor() != null && !getCapability().getServerColor().isEmpty();
     }
@@ -112,10 +140,14 @@ public class ThemeUtils {
      * adapted from https://github.com/nextcloud/server/blob/master/apps/theming/lib/Util.php#L90-L102
      */
     public static int fontColor() {
-        if (darkTheme()) {
-            return Color.WHITE;
-        } else {
-            return Color.BLACK;
+        try {
+            return Color.parseColor(getCapability().getServerTextColor());
+        } catch (Exception e) {
+            if (darkTheme()) {
+                return Color.WHITE;
+            } else {
+                return Color.BLACK;
+            }
         }
     }
 

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -37,6 +37,7 @@
 
     <!-- Colors -->
     <color name="standard_grey">#757575</color>
+    <color name="elementFallbackColor">#555555</color>
 
     <!-- standard material color definitions -->
 


### PR DESCRIPTION
Fallback will be to computed values, and if this does not work fallback to default one.

Also computes element color on very light themes.

Fixes: #1308 