### PR TITLE
E2e flag only on folders

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -503,6 +503,8 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
         mEtagInConflict = null;
         mShareWithSharee = false;
         mIsFavorite = false;
+        mIsEncrypted = false;
+        mEncryptedFileName = null;
     }
 
     /**

--- a/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -217,7 +217,9 @@ public class FileStorageUtils {
         file.setPermissions(remote.getPermissions());
         file.setRemoteId(remote.getRemoteId());
         file.setFavorite(remote.getIsFavorite());
-        file.setEncrypted(remote.getIsEncrypted());
+        if (file.isFolder()) {
+            file.setEncrypted(remote.getIsEncrypted());
+        }
         return file;
     }
 


### PR DESCRIPTION
Fix #2044 
The encryption flag is used for both server side and client side encryption.
As for client side encryption only the topmost folder is marked as encrypted, we can ignore encryption flag on files.

@schiessle @rullzer 