### PR TITLE
Prevent copy/move into encrypted folder

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -81,6 +81,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     private boolean mSyncInProgress = false;
 
     private boolean mSearchOnlyFolders = false;
+    private boolean mDoNotEnterEncryptedFolder = false;
 
     protected Button mCancelBtn;
     protected Button mChooseBtn;
@@ -106,10 +107,12 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                 case MOVE:
                     caption = getResources().getText(R.string.move_to).toString();
                     mSearchOnlyFolders = true;
+                    mDoNotEnterEncryptedFolder = true;
                     break;
                 case COPY:
                     caption = getResources().getText(R.string.copy_to).toString();
                     mSearchOnlyFolders = true;
+                    mDoNotEnterEncryptedFolder = true;
                     break;
                 default:
                     caption = ThemeUtils.getDefaultDisplayNameForRootFolder();
@@ -565,5 +568,9 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                 startSyncFolderOperation(folder, ignoreETag);
             }
         }
+    }
+
+    public boolean isDoNotEnterEncryptedFolder() {
+        return mDoNotEnterEncryptedFolder;
     }
 }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -907,11 +907,20 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                     } else {
                         // update state and view of this fragment
                         searchFragment = false;
-                        listDirectory(file, MainApp.isOnlyOnDevice(), false);
-                        // then, notify parent activity to let it update its state and view
-                        mContainerActivity.onBrowsedDownTo(file);
-                        // save index and top position
-                        saveIndexAndTopPosition(position);
+
+                        if (mContainerActivity instanceof FolderPickerActivity &&
+                                ((FolderPickerActivity) mContainerActivity)
+                                        .isDoNotEnterEncryptedFolder()) {
+                            Snackbar.make(getListView(),
+                                    R.string.copy_move_to_encrypted_folder_not_supported,
+                                    Snackbar.LENGTH_LONG).show();
+                        } else {
+                            listDirectory(file, MainApp.isOnlyOnDevice(), false);
+                            // then, notify parent activity to let it update its state and view
+                            mContainerActivity.onBrowsedDownTo(file);
+                            // save index and top position
+                            saveIndexAndTopPosition(position);
+                        }
                     }
                 } else {
                     // update state and view of this fragment

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -759,4 +759,5 @@
     <string name="end_to_end_encryption_unsuccessful">Storing keys was unsuccessful, please try it again!</string>
     <string name="end_to_end_encryption_dialog_close">Close</string>
     <string name="end_to_end_encryption_storing_keys">Storing keys</string>
+    <string name="copy_move_to_encrypted_folder_not_supported">Copy/move into encrypted folder currently not supported.</string>
 </resources>


### PR DESCRIPTION
As this is done via webdav calls (move/copy) this is a lot trickier than uploading.
Needs also handling directories, so postponing to M2 of E2E.

Steps to test:
Select a file and try to copy it to 
- encrypted folder -> Snackbar showing info
- unenecrypted folder -> working

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>