### PR TITLE
TimSort: Add correct null check

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -107,6 +107,9 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
 
             @Override
             public int compare(OCUpload upload1, OCUpload upload2) {
+                if (upload1 == null && upload2 == null) {
+                    return 0;
+                }
                 if (upload1 == null) {
                     return -1;
                 }
@@ -213,7 +216,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             final OCUpload upload = uploadsItems[position];
 
             // local file name
-            TextView fileTextView = (TextView) view.findViewById(R.id.upload_name);
+            TextView fileTextView = view.findViewById(R.id.upload_name);
             File remoteFile = new File(upload.getRemotePath());
             String fileName = remoteFile.getName();
             if (fileName.length() == 0) {
@@ -222,12 +225,12 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             fileTextView.setText(fileName);
 
             // remote path to parent folder
-            TextView pathTextView = (TextView) view.findViewById(R.id.upload_remote_path);
+            TextView pathTextView = view.findViewById(R.id.upload_remote_path);
             String remoteParentPath = new File(upload.getRemotePath()).getParent();
             pathTextView.setText(remoteParentPath);
 
             // file size
-            TextView fileSizeTextView = (TextView) view.findViewById(R.id.upload_file_size);
+            TextView fileSizeTextView = view.findViewById(R.id.upload_file_size);
             if (upload.getFileSize() != 0) {
                 fileSizeTextView.setText(DisplayUtils.bytesToHumanReadable(upload.getFileSize()) + ", ");
             } else {
@@ -235,7 +238,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             }
 
             //* upload date
-            TextView uploadDateTextView = (TextView) view.findViewById(R.id.upload_date);
+            TextView uploadDateTextView = view.findViewById(R.id.upload_date);
             long updateTime = upload.getUploadEndTimestamp();
             CharSequence dateString = DisplayUtils.getRelativeDateTimeString(
                     mParentActivity,
@@ -246,7 +249,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             );
             uploadDateTextView.setText(dateString);
 
-            TextView accountNameTextView = (TextView) view.findViewById(R.id.upload_account);
+            TextView accountNameTextView = view.findViewById(R.id.upload_account);
             Account account = AccountUtils.getOwnCloudAccountByName(mParentActivity, upload.getAccountName());
             if (account != null) {
                 accountNameTextView.setText(
@@ -257,9 +260,9 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                 accountNameTextView.setText(upload.getAccountName());
             }
 
-            TextView statusTextView = (TextView) view.findViewById(R.id.upload_status);
+            TextView statusTextView = view.findViewById(R.id.upload_status);
 
-            ProgressBar progressBar = (ProgressBar) view.findViewById(R.id.upload_progress_bar);
+            ProgressBar progressBar = view.findViewById(R.id.upload_progress_bar);
 
             /// Reset fields visibility
             uploadDateTextView.setVisibility(View.VISIBLE);
@@ -331,7 +334,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
 
             /// bind listeners to perform actions
             /// bind listeners to perform actions
-            ImageButton rightButton = (ImageButton) view.findViewById(R.id.upload_right_button);
+            ImageButton rightButton = view.findViewById(R.id.upload_right_button);
             if (upload.getUploadStatus() == UploadStatus.UPLOAD_IN_PROGRESS) {
                 //Cancel
                 rightButton.setImageResource(R.drawable.ic_action_cancel_grey);
@@ -402,7 +405,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             }
 
             /// Set icon or thumbnail
-            ImageView fileIcon = (ImageView) view.findViewById(R.id.thumbnail);
+            ImageView fileIcon = view.findViewById(R.id.thumbnail);
             fileIcon.setImageResource(R.drawable.file);
 
             /*
@@ -715,7 +718,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                     .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             convertView = inflaInflater.inflate(R.layout.upload_list_group, null);
         }
-        TextView tv = (TextView) convertView.findViewById(R.id.uploadListGroupName);
+        TextView tv = convertView.findViewById(R.id.uploadListGroupName);
         tv.setText(String.format(mParentActivity.getString(R.string.uploads_view_group_header),
                 group.getGroupName(), group.getGroupItemCount()));
         tv.setTextColor(ThemeUtils.primaryAccentColor());


### PR DESCRIPTION
Spend quite a long time on this to understand the problem.

Imagine you compare o1 and o2 and both are null.
Previous, depending on your compare order, it could happen:
compare(o1, o2) -> -1, which leads to o1 < o2
compare(o2, o1) -> -1, which leads to o2 < o1
and this is not allowed.

So if both are null, there is no sorting order, so it returns 0.

This, however does not solve other sorting problems, e.g. where OCFiles are sorted via the compareTo function in OCFile as there would be a NPE if some file/remote path is null.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>