### PR TITLE
OnServiceConnnected: File not found

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -120,7 +120,8 @@ public class FileDataStorageManager {
     }
 
 
-    public OCFile getFileById(long id) {
+    public @Nullable
+    OCFile getFileById(long id) {
         Cursor c = getFileCursorForValue(ProviderTableMeta._ID, String.valueOf(id));
         OCFile file = null;
         if (c.moveToFirst()) {

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1545,7 +1545,7 @@ public class FileDisplayActivity extends HookActivity
                 if (mWaitingToPreview != null && getStorageManager() != null) {
                     // update the file
                     mWaitingToPreview = getStorageManager().getFileById(mWaitingToPreview.getFileId());
-                    if (!mWaitingToPreview.isDown()) {
+                    if (mWaitingToPreview != null && !mWaitingToPreview.isDown()) {
                         requestForDownload();
                     }
                 }


### PR DESCRIPTION
Reported via google console

- file is updated, but somehow not anylonger in storagemanager
- check to prevent NPE on `!mWaitingToPreview.isDown()`
- add @Nullable to warn via IDE
(as somewhere discussed it is better to handle this via a real FileNotFoundException, but for now...)