### PR TITLE
Show infos on untrusted domain if available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.2'
 //    implementation project('nextcloud-android-library')
-    implementation 'com.github.nextcloud:android-library:1.0.35'
+    implementation 'com.github.nextcloud:android-library:1.0.36'
     versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1569,6 +1569,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             case MAINTENANCE_MODE:
                 mServerStatusText = getResources().getString(R.string.maintenance_mode);
                 break;
+            case UNTRUSTED_DOMAIN:
+                mServerStatusText = getResources().getString(R.string.untrusted_domain);
+                break;
             default:
                 mServerStatusText = "";
                 mServerStatusIcon = 0;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -760,4 +760,5 @@
     <string name="end_to_end_encryption_dialog_close">Close</string>
     <string name="end_to_end_encryption_storing_keys">Storing keys</string>
     <string name="copy_move_to_encrypted_folder_not_supported">Copy/move into encrypted folder currently not supported.</string>
+    <string name="untrusted_domain">Access through untrusted domain. Please see documentation for further infos.</string>
 </resources>


### PR DESCRIPTION
Needs Server: https://github.com/nextcloud/server/pull/7991
If the server pr is not available, it will fall back to "unknown error" as before.

@mario @AndyScherzinger do we want to add this in 3.0 (I know it is feature freeze) or do we want to wait for 3.1? Both is fine for me.

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>