### PR TITLE
Activity scrolling bug fix

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ActivitiesListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ActivitiesListActivity.java
@@ -215,7 +215,8 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
                 int firstVisibleItemIndex = layoutManager.findFirstVisibleItemPosition();
 
                 // synchronize loading state when item count changes
-                if (!isLoadingActivities && (totalItemCount - visibleItemCount) <= (firstVisibleItemIndex + 5)) {
+                if (!isLoadingActivities && (totalItemCount - visibleItemCount) <= (firstVisibleItemIndex + 5)
+                        && nextPageUrl != null && !nextPageUrl.isEmpty()) {
                     // Almost reached the end, continue to load new activities
                     fetchAndSetData(nextPageUrl);
                 }
@@ -254,7 +255,6 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
 
                     Log_OC.d(TAG, "BEFORE getRemoteActivitiesOperation.execute");
                     final RemoteOperationResult result = getRemoteNotificationOperation.execute(ownCloudClient);
-                    //result.get
 
                     if (result.isSuccess() && result.getData() != null) {
                         final ArrayList<Object> data = result.getData();
@@ -262,7 +262,7 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
                         nextPageUrl = (String) data.get(1);
 
                         runOnUiThread(() -> {
-                            populateList(activities, ownCloudClient);
+                            populateList(activities, ownCloudClient, pageUrl == null);
                             if (activities.size() > 0) {
                                 swipeEmptyListRefreshLayout.setVisibility(View.GONE);
                                 swipeListRefreshLayout.setVisibility(View.VISIBLE);
@@ -314,8 +314,8 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
         });
     }
 
-    private void populateList(List<Object> activities, OwnCloudClient mClient) {
-        adapter.setActivityItems(activities, mClient);
+    private void populateList(List<Object> activities, OwnCloudClient mClient, boolean clear) {
+        adapter.setActivityItems(activities, mClient, clear);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -97,9 +97,14 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         px = getThumbnailDimension();
     }
 
-    public void setActivityItems(List<Object> activityItems, OwnCloudClient client) {
+    public void setActivityItems(List<Object> activityItems, OwnCloudClient client, boolean clear) {
         this.mClient = client;
         String sTime = "";
+        
+        if (clear) {
+            mValues.clear();
+        }
+        
         for (Object o : activityItems) {
             Activity activity = (Activity) o;
             String time;
@@ -368,11 +373,11 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
         private ActivityViewHolder(View itemView) {
             super(itemView);
-            activityIcon = (ImageView) itemView.findViewById(R.id.activity_icon);
-            subject = (TextView) itemView.findViewById(R.id.activity_subject);
-            message = (TextView) itemView.findViewById(R.id.activity_message);
-            dateTime = (TextView) itemView.findViewById(R.id.activity_datetime);
-            list = (GridLayout) itemView.findViewById(R.id.list);
+            activityIcon = itemView.findViewById(R.id.activity_icon);
+            subject = itemView.findViewById(R.id.activity_subject);
+            message = itemView.findViewById(R.id.activity_message);
+            dateTime = itemView.findViewById(R.id.activity_datetime);
+            list = itemView.findViewById(R.id.list);
         }
     }
 
@@ -382,7 +387,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
         private ActivityViewHeaderHolder(View itemView) {
             super(itemView);
-            title = (TextView) itemView.findViewById(R.id.title_header);
+            title = itemView.findViewById(R.id.title_header);
 
         }
     }


### PR DESCRIPTION
if nextPageURL is empty/null do not load any more items, otherwise yo…u get the first items again
if pageURL is null (when manually refreshing), then clear list

@nickvergessen 