### PR TITLE
If e2e app is disabled, show info

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -75,6 +75,8 @@ import com.owncloud.android.lib.resources.files.SearchOperation;
 import com.owncloud.android.lib.resources.files.ToggleEncryptionOperation;
 import com.owncloud.android.lib.resources.files.ToggleFavoriteOperation;
 import com.owncloud.android.lib.resources.shares.GetRemoteSharesOperation;
+import com.owncloud.android.lib.resources.status.OCCapability;
+import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.activity.FolderPickerActivity;
@@ -887,11 +889,22 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                         return;
                     }
 
+                    Account account = ((FileActivity) mContainerActivity).getAccount();
+
+                    // check if e2e app is enabled
+                    OCCapability ocCapability = mContainerActivity.getStorageManager().getCapability(account.name);
+
+                    if (ocCapability.getEndToEndEncryption().isFalse() ||
+                            ocCapability.getEndToEndEncryption().isUnknown()) {
+                        Snackbar.make(mCurrentListView, R.string.end_to_end_encryption_not_enabled,
+                                Snackbar.LENGTH_LONG).show();
+                        return;
+                    }
+                    
                     // check if keys are stored
                     ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(
                             getContext().getContentResolver());
 
-                    Account account = ((FileActivity) mContainerActivity).getAccount();
                     String publicKey = arbitraryDataProvider.getValue(account, EncryptionUtils.PUBLIC_KEY);
                     String privateKey = arbitraryDataProvider.getValue(account, EncryptionUtils.PRIVATE_KEY);
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -76,7 +76,6 @@ import com.owncloud.android.lib.resources.files.ToggleEncryptionOperation;
 import com.owncloud.android.lib.resources.files.ToggleFavoriteOperation;
 import com.owncloud.android.lib.resources.shares.GetRemoteSharesOperation;
 import com.owncloud.android.lib.resources.status.OCCapability;
-import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.activity.FolderPickerActivity;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -763,6 +763,7 @@
     <string name="end_to_end_encryption_title">Set up encryption</string>
     <string name="end_to_end_encryption_passphrase_title">Make note of your 12 word encryption password</string>
     <string name="end_to_end_encryption_not_supported">Encryption only works on KitKat(4.4) and beyond.</string>
+    <string name="end_to_end_encryption_not_enabled">End to end encryption not enabled on server.</string>
     <string name="end_to_end_encryption_confirm_button">Set up encryption</string>
     <string name="end_to_end_encryption_password">Password&#8230;</string>
     <string name="end_to_end_encryption_unsuccessful">Could not save keys, please try again.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -763,7 +763,7 @@
     <string name="end_to_end_encryption_title">Set up encryption</string>
     <string name="end_to_end_encryption_passphrase_title">Make note of your 12 word encryption password</string>
     <string name="end_to_end_encryption_not_supported">Encryption only works on KitKat(4.4) and beyond.</string>
-    <string name="end_to_end_encryption_not_enabled">End to end encryption not enabled on server.</string>
+    <string name="end_to_end_encryption_not_enabled">End to end encryption disabled on server.</string>
     <string name="end_to_end_encryption_confirm_button">Set up encryption</string>
     <string name="end_to_end_encryption_password">Password&#8230;</string>
     <string name="end_to_end_encryption_unsuccessful">Could not save keys, please try again.</string>


### PR DESCRIPTION
Fixes #2242

- fresh installation
- have encrypted folders in account
- disable e2e app
- click on encrypted folder
-> warning as snackbar: End to end encryption not enabled on server.

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>