### PR TITLE
Add push channel for 8.x with default importance

### DIFF
--- a/src/gplay/java/com/owncloud/android/services/firebase/NCFirebaseMessagingService.java
+++ b/src/gplay/java/com/owncloud/android/services/firebase/NCFirebaseMessagingService.java
@@ -32,6 +32,7 @@ import com.google.firebase.messaging.RemoteMessage;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.ui.activity.NotificationsActivity;
+import com.owncloud.android.ui.notifications.NotificationUtils;
 import com.owncloud.android.utils.ThemeUtils;
 
 public class NCFirebaseMessagingService extends FirebaseMessagingService {
@@ -57,8 +58,11 @@ public class NCFirebaseMessagingService extends FirebaseMessagingService {
                 .setAutoCancel(true)
                 .setContentIntent(pendingIntent);
 
-        NotificationManager notificationManager =
-                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if ((android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)) {
+            notificationBuilder.setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_PUSH);
+        }
+
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
         notificationManager.notify(0, notificationBuilder.build());
     }

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -330,6 +330,10 @@ public class MainApp extends MultiDexApplication {
                 createChannel(notificationManager, NotificationUtils.NOTIFICATION_CHANNEL_FILE_OBSERVER,
                         R.string.notification_channel_file_observer_name, R.string
                                 .notification_channel_file_observer_description, context);
+
+                createChannel(notificationManager, NotificationUtils.NOTIFICATION_CHANNEL_PUSH,
+                        R.string.notification_channel_push_name, R.string
+                                .notification_channel_push_description, context, NotificationManager.IMPORTANCE_DEFAULT);
             } else {
                 Log_OC.e(TAG, "Notification manager is null");
             }
@@ -339,13 +343,19 @@ public class MainApp extends MultiDexApplication {
     private static void createChannel(NotificationManager notificationManager,
                                       String channelId, int channelName,
                                       int channelDescription, Context context) {
+        createChannel(notificationManager, channelId, channelName, channelDescription, context,
+                NotificationManager.IMPORTANCE_LOW);
+    }
+
+    private static void createChannel(NotificationManager notificationManager,
+                                      String channelId, int channelName,
+                                      int channelDescription, Context context, int importance) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O
                 && getAppContext() != null
                 && notificationManager.getNotificationChannel(channelId) == null) {
             CharSequence name = context.getString(channelName);
             String description = context.getString(channelDescription);
-            NotificationChannel channel = new NotificationChannel(channelId, name,
-                    NotificationManager.IMPORTANCE_LOW);
+            NotificationChannel channel = new NotificationChannel(channelId, name, importance);
 
             channel.setDescription(description);
             channel.enableLights(false);

--- a/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
+++ b/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
@@ -39,6 +39,7 @@ public class NotificationUtils {
     public static final String NOTIFICATION_CHANNEL_MEDIA = "NOTIFICATION_CHANNEL_MEDIA";
     public static final String NOTIFICATION_CHANNEL_FILE_SYNC = "NOTIFICATION_CHANNEL_FILE_SYNC";
     public static final String NOTIFICATION_CHANNEL_FILE_OBSERVER = "NOTIFICATION_CHANNEL_FILE_OBSERVER";
+    public static final String NOTIFICATION_CHANNEL_PUSH = "NOTIFICATION_CHANNEL_PUSH";
 
     /**
      * Factory method for {@link android.support.v4.app.NotificationCompat.Builder} instances.

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -770,4 +770,6 @@
     <string name="end_to_end_encryption_storing_keys">Storing keys</string>
     <string name="copy_move_to_encrypted_folder_not_supported">Copy/move into encrypted folder currently not supported.</string>
     <string name="untrusted_domain">Access through untrusted domain. Please see documentation for further info.</string>
+    <string name="notification_channel_push_name">Push notifications</string>
+    <string name="notification_channel_push_description">Show push notifications sent by server, e.g. when mentioned in comments, you receive a new remote share or an announcement was posted by an admin.</string>
 </resources>


### PR DESCRIPTION
For 8.x this adds a new channel to support push notifications.
Despite the other one, this will make a sound once a notification is received.

Left is called "Push notifications" (outdated screenshot)
![2018-03-12-143201](https://user-images.githubusercontent.com/5836855/37286700-fd86922c-2602-11e8-8b6e-8fad98eacc8a.png) ![2018-03-12-143243](https://user-images.githubusercontent.com/5836855/37286702-ff629c12-2602-11e8-9370-cfde68199068.png)

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>