### PR TITLE
E2E: do not modifiy userid

### DIFF
--- a/src/main/java/com/owncloud/android/utils/CsrHelper.java
+++ b/src/main/java/com/owncloud/android/utils/CsrHelper.java
@@ -58,7 +58,7 @@ public class CsrHelper {
      */
     private static PKCS10CertificationRequest generateCSR(KeyPair keyPair, String userId) throws IOException,
     OperatorCreationException {
-        String principal = "CN=" + userId.split("@")[0];
+        String principal = "CN=" + userId;
         AsymmetricKeyParameter privateKey = PrivateKeyFactory.createKey(keyPair.getPrivate().getEncoded());
         AlgorithmIdentifier signatureAlgorithm = new DefaultSignatureAlgorithmIdentifierFinder().find("SHA1WITHRSA");
         AlgorithmIdentifier digestAlgorithm = new DefaultDigestAlgorithmIdentifierFinder().find("SHA-1");


### PR DESCRIPTION
Fix #2173 
Fix #2134 

As we now have a call to get the uid, we shall not split the string, as usernames such as are valid: tobi@nc

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>