### PR TITLE
Re-assign accountmanager

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -171,6 +171,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
             
             mFile = savedInstanceState.getParcelable(KEY_FILE);
         }
+        mAccountManager = (AccountManager) getSystemService(Context.ACCOUNT_SERVICE);
 
         super.onCreate(savedInstanceState);
 
@@ -194,8 +195,6 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     @Override
     protected void setAccount(Account account, boolean savedAccount) {
-        mAccountManager = (AccountManager) getSystemService(Context.ACCOUNT_SERVICE);
-
         Account[] accounts = mAccountManager.getAccountsByType(MainApp.getAccountType(this));
         if (accounts.length == 0) {
             Log_OC.i(TAG, "No ownCloud account is available");


### PR DESCRIPTION
This is kind of strange:
Here it works without any problems: https://github.com/nextcloud/android/blob/88cf975861657b3c952e03e282c6616120c2a8c4/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java#L193-L197

But here 
https://github.com/nextcloud/android/blob/88cf975861657b3c952e03e282c6616120c2a8c4/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java#L1012-L1015
it crashes.
Therefore I re-assign AccountManager...

If you have any better idea...
Reported via google play console:
all 7.x
all Galaxy devices. Samsung...oh...Samsung... :fearful: 


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>