### PR TITLE
Fix walledGarden with resized images

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -352,11 +352,14 @@ public class ThumbnailsCacheManager {
                         }
                     }
                 } else {
-                    if (ConnectivityUtils.isInternetWalled(MainApp.getAppContext())) {
-                        previewImageFragment.setNoConnectionErrorMessage();
-                    } else {
-                        previewImageFragment.setErrorPreviewMessage();
-                    }
+                    new Thread(() -> {
+                        if (ConnectivityUtils.isInternetWalled(MainApp.getAppContext())) {
+                            previewImageFragment.setNoConnectionErrorMessage();
+                        } else {
+                            previewImageFragment.setErrorPreviewMessage();
+                        }
+                    }).start();
+                    
                 }
             }
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -224,7 +224,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         Log_OC.i(TAG, "onCreateView() start");
         View v = super.onCreateView(inflater, container, savedInstanceState);
-        bottomNavigationView = (BottomNavigationView) v.findViewById(R.id.bottom_navigation_view);
+        bottomNavigationView = v.findViewById(R.id.bottom_navigation_view);
 
         if (savedInstanceState != null) {
             currentSearchType = Parcels.unwrap(savedInstanceState.getParcelable(KEY_CURRENT_SEARCH_TYPE));
@@ -901,9 +901,9 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                                 type = VirtualFolderType.NONE;
                                 break;
                         }
-                        ((FileDisplayActivity) mContainerActivity).startImagePreview(file, type, false);
+                        ((FileDisplayActivity) mContainerActivity).startImagePreview(file, type, !file.isDown());
                     } else {
-                        ((FileDisplayActivity) mContainerActivity).startImagePreview(file, false);
+                        ((FileDisplayActivity) mContainerActivity).startImagePreview(file, !file.isDown());
                     }
                 } else if (file.isDown() && MimeTypeUtil.isVCard(file)) {
                     ((FileDisplayActivity) mContainerActivity).startContactListFragment(file);

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -54,8 +54,8 @@ import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.ShareActivity;
 import com.owncloud.android.ui.events.FavoriteEvent;
 import com.owncloud.android.ui.events.SyncEventFinished;
-import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.FileStorageUtils;
 
 import org.greenrobot.eventbus.EventBus;
 
@@ -168,8 +168,10 @@ public class FileOperationsHelper {
                     i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, account);
                     mFileActivity.startActivity(i);
                 } else {
-                    FileStorageUtils.checkIfFileFinishedSaving(file);
-                    EventBus.getDefault().post(new SyncEventFinished(intent));
+                    if (file.isDown()) {
+                        FileStorageUtils.checkIfFileFinishedSaving(file);
+                        EventBus.getDefault().post(new SyncEventFinished(intent));
+                    }
                 }
                 mFileActivity.dismissLoadingDialog();
             }


### PR DESCRIPTION
- moved check to thread, otherwise "not on main thread exception"
- show preview (resized image) if file is not downloaded
- check for file only if it is downloaded (prevents crash on clicking on an non-downloaded image)