### PR TITLE
Added confirmation before exit (Fixed #2276)

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -770,4 +770,6 @@
     <string name="end_to_end_encryption_storing_keys">Storing keys</string>
     <string name="copy_move_to_encrypted_folder_not_supported">Copy/move into encrypted folder currently not supported.</string>
     <string name="untrusted_domain">Access through untrusted domain. Please see documentation for further info.</string>
+
+    <string name="toast_exit">Press again to exit</string>
 </resources>


### PR DESCRIPTION
Fixed #2276 
Changes : Earlier hitting the back button once caused exit from the app. Now
a toast message is displayed that prompts the user to hit the back
button twice to exit from the app. This prevents unintentional exit
in case the user hits the back button by chance.

**Screenshot for the change :**

![confirmation_before_exit](https://user-images.githubusercontent.com/30979369/36950337-aa5392aa-201a-11e8-9b34-8f1b16bda52a.jpg)
