### PR TITLE
If no thumbnail exists, check if resized version exist and use this

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -536,10 +536,8 @@ public class ThumbnailsCacheManager {
                     if (resizedImage != null) {
                         thumbnail = ThumbnailUtils.extractThumbnail(resizedImage, pxW, pxH);
                     } else {
-                        //Download thumbnail from server
-                    OwnCloudVersion serverOCVersion = AccountUtils.getServerVersion(mAccount);
-                    if (mClient !=  null) {
-                        if (serverOCVersion.supportsRemoteThumbnails()) {
+                        // Download thumbnail from server
+                        if (mClient != null && AccountUtils.getServerVersion(mAccount).supportsRemoteThumbnails()) {
                             getMethod = null;
                             try {
                                 // thumbnail
@@ -551,32 +549,31 @@ public class ThumbnailsCacheManager {
                                 getMethod.setRequestHeader("Cookie",
                                         "nc_sameSiteCookielax=true;nc_sameSiteCookiestrict=true");
 
-                                    getMethod.setRequestHeader(RemoteOperation.OCS_API_HEADER,
-                                            RemoteOperation.OCS_API_HEADER_VALUE);
+                                getMethod.setRequestHeader(RemoteOperation.OCS_API_HEADER,
+                                        RemoteOperation.OCS_API_HEADER_VALUE);
 
-                                    int status = mClient.executeMethod(getMethod);
-                                    if (status == HttpStatus.SC_OK) {
-                                        InputStream inputStream = getMethod.getResponseBodyAsStream();
-                                        Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
-                                        thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
-                                    } else {
-                                        mClient.exhaustResponse(getMethod.getResponseBodyAsStream());
-                                    }
-
-                                    // Handle PNG
-                                    if (file.getMimetype().equalsIgnoreCase(PNG_MIMETYPE)) {
-                                        thumbnail = handlePNG(thumbnail, pxW, pxH);
-                                    }
-                                } catch (Exception e) {
-                                    Log_OC.d(TAG, e.getMessage(), e);
-                                } finally {
-                                    if (getMethod != null) {
-                                        getMethod.releaseConnection();
-                                    }
+                                int status = mClient.executeMethod(getMethod);
+                                if (status == HttpStatus.SC_OK) {
+                                    InputStream inputStream = getMethod.getResponseBodyAsStream();
+                                    Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
+                                    thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
+                                } else {
+                                    mClient.exhaustResponse(getMethod.getResponseBodyAsStream());
                                 }
-                            } else {
-                                Log_OC.d(TAG, "Server too old");
+
+                                // Handle PNG
+                                if (file.getMimetype().equalsIgnoreCase(PNG_MIMETYPE)) {
+                                    thumbnail = handlePNG(thumbnail, pxW, pxH);
+                                }
+                            } catch (Exception e) {
+                                Log_OC.d(TAG, e.getMessage(), e);
+                            } finally {
+                                if (getMethod != null) {
+                                    getMethod.releaseConnection();
+                                }
                             }
+                        } else {
+                            Log_OC.d(TAG, "Server too old");
                         }
                     }
 

--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -529,10 +529,16 @@ public class ThumbnailsCacheManager {
                     }
 
                 } else {
-                    // Download thumbnail from server
-                    OwnCloudVersion serverOCVersion = AccountUtils.getServerVersion(mAccount);
+                    // check if resized version is available
+                    String resizedImageKey = PREFIX_RESIZED_IMAGE + String.valueOf(file.getRemoteId());
+                    Bitmap resizedImage = getBitmapFromDiskCache(resizedImageKey);
 
-                    if (mClient != null) {
+                    if (resizedImage != null) {
+                        thumbnail = ThumbnailUtils.extractThumbnail(resizedImage, pxW, pxH);
+                    } else {
+                        //Download thumbnail from server
+                    OwnCloudVersion serverOCVersion = AccountUtils.getServerVersion(mAccount);
+                    if (mClient !=  null) {
                         if (serverOCVersion.supportsRemoteThumbnails()) {
                             getMethod = null;
                             try {
@@ -545,39 +551,39 @@ public class ThumbnailsCacheManager {
                                 getMethod.setRequestHeader("Cookie",
                                         "nc_sameSiteCookielax=true;nc_sameSiteCookiestrict=true");
 
-                                getMethod.setRequestHeader(RemoteOperation.OCS_API_HEADER,
-                                        RemoteOperation.OCS_API_HEADER_VALUE);
+                                    getMethod.setRequestHeader(RemoteOperation.OCS_API_HEADER,
+                                            RemoteOperation.OCS_API_HEADER_VALUE);
 
-                                int status = mClient.executeMethod(getMethod);
-                                if (status == HttpStatus.SC_OK) {
-                                    InputStream inputStream = getMethod.getResponseBodyAsStream();
-                                    Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
-                                    thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
-                                } else {
-                                    mClient.exhaustResponse(getMethod.getResponseBodyAsStream());
-                                }
+                                    int status = mClient.executeMethod(getMethod);
+                                    if (status == HttpStatus.SC_OK) {
+                                        InputStream inputStream = getMethod.getResponseBodyAsStream();
+                                        Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
+                                        thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
+                                    } else {
+                                        mClient.exhaustResponse(getMethod.getResponseBodyAsStream());
+                                    }
 
-                                // Handle PNG
-                                if (file.getMimetype().equalsIgnoreCase(PNG_MIMETYPE)) {
-                                    thumbnail = handlePNG(thumbnail, pxW, pxH);
+                                    // Handle PNG
+                                    if (file.getMimetype().equalsIgnoreCase(PNG_MIMETYPE)) {
+                                        thumbnail = handlePNG(thumbnail, pxW, pxH);
+                                    }
+                                } catch (Exception e) {
+                                    Log_OC.d(TAG, e.getMessage(), e);
+                                } finally {
+                                    if (getMethod != null) {
+                                        getMethod.releaseConnection();
+                                    }
                                 }
-
-                                // Add thumbnail to cache
-                                if (thumbnail != null) {
-                                    Log_OC.d(TAG, "add thumbnail to cache: " + file.getFileName());
-                                    addBitmapToCache(imageKey, thumbnail);
-                                }
-
-                            } catch (Exception e) {
-                                Log_OC.d(TAG, e.getMessage(), e);
-                            } finally {
-                                if (getMethod != null) {
-                                    getMethod.releaseConnection();
-                                }
+                            } else {
+                                Log_OC.d(TAG, "Server too old");
                             }
-                        } else {
-                            Log_OC.d(TAG, "Server too old");
                         }
+                    }
+
+                    // Add thumbnail to cache
+                    if (thumbnail != null) {
+                        Log_OC.d(TAG, "add thumbnail to cache: " + file.getFileName());
+                        addBitmapToCache(imageKey, thumbnail);
                     }
                 }
             }


### PR DESCRIPTION
This is useful if you have a very large image folder, scroll to a decent point and then immediately click on an image. While swiping the resized version is fetched.
If you then browse the file listing, the app would download the thumbnails, but now uses the resized images as source.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>