### PR TITLE
Show mnemonic based on device credentials

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -95,14 +95,6 @@ public class PassCodeManager {
             activity.startActivityForResult(i, PASSCODE_ACTIVITY);
         }
 
-        if (!sExemptOfPasscodeActivites.contains(activity.getClass()) && Build.VERSION.SDK_INT >=
-                Build.VERSION_CODES.M && deviceCredentialsShouldBeRequested() &&
-                !DeviceCredentialUtils.tryEncrypt()) {
-            Intent i = new Intent(MainApp.getAppContext(), RequestCredentialsActivity.class);
-            i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-            activity.startActivity(i);
-        }
-
         visibleActivitiesCounter++;    // keep it AFTER passCodeShouldBeRequested was checked
     }
 

--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -95,6 +95,14 @@ public class PassCodeManager {
             activity.startActivityForResult(i, PASSCODE_ACTIVITY);
         }
 
+        if (!sExemptOfPasscodeActivites.contains(activity.getClass()) && Build.VERSION.SDK_INT >=
+                Build.VERSION_CODES.M && deviceCredentialsShouldBeRequested() &&
+                !DeviceCredentialUtils.tryEncrypt()) {
+            Intent i = new Intent(MainApp.getAppContext(), RequestCredentialsActivity.class);
+            i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            activity.startActivity(i);
+        }
+
         visibleActivitiesCounter++;    // keep it AFTER passCodeShouldBeRequested was checked
     }
 
@@ -133,5 +141,11 @@ public class PassCodeManager {
                 || Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                         (PreferenceManager.isUseFingerprint(MainApp.getAppContext())
                                 && DeviceCredentialUtils.areCredentialsAvailable(activity));
+    }
+
+    private boolean deviceCredentialsShouldBeRequested() {
+        SharedPreferences appPrefs = PreferenceManager
+                .getDefaultSharedPreferences(MainApp.getAppContext());
+        return (appPrefs.getBoolean(Preferences.PREFERENCE_USE_DEVICE_CREDENTIALS, false));
     }
 }

--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -43,6 +43,8 @@ public class PassCodeManager {
 
     public static final int PASSCODE_ACTIVITY = 9999;
 
+    public static final int PASSCODE_ACTIVITY = 9999;
+
     static {
         exemptOfPasscodeActivities = new HashSet<>();
         exemptOfPasscodeActivities.add(PassCodeActivity.class);

--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -43,8 +43,6 @@ public class PassCodeManager {
 
     public static final int PASSCODE_ACTIVITY = 9999;
 
-    public static final int PASSCODE_ACTIVITY = 9999;
-
     static {
         exemptOfPasscodeActivities = new HashSet<>();
         exemptOfPasscodeActivities.add(PassCodeActivity.class);
@@ -135,11 +133,5 @@ public class PassCodeManager {
                 || Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                         (PreferenceManager.isUseFingerprint(MainApp.getAppContext())
                                 && DeviceCredentialUtils.areCredentialsAvailable(activity));
-    }
-
-    private boolean deviceCredentialsShouldBeRequested() {
-        SharedPreferences appPrefs = PreferenceManager
-                .getDefaultSharedPreferences(MainApp.getAppContext());
-        return (appPrefs.getBoolean(Preferences.PREFERENCE_USE_DEVICE_CREDENTIALS, false));
     }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -377,7 +377,6 @@ public class Preferences extends PreferenceActivity
         if (pFeedback != null) {
             if (feedbackEnabled) {
                 pFeedback.setOnPreferenceClickListener(new OnPreferenceClickListener() {
-
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
                         String feedbackMail = getString(R.string.mail_feedback);

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -377,6 +377,7 @@ public class Preferences extends PreferenceActivity
         if (pFeedback != null) {
             if (feedbackEnabled) {
                 pFeedback.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
                         String feedbackMail = getString(R.string.mail_feedback);

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -93,6 +93,9 @@ public class Preferences extends PreferenceActivity
     public static final String LOCK_DEVICE_CREDENTIALS = "device_credentials";
 
     public final static String PREFERENCE_USE_FINGERPRINT = "use_fingerprint";
+
+    public final static String PREFERENCE_USE_DEVICE_CREDENTIALS= "use_device_credentials";
+
     public static final String PREFERENCE_EXPERT_MODE = "expert_mode";
 
     private static final int ACTION_REQUEST_PASSCODE = 5;
@@ -519,6 +522,8 @@ public class Preferences extends PreferenceActivity
         boolean fSyncedFolderLightEnabled = getResources().getBoolean(R.bool.syncedFolder_light);
 
         setupLockPreference(preferenceCategoryDetails, fPassCodeEnabled, fDeviceCredentialsEnabled);
+
+        setupDeviceCredentialsPreference(preferenceCategoryDetails, fDeviceCredentialsEnabled);
 
         setupHiddenFilesPreference(preferenceCategoryDetails, fShowHiddenFilesEnabled);
 

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -47,6 +47,7 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatDelegate;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -60,6 +61,7 @@ import com.owncloud.android.BuildConfig;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
+import com.owncloud.android.authentication.PassCodeManager;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.ExternalLinksProvider;
 import com.owncloud.android.datastorage.DataStorageProvider;
@@ -71,6 +73,7 @@ import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.DeviceCredentialUtils;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.EncryptionUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.ThemeUtils;
 
@@ -120,7 +123,10 @@ public class Preferences extends PreferenceActivity
 
     private ListPreference mPrefStoragePath;
     private String mStoragePath;
-    private String pendingLock;
+    private String mPendingLock;
+
+    private Account mAccount;
+    private ArbitraryDataProvider mArbitraryDataProvider;
 
     public static class PreferenceKeys {
         public static final String STORAGE_PATH = "storage_path";
@@ -152,6 +158,9 @@ public class Preferences extends PreferenceActivity
         int accentColor = ThemeUtils.primaryAccentColor(this);
         String appVersion = getAppVersion();
         PreferenceScreen preferenceScreen = (PreferenceScreen) findPreference("preference_screen");
+
+        mAccount = AccountUtils.getCurrentOwnCloudAccount(getApplicationContext());
+        mArbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
 
         // General
         setupGeneralCategory(accentColor);
@@ -310,6 +319,8 @@ public class Preferences extends PreferenceActivity
 
         setupContactsBackupPreference(preferenceCategoryMore);
 
+        setupE2EMnemonicPreference(preferenceCategoryMore);
+
         setupHelpPreference(preferenceCategoryMore);
 
         setupRecommendPreference(preferenceCategoryMore);
@@ -436,6 +447,34 @@ public class Preferences extends PreferenceActivity
                 });
             } else {
                 preferenceCategoryMore.removePreference(pRecommend);
+            }
+        }
+    }
+
+    private void setupE2EMnemonicPreference(PreferenceCategory preferenceCategoryMore) {
+        String mnemonic = mArbitraryDataProvider.getValue(mAccount.name, EncryptionUtils.MNEMONIC);
+
+        Preference pMnemonic = findPreference("mnemonic");
+        if (pMnemonic != null) {
+            if (!mnemonic.isEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (DeviceCredentialUtils.areCredentialsAvailable(Preferences.this)) {
+                    pMnemonic.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+                        @Override
+                        public boolean onPreferenceClick(Preference preference) {
+
+                            Intent i = new Intent(MainApp.getAppContext(), RequestCredentialsActivity.class);
+                            i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                            Preferences.this.startActivityForResult(i, PassCodeManager.PASSCODE_ACTIVITY);
+
+                            return true;
+                        }
+                    });
+                } else {
+                    pMnemonic.setEnabled(false);
+                    pMnemonic.setSummary(R.string.prefs_e2e_no_device_credentials);
+                }
+            } else {
+                preferenceCategoryMore.removePreference(pMnemonic);
             }
         }
     }
@@ -620,14 +659,14 @@ public class Preferences extends PreferenceActivity
             mLock.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object o) {
-                    pendingLock = LOCK_NONE;
+                    mPendingLock = LOCK_NONE;
                     String oldValue = ((ListPreference) preference).getValue();
                     String newValue = (String) o;
                     if (!oldValue.equals(newValue)) {
                         if (oldValue.equals(LOCK_NONE)) {
                             enableLock(newValue);
                         } else {
-                            pendingLock = newValue;
+                            mPendingLock = newValue;
                             disableLock(oldValue);
                         }
                     }
@@ -650,16 +689,15 @@ public class Preferences extends PreferenceActivity
         } else {
             // Upload on WiFi
             final ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
-            final Account account = AccountUtils.getCurrentOwnCloudAccount(getApplicationContext());
 
             final SwitchPreference pUploadOnWifiCheckbox = (SwitchPreference) findPreference("synced_folder_on_wifi");
             pUploadOnWifiCheckbox.setChecked(
-                    arbitraryDataProvider.getBooleanValue(account, SYNCED_FOLDER_LIGHT_UPLOAD_ON_WIFI));
+                    arbitraryDataProvider.getBooleanValue(mAccount, SYNCED_FOLDER_LIGHT_UPLOAD_ON_WIFI));
 
             pUploadOnWifiCheckbox.setOnPreferenceClickListener(new OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
-                    arbitraryDataProvider.storeOrUpdateKeyValue(account.name, SYNCED_FOLDER_LIGHT_UPLOAD_ON_WIFI,
+                    arbitraryDataProvider.storeOrUpdateKeyValue(mAccount.name, SYNCED_FOLDER_LIGHT_UPLOAD_ON_WIFI,
                             String.valueOf(pUploadOnWifiCheckbox.isChecked()));
 
                     return true;
@@ -688,7 +726,7 @@ public class Preferences extends PreferenceActivity
     }
 
     private void enableLock(String lock) {
-        pendingLock = LOCK_NONE;
+        mPendingLock = LOCK_NONE;
         if (lock.equals(LOCK_PASSCODE)) {
             Intent i = new Intent(getApplicationContext(), PassCodeActivity.class);
             i.setAction(PassCodeActivity.ACTION_REQUEST_WITH_RESULT);
@@ -814,7 +852,7 @@ public class Preferences extends PreferenceActivity
             if (mUri != null) {
                 davDroidLoginIntent.putExtra("url", mUri.toString() + DAV_PATH);
             }
-            davDroidLoginIntent.putExtra("username", AccountUtils.getAccountUsername(account.name));
+            davDroidLoginIntent.putExtra("username", AccountUtils.getAccountUsername(mAccount.name));
             //loginIntent.putExtra("password", "...");
             startActivityForResult(davDroidLoginIntent, ACTION_REQUEST_CODE_DAVDROID_SETUP);
         } else {
@@ -840,8 +878,7 @@ public class Preferences extends PreferenceActivity
         Thread t = new Thread(new Runnable() {
             public void run() {
                 try {
-                    Account account = AccountUtils.getCurrentOwnCloudAccount(getApplicationContext());
-                    OwnCloudAccount ocAccount = new OwnCloudAccount(account, MainApp.getAppContext());
+                    OwnCloudAccount ocAccount = new OwnCloudAccount(mAccount, MainApp.getAppContext());
                     mUri = OwnCloudClientManagerFactory.getDefaultSingleton().
                             getClientFor(ocAccount, getApplicationContext()).getBaseUri();
                 } catch (Throwable t) {
@@ -884,8 +921,8 @@ public class Preferences extends PreferenceActivity
                 mLock.setSummary(mLock.getEntry());
 
                 DisplayUtils.showSnackMessage(this, R.string.pass_code_removed);
-                if (!pendingLock.equals(LOCK_NONE)) {
-                    enableLock(pendingLock);
+                if (!mPendingLock.equals(LOCK_NONE)) {
+                    enableLock(mPendingLock);
                 }
             }
         } else if (requestCode == ACTION_REQUEST_CODE_DAVDROID_SETUP && resultCode == RESULT_OK) {
@@ -893,14 +930,32 @@ public class Preferences extends PreferenceActivity
         } else if (requestCode == ACTION_CONFIRM_DEVICE_CREDENTIALS && resultCode == RESULT_OK &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 data.getIntExtra(RequestCredentialsActivity.KEY_CHECK_RESULT,
-                        RequestCredentialsActivity.KEY_CHECK_RESULT_FALSE) == 
+                        RequestCredentialsActivity.KEY_CHECK_RESULT_FALSE) ==
                         RequestCredentialsActivity.KEY_CHECK_RESULT_TRUE) {
             mLock.setValue(LOCK_NONE);
             mLock.setSummary(mLock.getEntry());
             DisplayUtils.showSnackMessage(this, R.string.credentials_disabled);
-            if (!pendingLock.equals(LOCK_NONE)) {
-                enableLock(pendingLock);
+            if (!mPendingLock.equals(LOCK_NONE)) {
+                enableLock(mPendingLock);
             }
+        } else if (requestCode == PassCodeManager.PASSCODE_ACTIVITY && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                data.getIntExtra(RequestCredentialsActivity.KEY_CHECK_RESULT,
+                        RequestCredentialsActivity.KEY_CHECK_RESULT_FALSE) ==
+                        RequestCredentialsActivity.KEY_CHECK_RESULT_TRUE) {
+
+            ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
+            String mnemonic = arbitraryDataProvider.getValue(mAccount.name, EncryptionUtils.MNEMONIC);
+
+            int accentColor = ThemeUtils.primaryAccentColor();
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(Preferences.this,
+                    R.style.FallbackTheming_Dialog);
+            builder.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_e2e_mnemonic),
+                    accentColor));
+            builder.setMessage(mnemonic);
+            builder.setPositiveButton(ThemeUtils.getColoredTitle(getString(R.string.common_ok),
+                    accentColor), (dialog, which) -> dialog.dismiss());
+            builder.show();
         }
     }
     

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -96,9 +96,6 @@ public class Preferences extends PreferenceActivity
     public static final String LOCK_DEVICE_CREDENTIALS = "device_credentials";
 
     public final static String PREFERENCE_USE_FINGERPRINT = "use_fingerprint";
-
-    public final static String PREFERENCE_USE_DEVICE_CREDENTIALS= "use_device_credentials";
-
     public static final String PREFERENCE_EXPERT_MODE = "expert_mode";
 
     private static final int ACTION_REQUEST_PASSCODE = 5;
@@ -123,7 +120,7 @@ public class Preferences extends PreferenceActivity
 
     private ListPreference mPrefStoragePath;
     private String mStoragePath;
-    private String mPendingLock;
+    private String pendingLock;
 
     private Account mAccount;
     private ArbitraryDataProvider mArbitraryDataProvider;
@@ -562,8 +559,6 @@ public class Preferences extends PreferenceActivity
 
         setupLockPreference(preferenceCategoryDetails, fPassCodeEnabled, fDeviceCredentialsEnabled);
 
-        setupDeviceCredentialsPreference(preferenceCategoryDetails, fDeviceCredentialsEnabled);
-
         setupHiddenFilesPreference(preferenceCategoryDetails, fShowHiddenFilesEnabled);
 
         setupExpertModePreference(preferenceCategoryDetails, fSyncedFolderLightEnabled);
@@ -659,14 +654,14 @@ public class Preferences extends PreferenceActivity
             mLock.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object o) {
-                    mPendingLock = LOCK_NONE;
+                    pendingLock = LOCK_NONE;
                     String oldValue = ((ListPreference) preference).getValue();
                     String newValue = (String) o;
                     if (!oldValue.equals(newValue)) {
                         if (oldValue.equals(LOCK_NONE)) {
                             enableLock(newValue);
                         } else {
-                            mPendingLock = newValue;
+                            pendingLock = newValue;
                             disableLock(oldValue);
                         }
                     }
@@ -726,7 +721,7 @@ public class Preferences extends PreferenceActivity
     }
 
     private void enableLock(String lock) {
-        mPendingLock = LOCK_NONE;
+        pendingLock = LOCK_NONE;
         if (lock.equals(LOCK_PASSCODE)) {
             Intent i = new Intent(getApplicationContext(), PassCodeActivity.class);
             i.setAction(PassCodeActivity.ACTION_REQUEST_WITH_RESULT);
@@ -843,8 +838,6 @@ public class Preferences extends PreferenceActivity
     }
 
     private void launchDavDroidLogin() {
-        Account account = AccountUtils.getCurrentOwnCloudAccount(getApplicationContext());
-
         Intent davDroidLoginIntent = new Intent();
         davDroidLoginIntent.setClassName("at.bitfire.davdroid", "at.bitfire.davdroid.ui.setup.LoginActivity");
         if (getPackageManager().resolveActivity(davDroidLoginIntent, 0) != null) {
@@ -921,8 +914,8 @@ public class Preferences extends PreferenceActivity
                 mLock.setSummary(mLock.getEntry());
 
                 DisplayUtils.showSnackMessage(this, R.string.pass_code_removed);
-                if (!mPendingLock.equals(LOCK_NONE)) {
-                    enableLock(mPendingLock);
+                if (!pendingLock.equals(LOCK_NONE)) {
+                    enableLock(pendingLock);
                 }
             }
         } else if (requestCode == ACTION_REQUEST_CODE_DAVDROID_SETUP && resultCode == RESULT_OK) {
@@ -935,8 +928,8 @@ public class Preferences extends PreferenceActivity
             mLock.setValue(LOCK_NONE);
             mLock.setSummary(mLock.getEntry());
             DisplayUtils.showSnackMessage(this, R.string.credentials_disabled);
-            if (!mPendingLock.equals(LOCK_NONE)) {
-                enableLock(mPendingLock);
+            if (!pendingLock.equals(LOCK_NONE)) {
+                enableLock(pendingLock);
             }
         } else if (requestCode == PassCodeManager.PASSCODE_ACTIVITY && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 data.getIntExtra(RequestCredentialsActivity.KEY_CHECK_RESULT,
@@ -946,7 +939,7 @@ public class Preferences extends PreferenceActivity
             ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
             String mnemonic = arbitraryDataProvider.getValue(mAccount.name, EncryptionUtils.MNEMONIC);
 
-            int accentColor = ThemeUtils.primaryAccentColor();
+            int accentColor = ThemeUtils.primaryAccentColor(this);
 
             AlertDialog.Builder builder = new AlertDialog.Builder(Preferences.this,
                     R.style.FallbackTheming_Dialog);

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -454,7 +454,7 @@ public class Preferences extends PreferenceActivity
         Preference pMnemonic = findPreference("mnemonic");
         if (pMnemonic != null) {
             if (!mnemonic.isEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (DeviceCredentialUtils.areCredentialsAvailable(Preferences.this)) {
+                if (DeviceCredentialUtils.areCredentialsAvailable(this)) {
                     pMnemonic.setOnPreferenceClickListener(new OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {
@@ -941,13 +941,11 @@ public class Preferences extends PreferenceActivity
 
             int accentColor = ThemeUtils.primaryAccentColor(this);
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(Preferences.this,
-                    R.style.FallbackTheming_Dialog);
-            builder.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_e2e_mnemonic),
-                    accentColor));
+            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.FallbackTheming_Dialog);
+            builder.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_e2e_mnemonic), accentColor));
             builder.setMessage(mnemonic);
-            builder.setPositiveButton(ThemeUtils.getColoredTitle(getString(R.string.common_ok),
-                    accentColor), (dialog, which) -> dialog.dismiss());
+            builder.setPositiveButton(ThemeUtils.getColoredTitle(getString(R.string.common_ok), accentColor),
+                    (dialog, which) -> dialog.dismiss());
             builder.show();
         }
     }

--- a/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -185,15 +185,19 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
 
                                 try {
                                     String privateKey = task.get();
+                                    String mnemonic = passwordField.getText().toString().replaceAll("\\s", "")
+                                            .toLowerCase(Locale.ROOT);
                                     String decryptedPrivateKey = EncryptionUtils.decryptPrivateKey(privateKey,
-                                            passwordField.getText().toString().replaceAll("\\s", "")
-                                                    .toLowerCase(Locale.ROOT));
+                                            mnemonic);
 
                                     arbitraryDataProvider.storeOrUpdateKeyValue(account.name,
                                             EncryptionUtils.PRIVATE_KEY, decryptedPrivateKey);
 
                                     dialog.dismiss();
                                     Log_OC.d(TAG, "Private key successfully decrypted and stored");
+
+                                    arbitraryDataProvider.storeOrUpdateKeyValue(account.name, EncryptionUtils.MNEMONIC,
+                                            mnemonic);
 
                                     Intent intentExisting = new Intent();
                                     intentExisting.putExtra(SUCCESS, true);
@@ -301,14 +305,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
 
                     textView.setText(R.string.end_to_end_encryption_keywords_description);
 
-                    StringBuilder stringBuilder = new StringBuilder();
-
-                    for (String string : keyWords) {
-                        stringBuilder.append(string).append(" ");
-                    }
-                    String keys = stringBuilder.toString();
-
-                    passphraseTextView.setText(keys);
+                    passphraseTextView.setText(generateMnemonicString(true));
 
                     passphraseTextView.setVisibility(View.VISIBLE);
                     positiveButton.setText(R.string.end_to_end_encryption_confirm_button);
@@ -379,15 +376,10 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
                     return "";
                 }
 
-                StringBuilder stringBuilder = new StringBuilder();
-                for (String string : keyWords) {
-                    stringBuilder.append(string);
-                }
-                String keyPhrase = stringBuilder.toString();
-
                 String privateKeyString = EncryptionUtils.encodeBytesToBase64String(privateKey.getEncoded());
                 String privatePemKeyString = EncryptionUtils.privateKeyToPEM(privateKey);
-                String encryptedPrivateKey = EncryptionUtils.encryptPrivateKey(privatePemKeyString, keyPhrase);
+                String encryptedPrivateKey = EncryptionUtils.encryptPrivateKey(privatePemKeyString,
+                        generateMnemonicString(false));
 
                 // upload encryptedPrivateKey
                 StorePrivateKeyOperation storePrivateKeyOperation = new StorePrivateKeyOperation(encryptedPrivateKey);
@@ -400,6 +392,8 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
                     arbitraryDataProvider.storeOrUpdateKeyValue(account.name, EncryptionUtils.PRIVATE_KEY,
                             privateKeyString);
                     arbitraryDataProvider.storeOrUpdateKeyValue(account.name, EncryptionUtils.PUBLIC_KEY, publicKey);
+                    arbitraryDataProvider.storeOrUpdateKeyValue(account.name, EncryptionUtils.MNEMONIC,
+                            generateMnemonicString(true));
 
                     keyResult = KEY_CREATED;
                     return (String) storePrivateKeyResult.getData().get(0);
@@ -437,5 +431,18 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
                         SETUP_ENCRYPTION_RESULT_CODE, intentExisting);
             }
         }
+    }
+
+    private String generateMnemonicString(boolean withWhitespace) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (String string : keyWords) {
+            stringBuilder.append(string);
+            if (withWhitespace) {
+                stringBuilder.append(" ");
+            }
+        }
+
+        return stringBuilder.toString();
     }
 }

--- a/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -439,7 +439,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
         for (String string : keyWords) {
             stringBuilder.append(string);
             if (withWhitespace) {
-                stringBuilder.append(" ");
+                stringBuilder.append(' ');
             }
         }
 

--- a/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -95,6 +95,7 @@ public class EncryptionUtils {
 
     public static final String PUBLIC_KEY = "PUBLIC_KEY";
     public static final String PRIVATE_KEY = "PRIVATE_KEY";
+    public static final String MNEMONIC = "MNEMONIC";
     public static final int ivLength = 16;
     public static final int saltLength = 40;
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -795,7 +795,9 @@
     <string name="sharee_add_failed">Adding sharee failed</string>
     <string name="unsharing_failed">Unsharing failed</string>
     <string name="updating_share_failed">Updating share failed</string>
-    <string name="whats_new_device_credentials_title">Use Android device protection</string>
+    <string name="prefs_e2e_mnemonic">E2E mnemonic</string>
+    <string name="prefs_e2e_no_device_credentials">To show mnemonic please enable device credentials.</string>
+    <string name="whats_new_device_credentials_title">Use Android\'s device internal protection</string>
     <string name="whats_new_device_credentials_content">Use anything like a pattern, password, pin or your fingerprint to keep your data safe.</string>
     <string name="restore_button_description">Restore deleted file</string>
 	<string name="restore">Restore file</string>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -45,7 +45,7 @@
 		<item name="colorAccent">#757575</item>
 	</style>
 
-	<style name="FallbackTheming.Dialog" parent="style/Theme.AppCompat.Light.Dialog.Alert">
+	<style name="FallbackTheming.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -45,6 +45,15 @@
 		<item name="colorAccent">#757575</item>
 	</style>
 
+	<style name="FallbackTheming.Dialog" parent="style/Theme.AppCompat.Light.Dialog.Alert">
+		<item name="colorPrimary">#424242</item>
+		<item name="colorPrimaryDark">#212121</item>
+		<item name="colorAccent">#757575</item>
+		<item name="windowNoTitle">false</item>
+		<item name="buttonBarButtonStyle">@style/Theme.ownCloud.Dialog.ButtonBar.Button</item>
+		<item name="buttonBarStyle">@style/Theme.ownCloud.Dialog.ButtonBar</item>
+	</style>
+
 	<!-- seperate action bar style for activities without an action bar -->
 	<style name="Theme.ownCloud.Toolbar" parent="Theme.AppCompat.Light.NoActionBar">
 		<item name="windowNoTitle">true</item>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -45,6 +45,9 @@
 			android:dialogTitle="@string/prefs_lock_title"
 			android:defaultValue="none"/>
 		<com.owncloud.android.ui.ThemeableSwitchPreference
+			android:title="@string/prefs_use_device_credentials"
+			android:key="use_device_credentials"/>
+		<com.owncloud.android.ui.ThemeableSwitchPreference
 			android:title="@string/prefs_show_hidden_files"
 			android:key="show_hidden_files"/>
 		<com.owncloud.android.ui.ThemeableSwitchPreference

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -45,9 +45,6 @@
 			android:dialogTitle="@string/prefs_lock_title"
 			android:defaultValue="none"/>
 		<com.owncloud.android.ui.ThemeableSwitchPreference
-			android:title="@string/prefs_use_device_credentials"
-			android:key="use_device_credentials"/>
-		<com.owncloud.android.ui.ThemeableSwitchPreference
 			android:title="@string/prefs_show_hidden_files"
 			android:key="show_hidden_files"/>
 		<com.owncloud.android.ui.ThemeableSwitchPreference

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -63,6 +63,10 @@
 			android:title="@string/actionbar_contacts"
 			android:key="contacts"
 			android:summary="@string/prefs_daily_contacts_sync_summary"/>
+		<Preference
+			android:title="@string/prefs_e2e_mnemonic"
+			android:key="mnemonic"
+			android:summary="Displays your E2E 12 words passphrase" />
 		<Preference android:title="@string/prefs_help" android:key="help" />
 		<Preference android:title="@string/prefs_recommend" android:key="recommend" />
 		<Preference android:title="@string/prefs_feedback" android:key="feedback" />


### PR DESCRIPTION
Fix #2128 

* [x] This is based on #1657, but not showing the diff correctly as #1657 is another repo. So once #1657 is merged, this will have a cleaner diff.
* [x] rebase to latest `master`

- show preference entry only if e2e mnemonic is saved
- showing mnemonic is only possible if device credentials are setup in android
![2018-03-21-103025](https://user-images.githubusercontent.com/5836855/37702753-d3dbc2e2-2cf3-11e8-9c8f-1738b35b112d.png)
- if enabled, show credentials request
	![resized_screenshot_1521625105](https://user-images.githubusercontent.com/5836855/37702831-122a4e74-2cf4-11e8-8741-5c21fff76fdc.png)
- then show mnemonic
![2018-03-21-103759](https://user-images.githubusercontent.com/5836855/37702790-eea48fd2-2cf3-11e8-8996-2662ab419bfa.png)

