### PR TITLE
Do not ignore ignoreEtags

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -276,7 +276,7 @@ public class FileDisplayActivity extends HookActivity
             }
         } else {
             createMinFragments(savedInstanceState);
-            refreshList(true);
+            refreshList(false);
         }
 
         setIndeterminate(mSyncInProgress);

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -123,7 +123,7 @@ public class ExtendedListFragment extends Fragment
     private ArrayList<Integer> mTops;
     private int mHeightCell = 0;
 
-    private SwipeRefreshLayout.OnRefreshListener mOnRefreshListener = null;
+    private OnEnforceableRefreshListener mOnRefreshListener = null;
 
     protected AbsListView mCurrentListView;
     private ExtendedListView mListView;
@@ -862,7 +862,7 @@ public class ExtendedListFragment extends Fragment
         mRefreshEmptyLayout.setRefreshing(false);
 
         if (mOnRefreshListener != null) {
-            mOnRefreshListener.onRefresh();
+            mOnRefreshListener.onRefresh(ignoreETag);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1676,7 +1676,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             mRefreshGridLayout.setRefreshing(false);
             mRefreshEmptyLayout.setRefreshing(false);
         } else {
-            super.onRefresh();
+            super.onRefresh(false);
         }
     }
 


### PR DESCRIPTION
Currently we have set ignoreEtags to true on refresh and on swap directories.
This leads to a full sync of folder and its direct content (fetching all metadata), even if the etag is not changed.

For browsing, refreshing I think it is safe to rely on changing Etags as this is the whole purpose of them.
@rullzer can you imagine any situation when you (on desktop) are doing a full resync of a folder?

"ignoreEtags" was introduced with this commit message, years ago:
> Add boolean parameter 'ignoreTag' to SyncronizeFolderOperation constructor and pass ignoreTag = true in calls to #startSyncFolderOperation at FileDisplayActivity and MoveActivity in #onRefresh()

