### PR TITLE
No path magic, but simply use parent id

### DIFF
--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -145,8 +145,7 @@ public class PreviewImageActivity extends FileActivity implements
                 filename = getFile().getFileName();
             }
             // get parent from path
-            String parentPath = getFile().getRemotePath().substring(0, getFile().getRemotePath().lastIndexOf(filename));
-            OCFile parentFolder = getStorageManager().getFileByPath(parentPath);
+            OCFile parentFolder = getStorageManager().getFileById(getFile().getParentId());
 
             if (parentFolder == null) {
                 // should not be necessary


### PR DESCRIPTION
Again from google dev console.
```
Caused by: java.lang.NullPointerException: 
  at java.lang.String.lastIndexOf (String.java:1776)
  at java.lang.String.lastIndexOf (String.java:1753)
  at java.lang.String.lastIndexOf (String.java:1733)
  at com.owncloud.android.ui.preview.PreviewImageActivity.initViewPager (PreviewImageActivity.java:148)
  at com.owncloud.android.ui.preview.PreviewImageActivity.onAccountSet (PreviewImageActivity.java:490)
  at com.owncloud.android.ui.activity.BaseActivity.onStart (BaseActivity.java:192)
  at com.owncloud.android.ui.activity.DrawerActivity.onStart (DrawerActivity.java:1339)
  at com.owncloud.android.ui.activity.FileActivity.onStart (FileActivity.java:188)
  at com.owncloud.android.ui.preview.PreviewImageActivity.onStart (PreviewImageActivity.java:178)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1256)
  at android.app.Activity.performStart (Activity.java:6972)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:2937)
```

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>