### PR TITLE
Apply new theming when folder refresh finishes

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -40,6 +40,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources.NotFoundException;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.Parcelable;
 import android.support.design.widget.BottomNavigationView;
@@ -60,7 +61,6 @@ import android.view.ViewTreeObserver;
 import android.widget.EditText;
 import android.widget.ImageView;
 
-import com.getbase.floatingactionbutton.AddFloatingActionButton;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -179,6 +179,8 @@ public class FileDisplayActivity extends HookActivity
     private String searchQuery;
 
     private SearchView searchView;
+
+    private Handler mHandler = new Handler();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -1643,6 +1645,9 @@ public class FileDisplayActivity extends HookActivity
 
         } else if (operation instanceof CopyFileOperation) {
             onCopyFileOperationFinish((CopyFileOperation) operation, result);
+
+        } else if (operation instanceof RefreshFolderOperation) {
+            onRefreshFolderOperationFinish((RefreshFolderOperation)operation, result);
         }
 
     }
@@ -1758,6 +1763,26 @@ public class FileDisplayActivity extends HookActivity
             }
         }
     }
+
+    /**
+     * Update theming of current activity and fragments, since Folder refresh can also update theming information.
+     *
+     * @param operation Folder refresh operation
+     * @param result    Result of folder refresh
+     */
+    private void onRefreshFolderOperationFinish(RefreshFolderOperation operation, RemoteOperationResult result) {
+        if (MainApp.isOnlyOnDevice()) {
+            setupDrawer(R.id.nav_on_device);
+        } else {
+            setupDrawer(R.id.nav_all_files);
+        }
+        setupToolbar();
+        OCFileListFragment listFragment = getListOfFilesFragment();
+        if (listFragment != null) {
+            listFragment.applyFABTheming();
+        }
+    }
+
 
     /**
      * Updates the view associated to the activity after the finish of an operation trying to rename
@@ -1927,8 +1952,8 @@ public class FileDisplayActivity extends HookActivity
                                         getAccount(),
                                         MainApp.getAppContext(),
                                         FileDisplayActivity.this,
-                                        null,
-                                        null
+                                        FileDisplayActivity.this.mHandler,
+                                        FileDisplayActivity.this
                                 );
 
                                 setIndeterminate(true);

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -715,7 +715,7 @@ public class ExtendedListFragment extends Fragment
     /**
      * Set tinting of FAB's from server data
      */
-    private void applyFABTheming() {
+    public void applyFABTheming() {
         AddFloatingActionButton addButton = getFabMain().getAddButton();
         addButton.setColorNormal(ThemeUtils.primaryColor());
         addButton.setColorPressed(ThemeUtils.primaryDarkColor());

--- a/src/main/java/com/owncloud/android/ui/theme/NCTheme.java
+++ b/src/main/java/com/owncloud/android/ui/theme/NCTheme.java
@@ -1,0 +1,125 @@
+/*
+ * Nextcloud Android client application
+ *
+ * Copyright (C) 2018 Bartosz Przybylski
+ * Copyright (C) 2018 Nextcloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.ui.theme;
+
+import android.accounts.Account;
+import android.content.Context;
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+
+import com.owncloud.android.R;
+import com.owncloud.android.lib.resources.status.OCCapability;
+import com.owncloud.android.utils.ThemeUtils;
+
+import static com.owncloud.android.utils.ThemeUtils.adjustLightness;
+
+/**
+ * @author Bartosz Przybylski
+ */
+public class NCTheme {
+
+    private @ColorInt int mPrimaryColor;
+    private @ColorInt int mPrimaryAccentColor;
+    private @ColorInt int mPrimaryDarkColor;
+    private @ColorInt int mElementColor;
+
+    static public NCTheme construct(Context context, Account account) {
+        OCCapability capability = ThemeUtils.getCapability(account);
+
+        @ColorInt int primaryColor = getPrimaryColor(context, capability);
+        @ColorInt int primaryAccent = getPrimaryAccent(primaryColor, context, capability);
+        @ColorInt int primaryDark = getPrimaryDark(context, capability);
+        @ColorInt int elementColor = getElementColor(primaryColor, context, capability);
+
+        return new NCTheme(primaryColor, primaryAccent, primaryDark, elementColor);
+    }
+
+    static private @ColorInt int getPrimaryColor(Context context, OCCapability capability) {
+        try {
+            return Color.parseColor(capability.getServerColor());
+        } catch (Exception e) {
+            return context.getResources().getColor(R.color.primary);
+        }
+    }
+
+    static private @ColorInt int getPrimaryAccent(int primaryColor, Context context, OCCapability capability) {
+        try {
+            float adjust = isDarkTheme(primaryColor) ? 0.1f : -0.1f;
+            return adjustLightness(adjust, Color.parseColor(capability.getServerColor()), 0.35f);
+        } catch (Exception e) {
+            return context.getResources().getColor(R.color.color_accent);
+        }
+    }
+
+    static private @ColorInt int getPrimaryDark(Context context, OCCapability capability) {
+        try {
+            return adjustLightness(-0.2f, Color.parseColor(capability.getServerColor()), -1f);
+        } catch (Exception e) {
+            return context.getResources().getColor(R.color.primary_dark);
+        }
+    }
+
+    static private @ColorInt int getElementColor(@ColorInt int primaryColor, Context context, OCCapability capability) {
+        try {
+            return Color.parseColor(capability.getServerElementColor());
+        } catch (Exception e) {
+            float[] hsl = ThemeUtils.colorToHSL(primaryColor);
+
+            if (hsl[2] > 0.8) {
+                return context.getResources().getColor(R.color.elementFallbackColor);
+            }
+            return primaryColor;
+        }
+    }
+
+    static private boolean isDarkTheme(@ColorInt int primaryColor) {
+        float hsl[] = ThemeUtils.colorToHSL(primaryColor);
+        return hsl[2] <= 0.55;
+    }
+
+
+
+
+
+    private NCTheme(@ColorInt int primaryColor, @ColorInt int primaryAccentColor, @ColorInt int primaryDarkColor,
+                    @ColorInt int elementColor) {
+        mPrimaryColor = primaryColor;
+        mPrimaryAccentColor = primaryAccentColor;
+        mPrimaryDarkColor = primaryDarkColor;
+        mElementColor = elementColor;
+    }
+
+    public int getPrimaryAccentColor() {
+        return mPrimaryAccentColor;
+    }
+
+    public int getPrimaryDarkColor() {
+        return mPrimaryDarkColor;
+    }
+
+    public int getPrimaryColor() {
+        return mPrimaryColor;
+    }
+
+    public int getElementColor() {
+        return mElementColor;
+    }
+}

--- a/src/main/java/com/owncloud/android/ui/theme/ThemableView.java
+++ b/src/main/java/com/owncloud/android/ui/theme/ThemableView.java
@@ -1,0 +1,29 @@
+/*
+ * Nextcloud Android client application
+ *
+ * Copyright (C) 2018 Bartosz Przybylski
+ * Copyright (C) 2018 Nextcloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.ui.theme;
+
+/**
+ * @author Bartosz Przybylski
+ */
+public interface ThemableView {
+
+    void applyTheme(NCTheme theme);
+}

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -224,7 +224,7 @@ public class ThemeUtils {
         return ColorUtils.HSLToColor(hsl);
     }
 
-    private static float[] colorToHSL(int color) {
+    public static float[] colorToHSL(int color) {
         float[] hsl = new float[3];
         ColorUtils.RGBToHSL(Color.red(color), Color.green(color), Color.blue(color), hsl);
 
@@ -370,7 +370,7 @@ public class ThemeUtils {
         return getCapability(null);
     }
 
-    private static OCCapability getCapability(Account acc) {
+    public static OCCapability getCapability(Account acc) {
         Account account;
 
         if (acc != null) {


### PR DESCRIPTION
When synchronization of the folder finishes it is possible that theming can also change. At this moment it is not possible to tell. So what we do is to re-setup parts of the UI to stay consistent with the server theming.


===

This is not even close to being elegant solution, but at the moment so many things would required to be hanged that the small pain of re-setup views doesn't sound as a bad trade-off.

The purest of the solution would require the following:
* Storing capabilities should be moved from ContentResolver to other database API, preferably Room, since it supports LiveData
* Activity should subscribe to the database by using LiveData for any theming changes, then apply them to its subchildren. Fragments could do the same
* Ideally there should be a way to generate Theme object on the fly and apply it to the children, doable, but have several drawbacks