### PR TITLE
Show long subtext of notification

### DIFF
--- a/src/main/res/layout/activity_list_item.xml
+++ b/src/main/res/layout/activity_list_item.xml
@@ -60,7 +60,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
-            android:maxLines="3"
             android:text="@string/placeholder_sentence"
             android:textColor="?android:attr/textColorSecondary"/>
 


### PR DESCRIPTION
Remove android:maxLines="3" to see long subtitles of notifications.

@tobiasKaminsky This time I´m succesful 😉 😜 

This PR fixes #2302 