### PR TITLE
Encryption: Get IV directly from the cipher object when encrypting the private key

### DIFF
--- a/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -514,7 +514,7 @@ public class EncryptionUtils {
         byte[] bytes = encodeStringToBase64Bytes(privateKey);
         byte[] encrypted = cipher.doFinal(bytes);
 
-        byte[] iv = cipher.getParameters().getParameterSpec(IvParameterSpec.class).getIV();
+        byte[] iv = cipher.getIV();
         String encodedIV = encodeBytesToBase64String(iv);
         String encodedSalt = encodeBytesToBase64String(salt);
         String encodedEncryptedBytes = encodeBytesToBase64String(encrypted);


### PR DESCRIPTION
In Android O and newer (at least) javax.crypto.spec.IvParameterSpec is unsupported. Get the IV directly from the cipher object instead. This has been tested on API level 27 and found to work well. E2E encryption keys can now be stored correctly since the private key can be encrypted successfully.

This fixes #2134 and all the other issues describing the same issue.