### PR TITLE
Init thumbnail cache: catch all exceptions

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -125,7 +125,7 @@ public class ThumbnailsCacheManager {
                         } else {
                             throw new FileNotFoundException("Thumbnail cache could not be opened");
                         }
-                    } catch (java.io.IOException e) {
+                    } catch (Exception e) {
                         Log_OC.d(TAG, e.getMessage());
                         mThumbnailCache = null;
                     }


### PR DESCRIPTION
Reported via google play console.

https://github.com/nextcloud/android/blob/1fb941252948860ee8c40fcc0cfdb718598e5080/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java#L117-L117

this can result in:
```
Caused by: java.lang.NullPointerException: 
  at android.os.Parcel.readException (Parcel.java:1478)
  at android.os.Parcel.readException (Parcel.java:1426)
  at android.os.storage.IMountService$Stub$Proxy.mkdirs (IMountService.java:750)
  at android.app.ContextImpl.ensureDirsExistOrFilter (ContextImpl.java:2169)
  at android.app.ContextImpl.getExternalCacheDirs (ContextImpl.java:925)
  at android.app.ContextImpl.getExternalCacheDir (ContextImpl.java:914)
  at android.content.ContextWrapper.getExternalCacheDir (ContextWrapper.java:235)
  at com.owncloud.android.datamodel.ThumbnailsCacheManager$InitDiskCacheTask.doInBackground (ThumbnailsCacheManager.java:117)
  at com.owncloud.android.datamodel.ThumbnailsCacheManager$InitDiskCacheTask.doInBackground (ThumbnailsCacheManager.java:107)
```

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>