### PR TITLE
Fix upgrade from 1.4.3 to 3.0.0

### DIFF
--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -1628,28 +1628,30 @@ public class FileContentProvider extends ContentProvider {
                         db.execSQL(ALTER_TABLE + ProviderTableMeta.FILE_TABLE_NAME +
                                 ADD_COLUMN + ProviderTableMeta.FILE_ENCRYPTED_NAME + " TEXT ");
                     }
-                    if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
-                            ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION) && oldVersion > 20) {
-                        db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
-                                ADD_COLUMN + ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION + " INTEGER ");
-                    }
-                    if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
-                            ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR) && oldVersion > 20) {
-                        db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
-                                ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + " TEXT ");
-                    }
-                    if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
-                            ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR) && oldVersion > 20) {
-                        db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
-                                ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + " TEXT ");
-                    }
-                    if (!checkIfColumnExists(db, ProviderTableMeta.FILESYSTEM_TABLE_NAME,
-                            ProviderTableMeta.FILESYSTEM_CRC32) && oldVersion > 20) {
-                        try {
-                            db.execSQL(ALTER_TABLE + ProviderTableMeta.FILESYSTEM_TABLE_NAME +
-                                    ADD_COLUMN + ProviderTableMeta.FILESYSTEM_CRC32 + " TEXT ");
-                        } catch (SQLiteException e) {
-                            Log_OC.d(TAG, "Known problem on adding same column twice when upgrading from 24->30");
+                    if (oldVersion > 20) {
+                        if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
+                                ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION)) {
+                            db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                                    ADD_COLUMN + ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION + " INTEGER ");
+                        }
+                        if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
+                                ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR)) {
+                            db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                                    ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + " TEXT ");
+                        }
+                        if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
+                                ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR)) {
+                            db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                                    ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + " TEXT ");
+                        }
+                        if (!checkIfColumnExists(db, ProviderTableMeta.FILESYSTEM_TABLE_NAME,
+                                ProviderTableMeta.FILESYSTEM_CRC32)) {
+                            try {
+                                db.execSQL(ALTER_TABLE + ProviderTableMeta.FILESYSTEM_TABLE_NAME +
+                                        ADD_COLUMN + ProviderTableMeta.FILESYSTEM_CRC32 + " TEXT ");
+                            } catch (SQLiteException e) {
+                                Log_OC.d(TAG, "Known problem on adding same column twice when upgrading from 24->30");
+                            }
                         }
                     }
 

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -1629,22 +1629,22 @@ public class FileContentProvider extends ContentProvider {
                                 ADD_COLUMN + ProviderTableMeta.FILE_ENCRYPTED_NAME + " TEXT ");
                     }
                     if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
-                            ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION)) {
+                            ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION) && oldVersion > 20) {
                         db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
                                 ADD_COLUMN + ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION + " INTEGER ");
                     }
                     if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
-                            ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR)) {
+                            ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR) && oldVersion > 20) {
                         db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
                                 ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + " TEXT ");
                     }
                     if (!checkIfColumnExists(db, ProviderTableMeta.CAPABILITIES_TABLE_NAME,
-                            ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR)) {
+                            ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR) && oldVersion > 20) {
                         db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
                                 ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + " TEXT ");
                     }
                     if (!checkIfColumnExists(db, ProviderTableMeta.FILESYSTEM_TABLE_NAME,
-                            ProviderTableMeta.FILESYSTEM_CRC32)) {
+                            ProviderTableMeta.FILESYSTEM_CRC32) && oldVersion > 20) {
                         try {
                             db.execSQL(ALTER_TABLE + ProviderTableMeta.FILESYSTEM_TABLE_NAME +
                                     ADD_COLUMN + ProviderTableMeta.FILESYSTEM_CRC32 + " TEXT ");


### PR DESCRIPTION
As checkIfColumnExists is not working reliable when the same column is altered within the same onUpgrade(), we need to check the old version.
1.4.3 has versionCode 20, so if you upgrade from this, it will get all needed columns on the respective upgrade step and therefore we can ignore it in the sanity step 30.
For all other version the sanity step 30 is needed as it can happen due to beta/alpha testing, that some columns are missing.

--> next time we never ever are allowed to change upgrade once it is published

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>