### PR TITLE
getExternalFilesDir(null) can be null --> preventing NPE

### DIFF
--- a/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
+++ b/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
@@ -111,13 +111,19 @@ public class DataStorageProvider {
 
         // Add external storage directory if available.
         if (isExternalStorageWritable()) {
-            storagePoint = new StoragePoint();
-            storagePoint.setPath(MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath());
-            storagePoint.setDescription(MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath());
-            storagePoint.setPrivacyType(StoragePoint.PrivacyType.PRIVATE);
-            storagePoint.setStorageType(StoragePoint.StorageType.EXTERNAL);
-            if (!paths.contains(MainApp.getAppContext().getExternalFilesDir(null).getAbsolutePath())) {
-                mCachedStoragePoints.add(storagePoint);
+            File externalFilesDir = MainApp.getAppContext().getExternalFilesDir(null);
+
+            if (externalFilesDir != null) {
+                String externalFilesDirPath = externalFilesDir.getAbsolutePath();
+
+                storagePoint = new StoragePoint();
+                storagePoint.setPath(externalFilesDirPath);
+                storagePoint.setDescription(externalFilesDirPath);
+                storagePoint.setPrivacyType(StoragePoint.PrivacyType.PRIVATE);
+                storagePoint.setStorageType(StoragePoint.StorageType.EXTERNAL);
+                if (!paths.contains(externalFilesDirPath)) {
+                    mCachedStoragePoints.add(storagePoint);
+                }
             }
         }
 


### PR DESCRIPTION
Reported via google dev console, only 1x, but still should be in 3.0 release.

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>