### PR TITLE
Resized images: snackbar fix

### DIFF
--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -741,12 +741,24 @@ public class PreviewImageFragment extends FileFragment {
     }
 
     public void setErrorPreviewMessage() {
-        Snackbar.make(mMultiView, R.string.resized_image_not_possible, Snackbar.LENGTH_INDEFINITE)
-                .setAction(R.string.common_yes, v -> downloadFile()).show();
+        try {
+            if (getActivity() != null) {
+                Snackbar.make(mMultiView, R.string.resized_image_not_possible_download, Snackbar.LENGTH_INDEFINITE)
+                        .setAction(R.string.common_yes, v -> downloadFile()).show();
+            } else {
+                Snackbar.make(mMultiView, R.string.resized_image_not_possible, Snackbar.LENGTH_INDEFINITE).show();
+            }
+        } catch (IllegalArgumentException e) {
+            Log_OC.d(TAG, e.getMessage());
+        }
     }
 
     public void setNoConnectionErrorMessage() {
+        try {
             Snackbar.make(mMultiView, R.string.auth_no_net_conn_title, Snackbar.LENGTH_LONG).show();
+        } catch (IllegalArgumentException e) {
+            Log_OC.d(TAG, e.getMessage());
+        }
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -669,7 +669,8 @@
     <string name="sync_in_progress">Fetching most recent version of the file.</string>
     <string name="date_unknown">Unknown</string>
 
-    <string name="resized_image_not_possible">No resized image available. Download full image?</string>
+    <string name="resized_image_not_possible">No resized image available.</string>
+    <string name="resized_image_not_possible_download">No resized image available. Download full image?</string>
     <string name="resized_images_download_full_image">Download full image?</string>
 
     <string name="store_short_desc">The Nextcloud Android app allows access to all files on your Nextcloud instance.</string>


### PR DESCRIPTION
Snackbar fix IAE: as the image generation is done in a thread it can happen that mMultiView for Snackbar no longer exists, and then it crashes.

Download only if activity exists, else show only snackbar without download option.
(I cannot reproduce a non-existing activity, but google dev console shows it happen some time)

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>