### PR TITLE
Tint delete account dialog buttons

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -56,10 +56,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import butterknife.BindString;
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.Unbinder;
+
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
@@ -78,6 +75,7 @@ import com.owncloud.android.ui.events.TokenPushEvent;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.PushUtils;
 import com.owncloud.android.utils.ThemeUtils;
+
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -85,6 +83,11 @@ import org.parceler.Parcels;
 
 import java.util.LinkedList;
 import java.util.List;
+
+import butterknife.BindString;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 /**
  * This Activity presents the user information.
@@ -346,6 +349,18 @@ public class UserInfoActivity extends FileActivity {
         public void onCreate(@Nullable Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             account = getArguments().getParcelable(KEY_ACCOUNT);
+        }
+
+        @Override
+        public void onStart() {
+            super.onStart();
+
+            int color = ThemeUtils.primaryAccentColor();
+
+            AlertDialog alertDialog = (AlertDialog) getDialog();
+
+            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(color);
+            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(color);
         }
 
         @NonNull


### PR DESCRIPTION
Previously "cancel" and "delete account" had the default NC blue.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>