### PR TITLE
Send icons: icon size, app chooser

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/SendButtonAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/SendButtonAdapter.java
@@ -25,6 +25,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
@@ -59,13 +60,15 @@ public class SendButtonAdapter extends RecyclerView.Adapter<SendButtonAdapter.Vi
 
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
-        private TextView sendButton;
+        private TextView text;
+        private ImageView icon;
         private SendButtonData sendButtonDataData;
 
         public ViewHolder(View itemView) {
             super(itemView);
             itemView.setOnClickListener(this);
-            sendButton = (TextView) itemView.findViewById(R.id.send_button);
+            text = itemView.findViewById(R.id.send_button_text);
+            icon = itemView.findViewById(R.id.send_button_icon);
         }
 
         @Override
@@ -77,8 +80,8 @@ public class SendButtonAdapter extends RecyclerView.Adapter<SendButtonAdapter.Vi
 
         public void setData(SendButtonData item) {
             sendButtonDataData = item;
-            sendButton.setCompoundDrawablesWithIntrinsicBounds(null, item.getDrawable(), null, null);
-            sendButton.setText(item.getTitle());
+            icon.setImageDrawable(item.getDrawable());
+            text.setText(item.getTitle());
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.java
@@ -169,27 +169,25 @@ public class SendShareDialog extends BottomSheetDialogFragment {
     @NonNull
     private SendButtonAdapter.ClickListener setupSendButtonClickListener(Intent sendIntent) {
         return sendButtonDataData -> {
+            String packageName = sendButtonDataData.getPackageName();
+            String activityName = sendButtonDataData.getActivityName();
 
-                if (MimeTypeUtil.isImage(file) && !file.isDown()) {
-                    fileOperationsHelper.sendCachedImage(file);
-                } else {
-                    String packageName = sendButtonDataData.getPackageName();
-                    String activityName = sendButtonDataData.getActivityName();
-
-                    // Obtain the file
-                    if (file.isDown()) {
-                        sendIntent.setComponent(new ComponentName(packageName, activityName));
-                        getActivity().startActivity(Intent.createChooser(sendIntent, getString(R.string.send)));
-
-                    } else {  // Download the file
-                        Log_OC.d(TAG, file.getRemotePath() + ": File must be downloaded");
-                        ((SendShareDialog.SendShareDialogDownloader) getActivity()).downloadFile(file, packageName,
-                                activityName);
-                    }
+            if (MimeTypeUtil.isImage(file) && !file.isDown()) {
+                fileOperationsHelper.sendCachedImage(file, packageName, activityName);
+            } else {
+                // Obtain the file
+                if (file.isDown()) {
+                    sendIntent.setComponent(new ComponentName(packageName, activityName));
+                    getActivity().startActivity(Intent.createChooser(sendIntent, getString(R.string.send)));
+                } else {  // Download the file
+                    Log_OC.d(TAG, file.getRemotePath() + ": File must be downloaded");
+                    ((SendShareDialog.SendShareDialogDownloader) getActivity()).downloadFile(file, packageName,
+                            activityName);
                 }
+            }
 
-                dismiss();
-            };
+            dismiss();
+        };
     }
 
     @NonNull

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -23,6 +23,7 @@ package com.owncloud.android.ui.helpers;
 
 import android.accounts.Account;
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -594,12 +595,13 @@ public class FileOperationsHelper {
         }
     }
 
-    public void sendCachedImage(OCFile file) {
+    public void sendCachedImage(OCFile file, String packageName, String activityName) {
         if (file != null) {
             Context context = MainApp.getAppContext();
             Intent sendIntent = new Intent(Intent.ACTION_SEND);
             // set MimeType
             sendIntent.setType(file.getMimetype());
+            sendIntent.setComponent(new ComponentName(packageName, activityName));
             sendIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse("content://" +
                     context.getResources().getString(R.string.image_cache_provider_authority) +
                     file.getRemotePath()));

--- a/src/main/res/layout/send_button.xml
+++ b/src/main/res/layout/send_button.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Nextcloud Android client application
 
  @author Tobias Kaminsky
@@ -20,18 +19,25 @@
  along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/standard_padding">
+
+    <ImageView
+        android:id="@+id/send_button_icon"
+        android:layout_width="@dimen/share_icon_size"
+        android:layout_height="@dimen/share_icon_size"
+        android:layout_gravity="center_horizontal"
+        android:contentDescription="@string/sendbutton_description" />
 
     <TextView
-        android:id="@+id/send_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:id="@+id/send_button_text"
+        android:layout_width="@dimen/share_icon_size"
+        android:layout_height="@dimen/share_icon_size"
         android:layout_gravity="center"
         android:gravity="center_horizontal"
-        android:drawablePadding="@dimen/standard_half_padding"
-        android:padding="@dimen/standard_padding"
-        android:textColor="@color/black"/>
-</FrameLayout>
+        android:paddingTop="@dimen/standard_half_padding"
+        android:textColor="@color/black" />
+</LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -772,5 +772,5 @@
     <string name="untrusted_domain">Access through untrusted domain. Please see documentation for further info.</string>
     <string name="notification_channel_push_name">Push notifications</string>
     <string name="notification_channel_push_description">Show push notifications sent by server, e.g. when mentioned in comments, you receive a new remote share or an announcement was posted by an admin.</string>
-    <string name="sendbutton_description">Icon for send button</string>
+    <string name="sendbutton_description">Send button icon</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -772,4 +772,5 @@
     <string name="untrusted_domain">Access through untrusted domain. Please see documentation for further info.</string>
     <string name="notification_channel_push_name">Push notifications</string>
     <string name="notification_channel_push_description">Show push notifications sent by server, e.g. when mentioned in comments, you receive a new remote share or an announcement was posted by an admin.</string>
+    <string name="sendbutton_description">Icon for send button</string>
 </resources>


### PR DESCRIPTION
Fix #2248

- equal sized icon
- fix showing app chooser twice

@xXSTrikeXx I also did not found a way to set a size to icons on TextView, so I added a new ImageView and wrapped this in a LinearLayout.

As it is a bug fix it should be in 3.1.

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>