### PR TITLE
use correct size for png

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -304,8 +304,8 @@ public class ThumbnailsCacheManager {
                                 }
 
                                 // Handle PNG
-                                if (file.getMimetype().equalsIgnoreCase(PNG_MIMETYPE)) {
-                                    thumbnail = handlePNG(thumbnail, pxW, pxH);
+                                if (thumbnail != null && file.getMimetype().equalsIgnoreCase(PNG_MIMETYPE)) {
+                                    thumbnail = handlePNG(thumbnail, thumbnail.getWidth(), thumbnail.getHeight());
                                 }
 
                                 // Add thumbnail to cache


### PR DESCRIPTION
Fix #2190 

For PNG we create a canvas. Previously it was fullscreen, which results in a small image if the image is smaller than the display.
--> use size of image instead and scale it up, if necessary.

![2018-02-19-170807](https://user-images.githubusercontent.com/5836855/36387057-244d4548-1598-11e8-88bf-cb3c89037915.png) ![2018-02-19-170917](https://user-images.githubusercontent.com/5836855/36387055-24334cec-1598-11e8-9b24-8e89b80a1c6b.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>