### PR TITLE
If image size is zero, try to get size from media store

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,9 +212,9 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.3'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    gplayImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
+    genericImplementation "com.github.nextcloud:android-library:zeroImages-SNAPSHOT"
+    gplayImplementation "com.github.nextcloud:android-library:zeroImages-SNAPSHOT"
+    versionDevImplementation 'com.github.nextcloud:android-library:zeroImages-SNAPSHOT' // use always latest master
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -22,8 +22,10 @@ package com.owncloud.android.operations;
 import android.accounts.Account;
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
+import android.provider.MediaStore;
 import android.support.annotation.RequiresApi;
 import android.util.Log;
 
@@ -564,6 +566,19 @@ public class UploadFileOperation extends SyncOperation {
                 size = new File(mFile.getStoragePath()).length();
             }
 
+            if (size == 0) {
+                Cursor cursor = getContext().getContentResolver().query(
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                        new String[]{MediaStore.MediaColumns.SIZE},
+                        MediaStore.Images.Media.DATA + " like ?",
+                        new String[]{mFile.getStoragePath()}, null);
+
+                if (cursor.moveToFirst()) {
+                    size = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE));
+                }
+                cursor.close();
+            }
+
             for (OCUpload ocUpload : uploadsStorageManager.getAllStoredUploads()) {
                 if (ocUpload.getUploadId() == getOCUploadId()) {
                     ocUpload.setFileSize(size);
@@ -576,11 +591,11 @@ public class UploadFileOperation extends SyncOperation {
             if (size > ChunkedUploadRemoteFileOperation.CHUNK_SIZE) {
                 mUploadOperation = new ChunkedUploadRemoteFileOperation(mContext, encryptedTempFile.getAbsolutePath(),
                         mFile.getParentRemotePath() + encryptedFileName, mFile.getMimeType(),
-                        mFile.getEtagInConflict(), timeStamp);
+                        mFile.getEtagInConflict(), timeStamp, size);
             } else {
                 mUploadOperation = new UploadRemoteFileOperation(encryptedTempFile.getAbsolutePath(),
                         mFile.getParentRemotePath() + encryptedFileName, mFile.getMimeType(),
-                        mFile.getEtagInConflict(), timeStamp);
+                        mFile.getEtagInConflict(), timeStamp, size);
             }
 
             Iterator<OnDatatransferProgressListener> listener = mDataTransferListeners.iterator();
@@ -803,6 +818,19 @@ public class UploadFileOperation extends SyncOperation {
                 size = new File(mFile.getStoragePath()).length();
             }
 
+            if (size == 0) {
+                Cursor cursor = getContext().getContentResolver().query(
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                        new String[]{MediaStore.MediaColumns.SIZE},
+                        MediaStore.Images.Media.DATA + " like ?",
+                        new String[]{mFile.getStoragePath()}, null);
+
+                if (cursor.moveToFirst()) {
+                    size = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE));
+                }
+                cursor.close();
+            }
+
             for (OCUpload ocUpload : uploadsStorageManager.getAllStoredUploads()) {
                 if (ocUpload.getUploadId() == getOCUploadId()) {
                     ocUpload.setFileSize(size);
@@ -814,10 +842,10 @@ public class UploadFileOperation extends SyncOperation {
             // perform the upload
             if (size > ChunkedUploadRemoteFileOperation.CHUNK_SIZE) {
                 mUploadOperation = new ChunkedUploadRemoteFileOperation(mContext, mFile.getStoragePath(),
-                        mFile.getRemotePath(), mFile.getMimeType(), mFile.getEtagInConflict(), timeStamp);
+                        mFile.getRemotePath(), mFile.getMimeType(), mFile.getEtagInConflict(), timeStamp, size);
             } else {
                 mUploadOperation = new UploadRemoteFileOperation(mFile.getStoragePath(),
-                        mFile.getRemotePath(), mFile.getMimeType(), mFile.getEtagInConflict(), timeStamp);
+                        mFile.getRemotePath(), mFile.getMimeType(), mFile.getEtagInConflict(), timeStamp, size);
             }
 
             Iterator<OnDatatransferProgressListener> listener = mDataTransferListeners.iterator();


### PR DESCRIPTION
This is a fix for certain OnePlus devices, where the image size taken by the default camera is zero.
I tested it with many images, but still some are uploaded corrupted. This then due to a wrong size reported by media store (instead of 0, it is something between 20-100kb).

So it is better than nothing, but not 100% reliable. As this is only used if file.length() is not working, it should have no impact on other devices.

Requires: https://github.com/nextcloud/android-library/pull/125
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>