### PR TITLE
Prevent crash when updating external links

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1373,7 +1373,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                                     externalLinksProvider.storeExternalLink(link);
                                 }
 
-                                updateExternalLinksInDrawer();
+                                runOnUiThread(() -> updateExternalLinksInDrawer());
                             }
                         } else {
                             sharedPreferences.edit().putInt(EXTERNAL_LINKS_COUNT, count + 1).apply();


### PR DESCRIPTION
Was crashing as only the calling thread can update the ui.