### PR TITLE
No blocking sync dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,7 @@ dependencies {
 //    implementation project('nextcloud-android-library')
     genericImplementation "com.github.nextcloud:android-library:${androidLibraryVersion}"
     gplayImplementation "com.github.nextcloud:android-library:${androidLibraryVersion}"
-    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
+    versionDevImplementation 'com.github.nextcloud:android-library:etag-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ configurations.all {
 ext {
     supportLibraryVersion = '26.1.0'
     googleLibraryVersion = '11.2.2'
-    androidLibraryVersion = '1.0.39'
+    androidLibraryVersion = 'etag-SNAPSHOT'
 
     travisBuild = System.getenv("TRAVIS") == "true"
 

--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -207,6 +207,9 @@ public class RefreshFolderOperation extends RemoteOperation {
                 // request for the synchronization of KEPT-IN-SYNC file contents
                 startContentSynchronizations(mFilesToSyncContents);
             }
+
+            mLocalFolder.setLastSyncDateForData(System.currentTimeMillis());
+            mStorageManager.saveFile(mLocalFolder);
         }
 
         if (!mSyncFullAccount) {
@@ -422,6 +425,10 @@ public class RefreshFolderOperation extends RemoteOperation {
                 );
                 updatedFile.setStoragePath(localFile.getStoragePath());
                 // eTag will not be updated unless file CONTENTS are synchronized
+                if (!updatedFile.isFolder() && localFile.isDown() &&
+                        !updatedFile.getEtag().equals(localFile.getEtag())) {
+                    updatedFile.setEtagInConflict(updatedFile.getEtag());
+                }
                 updatedFile.setEtag(localFile.getEtag());
                 if (updatedFile.isFolder()) {
                     updatedFile.setFileLength(remoteFile.getFileLength());
@@ -434,7 +441,6 @@ public class RefreshFolderOperation extends RemoteOperation {
                 updatedFile.setPublicLink(localFile.getPublicLink());
                 updatedFile.setShareViaLink(localFile.isSharedViaLink());
                 updatedFile.setShareWithSharee(localFile.isSharedWithSharee());
-                updatedFile.setEtagInConflict(localFile.getEtagInConflict());
             } else {
                 // remote eTag will not be updated unless file CONTENTS are synchronized
                 updatedFile.setEtag("");


### PR DESCRIPTION
- 30s timeout for checking if eTag changed
- show conflict icon

Test scenarios, start with a download text file.

Nothing changed:
- go into folder
- see green icon
- clicking on it opens up file directly

Changed server file:
- go into folder
- see red icon, indicating that file has changed
- clicking on it, shows blocking "sync dialog"

Offline
- device offline
- click on file
- file opens, but snackbar "File could not be synced. Showing latest available version." is sohwn

Wait >30s 
- go into folder
- wait >30s
- click on file
- very fast etag check is used
	- if file changed, see sync dialog
	- if file stayed the same, opens file

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>