### PR TITLE
Added the REQUEST_INSTALL_PACKAGES permission to the Android manifest.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -62,6 +62,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
 
     <application


### PR DESCRIPTION
With API 26 (Android O) any app that wants to install unknown apps must declare the REQUEST_INSTALL_PACKAGES permission. The user can then control what specific apps should be allowed to install unknown apps unlike the previous system where it was a system wide binary option for all apps. Without this declared permission the Nextcloud app will not be able to install apk's that the user have in their Nextcloud storage. With this permission added the user will be prompted to grant the app permission to install apps from unknown sources should they attempt to do so .

This fixes #2269 #2266