### PR TITLE
Fix crash on 4.x devices

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1645,11 +1645,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                     ActionBar actionBar = ((FileDisplayActivity) getActivity()).getSupportActionBar();
 
                     if (actionBar != null) {
-                        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
-                            actionBar.setTitle(title);
-                        } else {
                             ThemeUtils.setColoredTitle(actionBar, title);
-                        }
                     }
                 }
             }

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -172,8 +172,12 @@ public class ThemeUtils {
      */
     public static void setColoredTitle(ActionBar actionBar, String title) {
         if (actionBar != null) {
-            String colorHex = colorToHexString(fontColor());
-            actionBar.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + title + "</font>"));
+            if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
+                actionBar.setTitle(title);
+            } else {
+                String colorHex = colorToHexString(fontColor());
+                actionBar.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + title + "</font>"));
+            }
         }
     }
 
@@ -189,9 +193,13 @@ public class ThemeUtils {
      * @param titleId   title to be shown
      */
     public static void setColoredTitle(ActionBar actionBar, int titleId, Context context) {
-        String colorHex = colorToHexString(fontColor());
-        String title = context.getString(titleId);
-        actionBar.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + title + "</font>"));
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
+            actionBar.setTitle(titleId);
+        } else {
+            String colorHex = colorToHexString(fontColor());
+            String title = context.getString(titleId);
+            actionBar.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + title + "</font>"));
+        }
     }
 
     public static String getDefaultDisplayNameForRootFolder() {


### PR DESCRIPTION
Fix #2184 

Android 4.x does not allow tinting the action bar, so this is checked within the method and not on calling code.

I suggest a backport

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>