### PR TITLE
Wrap text properly in the grid view of All files activity (Fixed #2321)

### DIFF
--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -42,7 +42,7 @@
     <dimen name="standard_quarter_margin">4dp</dimen>
     <dimen name="standard_eighth_margin">2dp</dimen>
     <dimen name="min_list_item_size">56dp</dimen>
-    <dimen name="standard_list_item_size">72dp</dimen>
+    <dimen name="standard_list_item_size">64dp</dimen>
     <dimen name="two_line_primary_text_size">16sp</dimen>
     <dimen name="two_line_secondary_text_size">14sp</dimen>
     <dimen name="list_item_avatar_icon_margin">20dp</dimen>


### PR DESCRIPTION
Fixed #2321 

Changes : Earlier the image icon size was quite large due to which a fraction
of text height was invisible even though the layout_height for the
text view was set to wrap_content. Now, the image icon dimensions have
been changed from 72dp to 64dp so that the text is wrapped properly
within the text view.

**Screenshot for the change**

![nextcloud_text_height](https://user-images.githubusercontent.com/30979369/37527021-fb4a1932-2956-11e8-99de-751656918b9b.jpg)
