### PR TITLE
Pullapprove: label

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,8 +4,7 @@ version: 2
 always_pending:
   title_regex: '(WIP|wip)'
   labels:
-    - 1. to develop
-    - 2. developing
+    - 1. developing
   # custom message that will be used for the GitHub status
   explanation: 'This PR is a work in progress...'
 


### PR DESCRIPTION
Changes label.

https://docs.pullapprove.com/groups/users/ 
> The GitHub users who are in this group. Case-insensitive.

So I do not get why pullapprove currently misbehaves.