### PR TITLE
Show correct error message if virus is detected

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   test:
-    image: nextcloudci/android:android-32
+    image: nextcloudci/android:android-35
     commands:
       # uncomment gplay for Gplay, Modified only
       - sh -c "if [ '$FLAVOUR' != 'Generic' ]; then sed -i '/.*com.google.*/s/^.*\\/\\///g' build.gradle; fi"

--- a/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -363,7 +363,7 @@ public class UploadsStorageManager extends Observable {
      * Get all failed uploads.
      */
     public OCUpload[] getFailedUploads() {
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "== ?" +
+        return getUploads("(" + ProviderTableMeta.UPLOADS_STATUS + "== ?" +
                 " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
                         "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
                         " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
@@ -371,7 +371,9 @@ public class UploadsStorageManager extends Observable {
                         " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
                         "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
                         " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                        "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue()
+                        "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
+                        " ) AND " + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                        "!= " + UploadResult.VIRUS_DETECTED.getValue()
                 , new String[]{String.valueOf(UploadStatus.UPLOAD_FAILED.value)});
     }
 

--- a/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -38,7 +38,8 @@ public enum UploadResult {
     MAINTENANCE_MODE(12),
     LOCK_FAILED(13),
     DELAYED_IN_POWER_SAVE_MODE(14),
-    SSL_RECOVERABLE_PEER_UNVERIFIED(15);
+    SSL_RECOVERABLE_PEER_UNVERIFIED(15),
+    VIRUS_DETECTED(16);
 
     private final int value;
 
@@ -86,6 +87,8 @@ public enum UploadResult {
                 return DELAYED_IN_POWER_SAVE_MODE;
             case 15:
                 return SSL_RECOVERABLE_PEER_UNVERIFIED;
+            case 16:
+                return VIRUS_DETECTED;
         }
         return null;
     }
@@ -134,9 +137,10 @@ public enum UploadResult {
                 return UNKNOWN;
             case LOCK_FAILED:
                 return LOCK_FAILED;
+            case VIRUS_DETECTED:
+                return VIRUS_DETECTED;
             default:
                 return UNKNOWN;
         }
-
     }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -488,6 +488,9 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                         status = mParentActivity.getString(
                                 R.string.uploads_view_upload_status_waiting_exit_power_save_mode);
                         break;
+                    case VIRUS_DETECTED:
+                        status = mParentActivity.getString(R.string.uploads_view_upload_status_virus_detected);
+                        break;
                     default:
                         status = "New fail result but no description for the user";
                         break;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -783,4 +783,5 @@
     <string name="upload_files">Upload files</string>
     <string name="upload_content_from_other_apps">Upload content from other apps</string>
     <string name="create_new_folder">Create new folder</string>
+    <string name="uploads_view_upload_status_virus_detected">Virus detected. Upload cannot be completed!</string>
 </resources>


### PR DESCRIPTION
- in notification message, even with correct virus name
- in upload list: generic virus warning

![2018-03-15-110701](https://user-images.githubusercontent.com/5836855/37459782-73a76df8-2849-11e8-9bcc-1d6878c53b0b.png) ![2018-03-15-112036](https://user-images.githubusercontent.com/5836855/37459788-7663ae80-2849-11e8-9b9b-0a4df9efd463.png)


Do not try to resume virus upload automatically, as it is useless, but still the user can retry it manually

needs https://github.com/nextcloud/android-library/pull/135
fixes #1391

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>