### PR TITLE
App context is maybe null, so use getContentResolver() directly

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1140,7 +1140,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
         mMenuAccountAvatarRadiusDimension = getResources()
                 .getDimension(R.dimen.nav_drawer_menu_avatar_radius);
 
-        externalLinksProvider = new ExternalLinksProvider(MainApp.getAppContext().getContentResolver());
+        externalLinksProvider = new ExternalLinksProvider(getContentResolver());
         arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
     }
 


### PR DESCRIPTION
Of course this should never be null, but according to google dev console this is happening :S

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>