### PR TITLE
Fix crashing search while copy/move

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,8 +227,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:3.7.0'
     implementation 'com.caverock:androidsvg:1.2.1'
     implementation "com.android.support:support-annotations:${supportLibraryVersion}"
-
-    compile 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.8.2'
 
     // dependencies for local unit tests
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -228,6 +228,8 @@ dependencies {
     implementation 'com.caverock:androidsvg:1.2.1'
     implementation "com.android.support:support-annotations:${supportLibraryVersion}"
 
+    compile 'com.google.code.gson:gson:2.8.2'
+
     // dependencies for local unit tests
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.2'
 //    implementation project('nextcloud-android-library')
-    implementation 'com.github.nextcloud:android-library:1.0.34'
+    implementation 'com.github.nextcloud:android-library:1.0.35'
     versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -64,12 +64,11 @@ import java.util.ArrayList;
 public class FolderPickerActivity extends FileActivity implements FileFragment.ContainerActivity,
     OnClickListener, OnEnforceableRefreshListener {
 
-    public static final String EXTRA_FOLDER = FolderPickerActivity.class.getCanonicalName()
-                                                            + ".EXTRA_FOLDER";
-    public static final String EXTRA_FILES = FolderPickerActivity.class.getCanonicalName()
-            + ".EXTRA_FILES";
-    public static final String EXTRA_ACTION = FolderPickerActivity.class.getCanonicalName()
-            + ".EXTRA_ACTION";
+    public static final String EXTRA_FOLDER = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_FOLDER";
+    public static final String EXTRA_FILES = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_FILES";
+    public static final String EXTRA_ACTION = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_ACTION";
+    public static final String MOVE = "MOVE";
+    public static final String COPY = "COPY";
 
     private SyncBroadcastReceiver mSyncBroadcastReceiver;
 
@@ -80,6 +79,8 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     private static final String TAG_LIST_OF_FOLDERS = "LIST_OF_FOLDERS";
        
     private boolean mSyncInProgress = false;
+
+    private boolean mSearchOnlyFolders = false;
 
     protected Button mCancelBtn;
     protected Button mChooseBtn;
@@ -92,10 +93,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.files_folder_picker);
-        
-        if (savedInstanceState == null) {
-            createFragments();
-        }
+
 
         // sets callback listeners for UI elements
         initControls();
@@ -104,9 +102,25 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         setupToolbar();
         
         if (getIntent().getStringExtra(EXTRA_ACTION) != null) {
-            caption = getIntent().getStringExtra(EXTRA_ACTION);
+            switch (getIntent().getStringExtra(EXTRA_ACTION)) {
+                case MOVE:
+                    caption = getResources().getText(R.string.move_to).toString();
+                    mSearchOnlyFolders = true;
+                    break;
+                case COPY:
+                    caption = getResources().getText(R.string.copy_to).toString();
+                    mSearchOnlyFolders = true;
+                    break;
+                default:
+                    caption = ThemeUtils.getDefaultDisplayNameForRootFolder();
+                    break;
+            }
         } else {
             caption = ThemeUtils.getDefaultDisplayNameForRootFolder();
+        }
+
+        if (savedInstanceState == null) {
+            createFragments();
         }
 
         if (getSupportActionBar() != null) {
@@ -166,6 +180,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         args.putBoolean(OCFileListFragment.ARG_JUST_FOLDERS, true);
         args.putBoolean(OCFileListFragment.ARG_HIDE_FAB, true);
         args.putBoolean(OCFileListFragment.ARG_HIDE_ITEM_OPTIONS, true);
+        args.putBoolean(OCFileListFragment.ARG_SEARCH_ONLY_FOLDER, mSearchOnlyFolders);
         listOfFiles.setArguments(args);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.add(R.id.fragment_container, listOfFiles, TAG_LIST_OF_FOLDERS);
@@ -371,9 +386,9 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
      * Set per-view controllers
      */
     private void initControls(){
-        mCancelBtn = (Button) findViewById(R.id.folder_picker_btn_cancel);
+        mCancelBtn = findViewById(R.id.folder_picker_btn_cancel);
         mCancelBtn.setOnClickListener(this);
-        mChooseBtn = (Button) findViewById(R.id.folder_picker_btn_choose);
+        mChooseBtn = findViewById(R.id.folder_picker_btn_choose);
         mChooseBtn.getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
         mChooseBtn.setOnClickListener(this);
     }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -79,6 +79,7 @@ import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.activity.FolderPickerActivity;
 import com.owncloud.android.ui.activity.OnEnforceableRefreshListener;
+import com.owncloud.android.ui.activity.ToolbarActivity;
 import com.owncloud.android.ui.activity.UploadFilesActivity;
 import com.owncloud.android.ui.adapter.FileListListAdapter;
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
@@ -1542,7 +1543,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                             mAdapter.setData(remoteOperationResult.getData(), currentSearchType, storageManager, mFile);
                         }
 
-                        final FileDisplayActivity fileDisplayActivity = (FileDisplayActivity) getActivity();
+                        final ToolbarActivity fileDisplayActivity = (ToolbarActivity) getActivity();
                         if (fileDisplayActivity != null) {
                             fileDisplayActivity.runOnUiThread(new Runnable() {
                                 @Override

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -132,6 +132,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
     public final static String ARG_ALLOW_CONTEXTUAL_ACTIONS = MY_PACKAGE + ".ALLOW_CONTEXTUAL";
     public final static String ARG_HIDE_FAB = MY_PACKAGE + ".HIDE_FAB";
     public final static String ARG_HIDE_ITEM_OPTIONS = MY_PACKAGE + ".HIDE_ITEM_OPTIONS";
+    public final static String ARG_SEARCH_ONLY_FOLDER = MY_PACKAGE + ".SEARCH_ONLY_FOLDER";
 
     public static final String DOWNLOAD_BEHAVIOUR = "DOWNLOAD_BEHAVIOUR";
     public static final String DOWNLOAD_SEND = "DOWNLOAD_SEND";
@@ -1075,14 +1076,14 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             case R.id.action_move: {
                 Intent action = new Intent(getActivity(), FolderPickerActivity.class);
                 action.putParcelableArrayListExtra(FolderPickerActivity.EXTRA_FILES, checkedFiles);
-                action.putExtra(FolderPickerActivity.EXTRA_ACTION, getResources().getText(R.string.move_to));
+                action.putExtra(FolderPickerActivity.EXTRA_ACTION, FolderPickerActivity.MOVE);
                 getActivity().startActivityForResult(action, FileDisplayActivity.REQUEST_CODE__MOVE_FILES);
                 return true;
             }
             case R.id.action_copy: {
                 Intent action = new Intent(getActivity(), FolderPickerActivity.class);
                 action.putParcelableArrayListExtra(FolderPickerActivity.EXTRA_FILES, checkedFiles);
-                action.putExtra(FolderPickerActivity.EXTRA_ACTION, getResources().getText(R.string.copy_to));
+                action.putExtra(FolderPickerActivity.EXTRA_ACTION, FolderPickerActivity.COPY);
                 getActivity().startActivityForResult(action, FileDisplayActivity.REQUEST_CODE__COPY_FILES);
                 return true;
             }
@@ -1517,7 +1518,12 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
 
         final RemoteOperation remoteOperation;
         if (!currentSearchType.equals(SearchType.SHARED_FILTER)) {
-            remoteOperation = new SearchOperation(event.getSearchQuery(), event.getSearchType());
+            boolean searchOnlyFolders = false;
+            if (getArguments() != null && getArguments().getBoolean(ARG_SEARCH_ONLY_FOLDER, false)) {
+                searchOnlyFolders = true;
+            }
+
+            remoteOperation = new SearchOperation(event.getSearchQuery(), event.getSearchType(), searchOnlyFolders);
         } else {
             remoteOperation = new GetRemoteSharesOperation();
         }


### PR DESCRIPTION
fix #1800

Remaining: when searching in copy/move only folders should be shown, as files cannot be a target for copy/move
@mario as you implemented the search: can I limit the scope to folders only easily?

**NOTE: in order to test/compile it is currently linked against master branch of library. This must then be changed prior merge**

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>