### PR TITLE
Use long instead of integer

### DIFF
--- a/src/main/java/third_parties/daveKoeller/AlphanumComparator.java
+++ b/src/main/java/third_parties/daveKoeller/AlphanumComparator.java
@@ -123,35 +123,41 @@ public class AlphanumComparator<T> implements Comparator<T>, Serializable {
                 // extract digits
                 int thisChunkZeroCount = 0;
                 boolean zero = true;
-                int c = 0;
-                while (c < (thisChunk.length()) && isDigit(thisChunk.charAt(c))) {
+                int countThis = 0;
+                while (countThis < (thisChunk.length()) && isDigit(thisChunk.charAt(countThis))) {
                     if (zero) {
-                        if (Character.getNumericValue(thisChunk.charAt(c)) == 0) {
+                        if (Character.getNumericValue(thisChunk.charAt(countThis)) == 0) {
                             thisChunkZeroCount++;
                         } else {
                             zero = false;
                         }
                     }
-                    c++;
+                    countThis++;
                 }
-                int thisChunkValue = Integer.parseInt(thisChunk.substring(0, c));
+
 
                 int thatChunkZeroCount = 0;
-                c = 0;
+                int countThat = 0;
                 zero = true;
-                while (c < (thatChunk.length()) && isDigit(thatChunk.charAt(c))) {
+                while (countThat < (thatChunk.length()) && isDigit(thatChunk.charAt(countThat))) {
                     if (zero) {
-                        if (Character.getNumericValue(thatChunk.charAt(c)) == 0) {
+                        if (Character.getNumericValue(thatChunk.charAt(countThat)) == 0) {
                             thatChunkZeroCount++;
                         } else {
                             zero = false;
                         }
                     }
-                    c++;
+                    countThat++;
                 }
-                int thatChunkValue = Integer.parseInt(thatChunk.substring(0, c));
 
-                result = Integer.compare(thisChunkValue, thatChunkValue);
+                try {
+                    long thisChunkValue = Long.parseLong(thisChunk.substring(0, countThis));
+                    long thatChunkValue = Long.parseLong(thatChunk.substring(0, countThat));
+
+                    result = Long.compare(thisChunkValue, thatChunkValue);
+                } catch (NumberFormatException exception) {
+                    result = thisChunk.substring(0, countThis).compareTo(thatChunk.substring(0, countThat));
+                }
                 
                 if (result == 0) {
                     // value is equal, compare leading zeros

--- a/src/test/java/com/owncloud/android/utils/TestSorting.java
+++ b/src/test/java/com/owncloud/android/utils/TestSorting.java
@@ -62,7 +62,9 @@ public class TestSorting {
 
     @Test
     public void testLeadingZeros() {
-        String[] sortedArray = {"T 0 abc", "T 00 abc", "T 000 abc", "T 1 abc", "T 01 abc",
+        String[] sortedArray = {"2012-09-15 22.50.37.jpg", "2012-Card.jpg", "1584164_460s_v1.jpg", "08082008.jpg",
+                "02122011150.jpg", "03122011151.jpg", "9999999999999999999999999999991.jpg",
+                "9999999999999999999999999999992.jpg", "T 0 abc", "T 00 abc", "T 000 abc", "T 1 abc", "T 01 abc",
                 "T 001 abc", "T 2 abc", "T 02 abc", "T 3 abc", "T 03 abc"};
 
         assertTrue(sortAndTest(Arrays.asList(sortedArray)));
@@ -70,7 +72,6 @@ public class TestSorting {
 
     @Test
     public void testTrailingDigits() {
-        String[] unsortedArray = {"Zeros 2", "Zeros", "T 2", "T", "T 01", "T 003", "A"};
         String[] sortedArray = {"A", "T", "T 01", "T 2", "T 003", "Zeros", "Zeros 2"};
 
         assertTrue(sortAndTest(Arrays.asList(sortedArray)));


### PR DESCRIPTION
I discovered this with dev version, so yeah for dev having this ;-)

Integer is too small. 
Long is also not unlimited, but if number is too big, then it falls back to string comparison, which might not be exact, but at least does not lead to an Exception.

Please in 3.1 as it is a bugfix.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>