### PR TITLE
Count moved & check for dev version

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -615,7 +615,7 @@ public abstract class FileActivity extends DrawerActivity
             Log_OC.e(TAG, "Error detecting app version", e);
         }
         if (latestVersion == -1 || currentVersion == -1) {
-            Snackbar.make(view, R.string.dev_version_no_information_available, Snackbar.LENGTH_SHORT).show();
+            Snackbar.make(view, R.string.dev_version_no_information_available, Snackbar.LENGTH_LONG).show();
         }
         if (latestVersion > currentVersion) {
             if (openDirectly) {
@@ -625,7 +625,7 @@ public abstract class FileActivity extends DrawerActivity
                 context.startActivity(intent);
             } else {
                 Integer finalLatestVersion = latestVersion;
-                Snackbar.make(view, R.string.dev_version_new_version_available, Snackbar.LENGTH_SHORT)
+                Snackbar.make(view, R.string.dev_version_new_version_available, Snackbar.LENGTH_LONG)
                         .setAction(context.getString(R.string.version_dev_download), v -> {
                             String devApkLink = (String) context.getText(R.string.dev_link)
                                     + finalLatestVersion + ".apk";
@@ -635,7 +635,7 @@ public abstract class FileActivity extends DrawerActivity
                         }).show();
             }
         } else {
-            Snackbar.make(view, R.string.dev_version_no_new_version_available, Snackbar.LENGTH_SHORT).show();
+            Snackbar.make(view, R.string.dev_version_no_new_version_available, Snackbar.LENGTH_LONG).show();
         }
     }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2191,6 +2191,14 @@ public class FileDisplayActivity extends HookActivity
     public void onStart() {
         super.onStart();
         EventBus.getDefault().post(new TokenPushEvent());
+
+        checkForNewDevVersionNecessary(findViewById(R.id.root_layout), getApplicationContext());
     }
 
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+
+        checkForNewDevVersionNecessary(findViewById(R.id.root_layout), getApplicationContext());
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -47,7 +47,6 @@ import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.support.annotation.LayoutRes;
-import android.support.design.widget.Snackbar;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatDelegate;
@@ -71,14 +70,12 @@ import com.owncloud.android.lib.common.ExternalLinkType;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.utils.Log_OC;
-import com.owncloud.android.ui.asynctasks.LoadingVersionNumberTask;
 import com.owncloud.android.utils.AnalyticsUtils;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.ThemeUtils;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * An Activity that allows the user to change the application's settings.
@@ -182,32 +179,8 @@ public class Preferences extends PreferenceActivity
             if (pDevLink != null) {
                 if (getResources().getBoolean(R.bool.dev_version_direct_download_enabled)) {
                     pDevLink.setOnPreferenceClickListener(preference -> {
-                        Integer latestVersion = -1;
-                        Integer currentVersion = -1;
-                        try {
-                            currentVersion = getPackageManager().getPackageInfo(getPackageName(), 0).versionCode;
-                            String url = getString(R.string.dev_latest);
-                            LoadingVersionNumberTask loadTask = new LoadingVersionNumberTask();
-                            loadTask.execute(url);
-                            latestVersion = loadTask.get();
-                        } catch (InterruptedException | ExecutionException | NameNotFoundException e) {
-                            Log_OC.e(TAG, "Error detecting app version", e);
-                        }
-                        if (latestVersion == -1 || currentVersion == -1) {
-                            Snackbar.make(getListView(), R.string.dev_version_no_information_available,
-                                    Snackbar.LENGTH_SHORT).show();
-                        }
-                        if (latestVersion > currentVersion) {
-                            String devApkLink = (String) getText(R.string.dev_link) + latestVersion + ".apk";
-                            Uri uriUrl = Uri.parse(devApkLink);
-                            Intent intent = new Intent(Intent.ACTION_VIEW, uriUrl);
-                            startActivity(intent);
-                            return true;
-                        } else {
-                            Snackbar.make(getListView(), R.string.dev_version_no_new_version_available,
-                                    Snackbar.LENGTH_SHORT).show();
-                            return true;
-                        }
+                        FileActivity.checkForNewDevVersion(getListView(), getApplicationContext(), true);
+                        return true;
                     });
                 } else {
                     preferenceCategoryDev.removePreference(pDevLink);

--- a/src/main/res/layout/files.xml
+++ b/src/main/res/layout/files.xml
@@ -28,6 +28,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:id="@+id/root_layout"
         android:orientation="vertical">
 
         <include

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -723,6 +723,8 @@
     <string name="dev_version_no_information_available">No information available.</string>
     <string name="dev_version_no_new_version_available">No new version available.</string>
     <string name="folder_icon">Folder icon</string>
+    <string name="dev_version_new_version_available">New version available</string>
+    <string name="version_dev_download">Download</string>
 
     <string name="send">Send</string>
     <string name="share">Share</string>


### PR DESCRIPTION
fix #172, fix #1850 
- moved check count from shared pref to arbitrary provider (fixes #1850)
- use it also for checking new dev version (enabled only for direct downloads)