### PR TITLE
Tint background on drawer/user info as fallback

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -30,7 +30,9 @@ import android.accounts.AccountManagerFuture;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -1050,10 +1052,14 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                     SimpleTarget target = new SimpleTarget<Drawable>() {
                         @Override
                         public void onResourceReady(Drawable resource, GlideAnimation glideAnimation) {
+                            int primaryColor = ThemeUtils.primaryColor(getAccount());
+                            Drawable[] drawables = {new ColorDrawable(primaryColor), resource};
+                            LayerDrawable layerDrawable = new LayerDrawable(drawables);
+                            
                             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-                                navigationHeader.setBackgroundDrawable(resource);
+                                navigationHeader.setBackgroundDrawable(layerDrawable);
                             } else {
-                                navigationHeader.setBackground(resource);
+                                navigationHeader.setBackground(layerDrawable);
                             }
                         }
                     };

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1046,16 +1046,29 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
 
             if (navigationHeader != null) {
                 String background = getStorageManager().getCapability(getAccount().name).getServerBackground();
+                int primaryColor = ThemeUtils.primaryColor(getAccount());
 
                 if (URLUtil.isValidUrl(background) || background.isEmpty()) {
                     // background image
                     SimpleTarget target = new SimpleTarget<Drawable>() {
                         @Override
                         public void onResourceReady(Drawable resource, GlideAnimation glideAnimation) {
-                            int primaryColor = ThemeUtils.primaryColor(getAccount());
                             Drawable[] drawables = {new ColorDrawable(primaryColor), resource};
                             LayerDrawable layerDrawable = new LayerDrawable(drawables);
                             
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+                                navigationHeader.setBackgroundDrawable(layerDrawable);
+                            } else {
+                                navigationHeader.setBackground(layerDrawable);
+                            }
+                        }
+
+                        @Override
+                        public void onLoadFailed(Exception e, Drawable errorDrawable) {
+                            Drawable[] drawables = {new ColorDrawable(primaryColor),
+                                    getResources().getDrawable(R.drawable.background)};
+                            LayerDrawable layerDrawable = new LayerDrawable(drawables);
+
                             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
                                 navigationHeader.setBackgroundDrawable(layerDrawable);
                             } else {

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -33,7 +33,9 @@ import android.content.ContentResolver;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
@@ -285,10 +287,14 @@ public class UserInfoActivity extends FileActivity {
                     SimpleTarget target = new SimpleTarget<Drawable>() {
                         @Override
                         public void onResourceReady(Drawable resource, GlideAnimation glideAnimation) {
+                            int primaryColor = ThemeUtils.primaryColor(getAccount());
+                            Drawable[] drawables = {new ColorDrawable(primaryColor), resource};
+                            LayerDrawable layerDrawable = new LayerDrawable(drawables);
+                            
                             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-                                appBar.setBackgroundDrawable(resource);
+                                appBar.setBackgroundDrawable(layerDrawable);
                             } else {
-                                appBar.setBackground(resource);
+                                appBar.setBackground(layerDrawable);
                             }
                         }
                     };

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -281,16 +281,29 @@ public class UserInfoActivity extends FileActivity {
 
             if (appBar != null) {
                 String background = getStorageManager().getCapability(account.name).getServerBackground();
+                int primaryColor = ThemeUtils.primaryColor(getAccount());
 
                 if (URLUtil.isValidUrl(background)) {
                     // background image
                     SimpleTarget target = new SimpleTarget<Drawable>() {
                         @Override
                         public void onResourceReady(Drawable resource, GlideAnimation glideAnimation) {
-                            int primaryColor = ThemeUtils.primaryColor(getAccount());
                             Drawable[] drawables = {new ColorDrawable(primaryColor), resource};
                             LayerDrawable layerDrawable = new LayerDrawable(drawables);
                             
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+                                appBar.setBackgroundDrawable(layerDrawable);
+                            } else {
+                                appBar.setBackground(layerDrawable);
+                            }
+                        }
+
+                        @Override
+                        public void onLoadFailed(Exception e, Drawable errorDrawable) {
+                            Drawable[] drawables = {new ColorDrawable(primaryColor),
+                                    getResources().getDrawable(R.drawable.background)};
+                            LayerDrawable layerDrawable = new LayerDrawable(drawables);
+
                             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
                                 appBar.setBackgroundDrawable(layerDrawable);
                             } else {


### PR DESCRIPTION
In theming app one can set an image or a plain color.
On NC12 it was both on the same string via capabilities: either url (image) or hex code (color)
On NC13 this changed: it is always an image, but on color it is a transparent png.

This now always paints the background with the primary color and on top shows always the image.