### PR TITLE
Brander: support for custom weblogin urls

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -368,13 +368,17 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         mLoginWebView.getSettings().setSaveFormData(false);
         mLoginWebView.getSettings().setSavePassword(false);
 
-        if (baseURL != null && !baseURL.isEmpty()){
-            Map<String, String> headers = new HashMap<>();
-            headers.put(RemoteOperation.OCS_API_HEADER, RemoteOperation.OCS_API_HEADER_VALUE);
-            mLoginWebView.loadUrl(baseURL + WEB_LOGIN, headers);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(RemoteOperation.OCS_API_HEADER, RemoteOperation.OCS_API_HEADER_VALUE);
+
+        String url;
+        if (baseURL != null && !baseURL.isEmpty()) {
+            url = baseURL + WEB_LOGIN;
         } else {
-            mLoginWebView.loadUrl(getResources().getString(R.string.webview_login_url));
+            url = getResources().getString(R.string.webview_login_url);
         }
+
+        mLoginWebView.loadUrl(url, headers);
 
         mLoginWebView.setWebViewClient(new WebViewClient() {
             @Override

--- a/src/main/res/values/setup.xml
+++ b/src/main/res/values/setup.xml
@@ -132,7 +132,7 @@
 
     <!-- login data links -->
     <string name="login_data_own_scheme" translatable="false">nc</string>
-    <!-- url for webview login, with the protocol prefix
+    <!-- url for webview login, with the protocol prefix and with full url (normally /index.php/login/flow)
     If set, will replace all other login methods available -->
     <string name="webview_login_url" translatable="false"></string>
 


### PR DESCRIPTION
Always use ocs-api header.
weblogin_url in setup.xml is generic on purpose so that any url/server can handle this.