### PR TITLE
Delete public key if storage of private key did not worked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.2'
 //    implementation project('nextcloud-android-library')
-    implementation 'com.github.nextcloud:android-library:1.0.37'
+    implementation 'com.github.nextcloud:android-library:1.0.38'
     versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"

--- a/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -41,6 +41,7 @@ import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.lib.common.UserInfo;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.users.DeletePublicKeyOperation;
 import com.owncloud.android.lib.resources.users.GetPrivateKeyOperation;
 import com.owncloud.android.lib.resources.users.GetPublicKeyOperation;
 import com.owncloud.android.lib.resources.users.GetRemoteUserInfoOperation;
@@ -346,8 +347,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
 
                 // get user id
                 String userID;
-                GetRemoteUserInfoOperation remoteUserNameOperation =
-                        new GetRemoteUserInfoOperation();
+                GetRemoteUserInfoOperation remoteUserNameOperation = new GetRemoteUserInfoOperation();
                 RemoteOperationResult remoteUserNameOperationResult = remoteUserNameOperation
                         .execute(account, getContext(), true);
 
@@ -398,8 +398,10 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
 
                     keyResult = KEY_CREATED;
                     return (String) storePrivateKeyResult.getData().get(0);
+                } else {
+                    DeletePublicKeyOperation deletePublicKeyOperation = new DeletePublicKeyOperation();
+                    deletePublicKeyOperation.execute(account, getContext(), true);
                 }
-
             } catch (Exception e) {
                 Log_OC.e(TAG, e.getMessage());
             }


### PR DESCRIPTION
Fix #2153 

First we generate a public key, if this fails, nothing is stored on server, so everything is fine.
If public key is stored successfully, we generate a private key and store this. 
If private key is stored correctly, we store both locally.

This PR now removes the public key if storage of the private key fails.