### PR TITLE
Overhauled data storage management

### DIFF
--- a/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -98,7 +98,7 @@ public class PushUtils {
     }
     
     private static int generateRsa2048KeyPair() {
-        String keyPath = MainApp.getStoragePath() + File.separator + MainApp.getDataFolder() + File.separator
+        String keyPath = MainApp.getAppContext().getFilesDir().getAbsolutePath() + File.separator + MainApp.getDataFolder() + File.separator
                 + KEYPAIR_FOLDER;
 
         String privateKeyPath = keyPath + File.separator + KEYPAIR_FILE_NAME + KEYPAIR_PRIV_EXTENSION;
@@ -270,7 +270,7 @@ public class PushUtils {
     }
 
     public static Key readKeyFromFile(boolean readPublicKey) {
-        String keyPath = MainApp.getStoragePath() + File.separator + MainApp.getDataFolder() + File.separator
+        String keyPath = MainApp.getAppContext().getFilesDir().getAbsolutePath() + File.separator + MainApp.getDataFolder() + File.separator
                 + KEYPAIR_FOLDER;
 
         String privateKeyPath = keyPath + File.separator + KEYPAIR_FILE_NAME + KEYPAIR_PRIV_EXTENSION;

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -111,8 +111,8 @@ public class MainApp extends MultiDexApplication {
 
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-        MainApp.storagePath = appPrefs.getString(Preferences.PreferenceKeys.STORAGE_PATH, Environment.
-                getExternalStorageDirectory().getAbsolutePath());
+        MainApp.storagePath = appPrefs.getString(Preferences.PreferenceKeys.STORAGE_PATH,
+                Environment.getExternalStorageDirectory().getAbsolutePath());
 
         boolean isSamlAuth = AUTH_ON.equals(getString(R.string.auth_method_saml_web_sso));
 

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -112,7 +112,7 @@ public class MainApp extends MultiDexApplication {
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         MainApp.storagePath = appPrefs.getString(Preferences.PreferenceKeys.STORAGE_PATH,
-                Environment.getExternalStorageDirectory().getAbsolutePath());
+                getApplicationContext().getFilesDir().getAbsolutePath());
 
         boolean isSamlAuth = AUTH_ON.equals(getString(R.string.auth_method_saml_web_sso));
 

--- a/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -28,7 +28,9 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.v4.content.FileProvider;
 
+import com.owncloud.android.R;
 import com.owncloud.android.lib.common.network.WebdavUtils;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.MimeType;
@@ -283,25 +285,16 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
             return null;
         }
         if (mExposedFileUri == null) {
-            /*if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-                // TODO - use FileProvider with any Android version, with deeper testing -> 2.2.0
-                mExposedFileUri = Uri.parse(
-                        ContentResolver.SCHEME_FILE + "://" + WebdavUtils.encodePath(mLocalPath)
-                );
-            } else {
-                // Use the FileProvider to get a content URI
-                try {
-                    mExposedFileUri = FileProvider.getUriForFile(
-                            context,
-                            context.getString(R.string.file_provider_authority),
-                            new File(mLocalPath)
-                    );
-                } catch (IllegalArgumentException e) {
-                    Log_OC.e(TAG, "File can't be exported");
-                }
+            try {
+                mExposedFileUri = FileProvider.getUriForFile(
+                        context,
+                        context.getString(R.string.file_provider_authority),
+                        new File(mLocalPath));
+            } catch (IllegalArgumentException ex) {
+                // Could not share file using FileProvider URI scheme.
+                // Fall back to legacy URI parsing.
+                return Uri.parse(ContentResolver.SCHEME_FILE + "://" + WebdavUtils.encodePath(mLocalPath));
             }
-        }*/
-            return Uri.parse(ContentResolver.SCHEME_FILE + "://" + WebdavUtils.encodePath(mLocalPath));
         }
         
         return mExposedFileUri;

--- a/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -277,6 +277,19 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
         return mLocalUri;
     }
 
+
+    public Uri getLegacyExposedFileUri(Context context) {
+        if (mLocalPath == null || mLocalPath.length() == 0) {
+            return null;
+        }
+
+        if (mExposedFileUri == null) {
+            return Uri.parse(ContentResolver.SCHEME_FILE + "://" + WebdavUtils.encodePath(mLocalPath));
+        }
+
+        return mExposedFileUri;
+
+    }
     /*
         Partly disabled because not all apps understand paths that we get via this method for now
      */
@@ -293,7 +306,7 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
             } catch (IllegalArgumentException ex) {
                 // Could not share file using FileProvider URI scheme.
                 // Fall back to legacy URI parsing.
-                return Uri.parse(ContentResolver.SCHEME_FILE + "://" + WebdavUtils.encodePath(mLocalPath));
+                getLegacyExposedFileUri(context);
             }
         }
         

--- a/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
+++ b/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
@@ -21,7 +21,7 @@
 
 package com.owncloud.android.datastorage;
 
-import android.os.Build;
+import android.os.Environment;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datastorage.providers.EnvironmentStoragePointProvider;
@@ -31,7 +31,6 @@ import com.owncloud.android.datastorage.providers.MountCommandStoragePointProvid
 import com.owncloud.android.datastorage.providers.SystemDefaultStoragePointProvider;
 import com.owncloud.android.datastorage.providers.VDCStoragePointProvider;
 
-import java.io.File;
 import java.util.Vector;
 
 /**
@@ -63,18 +62,14 @@ public class DataStorageProvider {
             return mCachedStoragePoints.toArray(new StoragePoint[mCachedStoragePoints.size()]);
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            for (File f : MainApp.getAppContext().getExternalMediaDirs()) {
-                if (f != null) {
-                    mCachedStoragePoints.add(new StoragePoint(f.getAbsolutePath(), f.getAbsolutePath()));
-                }
-            }
-        } else {
-            for (IStoragePointProvider p : mStorageProviders) {
-                if (p.canProvideStoragePoints()) {
-                    mCachedStoragePoints.addAll(p.getAvailableStoragePoint());
-                }
-            }
+        // Add internal storage directory
+        mCachedStoragePoints.add(new StoragePoint(MainApp.getAppContext().getFilesDir().getAbsolutePath(),
+                MainApp.getAppContext().getFilesDir().getAbsolutePath()));
+
+        // Add external storage directory if available.
+        if (isExternalStorageReadable() && isExternalStorageWritable()) {
+            mCachedStoragePoints.add(new StoragePoint(MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath(),
+                    MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath()));
         }
 
         return mCachedStoragePoints.toArray(new StoragePoint[mCachedStoragePoints.size()]);
@@ -97,4 +92,24 @@ public class DataStorageProvider {
     public void removeStoragePointProvider(IStoragePointProvider provider) {
         mStorageProviders.remove(provider);
     }
+
+    /* Checks if external storage is available for read and write */
+    public boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
+    /* Checks if external storage is available to at least read */
+    public boolean isExternalStorageReadable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state) ||
+                Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
+++ b/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
@@ -67,7 +67,7 @@ public class DataStorageProvider {
                 MainApp.getAppContext().getFilesDir().getAbsolutePath()));
 
         // Add external storage directory if available.
-        if (isExternalStorageReadable() && isExternalStorageWritable()) {
+        if (isExternalStorageWritable()) {
             mCachedStoragePoints.add(new StoragePoint(MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath(),
                     MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath()));
         }
@@ -96,20 +96,7 @@ public class DataStorageProvider {
     /* Checks if external storage is available for read and write */
     public boolean isExternalStorageWritable() {
         String state = Environment.getExternalStorageState();
-        if (Environment.MEDIA_MOUNTED.equals(state)) {
-            return true;
-        }
-        return false;
-    }
-
-    /* Checks if external storage is available to at least read */
-    public boolean isExternalStorageReadable() {
-        String state = Environment.getExternalStorageState();
-        if (Environment.MEDIA_MOUNTED.equals(state) ||
-                Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
-            return true;
-        }
-        return false;
+        return Environment.MEDIA_MOUNTED.equals(state);
     }
 
 }

--- a/src/main/java/com/owncloud/android/datastorage/providers/SystemDefaultStoragePointProvider.java
+++ b/src/main/java/com/owncloud/android/datastorage/providers/SystemDefaultStoragePointProvider.java
@@ -25,10 +25,7 @@ import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datastorage.StoragePoint;
 
-import java.io.File;
 import java.util.Vector;
-
-import static android.os.Environment.getExternalStorageDirectory;
 
 /**
  * @author Bartosz Przybylski
@@ -44,16 +41,9 @@ public class SystemDefaultStoragePointProvider extends AbstractStoragePointProvi
         Vector<StoragePoint> result = new Vector<>();
 
         final String defaultStringDesc = MainApp.getAppContext().getString(R.string.storage_description_default);
-        File path;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-            path = MainApp.getAppContext().getExternalMediaDirs()[0];
-        } else {
-            path = getExternalStorageDirectory();
-        }
-
-        if (path != null && path.canWrite()) {
-            result.add(new StoragePoint(defaultStringDesc, path.getAbsolutePath()));
-        }
+        // Add private internal storage data directory.
+        result.add(new StoragePoint(defaultStringDesc,
+                MainApp.getAppContext().getFilesDir().getAbsolutePath()));
 
         return result;
     }

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -62,8 +62,6 @@ import java.util.Locale;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class FileContentProvider extends ContentProvider {
 
-    private DataBaseHelper mDbHelper;
-
     private static final int SINGLE_FILE = 1;
     private static final int DIRECTORY = 2;
     private static final int ROOT_DIRECTORY = 3;
@@ -75,10 +73,7 @@ public class FileContentProvider extends ContentProvider {
     private static final int ARBITRARY_DATA = 9;
     private static final int VIRTUAL = 10;
     private static final int FILESYSTEM = 11;
-
     private static final String TAG = FileContentProvider.class.getSimpleName();
-
-    private UriMatcher mUriMatcher;
     // todo avoid string concatenation and use string formatting instead later.
     private static final String ERROR = "ERROR ";
     private static final String SQL = "SQL";
@@ -87,6 +82,8 @@ public class FileContentProvider extends ContentProvider {
     private static final String ALTER_TABLE = "ALTER TABLE ";
     private static final String ADD_COLUMN = " ADD COLUMN ";
     private static final String UPGRADE_VERSION_MSG = "OUT of the ADD in onUpgrade; oldVersion == %d, newVersion == %d";
+    private DataBaseHelper mDbHelper;
+    private UriMatcher mUriMatcher;
 
     @Override
     public int delete(Uri uri, String where, String[] whereArgs) {
@@ -593,11 +590,10 @@ public class FileContentProvider extends ContentProvider {
         }
 
         if (selectionArgs == null) {
-            selectionArgs = new String[]{selection};
             selection = "(?)";
+            selectionArgs = new String[]{selection};
         }
 
-        sqlQuery.setStrict(true);
         Cursor c = sqlQuery.query(db, projectionArray, selection, selectionArgs, null, null, order);
         c.setNotificationUri(getContext().getContentResolver(), uri);
         return c;
@@ -671,6 +667,300 @@ public class FileContentProvider extends ContentProvider {
         return results;
     }
 
+    private boolean checkIfColumnExists(SQLiteDatabase database, String table, String column) {
+        Cursor cursor = database.rawQuery("SELECT * FROM " + table + " LIMIT 0", null);
+        boolean exists = cursor.getColumnIndex(column) != -1;
+
+        cursor.close();
+
+        return exists;
+    }
+
+    private void createFilesTable(SQLiteDatabase db) {
+
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.FILE_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
+                + ProviderTableMeta.FILE_NAME + TEXT
+                + ProviderTableMeta.FILE_PATH + TEXT
+                + ProviderTableMeta.FILE_PARENT + INTEGER
+                + ProviderTableMeta.FILE_CREATION + INTEGER
+                + ProviderTableMeta.FILE_MODIFIED + INTEGER
+                + ProviderTableMeta.FILE_CONTENT_TYPE + TEXT
+                + ProviderTableMeta.FILE_CONTENT_LENGTH + INTEGER
+                + ProviderTableMeta.FILE_STORAGE_PATH + TEXT
+                + ProviderTableMeta.FILE_ACCOUNT_OWNER + TEXT
+                + ProviderTableMeta.FILE_LAST_SYNC_DATE + INTEGER
+                + ProviderTableMeta.FILE_KEEP_IN_SYNC + INTEGER
+                + ProviderTableMeta.FILE_LAST_SYNC_DATE_FOR_DATA + INTEGER
+                + ProviderTableMeta.FILE_MODIFIED_AT_LAST_SYNC_FOR_DATA + INTEGER
+                + ProviderTableMeta.FILE_ETAG + TEXT
+                + ProviderTableMeta.FILE_SHARED_VIA_LINK + INTEGER
+                + ProviderTableMeta.FILE_PUBLIC_LINK + TEXT
+                + ProviderTableMeta.FILE_PERMISSIONS + " TEXT null,"
+                + ProviderTableMeta.FILE_REMOTE_ID + " TEXT null,"
+                + ProviderTableMeta.FILE_UPDATE_THUMBNAIL + INTEGER //boolean
+                + ProviderTableMeta.FILE_IS_DOWNLOADING + INTEGER //boolean
+                + ProviderTableMeta.FILE_FAVORITE + INTEGER // boolean
+                + ProviderTableMeta.FILE_ETAG_IN_CONFLICT + TEXT
+                + ProviderTableMeta.FILE_SHARED_WITH_SHAREE + " INTEGER);"
+        );
+    }
+
+    private void createOCSharesTable(SQLiteDatabase db) {
+        // Create ocshares table
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.OCSHARES_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
+                + ProviderTableMeta.OCSHARES_FILE_SOURCE + INTEGER
+                + ProviderTableMeta.OCSHARES_ITEM_SOURCE + INTEGER
+                + ProviderTableMeta.OCSHARES_SHARE_TYPE + INTEGER
+                + ProviderTableMeta.OCSHARES_SHARE_WITH + TEXT
+                + ProviderTableMeta.OCSHARES_PATH + TEXT
+                + ProviderTableMeta.OCSHARES_PERMISSIONS + INTEGER
+                + ProviderTableMeta.OCSHARES_SHARED_DATE + INTEGER
+                + ProviderTableMeta.OCSHARES_EXPIRATION_DATE + INTEGER
+                + ProviderTableMeta.OCSHARES_TOKEN + TEXT
+                + ProviderTableMeta.OCSHARES_SHARE_WITH_DISPLAY_NAME + TEXT
+                + ProviderTableMeta.OCSHARES_IS_DIRECTORY + INTEGER  // boolean
+                + ProviderTableMeta.OCSHARES_USER_ID + INTEGER
+                + ProviderTableMeta.OCSHARES_ID_REMOTE_SHARED + INTEGER
+                + ProviderTableMeta.OCSHARES_ACCOUNT_OWNER + " TEXT );");
+    }
+
+    private void createCapabilitiesTable(SQLiteDatabase db) {
+        // Create capabilities table
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.CAPABILITIES_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
+                + ProviderTableMeta.CAPABILITIES_ACCOUNT_NAME + TEXT
+                + ProviderTableMeta.CAPABILITIES_VERSION_MAYOR + INTEGER
+                + ProviderTableMeta.CAPABILITIES_VERSION_MINOR + INTEGER
+                + ProviderTableMeta.CAPABILITIES_VERSION_MICRO + INTEGER
+                + ProviderTableMeta.CAPABILITIES_VERSION_STRING + TEXT
+                + ProviderTableMeta.CAPABILITIES_VERSION_EDITION + TEXT
+                + ProviderTableMeta.CAPABILITIES_CORE_POLLINTERVAL + INTEGER
+                + ProviderTableMeta.CAPABILITIES_SHARING_API_ENABLED + INTEGER // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_ENABLED + INTEGER  // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_PASSWORD_ENFORCED + INTEGER    // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_ENABLED + INTEGER  // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_DAYS + INTEGER
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_ENFORCED + INTEGER // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_SEND_MAIL + INTEGER    // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_UPLOAD + INTEGER       // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_USER_SEND_MAIL + INTEGER      // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_RESHARING + INTEGER           // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_FEDERATION_OUTGOING + INTEGER     // boolean
+                + ProviderTableMeta.CAPABILITIES_SHARING_FEDERATION_INCOMING + INTEGER     // boolean
+                + ProviderTableMeta.CAPABILITIES_FILES_BIGFILECHUNKING + INTEGER   // boolean
+                + ProviderTableMeta.CAPABILITIES_FILES_UNDELETE + INTEGER  // boolean
+                + ProviderTableMeta.CAPABILITIES_FILES_VERSIONING + INTEGER   // boolean
+                + ProviderTableMeta.CAPABILITIES_FILES_DROP + INTEGER  // boolean
+                + ProviderTableMeta.CAPABILITIES_EXTERNAL_LINKS + INTEGER  // boolean
+                + ProviderTableMeta.CAPABILITIES_SERVER_NAME + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_COLOR + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN + TEXT
+                + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL + " TEXT );");
+    }
+
+    private void createUploadsTable(SQLiteDatabase db) {
+        // Create uploads table
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.UPLOADS_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
+                + ProviderTableMeta.UPLOADS_LOCAL_PATH + TEXT
+                + ProviderTableMeta.UPLOADS_REMOTE_PATH + TEXT
+                + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + TEXT
+                + ProviderTableMeta.UPLOADS_FILE_SIZE + " LONG, "
+                + ProviderTableMeta.UPLOADS_STATUS + INTEGER               // UploadStatus
+                + ProviderTableMeta.UPLOADS_LOCAL_BEHAVIOUR + INTEGER      // Upload LocalBehaviour
+                + ProviderTableMeta.UPLOADS_UPLOAD_TIME + INTEGER
+                + ProviderTableMeta.UPLOADS_FORCE_OVERWRITE + INTEGER  // boolean
+                + ProviderTableMeta.UPLOADS_IS_CREATE_REMOTE_FOLDER + INTEGER  // boolean
+                + ProviderTableMeta.UPLOADS_UPLOAD_END_TIMESTAMP + INTEGER
+                + ProviderTableMeta.UPLOADS_LAST_RESULT + INTEGER     // Upload LastResult
+                + ProviderTableMeta.UPLOADS_IS_WHILE_CHARGING_ONLY + INTEGER  // boolean
+                + ProviderTableMeta.UPLOADS_IS_WIFI_ONLY + INTEGER // boolean
+                + ProviderTableMeta.UPLOADS_CREATED_BY + " INTEGER );"    // Upload createdBy
+        );
+
+
+        /* before:
+        // PRIMARY KEY should always imply NOT NULL. Unfortunately, due to a
+        // bug in some early versions, this is not the case in SQLite.
+        //db.execSQL("CREATE TABLE " + TABLE_UPLOAD + " (" + " path TEXT PRIMARY KEY NOT NULL UNIQUE,"
+        //        + " uploadStatus INTEGER NOT NULL, uploadObject TEXT NOT NULL);");
+        // uploadStatus is used to easy filtering, it has precedence over
+        // uploadObject.getUploadStatus()
+        */
+    }
+
+    private void createSyncedFoldersTable(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.SYNCED_FOLDERS_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "                          // id
+                + ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH + " TEXT, "           // local path
+                + ProviderTableMeta.SYNCED_FOLDER_REMOTE_PATH + " TEXT, "           // remote path
+                + ProviderTableMeta.SYNCED_FOLDER_WIFI_ONLY + " INTEGER, "          // wifi_only
+                + ProviderTableMeta.SYNCED_FOLDER_CHARGING_ONLY + " INTEGER, "      // charging only
+                + ProviderTableMeta.SYNCED_FOLDER_ENABLED + " INTEGER, "            // enabled
+                + ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE + " INTEGER, "  // subfolder by date
+                + ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + "  TEXT, "              // account
+                + ProviderTableMeta.SYNCED_FOLDER_UPLOAD_ACTION + " INTEGER, "     // upload action
+                + ProviderTableMeta.SYNCED_FOLDER_TYPE + " INTEGER );"               // type
+        );
+    }
+
+    private void createExternalLinksTable(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.EXTERNAL_LINKS_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "          // id
+                + ProviderTableMeta.EXTERNAL_LINKS_ICON_URL + " TEXT, "     // icon url
+                + ProviderTableMeta.EXTERNAL_LINKS_LANGUAGE + " TEXT, "     // language
+                + ProviderTableMeta.EXTERNAL_LINKS_TYPE + " INTEGER, "      // type
+                + ProviderTableMeta.EXTERNAL_LINKS_NAME + " TEXT, "         // name
+                + ProviderTableMeta.EXTERNAL_LINKS_URL + " TEXT );"          // url
+        );
+    }
+
+    private void createArbitraryData(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.ARBITRARY_DATA_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "      // id
+                + ProviderTableMeta.ARBITRARY_DATA_CLOUD_ID + " TEXT, " // cloud id (account name + FQDN)
+                + ProviderTableMeta.ARBITRARY_DATA_KEY + " TEXT, "      // key
+                + ProviderTableMeta.ARBITRARY_DATA_VALUE + " TEXT );"    // value
+        );
+    }
+
+    private void createVirtualTable(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + ProviderTableMeta.VIRTUAL_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "          // id
+                + ProviderTableMeta.VIRTUAL_TYPE + " TEXT, "                // type
+                + ProviderTableMeta.VIRTUAL_OCFILE_ID + " INTEGER )"        // file id
+        );
+    }
+
+    private void createFileSystemTable(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + ProviderTableMeta.FILESYSTEM_TABLE_NAME + "("
+                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "      // id
+                + ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " TEXT, "
+                + ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER + " INTEGER, "
+                + ProviderTableMeta.FILESYSTEM_FILE_FOUND_RECENTLY + " LONG, "
+                + ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD + " INTEGER, "
+                + ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " STRING, "
+                + ProviderTableMeta.FILESYSTEM_FILE_MODIFIED + " LONG );"
+        );
+    }
+
+    /**
+     * Version 10 of database does not modify its scheme. It coincides with the upgrade of the ownCloud account names
+     * structure to include in it the path to the server instance. Updating the account names and path to local files
+     * in the files table is a must to keep the existing account working and the database clean.
+     *
+     * @param db Database where table of files is included.
+     */
+    private void updateAccountName(SQLiteDatabase db) {
+        Log_OC.d(SQL, "THREAD:  " + Thread.currentThread().getName());
+        AccountManager ama = AccountManager.get(getContext());
+        try {
+            // get accounts from AccountManager ;  we can't be sure if accounts in it are updated or not although
+            // we know the update was previously done in {link @FileActivity#onCreate} because the changes through
+            // AccountManager are not synchronous
+            Account[] accounts = AccountManager.get(getContext()).getAccountsByType(
+                    MainApp.getAccountType());
+            String serverUrl;
+            String username;
+            String oldAccountName;
+            String newAccountName;
+
+            for (Account account : accounts) {
+                // build both old and new account name
+                serverUrl = ama.getUserData(account, AccountUtils.Constants.KEY_OC_BASE_URL);
+                username = AccountUtils.getUsernameForAccount(account);
+                oldAccountName = AccountUtils.buildAccountNameOld(Uri.parse(serverUrl), username);
+                newAccountName = AccountUtils.buildAccountName(Uri.parse(serverUrl), username);
+
+                // update values in database
+                db.beginTransaction();
+                try {
+                    ContentValues cv = new ContentValues();
+                    cv.put(ProviderTableMeta.FILE_ACCOUNT_OWNER, newAccountName);
+                    int num = db.update(ProviderTableMeta.FILE_TABLE_NAME,
+                            cv,
+                            ProviderTableMeta.FILE_ACCOUNT_OWNER + "=?",
+                            new String[]{oldAccountName});
+
+                    Log_OC.d(SQL, "Updated account in database: old name == " + oldAccountName +
+                            ", new name == " + newAccountName + " (" + num + " rows updated )");
+
+                    // update path for downloaded files
+                    updateDownloadedFiles(db, newAccountName, oldAccountName);
+
+                    db.setTransactionSuccessful();
+
+                } catch (SQLException e) {
+                    Log_OC.e(TAG, "SQL Exception upgrading account names or paths in database", e);
+                } finally {
+                    db.endTransaction();
+                }
+            }
+        } catch (Exception e) {
+            Log_OC.e(TAG, "Exception upgrading account names or paths in database", e);
+        }
+    }
+
+    /**
+     * Rename the local ownCloud folder of one account to match the a rename of the account itself. Updates the
+     * table of files in database so that the paths to the local files keep being the same.
+     *
+     * @param db             Database where table of files is included.
+     * @param newAccountName New name for the target OC account.
+     * @param oldAccountName Old name of the target OC account.
+     */
+    private void updateDownloadedFiles(SQLiteDatabase db, String newAccountName,
+                                       String oldAccountName) {
+
+        String whereClause = ProviderTableMeta.FILE_ACCOUNT_OWNER + "=? AND " +
+                ProviderTableMeta.FILE_STORAGE_PATH + " IS NOT NULL";
+
+        Cursor c = db.query(ProviderTableMeta.FILE_TABLE_NAME,
+                null,
+                whereClause,
+                new String[]{newAccountName},
+                null, null, null);
+
+        try {
+            if (c.moveToFirst()) {
+                // create storage path
+                String oldAccountPath = FileStorageUtils.getSavePath(oldAccountName);
+                String newAccountPath = FileStorageUtils.getSavePath(newAccountName);
+
+                // move files
+                File oldAccountFolder = new File(oldAccountPath);
+                File newAccountFolder = new File(newAccountPath);
+                oldAccountFolder.renameTo(newAccountFolder);
+
+                // update database
+                do {
+                    // Update database
+                    String oldPath = c.getString(
+                            c.getColumnIndex(ProviderTableMeta.FILE_STORAGE_PATH));
+                    OCFile file = new OCFile(
+                            c.getString(c.getColumnIndex(ProviderTableMeta.FILE_PATH)));
+                    String newPath = FileStorageUtils.getDefaultSavePathFor(newAccountName, file);
+
+                    ContentValues cv = new ContentValues();
+                    cv.put(ProviderTableMeta.FILE_STORAGE_PATH, newPath);
+                    db.update(ProviderTableMeta.FILE_TABLE_NAME,
+                            cv,
+                            ProviderTableMeta.FILE_STORAGE_PATH + "=?",
+                            new String[]{oldPath});
+
+                    Log_OC.v(SQL, "Updated path of downloaded file: old file name == " + oldPath +
+                            ", new file name == " + newPath);
+
+                } while (c.moveToNext());
+            }
+        } finally {
+            c.close();
+        }
+    }
 
     class DataBaseHelper extends SQLiteOpenHelper {
 
@@ -1200,303 +1490,6 @@ public class FileContentProvider extends ContentProvider {
                 // nothing needs to be done as the upgrade was adding columns only if they did not exist
                 Log_OC.i(TAG, "Downgrading v" + oldVersion + " to " + newVersion);
             }
-        }
-    }
-
-    private boolean checkIfColumnExists(SQLiteDatabase database, String table, String column) {
-        Cursor cursor = database.rawQuery("SELECT * FROM " + table + " LIMIT 0", null);
-        boolean exists = cursor.getColumnIndex(column) != -1;
-
-        cursor.close();
-
-        return exists;
-    }
-
-    private void createFilesTable(SQLiteDatabase db) {
-
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.FILE_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
-                + ProviderTableMeta.FILE_NAME + TEXT
-                + ProviderTableMeta.FILE_PATH + TEXT
-                + ProviderTableMeta.FILE_PARENT + INTEGER
-                + ProviderTableMeta.FILE_CREATION + INTEGER
-                + ProviderTableMeta.FILE_MODIFIED + INTEGER
-                + ProviderTableMeta.FILE_CONTENT_TYPE + TEXT
-                + ProviderTableMeta.FILE_CONTENT_LENGTH + INTEGER
-                + ProviderTableMeta.FILE_STORAGE_PATH + TEXT
-                + ProviderTableMeta.FILE_ACCOUNT_OWNER + TEXT
-                + ProviderTableMeta.FILE_LAST_SYNC_DATE + INTEGER
-                + ProviderTableMeta.FILE_KEEP_IN_SYNC + INTEGER
-                + ProviderTableMeta.FILE_LAST_SYNC_DATE_FOR_DATA + INTEGER
-                + ProviderTableMeta.FILE_MODIFIED_AT_LAST_SYNC_FOR_DATA + INTEGER
-                + ProviderTableMeta.FILE_ETAG + TEXT
-                + ProviderTableMeta.FILE_SHARED_VIA_LINK + INTEGER
-                + ProviderTableMeta.FILE_PUBLIC_LINK + TEXT
-                + ProviderTableMeta.FILE_PERMISSIONS + " TEXT null,"
-                + ProviderTableMeta.FILE_REMOTE_ID + " TEXT null,"
-                + ProviderTableMeta.FILE_UPDATE_THUMBNAIL + INTEGER //boolean
-                + ProviderTableMeta.FILE_IS_DOWNLOADING + INTEGER //boolean
-                + ProviderTableMeta.FILE_FAVORITE + INTEGER // boolean
-                + ProviderTableMeta.FILE_ETAG_IN_CONFLICT + TEXT
-                + ProviderTableMeta.FILE_SHARED_WITH_SHAREE + " INTEGER);"
-        );
-    }
-
-    private void createOCSharesTable(SQLiteDatabase db) {
-        // Create ocshares table
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.OCSHARES_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
-                + ProviderTableMeta.OCSHARES_FILE_SOURCE + INTEGER
-                + ProviderTableMeta.OCSHARES_ITEM_SOURCE + INTEGER
-                + ProviderTableMeta.OCSHARES_SHARE_TYPE + INTEGER
-                + ProviderTableMeta.OCSHARES_SHARE_WITH + TEXT
-                + ProviderTableMeta.OCSHARES_PATH + TEXT
-                + ProviderTableMeta.OCSHARES_PERMISSIONS + INTEGER
-                + ProviderTableMeta.OCSHARES_SHARED_DATE + INTEGER
-                + ProviderTableMeta.OCSHARES_EXPIRATION_DATE + INTEGER
-                + ProviderTableMeta.OCSHARES_TOKEN + TEXT
-                + ProviderTableMeta.OCSHARES_SHARE_WITH_DISPLAY_NAME + TEXT
-                + ProviderTableMeta.OCSHARES_IS_DIRECTORY + INTEGER  // boolean
-                + ProviderTableMeta.OCSHARES_USER_ID + INTEGER
-                + ProviderTableMeta.OCSHARES_ID_REMOTE_SHARED + INTEGER
-                + ProviderTableMeta.OCSHARES_ACCOUNT_OWNER + " TEXT );");
-    }
-
-    private void createCapabilitiesTable(SQLiteDatabase db) {
-        // Create capabilities table
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.CAPABILITIES_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
-                + ProviderTableMeta.CAPABILITIES_ACCOUNT_NAME + TEXT
-                + ProviderTableMeta.CAPABILITIES_VERSION_MAYOR + INTEGER
-                + ProviderTableMeta.CAPABILITIES_VERSION_MINOR + INTEGER
-                + ProviderTableMeta.CAPABILITIES_VERSION_MICRO + INTEGER
-                + ProviderTableMeta.CAPABILITIES_VERSION_STRING + TEXT
-                + ProviderTableMeta.CAPABILITIES_VERSION_EDITION + TEXT
-                + ProviderTableMeta.CAPABILITIES_CORE_POLLINTERVAL + INTEGER
-                + ProviderTableMeta.CAPABILITIES_SHARING_API_ENABLED + INTEGER // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_ENABLED + INTEGER  // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_PASSWORD_ENFORCED + INTEGER    // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_ENABLED + INTEGER  // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_DAYS + INTEGER
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_ENFORCED + INTEGER // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_SEND_MAIL + INTEGER    // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_UPLOAD + INTEGER       // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_USER_SEND_MAIL + INTEGER      // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_RESHARING + INTEGER           // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_FEDERATION_OUTGOING + INTEGER     // boolean
-                + ProviderTableMeta.CAPABILITIES_SHARING_FEDERATION_INCOMING + INTEGER     // boolean
-                + ProviderTableMeta.CAPABILITIES_FILES_BIGFILECHUNKING + INTEGER   // boolean
-                + ProviderTableMeta.CAPABILITIES_FILES_UNDELETE + INTEGER  // boolean
-                + ProviderTableMeta.CAPABILITIES_FILES_VERSIONING + INTEGER   // boolean
-                + ProviderTableMeta.CAPABILITIES_FILES_DROP + INTEGER  // boolean
-                + ProviderTableMeta.CAPABILITIES_EXTERNAL_LINKS + INTEGER  // boolean
-                + ProviderTableMeta.CAPABILITIES_SERVER_NAME + TEXT
-                + ProviderTableMeta.CAPABILITIES_SERVER_COLOR + TEXT
-                + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + TEXT
-                + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + TEXT
-                + ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN + TEXT
-                + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL + " TEXT );");
-    }
-
-    private void createUploadsTable(SQLiteDatabase db) {
-        // Create uploads table
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.UPLOADS_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "
-                + ProviderTableMeta.UPLOADS_LOCAL_PATH + TEXT
-                + ProviderTableMeta.UPLOADS_REMOTE_PATH + TEXT
-                + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + TEXT
-                + ProviderTableMeta.UPLOADS_FILE_SIZE + " LONG, "
-                + ProviderTableMeta.UPLOADS_STATUS + INTEGER               // UploadStatus
-                + ProviderTableMeta.UPLOADS_LOCAL_BEHAVIOUR + INTEGER      // Upload LocalBehaviour
-                + ProviderTableMeta.UPLOADS_UPLOAD_TIME + INTEGER
-                + ProviderTableMeta.UPLOADS_FORCE_OVERWRITE + INTEGER  // boolean
-                + ProviderTableMeta.UPLOADS_IS_CREATE_REMOTE_FOLDER + INTEGER  // boolean
-                + ProviderTableMeta.UPLOADS_UPLOAD_END_TIMESTAMP + INTEGER
-                + ProviderTableMeta.UPLOADS_LAST_RESULT + INTEGER     // Upload LastResult
-                + ProviderTableMeta.UPLOADS_IS_WHILE_CHARGING_ONLY + INTEGER  // boolean
-                + ProviderTableMeta.UPLOADS_IS_WIFI_ONLY + INTEGER // boolean
-                + ProviderTableMeta.UPLOADS_CREATED_BY + " INTEGER );"    // Upload createdBy
-        );
-
-
-        /* before:
-        // PRIMARY KEY should always imply NOT NULL. Unfortunately, due to a
-        // bug in some early versions, this is not the case in SQLite.
-        //db.execSQL("CREATE TABLE " + TABLE_UPLOAD + " (" + " path TEXT PRIMARY KEY NOT NULL UNIQUE,"
-        //        + " uploadStatus INTEGER NOT NULL, uploadObject TEXT NOT NULL);");
-        // uploadStatus is used to easy filtering, it has precedence over
-        // uploadObject.getUploadStatus()
-        */
-    }
-
-    private void createSyncedFoldersTable(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.SYNCED_FOLDERS_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "                          // id
-                + ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH + " TEXT, "           // local path
-                + ProviderTableMeta.SYNCED_FOLDER_REMOTE_PATH + " TEXT, "           // remote path
-                + ProviderTableMeta.SYNCED_FOLDER_WIFI_ONLY + " INTEGER, "          // wifi_only
-                + ProviderTableMeta.SYNCED_FOLDER_CHARGING_ONLY + " INTEGER, "      // charging only
-                + ProviderTableMeta.SYNCED_FOLDER_ENABLED + " INTEGER, "            // enabled
-                + ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE + " INTEGER, "  // subfolder by date
-                + ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + "  TEXT, "              // account
-                + ProviderTableMeta.SYNCED_FOLDER_UPLOAD_ACTION + " INTEGER, "     // upload action
-                + ProviderTableMeta.SYNCED_FOLDER_TYPE + " INTEGER );"               // type
-        );
-    }
-
-    private void createExternalLinksTable(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.EXTERNAL_LINKS_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "          // id
-                + ProviderTableMeta.EXTERNAL_LINKS_ICON_URL + " TEXT, "     // icon url
-                + ProviderTableMeta.EXTERNAL_LINKS_LANGUAGE + " TEXT, "     // language
-                + ProviderTableMeta.EXTERNAL_LINKS_TYPE + " INTEGER, "      // type
-                + ProviderTableMeta.EXTERNAL_LINKS_NAME + " TEXT, "         // name
-                + ProviderTableMeta.EXTERNAL_LINKS_URL + " TEXT );"          // url
-        );
-    }
-
-    private void createArbitraryData(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.ARBITRARY_DATA_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "      // id
-                + ProviderTableMeta.ARBITRARY_DATA_CLOUD_ID + " TEXT, " // cloud id (account name + FQDN)
-                + ProviderTableMeta.ARBITRARY_DATA_KEY + " TEXT, "      // key
-                + ProviderTableMeta.ARBITRARY_DATA_VALUE + " TEXT );"    // value
-        );
-    }
-
-    private void createVirtualTable(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE " + ProviderTableMeta.VIRTUAL_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "          // id
-                + ProviderTableMeta.VIRTUAL_TYPE + " TEXT, "                // type
-                + ProviderTableMeta.VIRTUAL_OCFILE_ID + " INTEGER )"        // file id
-        );
-    }
-
-    private void createFileSystemTable(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE IF NOT EXISTS " + ProviderTableMeta.FILESYSTEM_TABLE_NAME + "("
-                + ProviderTableMeta._ID + " INTEGER PRIMARY KEY, "      // id
-                + ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " TEXT, "
-                + ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER + " INTEGER, "
-                + ProviderTableMeta.FILESYSTEM_FILE_FOUND_RECENTLY + " LONG, "
-                + ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD + " INTEGER, "
-                + ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " STRING, "
-                + ProviderTableMeta.FILESYSTEM_FILE_MODIFIED + " LONG );"
-        );
-    }
-
-
-    /**
-     * Version 10 of database does not modify its scheme. It coincides with the upgrade of the ownCloud account names
-     * structure to include in it the path to the server instance. Updating the account names and path to local files
-     * in the files table is a must to keep the existing account working and the database clean.
-     *
-     * @param db Database where table of files is included.
-     */
-    private void updateAccountName(SQLiteDatabase db) {
-        Log_OC.d(SQL, "THREAD:  " + Thread.currentThread().getName());
-        AccountManager ama = AccountManager.get(getContext());
-        try {
-            // get accounts from AccountManager ;  we can't be sure if accounts in it are updated or not although
-            // we know the update was previously done in {link @FileActivity#onCreate} because the changes through
-            // AccountManager are not synchronous
-            Account[] accounts = AccountManager.get(getContext()).getAccountsByType(
-                    MainApp.getAccountType());
-            String serverUrl;
-            String username;
-            String oldAccountName;
-            String newAccountName;
-
-            for (Account account : accounts) {
-                // build both old and new account name
-                serverUrl = ama.getUserData(account, AccountUtils.Constants.KEY_OC_BASE_URL);
-                username = AccountUtils.getUsernameForAccount(account);
-                oldAccountName = AccountUtils.buildAccountNameOld(Uri.parse(serverUrl), username);
-                newAccountName = AccountUtils.buildAccountName(Uri.parse(serverUrl), username);
-
-                // update values in database
-                db.beginTransaction();
-                try {
-                    ContentValues cv = new ContentValues();
-                    cv.put(ProviderTableMeta.FILE_ACCOUNT_OWNER, newAccountName);
-                    int num = db.update(ProviderTableMeta.FILE_TABLE_NAME,
-                            cv,
-                            ProviderTableMeta.FILE_ACCOUNT_OWNER + "=?",
-                            new String[]{oldAccountName});
-
-                    Log_OC.d(SQL, "Updated account in database: old name == " + oldAccountName +
-                            ", new name == " + newAccountName + " (" + num + " rows updated )");
-
-                    // update path for downloaded files
-                    updateDownloadedFiles(db, newAccountName, oldAccountName);
-
-                    db.setTransactionSuccessful();
-
-                } catch (SQLException e) {
-                    Log_OC.e(TAG, "SQL Exception upgrading account names or paths in database", e);
-                } finally {
-                    db.endTransaction();
-                }
-            }
-        } catch (Exception e) {
-            Log_OC.e(TAG, "Exception upgrading account names or paths in database", e);
-        }
-    }
-
-
-    /**
-     * Rename the local ownCloud folder of one account to match the a rename of the account itself. Updates the
-     * table of files in database so that the paths to the local files keep being the same.
-     *
-     * @param db             Database where table of files is included.
-     * @param newAccountName New name for the target OC account.
-     * @param oldAccountName Old name of the target OC account.
-     */
-    private void updateDownloadedFiles(SQLiteDatabase db, String newAccountName,
-                                       String oldAccountName) {
-
-        String whereClause = ProviderTableMeta.FILE_ACCOUNT_OWNER + "=? AND " +
-                ProviderTableMeta.FILE_STORAGE_PATH + " IS NOT NULL";
-
-        Cursor c = db.query(ProviderTableMeta.FILE_TABLE_NAME,
-                null,
-                whereClause,
-                new String[]{newAccountName},
-                null, null, null);
-
-        try {
-            if (c.moveToFirst()) {
-                // create storage path
-                String oldAccountPath = FileStorageUtils.getSavePath(oldAccountName);
-                String newAccountPath = FileStorageUtils.getSavePath(newAccountName);
-
-                // move files
-                File oldAccountFolder = new File(oldAccountPath);
-                File newAccountFolder = new File(newAccountPath);
-                oldAccountFolder.renameTo(newAccountFolder);
-
-                // update database
-                do {
-                    // Update database
-                    String oldPath = c.getString(
-                            c.getColumnIndex(ProviderTableMeta.FILE_STORAGE_PATH));
-                    OCFile file = new OCFile(
-                            c.getString(c.getColumnIndex(ProviderTableMeta.FILE_PATH)));
-                    String newPath = FileStorageUtils.getDefaultSavePathFor(newAccountName, file);
-
-                    ContentValues cv = new ContentValues();
-                    cv.put(ProviderTableMeta.FILE_STORAGE_PATH, newPath);
-                    db.update(ProviderTableMeta.FILE_TABLE_NAME,
-                            cv,
-                            ProviderTableMeta.FILE_STORAGE_PATH + "=?",
-                            new String[]{oldPath});
-
-                    Log_OC.v(SQL, "Updated path of downloaded file: old file name == " + oldPath +
-                            ", new file name == " + newPath);
-
-                } while (c.moveToNext());
-            }
-        } finally {
-            c.close();
         }
     }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -1044,8 +1044,9 @@ public class Preferences extends PreferenceActivity
     private void loadStoragePath() {
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-        mStoragePath = appPrefs.getString(PreferenceKeys.STORAGE_PATH, Environment.getExternalStorageDirectory()
-                .getAbsolutePath());
+        // Load storage path from shared preferences. Use private internal storage by default.
+        mStoragePath = appPrefs.getString(PreferenceKeys.STORAGE_PATH,
+                getApplicationContext().getFilesDir().getAbsolutePath());
         String storageDescription = DataStorageProvider.getInstance().getStorageDescriptionByPath(mStoragePath);
         mPrefStoragePath.setSummary(storageDescription);
     }

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -59,6 +59,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -148,6 +149,20 @@ public class FileOperationsHelper {
         if (file != null) {
             String storagePath = file.getStoragePath();
 
+            String[] officeExtensions = MainApp.getAppContext().getResources().getStringArray(R.array
+                    .ms_office_extensions);
+
+            Uri fileUri;
+
+            if (file.getFileName().contains(".") &&
+                    Arrays.asList(officeExtensions).contains(file.getFileName().substring(file.getFileName().
+                            lastIndexOf(".") + 1, file.getFileName().length())) &&
+                    !file.getStoragePath().startsWith(MainApp.getAppContext().getFilesDir().getAbsolutePath())) {
+                fileUri = file.getLegacyExposedFileUri(mFileActivity);
+            } else {
+                fileUri = file.getExposedFileUri(mFileActivity);
+            }
+
             Intent openFileWithIntent = null;
             int lastIndexOfDot = storagePath.lastIndexOf('.');
             if (lastIndexOfDot >= 0) {
@@ -157,7 +172,7 @@ public class FileOperationsHelper {
                     openFileWithIntent = new Intent(Intent.ACTION_VIEW);
                     openFileWithIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
                     openFileWithIntent.setDataAndType(
-                            file.getExposedFileUri(mFileActivity),
+                            fileUri,
                             guessedMimeType
                     );
                 }
@@ -170,7 +185,7 @@ public class FileOperationsHelper {
             if (openFileWithIntent == null) {
                 openFileWithIntent = new Intent(Intent.ACTION_VIEW);
                 openFileWithIntent.setDataAndType(
-                        file.getExposedFileUri(mFileActivity),
+                        fileUri,
                         file.getMimetype()
                 );
             }

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -155,6 +155,7 @@ public class FileOperationsHelper {
                 String guessedMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt);
                 if (guessedMimeType != null) {
                     openFileWithIntent = new Intent(Intent.ACTION_VIEW);
+                    openFileWithIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
                     openFileWithIntent.setDataAndType(
                             file.getExposedFileUri(mFileActivity),
                             guessedMimeType

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <array name="ms_office_extensions">
+        <item>doc</item>
+        <item>dot</item>
+        <item>docx</item>
+        <item>dotx</item>
+        <item>docm</item>
+        <item>dotm</item>
+        <item>xls</item>
+        <item>xlt</item>
+        <item>xla</item>
+        <item>xlsx</item>
+        <item>xltx</item>
+        <item>xlsm</item>
+        <item>xltm</item>
+        <item>xlam</item>
+        <item>xlsb</item>
+        <item>ppt</item>
+        <item>pot</item>
+        <item>pps</item>
+        <item>ppa</item>
+        <item>pptx</item>
+        <item>potx</item>
+        <item>ppsx</item>
+        <item>ppam</item>
+        <item>pptm</item>
+        <item>potm</item>
+        <item>ppsm</item>
+        <item>mdb</item>
+    </array>
+</resources>

--- a/src/main/res/xml/exposed_filepaths.xml
+++ b/src/main/res/xml/exposed_filepaths.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
+    <files-path name="user_files_internal" path="nextcloud/"/>
     <files-path
         path="log/"
         name="log"/>

--- a/src/modified/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/modified/java/com/owncloud/android/utils/PushUtils.java
@@ -98,7 +98,7 @@ public class PushUtils {
     }
 
     private static int generateRsa2048KeyPair() {
-        String keyPath = MainApp.getStoragePath() + File.separator + MainApp.getDataFolder() + File.separator
+        String keyPath = MainApp.getAppContext().getFilesDir().getAbsolutePath() + File.separator + MainApp.getDataFolder() + File.separator
                 + KEYPAIR_FOLDER;
 
         String privateKeyPath = keyPath + File.separator + KEYPAIR_FILE_NAME + KEYPAIR_PRIV_EXTENSION;
@@ -266,7 +266,7 @@ public class PushUtils {
     }
 
     public static Key readKeyFromFile(boolean readPublicKey) {
-        String keyPath = MainApp.getStoragePath() + File.separator + MainApp.getDataFolder() + File.separator
+        String keyPath = MainApp.getAppContext().getFilesDir().getAbsolutePath() + File.separator + MainApp.getDataFolder() + File.separator
                 + KEYPAIR_FOLDER;
 
         String privateKeyPath = keyPath + File.separator + KEYPAIR_FILE_NAME + KEYPAIR_PRIV_EXTENSION;


### PR DESCRIPTION
Storing user data and RSA keys on the root of the external storage is not a good idea. The data storage system has been overhauled here with the following changes.

- The `STORAGE_PATH` user preference is now set to the [private internal app storage directory](https://developer.android.com/guide/topics/data/data-storage.html#filesInternal) by default.
- The DataStorageProvider's getAvailableStoragePoints method now returns the [private internal data directory](https://developer.android.com/guide/topics/data/data-storage.html#filesInternal) and, if available, the [private external storage directory](https://developer.android.com/guide/topics/data/data-storage.html#filesExternal).
- `PushUtils` will now store and handle the RSA keypair in the [private internal storage directory](https://developer.android.com/guide/topics/data/data-storage.html#filesInternal). The keys need to be here since even the private external storage directory is accessible to everyone with the `READ_EXTERNAL_STORAGE` permission. Therefore we specify the internal storage directory for these instead of using the `STORAGE_PATH` preference. 

Please ignore 8ca99c6. I updated this as intended in d4670ad

This fixes #1833
fix #1707 