### PR TITLE
context might be null, so fallback

### DIFF
--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -380,16 +380,19 @@ public class ThemeUtils {
 
     private static OCCapability getCapability(Account acc) {
         Account account;
+        Context context = MainApp.getAppContext();
+
+        if (context == null) {
+            return new OCCapability();
+        }
 
         if (acc != null) {
             account = acc;
         } else {
-            account = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext());
+            account = AccountUtils.getCurrentOwnCloudAccount(context);
         }
 
         if (account != null) {
-            Context context = MainApp.getAppContext();
-
             FileDataStorageManager storageManager = new FileDataStorageManager(account, context.getContentResolver());
             return storageManager.getCapability(account.name);
         } else {


### PR DESCRIPTION
Reported via google play console.

We are using this in all static theming calls.
It seems to happen, maybe due to race conditions, that context is null (MainApp not entirely set up yet), but there is already a call to theming.

This prevents from having a NPE within AccountUtils.getCurrentOwnCloudAccount(context) when context is null.
Instead we simply return a default OCCapability.

This function is only used from within ThemeUtils, so the "worst" that could happen is that we fallback to the default theming.

Signed-off-by: tobiaskaminsky <tobias@kaminsky.me>