### PR TITLE
if nothing received to upload, app crashed

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -192,22 +192,23 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     @Override
     protected void setAccount(Account account, boolean savedAccount) {
-        if (somethingToUpload()) {
-            mAccountManager = (AccountManager) getSystemService(Context.ACCOUNT_SERVICE);
-            Account[] accounts = mAccountManager.getAccountsByType(MainApp.getAccountType());
-            if (accounts.length == 0) {
-                Log_OC.i(TAG, "No ownCloud account is available");
-                DialogNoAccount dialog = new DialogNoAccount();
-                dialog.show(getSupportFragmentManager(), null);
-            } else {
-                if (!savedAccount) {
-                    setAccount(accounts[0]);
-                }
-            }
+        mAccountManager = (AccountManager) getSystemService(Context.ACCOUNT_SERVICE);
+
+        Account[] accounts = mAccountManager.getAccountsByType(MainApp.getAccountType());
+        if (accounts.length == 0) {
+            Log_OC.i(TAG, "No ownCloud account is available");
+            DialogNoAccount dialog = new DialogNoAccount();
+            dialog.show(getSupportFragmentManager(), null);
         } else {
+            if (!savedAccount) {
+                setAccount(accounts[0]);
+            }
+        }
+
+        if (!somethingToUpload()) {
             showErrorDialog(
-                R.string.uploader_error_message_no_file_to_upload,
-                R.string.uploader_error_title_no_file_to_upload
+                    R.string.uploader_error_message_no_file_to_upload,
+                    R.string.uploader_error_title_no_file_to_upload
             );
         }
 

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -199,10 +199,8 @@ public class ReceiveExternalFilesActivity extends FileActivity
             Log_OC.i(TAG, "No ownCloud account is available");
             DialogNoAccount dialog = new DialogNoAccount();
             dialog.show(getSupportFragmentManager(), null);
-        } else {
-            if (!savedAccount) {
-                setAccount(accounts[0]);
-            }
+        } else if (!savedAccount) {
+            setAccount(accounts[0]);
         }
 
         if (!somethingToUpload()) {


### PR DESCRIPTION
Via google play console:

The cause was that mAccountManager was only created if somethingToUpload() == true.
Still https://github.com/nextcloud/android/blob/d04bb1eba5d145c9ca0a1862bfac1a514c81f1c3/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java#L1010-L1010 was executed and this then crashed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>