### PR TITLE
harden notificationManager

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileDownloader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileDownloader.java
@@ -566,6 +566,10 @@ public class FileDownloader extends Service
             String text = String.format(getString(R.string.downloader_download_in_progress_content), percent, fileName);
             mNotificationBuilder.setContentText(text);
 
+            if (mNotificationManager == null) {
+                mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            }
+            
             if (mNotificationManager != null) {
                 mNotificationManager.notify(R.string.downloader_download_in_progress_ticker,
                         mNotificationBuilder.build());
@@ -623,9 +627,8 @@ public class FileDownloader extends Service
             } else {
                 // TODO put something smart in showDetailsIntent
                 Intent showDetailsIntent = new Intent();
-                mNotificationBuilder
-                        .setContentIntent(PendingIntent.getActivity(
-                                this, (int) System.currentTimeMillis(), showDetailsIntent, 0));
+                mNotificationBuilder.setContentIntent(PendingIntent.getActivity(this, (int) System.currentTimeMillis(),
+                        showDetailsIntent, 0));
             }
 
             mNotificationBuilder.setContentText(ErrorMessageAdapter.getErrorCauseMessage(downloadResult,

--- a/src/main/java/com/owncloud/android/files/services/FileDownloader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileDownloader.java
@@ -121,8 +121,7 @@ public class FileDownloader extends Service
         super.onCreate();
         Log_OC.d(TAG, "Creating service");
         mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        HandlerThread thread = new HandlerThread("FileDownloaderThread",
-                Process.THREAD_PRIORITY_BACKGROUND);
+        HandlerThread thread = new HandlerThread("FileDownloaderThread", Process.THREAD_PRIORITY_BACKGROUND);
         thread.start();
         mServiceLooper = thread.getLooper();
         mServiceHandler = new ServiceHandler(mServiceLooper, this);
@@ -541,11 +540,16 @@ public class FileDownloader extends Service
         showDetailsIntent.putExtra(FileActivity.EXTRA_ACCOUNT, download.getAccount());
         showDetailsIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
-        mNotificationBuilder.setContentIntent(PendingIntent.getActivity(
-                this, (int) System.currentTimeMillis(), showDetailsIntent, 0
-        ));
+        mNotificationBuilder.setContentIntent(PendingIntent.getActivity(this, (int) System.currentTimeMillis(),
+                showDetailsIntent, 0));
 
-        mNotificationManager.notify(R.string.downloader_download_in_progress_ticker, mNotificationBuilder.build());
+
+        if (mNotificationManager == null) {
+            mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        }
+        if (mNotificationManager != null) {
+            mNotificationManager.notify(R.string.downloader_download_in_progress_ticker, mNotificationBuilder.build());
+        }
     }
 
 
@@ -561,7 +565,11 @@ public class FileDownloader extends Service
             String fileName = filePath.substring(filePath.lastIndexOf(FileUtils.PATH_SEPARATOR) + 1);
             String text = String.format(getString(R.string.downloader_download_in_progress_content), percent, fileName);
             mNotificationBuilder.setContentText(text);
-            mNotificationManager.notify(R.string.downloader_download_in_progress_ticker, mNotificationBuilder.build());
+
+            if (mNotificationManager != null) {
+                mNotificationManager.notify(R.string.downloader_download_in_progress_ticker,
+                        mNotificationBuilder.build());
+            }
         }
         mLastPercent = percent;
     }
@@ -575,7 +583,13 @@ public class FileDownloader extends Service
      */
     private void notifyDownloadResult(DownloadFileOperation download,
                                       RemoteOperationResult downloadResult) {
-        mNotificationManager.cancel(R.string.downloader_download_in_progress_ticker);
+        if (mNotificationManager == null) {
+            mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        }
+
+        if (mNotificationManager != null) {
+            mNotificationManager.cancel(R.string.downloader_download_in_progress_ticker);
+        }
         if (!downloadResult.isCancelled()) {
             int tickerId = (downloadResult.isSuccess()) ? R.string.downloader_download_succeeded_ticker :
                     R.string.downloader_download_failed_ticker;
@@ -604,11 +618,8 @@ public class FileDownloader extends Service
                 updateAccountCredentials.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 updateAccountCredentials.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
                 updateAccountCredentials.addFlags(Intent.FLAG_FROM_BACKGROUND);
-                mNotificationBuilder
-                        .setContentIntent(PendingIntent.getActivity(
-                                this, (int) System.currentTimeMillis(), updateAccountCredentials,
-                                PendingIntent.FLAG_ONE_SHOT));
-
+                mNotificationBuilder.setContentIntent(PendingIntent.getActivity(this, (int) System.currentTimeMillis(),
+                        updateAccountCredentials, PendingIntent.FLAG_ONE_SHOT));
             } else {
                 // TODO put something smart in showDetailsIntent
                 Intent showDetailsIntent = new Intent();
@@ -617,21 +628,19 @@ public class FileDownloader extends Service
                                 this, (int) System.currentTimeMillis(), showDetailsIntent, 0));
             }
 
-            mNotificationBuilder.setContentText(
-                    ErrorMessageAdapter.getErrorCauseMessage(downloadResult, download,
-                            getResources())
-            );
-            mNotificationManager.notify(tickerId, mNotificationBuilder.build());
+            mNotificationBuilder.setContentText(ErrorMessageAdapter.getErrorCauseMessage(downloadResult,
+                    download, getResources()));
 
-            // Remove success notification
-            if (downloadResult.isSuccess()) {
-                // Sleep 2 seconds, so show the notification before remove it
-                NotificationUtils.cancelWithDelay(
-                        mNotificationManager,
-                        R.string.downloader_download_succeeded_ticker,
-                        2000);
+            if (mNotificationManager != null) {
+                mNotificationManager.notify(tickerId, mNotificationBuilder.build());
+
+                // Remove success notification
+                if (downloadResult.isSuccess()) {
+                    // Sleep 2 seconds, so show the notification before remove it
+                    NotificationUtils.cancelWithDelay(mNotificationManager,
+                            R.string.downloader_download_succeeded_ticker, 2000);
+                }
             }
-
         }
     }
 


### PR DESCRIPTION
From Google dev console:
```
java.lang.NullPointerException: 
  at com.owncloud.android.files.services.FileDownloader.notifyDownloadResult (FileDownloader.java:578)
  at com.owncloud.android.files.services.FileDownloader.downloadFile (FileDownloader.java:470)
  at com.owncloud.android.files.services.FileDownloader.access$500 (FileDownloader.java:73)
  at com.owncloud.android.files.services.FileDownloader$ServiceHandler.handleMessage (FileDownloader.java:404)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:164)
  at android.os.HandlerThread.run (HandlerThread.java:65)
```

This tries to get a notification manager if it is null.
It is not a real fix, but more a work around as I do not get why this can be null.

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>