### PR TITLE
Move lib implementation to flavors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ configurations.all {
 ext {
     supportLibraryVersion = '26.1.0'
     googleLibraryVersion = '11.2.2'
+    androidLibraryVersion = '1.0.39'
 
     travisBuild = System.getenv("TRAVIS") == "true"
 
@@ -195,7 +196,8 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.2'
 //    implementation project('nextcloud-android-library')
-    implementation 'com.github.nextcloud:android-library:1.0.39'
+    genericImplementation "com.github.nextcloud:android-library:${androidLibraryVersion}"
+    gplayImplementation "com.github.nextcloud:android-library:${androidLibraryVersion}"
     versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"


### PR DESCRIPTION
On the old implementation the stable lib was used for versionDev.
So stable lib has to be set for each flavor.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>