### PR TITLE
MIME type lookup assumes to have lowercase MIME types

### DIFF
--- a/src/main/java/com/owncloud/android/utils/UriUtils.java
+++ b/src/main/java/com/owncloud/android/utils/UriUtils.java
@@ -32,6 +32,8 @@ import android.webkit.MimeTypeMap;
 
 import com.owncloud.android.lib.common.utils.Log_OC;
 
+import java.util.Locale;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 
@@ -218,7 +220,7 @@ public class UriUtils {
                 // Add best possible extension
                 int index = displayName.lastIndexOf('.');
                 if (index == -1 || MimeTypeMap.getSingleton().
-                        getMimeTypeFromExtension(displayName.substring(index + 1)) == null) {
+                        getMimeTypeFromExtension(displayName.substring(index + 1).toLowerCase(Locale.ROOT)) == null) {
                     String mimeType = context.getContentResolver().getType(uri);
                     String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
                     if (extension != null) {


### PR DESCRIPTION
fix #1882 

The (internal) MIME type lookup function from Android fails if we use uppercase MIME types.
Strangely this does not happen in every situation, see #1882 for details.