### PR TITLE
Fixes #2070: Move the responsibility of FAB's theming to theris owner

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -595,16 +595,6 @@ public class FileDisplayActivity extends HookActivity
         OCFileListFragment fileListFragment = getListOfFilesFragment();
         if (fileListFragment != null) {
             fileListFragment.listDirectory(MainApp.isOnlyOnDevice(), fromSearch);
-
-            AddFloatingActionButton addButton = fileListFragment.getFabMain().getAddButton();
-            addButton.setColorNormal(ThemeUtils.primaryColor());
-            addButton.setColorPressed(ThemeUtils.primaryDarkColor());
-            addButton.setPlusColor(ThemeUtils.fontColor());
-
-            ThemeUtils.tintFloatingActionButton(fileListFragment.getFabUpload(), R.drawable.ic_action_upload);
-            ThemeUtils.tintFloatingActionButton(fileListFragment.getFabMkdir(), R.drawable.ic_action_create_dir);
-            ThemeUtils.tintFloatingActionButton(fileListFragment.getFabUploadFromApp(), R.drawable.ic_import);
-
             setupToolbar();
         }
     }

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -58,6 +58,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.getbase.floatingactionbutton.AddFloatingActionButton;
 import com.getbase.floatingactionbutton.FloatingActionButton;
 import com.getbase.floatingactionbutton.FloatingActionsMenu;
 import com.owncloud.android.MainApp;
@@ -441,6 +442,8 @@ public class ExtendedListFragment extends Fragment
         mFabMkdir = v.findViewById(R.id.fab_mkdir);
         mFabUploadFromApp = v.findViewById(R.id.fab_upload_from_app);
 
+        applyFABTheming();
+
         boolean searchSupported = AccountUtils.hasSearchSupport(AccountUtils.
                 getCurrentOwnCloudAccount(MainApp.getAppContext()));
 
@@ -706,6 +709,21 @@ public class ExtendedListFragment extends Fragment
                 }
             });
         }
+    }
+
+
+    /**
+     * Set tinting of FAB's from server data
+     */
+    private void applyFABTheming() {
+        AddFloatingActionButton addButton = getFabMain().getAddButton();
+        addButton.setColorNormal(ThemeUtils.primaryColor());
+        addButton.setColorPressed(ThemeUtils.primaryDarkColor());
+        addButton.setPlusColor(ThemeUtils.fontColor());
+
+        ThemeUtils.tintFloatingActionButton(getFabUpload(), R.drawable.ic_action_upload);
+        ThemeUtils.tintFloatingActionButton(getFabMkdir(), R.drawable.ic_action_create_dir);
+        ThemeUtils.tintFloatingActionButton(getFabUploadFromApp(), R.drawable.ic_import);
     }
 
     /**


### PR DESCRIPTION
Since ExtendedListFragment is owning all FAB's where is no need for any other activity to alter the theming of those buttons. ThemeUtils are wide accessible, and at the time of construction, so apply the theming there.