### PR TITLE
Internet walled: catch any exception

### DIFF
--- a/src/main/java/com/owncloud/android/utils/ConnectivityUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ConnectivityUtils.java
@@ -38,7 +38,6 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 
 import org.apache.commons.httpclient.methods.GetMethod;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
@@ -78,7 +77,7 @@ public class ConnectivityUtils {
 
                                 String json = get.getResponseBodyAsString();
                                 return new JSONObject(json).getBoolean("maintenance");
-                            } catch (JSONException e) {
+                            } catch (Exception e) {
                                 return true;
                             }
                         } else {


### PR DESCRIPTION
This happens if getMethod returns null as response body.
I think this means an error and thus we can catch it and return true (=> internet walled).

```
java.lang.NullPointerException: 
  at org.json.JSONTokener.nextCleanInternal (JSONTokener.java:116)
  at org.json.JSONTokener.nextValue (JSONTokener.java:94)
  at org.json.JSONObject.<init> (JSONObject.java:155)
  at org.json.JSONObject.<init> (JSONObject.java:172)
  at com.owncloud.android.utils.ConnectivityUtils.isInternetWalled (ConnectivityUtils.java:80)
 ```
Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>