### PR TITLE
Close cursor

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -849,13 +849,16 @@ public class FileDataStorageManager {
             );
         }
 
-        if (c != null && c.moveToFirst()) {
-            do {
-                OCFile child = createFileInstance(c);
-                if (!onlyOnDevice || child.existsOnDevice()) {
-                    ret.add(child);
-                }
-            } while (c.moveToNext());
+        if (c != null) {
+            if (c.moveToFirst()) {
+                do {
+                    OCFile child = createFileInstance(c);
+                    if (!onlyOnDevice || child.existsOnDevice()) {
+                        ret.add(child);
+                    }
+                } while (c.moveToNext());
+            }
+            
             c.close();
         }
 
@@ -2009,7 +2012,6 @@ public class FileDataStorageManager {
         }
 
         return c;
-
     }
 
     public OCCapability getCapability(String accountName) {

--- a/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Nextcloud Android client application
  *
  * Copyright (C) 2017 Mario Danic
@@ -88,17 +88,19 @@ public class FilesystemDataProvider {
                 new String[]{likeParam, syncedFolderId, "0", "0"},
                 null);
 
-        if (cursor != null && cursor.moveToFirst()) {
-            do {
-                String value = cursor.getString(cursor.getColumnIndex(
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
-                if (value == null) {
-                    Log_OC.e(TAG, "Cannot get local path");
-                } else {
-                    localPathsToUpload.add(value);
-                }
-            } while (cursor.moveToNext());
-
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                do {
+                    String value = cursor.getString(cursor.getColumnIndex(
+                            ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
+                    if (value == null) {
+                        Log_OC.e(TAG, "Cannot get local path");
+                    } else {
+                        localPathsToUpload.add(value);
+                    }
+                } while (cursor.moveToNext());
+            }
+            
             cursor.close();
         }
 
@@ -211,7 +213,7 @@ public class FilesystemDataProvider {
 
     private long getFileChecksum(String filepath) {
 
-        InputStream inputStream = null;
+        InputStream inputStream;
         try {
             inputStream = new BufferedInputStream(new FileInputStream(filepath));
             CRC32 crc = new CRC32();

--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Nextcloud Android client application
  *
  * @author Andy Scherzinger
@@ -143,7 +143,6 @@ public class SyncedFolderProvider extends Observable {
                 // update sync folder object in db
                 result = updateSyncFolder(syncedFolder);
 
-                cursor.close();
             }
         } else {
             if (cursor == null) {
@@ -152,6 +151,10 @@ public class SyncedFolderProvider extends Observable {
                 Log_OC.e(TAG, cursor.getCount() + " items for id=" + id + " available in sync folder database. " +
                         "Expected 1. Failed to update sync folder db.");
             }
+        }
+
+        if (cursor != null) {
+            cursor.close();
         }
 
         return result;
@@ -175,7 +178,6 @@ public class SyncedFolderProvider extends Observable {
 
         if (cursor != null && cursor.getCount() == 1) {
             result = createSyncedFolderFromCursor(cursor);
-            cursor.close();
         } else {
             if (cursor == null) {
                 Log_OC.e(TAG, "Sync folder db cursor for local path=" + localPath + " in NULL.");
@@ -183,6 +185,10 @@ public class SyncedFolderProvider extends Observable {
                 Log_OC.e(TAG, cursor.getCount() + " items for local path=" + localPath
                         + " available in sync folder db. Expected 1. Failed to update sync folder db.");
             }
+        }
+
+        if (cursor != null) {
+            cursor.close();
         }
 
         return result;

--- a/src/main/java/com/owncloud/android/jobs/ContactsBackupJob.java
+++ b/src/main/java/com/owncloud/android/jobs/ContactsBackupJob.java
@@ -70,7 +70,7 @@ public class ContactsBackupJob extends Job {
 
     @NonNull
     @Override
-    protected Result onRunJob(Params params) {
+    protected Result onRunJob(@NonNull Params params) {
         final Context context = MainApp.getAppContext();
         PersistableBundleCompat bundle = params.getExtras();
 
@@ -139,6 +139,10 @@ public class ContactsBackupJob extends Job {
             } catch (IOException e) {
                 Log_OC.d(TAG, "Error ", e);
             } finally {
+                if (cursor != null) {
+                    cursor.close();
+                }
+                
                 if (fw != null) {
                     try {
                         fw.close();

--- a/src/main/java/com/owncloud/android/jobs/ContactsImportJob.java
+++ b/src/main/java/com/owncloud/android/jobs/ContactsImportJob.java
@@ -1,20 +1,20 @@
-/**
+/*
  * Nextcloud Android client application
  *
  * @author Tobias Kaminsky
  * Copyright (C) 2017 Tobias Kaminsky
  * Copyright (C) 2017 Nextcloud GmbH.
- * <p>
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * at your option) any later version.
- * <p>
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * <p>
+ * 
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -56,7 +56,7 @@ public class ContactsImportJob extends Job {
 
     @NonNull
     @Override
-    protected Result onRunJob(Params params) {
+    protected Result onRunJob(@NonNull Params params) {
         PersistableBundleCompat bundle = params.getExtras();
 
         String vCardFilePath = bundle.getString(VCARD_FILE_PATH, "");
@@ -67,11 +67,12 @@ public class ContactsImportJob extends Job {
         File file = new File(vCardFilePath);
         ArrayList<VCard> vCards = new ArrayList<>();
 
+        Cursor cursor = null;
         try {
             ContactOperations operations = new ContactOperations(getContext(), accountName, accountType);
             vCards.addAll(Ezvcard.parse(file).all());
             Collections.sort(vCards, new ContactListFragment.VCardComparator());
-            Cursor cursor = getContext().getContentResolver().query(ContactsContract.Contacts.CONTENT_URI, null,
+            cursor = getContext().getContentResolver().query(ContactsContract.Contacts.CONTENT_URI, null,
                     null, null, null);
 
             TreeMap<VCard, Long> ownContactList = new TreeMap<>(new ContactListFragment.VCardComparator());
@@ -101,6 +102,10 @@ public class ContactsImportJob extends Job {
             }
         } catch (Exception e) {
             Log_OC.e(TAG, e.getMessage());
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
         }
 
         return Result.SUCCESS;


### PR DESCRIPTION
Found via google play console: android.database.CursorWindowAllocationException

This means that there are too many open cursors.

The main reason is that cursor was only closed if != null, which is sane, but also only if c.moveToFirst() was true. But it can happen that an empty cursor exists (cursor with no result) and this then would never be closed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>