### PR TITLE
Copy/move starts within current folder

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -67,6 +67,8 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     public static final String EXTRA_FOLDER = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_FOLDER";
     public static final String EXTRA_FILES = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_FILES";
     public static final String EXTRA_ACTION = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_ACTION";
+    public static final String EXTRA_CURRENT_FOLDER = FolderPickerActivity.class.getCanonicalName() +
+            ".EXTRA_CURRENT_FOLDER";
     public static final String MOVE = "MOVE";
     public static final String COPY = "COPY";
 
@@ -120,6 +122,10 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
             }
         } else {
             caption = ThemeUtils.getDefaultDisplayNameForRootFolder();
+        }
+
+        if (getIntent().getParcelableExtra(EXTRA_CURRENT_FOLDER) != null) {
+            setFile(getIntent().getParcelableExtra(EXTRA_CURRENT_FOLDER));
         }
 
         if (savedInstanceState == null) {

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1079,6 +1079,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             case R.id.action_move: {
                 Intent action = new Intent(getActivity(), FolderPickerActivity.class);
                 action.putParcelableArrayListExtra(FolderPickerActivity.EXTRA_FILES, checkedFiles);
+                action.putExtra(FolderPickerActivity.EXTRA_CURRENT_FOLDER, mFile);
                 action.putExtra(FolderPickerActivity.EXTRA_ACTION, FolderPickerActivity.MOVE);
                 getActivity().startActivityForResult(action, FileDisplayActivity.REQUEST_CODE__MOVE_FILES);
                 return true;
@@ -1086,6 +1087,7 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             case R.id.action_copy: {
                 Intent action = new Intent(getActivity(), FolderPickerActivity.class);
                 action.putParcelableArrayListExtra(FolderPickerActivity.EXTRA_FILES, checkedFiles);
+                action.putExtra(FolderPickerActivity.EXTRA_CURRENT_FOLDER, mFile);
                 action.putExtra(FolderPickerActivity.EXTRA_ACTION, FolderPickerActivity.COPY);
                 getActivity().startActivityForResult(action, FileDisplayActivity.REQUEST_CODE__COPY_FILES);
                 return true;


### PR DESCRIPTION
Fix #400 

When copy/move a file the folder picker activity will start with current folder.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>