### PR TITLE
Show files in FolderPicker

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -180,7 +180,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     private void createFragments() {
         OCFileListFragment listOfFiles = new OCFileListFragment();
         Bundle args = new Bundle();
-        args.putBoolean(OCFileListFragment.ARG_JUST_FOLDERS, true);
+        args.putBoolean(OCFileListFragment.ARG_ONLY_FOLDERS_CLICKABLE, true);
         args.putBoolean(OCFileListFragment.ARG_HIDE_FAB, true);
         args.putBoolean(OCFileListFragment.ARG_HIDE_ITEM_OPTIONS, true);
         args.putBoolean(OCFileListFragment.ARG_SEARCH_ONLY_FOLDER, mSearchOnlyFolders);

--- a/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -99,11 +99,10 @@ public class FileListListAdapter extends BaseAdapter {
 
     private ArrayList<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks = new ArrayList<>();
 
-    public FileListListAdapter(boolean justFolders, Context context, ComponentsGetter transferServiceGetter,
+    public FileListListAdapter(Context context, ComponentsGetter transferServiceGetter,
                                OCFileListFragmentInterface OCFileListFragmentInterface, boolean argHideItemOptions) {
 
         this.OCFileListFragmentInterface = OCFileListFragmentInterface;
-        mJustFolders = justFolders;
         mContext = context;
         mAccount = AccountUtils.getCurrentOwnCloudAccount(mContext);
         mHideItemOptions = argHideItemOptions;


### PR DESCRIPTION
Fix #2220 

This is used in 
- copy
- move
- select remote folder on synced folder

Clicking on a file just does nothing.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>