### PR TITLE
Prevent index out of bounds exception

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -856,7 +856,8 @@ public class ReceiveExternalFilesActivity extends FileActivity
             mStreamsToUpload = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
         }
 
-        if (mStreamsToUpload == null || mStreamsToUpload.get(0) == null) {
+        if (mStreamsToUpload == null || mStreamsToUpload.size() == 0 ||
+                mStreamsToUpload.get(0) == null) {
             mStreamsToUpload = null;
             saveTextsFromIntent(intent);
         }


### PR DESCRIPTION
```
mStreamsToUpload.get(0) == null
```
can throw IndexOutOfBoundsException if we pass a new ArrayList() on it.
Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>