### PR TITLE
Fix time display in activities list

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -147,7 +147,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             Activity activity = (Activity) mValues.get(position);
             if (activity.getDatetime() != null) {
                 activityViewHolder.dateTime.setVisibility(View.VISIBLE);
-                activityViewHolder.dateTime.setText(DateFormat.format("HH:MM", activity.getDatetime().getTime()));
+                activityViewHolder.dateTime.setText(DateFormat.format("HH:mm", activity.getDatetime().getTime()));
             } else {
                 activityViewHolder.dateTime.setVisibility(View.GONE);
             }


### PR DESCRIPTION
Fix #2141

Error has been the use of ```HH:MM``` instead of ```HH:mm``` since ```MM``` is month not minute.

cc @mario @tobiasKaminsky - Do we want to backport this for 3.0.1?