### PR TITLE
Remove unused translations from values/strings.xml

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -124,13 +124,10 @@
     <string name="common_yes">Yes</string>
     <string name="common_no">No</string>
     <string name="common_ok">OK</string>
-    <string name="common_remove_upload">Delete upload</string>
-    <string name="common_retry_upload">Retry uploading</string>
     <string name="common_cancel_sync">Cancel sync</string>
     <string name="common_cancel">Cancel</string>
     <string name="common_back">Back</string>
     <string name="common_save">Save</string>
-    <string name="common_error">Error</string>
     <string name="common_loading">Loading &#8230;</string>
     <string name="common_unknown">unknown</string>
     <string name="common_error_unknown">Unknown error</string>
@@ -158,9 +155,7 @@
     <string name="uploads_view_group_finished_uploads">Uploaded</string>
     <string name="uploads_view_upload_status_succeeded">Completed</string>
     <string name="uploads_view_upload_status_cancelled">Cancelled</string>
-    <string name="uploads_view_upload_status_paused">Paused</string>
     <string name="uploads_view_upload_status_failed_connection_error">Connection error</string>
-    <string name="uploads_view_upload_status_failed_retry">Upload will be retried shortly</string>
     <string name="uploads_view_upload_status_failed_credentials_error">Credentials error</string>
     <string name="uploads_view_upload_status_failed_folder_error">Folder error</string>
     <string name="uploads_view_upload_status_failed_file_error">File error</string>
@@ -264,7 +259,6 @@
 	<string name="auth_expired_basic_auth_toast">Please enter the current password</string>
 	<string name="auth_expired_saml_sso_token_toast">Your session expired. Please connect again</string>
 	<string name="auth_connecting_auth_server">Connecting to authentication server&#8230;</string>
-	<string name="auth_unsupported_auth_method">The server does not support this authentication method</string>
 	<string name="auth_unsupported_multiaccount">%1$s does not support multiple accounts</string>
 	<string name="auth_fail_get_user_name">Your server is not returning a correct user ID, please contact an administrator</string>
 	<string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
@@ -286,7 +280,6 @@
     <string name="rename_dialog_title">Enter a new name</string>
     <string name="rename_local_fail_msg">Local copy could not be renamed, try a different name</string>
     <string name="rename_server_fail_msg">Could not give server new name</string>
-    <string name="sync_file_fail_msg">Could not check remote file</string>
     <string name="sync_file_nothing_to_do_msg">File contents already synchronized</string>
     <string name="create_dir_fail_msg">Could not create folder</string>
     <string name="filename_forbidden_characters">Forbidden characters: / \\ &lt; &gt; : " | ? *</string>
@@ -294,7 +287,6 @@
     <string name="filename_empty">File name cannot be empty</string>
     <string name="wait_a_moment">Wait a moment&#8230;</string>
     <string name="wait_checking_credentials">Checking stored credentials</string>
-    <string name="filedisplay_unexpected_bad_get_content">Unexpected problem, please select the file from a different app</string>
     <string name="filedisplay_no_file_selected">No file selected</string>
     <string name="activity_chooser_title">Send link to &#8230;</string>
     <string name="wait_for_tmp_copy_from_private_storage">Copying file from private storage</string>
@@ -337,7 +329,6 @@
     <string name="placeholder_media_time">12:23:45</string>
 
     <string name="auto_upload_on_wifi">Only upload on Wi-Fi</string>
-    <string name="instant_video_upload_on_charging">Only upload when charging</string>
     <string name="instant_upload_on_charging">Only upload when charging</string>
     <string name="instant_upload_path">/InstantUpload</string>
     <string name="auto_upload_path">/AutoUpload</string>
@@ -394,7 +385,6 @@
     <string name="downloader_download_file_not_found">The file is no longer available on the server</string>
 
     <string name="file_migration_dialog_title">Updating storage path</string>
-    <string name="file_migration_finish_button">Finish</string>
     <string name="file_migration_preparing">Preparing migration&#8230;</string>
     <string name="file_migration_checking_destination">Checking destination&#8230;</string>
     <string name="file_migration_saving_accounts_configuration">Saving configuration of accounts&#8230;</string>
@@ -452,9 +442,6 @@
 
     <string name="sync_folder_failed_content">Synchronization of %1$s folder could not be completed</string>
 
-	<string name="shared_subject_header">shared</string>
-	<string name="with_you_subject_header">with you</string>
-    
 	<string name="subject_user_shared_with_you">%1$s shared \"%2$s\" with you</string>
     <string name="subject_shared_with_you">\"%1$s\" has been shared with you</string>
 
@@ -477,8 +464,6 @@
 
     <string name="prefs_instant_behaviour_dialogTitle">Original file will be&#8230;</string>
     <string name="prefs_instant_behaviour_title">Original file will be&#8230;</string>
-    <string name="upload_copy_files">Copy file</string>
-    <string name="upload_move_files">Move file</string>
     <string name="select_all">Select all</string>
     <string name="deselect_all">Deselect all</string>
 
@@ -520,8 +505,6 @@
     <string name="share_privilege_can_edit_create">create</string>
     <string name="share_privilege_can_edit_change">change</string>
     <string name="share_privilege_can_edit_delete">delete</string>
-    <string name="edit_share_unshare">Stop sharing</string>
-    <string name="edit_share_done">done</string>
 
     <string name="action_retry_uploads">Retry failed uploads</string>
     <string name="action_clear_failed_uploads">Clear failed uploads</string>
@@ -534,14 +517,12 @@
     <string name="manage_space_title">Manage space</string>
     <string name="manage_space_description">Settings, database and server certificates from %1$s\'s data will be deleted permanently. \n\nDownloaded files will be kept untouched.\n\nThis process can take a while.</string>
     <string name="manage_space_clear_data">Clear data</string>
-    <string name="manage_space_error">Some files could not be deleted.</string>
 
     <string name="permission_storage_access">Additional permissions required to upload and download files.</string>
     <string name="local_file_not_found_toast">File not found in local file system</string>
     <string name="confirmation_remove_files_alert">Do you really want to delete the selected items?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to delete the selected items and their contents?</string>
     <string name="maintenance_mode">Server in maintenance mode</string>
-    <string name="lock_failed">Failed to lock the file</string>
 
     <string name="uploads_view_upload_status_waiting_for_charging">Awaiting charge</string>
     <string name="actionbar_search">Search</string>
@@ -579,7 +560,6 @@
     <string name="synced_folders_loading_folders">Loading folders&#8230;</string>
     <string name="synced_folders_no_results">No media folders found.</string>
     <string name="synced_folders_preferences">Preferences for auto uploading</string>
-    <string name="synced_folders_settings">Settings</string>
     <string name="synced_folders_new_info">Instant uploading has been revamped completely. Re-configure your auto upload from within the main menu.\n\nEnjoy the new and extended auto uploading.</string>
     <string name="synced_folders_preferences_folder_path">For %1$s</string>
     <string name="synced_folders_plus" translatable="false">+</string>
@@ -595,9 +575,6 @@
         <item quantity="other">%d selected</item>
     </plurals>
 
-    <string name="activity_list_loading_activity">Loading activities&#8230;</string>
-    <string name="activity_list_no_results">No activities found.</string>
-
     <string name="notifications_loading_activity">Loading notifications&#8230;</string>
     <string name="notifications_no_results_headline">No notifications</string>
     <string name="notifications_no_results_message">Please check back later.</string>
@@ -610,8 +587,6 @@
     <string name="upload_file_dialog_filetype_googlemap_shortcut">Google Maps shortcut file(%s)</string>
 
     <string name="storage_description_default">Default</string>
-    <string name="storage_description_sd_no">SD card %1$d</string>
-    <string name="storage_description_unknown">Unknown</string>
 
     <!-- What's new feature and texts to show -->
     <string name="whats_new_title">What\'s new in %1$s</string>
@@ -644,20 +619,17 @@
     <string name="fingerprint_unknown">Finger not recognized</string>
 
     <!-- User information -->
-    <string name="user_info_full_name">Full name</string>
     <string name="user_info_email">E-mail</string>
     <string name="user_info_phone">Phone number</string>
     <string name="user_info_address">Address</string>
     <string name="user_info_website">Website</string>
     <string name="user_info_twitter">Twitter</string>
 
-    <string name="user_information_description">User information</string>
     <string name="user_information_retrieval_error">Error retrieving user information</string>
 
     <!-- Activities -->
     <string name="activities_no_results_headline">No activity yet</string>
     <string name="activities_no_results_message">This stream will show events like\nadditions, changes and shares</string>
-    <string name="webview_error">Error occurred</string>
     <string name="prefs_category_about">About</string>
 
     <string name="actionbar_contacts">Back up contacts</string>
@@ -666,8 +638,6 @@
     <string name="contacts_automatic_backup">Automatic backup</string>
     <string name="contacts_last_backup">Last backup</string>
     <string name="contacts_read_permission">Permission to read contact list needed</string>
-    <string name="contacts_write_permission">Permission to change contact list needed</string>
-    <string name="contactlist_title">Restore contacts</string>
     <string name="contaclist_restore_selected">Restore selected contacts</string>
     <string name="contactlist_account_chooser_title">Choose account to import</string>
     <string name="contactlist_no_permission">No permission given, nothing imported!</string>
@@ -679,7 +649,6 @@
     <string name="contacts_preferences_import_scheduled">Import scheduled and will start shortly</string>
 
     <!-- Notifications -->
-    <string name="new_notification_received">New notification received</string>
     <string name="drawer_logout">Logout</string>
     <string name="picture_set_as_no_app">No app found to set a picture with!</string>
     <string name="privacy">Privacy</string>


### PR DESCRIPTION
Before we used lint we removed many code references without removing the strings, so this is only a cleanup.
When we merge this some time ahead of next release we can see in dev version if some translations are missing.