### PR TITLE
Force install location to internal, even if this is default

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
         android:theme="@style/Theme.ownCloud.Toolbar"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
+        android:installLocation="internalOnly"
         android:manageSpaceActivity="com.owncloud.android.ui.activity.ManageSpaceActivity">
         <activity
             android:name=".ui.activity.FileDisplayActivity"


### PR DESCRIPTION
As discussed in #1531, this maybe helps.
@mario @AndyScherzinger do we want to backport this to 3.0 final, even without RC?
(I cannot test it on emulator and I do not have any device which let's me use the sdcard as adoptable storage).

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>