### PR TITLE
NPE if activity is already closed

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ActivitiesListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ActivitiesListActivity.java
@@ -307,8 +307,12 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
 
     private void hideRefreshLayoutLoader() {
         runOnUiThread(() -> {
-            swipeListRefreshLayout.setRefreshing(false);
-            swipeEmptyListRefreshLayout.setRefreshing(false);
+            if (swipeListRefreshLayout != null) {
+                swipeListRefreshLayout.setRefreshing(false);
+            }
+            if (swipeEmptyListRefreshLayout != null) {
+                swipeEmptyListRefreshLayout.setRefreshing(false);
+            }
             isLoadingActivities = false;
             setIndeterminate(isLoadingActivities);
         });


### PR DESCRIPTION
- open activity
- have a slow connection
- while loading switch activity, e.g. go to files
-> crash

```
java.lang.NullPointerException: 
  at com.owncloud.android.ui.activity.ActivitiesListActivity.lambda$hideRefreshLayoutLoader$6$ActivitiesListActivity (ActivitiesListActivity.java:310)
  at com.owncloud.android.ui.activity.ActivitiesListActivity$$Lambda$3.run (Unknown Source:2)
```

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>