### PR TITLE
Any theming call has now context, instead of app context

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -639,10 +639,12 @@ public class ThumbnailsCacheManager {
         private final WeakReference<ImageView> mImageViewReference;
         private File mFile;
         private String mImageKey = null;
+        private Context mContext;
 
-        public MediaThumbnailGenerationTask(ImageView imageView) {
+        public MediaThumbnailGenerationTask(ImageView imageView, Context context) {
             // Use a WeakReference to ensure the ImageView can be garbage collected
             mImageViewReference = new WeakReference<>(imageView);
+            mContext = context;
         }
 
         @Override
@@ -689,7 +691,7 @@ public class ThumbnailsCacheManager {
                 } else {
                     if (mFile != null) {
                         if (mFile.isDirectory()) {
-                            imageView.setImageDrawable(MimeTypeUtil.getDefaultFolderIcon());
+                            imageView.setImageDrawable(MimeTypeUtil.getDefaultFolderIcon(mContext));
                         } else {
                             if (MimeTypeUtil.isVideo(mFile)) {
                                 imageView.setImageBitmap(ThumbnailsCacheManager.mDefaultVideo);

--- a/src/main/java/com/owncloud/android/files/services/FileDownloader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileDownloader.java
@@ -132,7 +132,7 @@ public class FileDownloader extends Service
                 .setContentText(getApplicationContext().getResources().getString(R.string.foreground_service_download))
                 .setSmallIcon(R.drawable.notification_icon)
                 .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.drawable.notification_icon))
-                .setColor(ThemeUtils.primaryColor());
+                .setColor(ThemeUtils.primaryColor(getApplicationContext()));
 
         if ((android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)) {
             builder.setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD);

--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -468,7 +468,7 @@ public class FileUploader extends Service
                 .setContentText(getApplicationContext().getResources().getString(R.string.foreground_service_upload))
                 .setSmallIcon(R.drawable.notification_icon)
                 .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.drawable.notification_icon))
-                .setColor(ThemeUtils.primaryColor());
+                .setColor(ThemeUtils.primaryColor(getApplicationContext()));
 
         if ((android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)) {
             builder.setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD);

--- a/src/main/java/com/owncloud/android/jobs/NotificationJob.java
+++ b/src/main/java/com/owncloud/android/jobs/NotificationJob.java
@@ -119,7 +119,7 @@ public class NotificationJob extends Job {
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.notification_icon)
                 .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.drawable.notification_icon))
-                .setColor(ThemeUtils.primaryColor())
+                .setColor(ThemeUtils.primaryColor(context))
                 .setShowWhen(true)
                 .setSubText(account.name)
                 .setContentTitle(contentTitle)

--- a/src/main/java/com/owncloud/android/media/MediaControlView.java
+++ b/src/main/java/com/owncloud/android/media/MediaControlView.java
@@ -222,10 +222,10 @@ public class MediaControlView extends FrameLayout /* implements OnLayoutChangeLi
         if (mProgress != null) {
             if (mProgress instanceof SeekBar) {
                 SeekBar seeker = (SeekBar) mProgress;
-                ThemeUtils.colorHorizontalSeekBar(seeker);
+                ThemeUtils.colorHorizontalSeekBar(seeker, getContext());
                 seeker.setOnSeekBarChangeListener(this);
             } else {
-                ThemeUtils.colorHorizontalProgressBar(mProgress, ThemeUtils.primaryAccentColor());
+                ThemeUtils.colorHorizontalProgressBar(mProgress, ThemeUtils.primaryAccentColor(getContext()));
             }
             mProgress.setMax(1000);
         }

--- a/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/src/main/java/com/owncloud/android/media/MediaService.java
@@ -226,7 +226,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
 
         mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         mNotificationBuilder = new NotificationCompat.Builder(this);
-        mNotificationBuilder.setColor(ThemeUtils.primaryColor());
+        mNotificationBuilder.setColor(ThemeUtils.primaryColor(this));
         mAudioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
         mBinder = new MediaServiceBinder(this);
     }

--- a/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -518,7 +518,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
     private NotificationCompat.Builder createNotificationBuilder() {
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(getContext());
         notificationBuilder.setSmallIcon(R.drawable.notification_icon).setAutoCancel(true);
-        notificationBuilder.setColor(ThemeUtils.primaryColor());
+        notificationBuilder.setColor(ThemeUtils.primaryColor(getContext()));
         return notificationBuilder;
     }
     

--- a/src/main/java/com/owncloud/android/ui/ThemeableSwitchPreference.java
+++ b/src/main/java/com/owncloud/android/ui/ThemeableSwitchPreference.java
@@ -70,7 +70,7 @@ public class ThemeableSwitchPreference extends SwitchPreference {
             if (child instanceof Switch) {
                 Switch switchView = (Switch) child;
 
-                int color = ThemeUtils.primaryAccentColor();
+                int color = ThemeUtils.primaryAccentColor(getContext());
                 int trackColor = Color.argb(77, Color.red(color), Color.green(color), Color.blue(color));
 
                 // setting the thumb color

--- a/src/main/java/com/owncloud/android/ui/activity/ActivitiesListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ActivitiesListActivity.java
@@ -144,7 +144,7 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
         setupDrawer(R.id.nav_activity);
         ActionBar actionBar = getSupportActionBar();
         if(actionBar != null) {
-            ThemeUtils.setColoredTitle(actionBar, getString(R.string.drawer_item_activities));
+            ThemeUtils.setColoredTitle(actionBar, getString(R.string.drawer_item_activities), this);
         }
 
         swipeListRefreshLayout.setOnRefreshListener(() -> {
@@ -167,9 +167,9 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
     }
 
     protected void onCreateSwipeToRefresh(SwipeRefreshLayout refreshLayout) {
-        int primaryColor = ThemeUtils.primaryColor();
-        int darkColor = ThemeUtils.primaryDarkColor();
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int primaryColor = ThemeUtils.primaryColor(this);
+        int darkColor = ThemeUtils.primaryDarkColor(this);
+        int accentColor = ThemeUtils.primaryAccentColor(this);
 
         // Colors in animations
         refreshLayout.setColorSchemeColors(accentColor, primaryColor, darkColor);
@@ -193,7 +193,7 @@ public class ActivitiesListActivity extends FileActivity implements ActivityList
      */
     private void setupContent() {
         emptyContentIcon.setImageResource(R.drawable.ic_activity_light_grey);
-        emptyContentProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(),
+        emptyContentProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(this),
                 PorterDuff.Mode.SRC_IN);
         setLoadingMessage();
 

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -258,7 +258,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
         // Set the drawer toggle as the DrawerListener
         mDrawerLayout.addDrawerListener(mDrawerToggle);
         mDrawerToggle.setDrawerIndicatorEnabled(true);
-        mDrawerToggle.getDrawerArrowDrawable().setColor(ThemeUtils.fontColor());
+        mDrawerToggle.getDrawerArrowDrawable().setColor(ThemeUtils.fontColor(this));
     }
 
     /**
@@ -270,7 +270,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
         mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
 
         mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toggle);
-        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor());
+        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor(this));
 
         if (getResources().getBoolean(R.bool.allow_profile_click)) {
             mAccountChooserToggle.setImageResource(R.drawable.ic_down);
@@ -295,7 +295,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
         mQuotaProgressBar = (ProgressBar) findQuotaViewById(R.id.drawer_quota_ProgressBar);
         mQuotaTextPercentage = (TextView) findQuotaViewById(R.id.drawer_quota_percentage);
         mQuotaTextLink = (TextView) findQuotaViewById(R.id.drawer_quota_link);
-        ThemeUtils.colorHorizontalProgressBar(mQuotaProgressBar, ThemeUtils.primaryAccentColor());
+        ThemeUtils.colorHorizontalProgressBar(mQuotaProgressBar, ThemeUtils.primaryAccentColor(this));
     }
 
     /**
@@ -330,7 +330,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
             navigationView.getMenu().setGroupVisible(R.id.drawer_menu_accounts, false);
         }
 
-        Account account = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext());
+        Account account = AccountUtils.getCurrentOwnCloudAccount(this);
         boolean searchSupported = AccountUtils.hasSearchSupport(account);
 
         if (getResources().getBoolean(R.bool.bottom_toolbar_enabled) && account != null) {
@@ -746,11 +746,11 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
             TextView username = (TextView) findNavigationViewChildById(R.id.drawer_username);
             TextView usernameFull = (TextView) findNavigationViewChildById(R.id.drawer_username_full);
             usernameFull.setText(account.name);
-            usernameFull.setTextColor(ThemeUtils.fontColor());
+            usernameFull.setTextColor(ThemeUtils.fontColor(this));
             try {
                 OwnCloudAccount oca = new OwnCloudAccount(account, this);
                 username.setText(oca.getDisplayName());
-                username.setTextColor(ThemeUtils.fontColor());
+                username.setTextColor(ThemeUtils.fontColor(this));
             } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
                 Log_OC.w(TAG, "Couldn't read display name of account fallback to account name");
                 username.setText(AccountUtils.getAccountUsername(account.name));
@@ -928,7 +928,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 }
             }
 
-            int elementColor = ThemeUtils.elementColor();
+            int elementColor = ThemeUtils.elementColor(this);
             ThemeUtils.tintDrawable(item.getIcon(), elementColor);
 
             String colorHex = ThemeUtils.colorToHexString(elementColor);
@@ -1068,7 +1068,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 String background = capability.getServerBackground();
                 CapabilityBooleanType backgroundDefault = capability.getServerBackgroundDefault();
                 CapabilityBooleanType backgroundPlain = capability.getServerBackgroundPlain();
-                int primaryColor = ThemeUtils.primaryColor(getAccount());
+                int primaryColor = ThemeUtils.primaryColor(getAccount(), this);
 
                 if (backgroundDefault.isTrue() && backgroundPlain.isTrue()) {
                     // use only solid color

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -671,12 +671,12 @@ public class FileDisplayActivity extends HookActivity
         searchView = (SearchView) MenuItemCompat.getActionView(item);
 
         // hacky as no default way is provided
-        int fontColor = ThemeUtils.fontColor();
+        int fontColor = ThemeUtils.fontColor(this);
         EditText editText = searchView.findViewById(android.support.v7.appcompat.R.id.search_src_text);
         editText.setHintTextColor(fontColor);
         editText.setTextColor(fontColor);
         ImageView searchClose = searchView.findViewById(android.support.v7.appcompat.R.id.search_close_btn);
-        searchClose.setColorFilter(ThemeUtils.fontColor());
+        searchClose.setColorFilter(ThemeUtils.fontColor(this));
 
         // populate list of menu items to show/hide when drawer is opened/closed
         mDrawerMenuItemstoShowHideList = new ArrayList<>(4);

--- a/src/main/java/com/owncloud/android/ui/activity/FingerprintActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FingerprintActivity.java
@@ -96,16 +96,16 @@ public class FingerprintActivity extends AppCompatActivity {
         setContentView(R.layout.fingerprintlock);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().setStatusBarColor(ThemeUtils.primaryDarkColor());
+            getWindow().setStatusBarColor(ThemeUtils.primaryDarkColor(this));
         }
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setTitleTextColor(ThemeUtils.fontColor());
-        toolbar.setBackground(new ColorDrawable(ThemeUtils.primaryColor()));
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        toolbar.setTitleTextColor(ThemeUtils.fontColor(this));
+        toolbar.setBackground(new ColorDrawable(ThemeUtils.primaryColor(this)));
     }
 
     private void startFingerprint() {
-        TextView fingerprintTextView = (TextView) findViewById(R.id.scanfingerprinttext);
+        TextView fingerprintTextView = findViewById(R.id.scanfingerprinttext);
 
         FingerprintManager fingerprintManager =
                 (FingerprintManager) MainApp.getAppContext().getSystemService(Context.FINGERPRINT_SERVICE);
@@ -130,7 +130,7 @@ public class FingerprintActivity extends AppCompatActivity {
                     @Override
                     public void onFailed(String error) {
                         Toast.makeText(MainApp.getAppContext(), error, Toast.LENGTH_LONG).show();
-                        ImageView imageView = (ImageView) findViewById(R.id.fingerprinticon);
+                        ImageView imageView = findViewById(R.id.fingerprinticon);
                         int[][] states = new int[][]{
                                 new int[]{android.R.attr.state_activated},
                                 new int[]{-android.R.attr.state_activated}
@@ -159,8 +159,8 @@ public class FingerprintActivity extends AppCompatActivity {
         super.onResume();
         AnalyticsUtils.setCurrentScreenName(this, SCREEN_NAME, TAG);
         startFingerprint();
-        ImageView imageView = (ImageView)findViewById(R.id.fingerprinticon);
-        imageView.setImageDrawable(ThemeUtils.tintDrawable(R.drawable.ic_fingerprint, ThemeUtils.primaryColor()));
+        ImageView imageView = findViewById(R.id.fingerprinticon);
+        imageView.setImageDrawable(ThemeUtils.tintDrawable(R.drawable.ic_fingerprint, ThemeUtils.primaryColor(this)));
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -117,11 +117,11 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                     mDoNotEnterEncryptedFolder = true;
                     break;
                 default:
-                    caption = ThemeUtils.getDefaultDisplayNameForRootFolder();
+                    caption = ThemeUtils.getDefaultDisplayNameForRootFolder(this);
                     break;
             }
         } else {
-            caption = ThemeUtils.getDefaultDisplayNameForRootFolder();
+            caption = ThemeUtils.getDefaultDisplayNameForRootFolder(this);
         }
 
         if (getIntent().getParcelableExtra(EXTRA_CURRENT_FOLDER) != null) {
@@ -398,7 +398,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         mCancelBtn = findViewById(R.id.folder_picker_btn_cancel);
         mCancelBtn.setOnClickListener(this);
         mChooseBtn = findViewById(R.id.folder_picker_btn_choose);
-        mChooseBtn.getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
+        mChooseBtn.getBackground().setColorFilter(ThemeUtils.primaryColor(this), PorterDuff.Mode.SRC_ATOP);
         mChooseBtn.setOnClickListener(this);
     }
     

--- a/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -82,7 +82,7 @@ public class LogHistoryActivity extends ToolbarActivity {
         }
         Button deleteHistoryButton = findViewById(R.id.deleteLogHistoryButton);
         Button sendHistoryButton = findViewById(R.id.sendLogHistoryButton);
-        sendHistoryButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+        sendHistoryButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
         TextView logTV = findViewById(R.id.logTV);
 
         deleteHistoryButton.setOnClickListener(new OnClickListener() {

--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -101,12 +101,12 @@ public class ManageAccountsActivity extends FileActivity
         super.onCreate(savedInstanceState);
 
         mTintedCheck = DrawableCompat.wrap(ContextCompat.getDrawable(this, R.drawable.ic_account_circle_white_18dp));
-        int tint = ThemeUtils.primaryColor();
+        int tint = ThemeUtils.primaryColor(this);
         DrawableCompat.setTint(mTintedCheck, tint);
 
         setContentView(R.layout.accounts_layout);
 
-        mListView = (ListView) findViewById(R.id.account_list);
+        mListView = findViewById(R.id.account_list);
 
         setupToolbar();
         updateActionBarTitleAndHomeButtonByString(getResources().getString(R.string.prefs_manage_accounts));

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -136,7 +136,7 @@ public class NotificationsActivity extends FileActivity {
 
         // setup drawer
         setupDrawer(R.id.nav_notifications);
-        ThemeUtils.setColoredTitle(getSupportActionBar(), getString(R.string.drawer_item_notifications));
+        ThemeUtils.setColoredTitle(getSupportActionBar(), getString(R.string.drawer_item_notifications), this);
 
         swipeListRefreshLayout.setOnRefreshListener(() -> {
             setLoadingMessage();
@@ -227,7 +227,7 @@ public class NotificationsActivity extends FileActivity {
      */
     private void setupContent() {
         emptyContentIcon.setImageResource(R.drawable.ic_notification_light_grey);
-        emptyContentProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(),
+        emptyContentProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(this),
                 PorterDuff.Mode.SRC_IN);
         setLoadingMessage();
 

--- a/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
@@ -58,7 +58,7 @@ public class ParticipateActivity extends FileActivity {
 
         if (getSupportActionBar() != null) {
             getSupportActionBar().setTitle(ThemeUtils.getColoredTitle(getString(R.string.drawer_participate),
-                    ThemeUtils.fontColor()));
+                    ThemeUtils.fontColor(this)));
         }
 
         setupContent();
@@ -71,43 +71,43 @@ public class ParticipateActivity extends FileActivity {
     }
 
     private void setupContent() {
-        TextView rcView = (TextView) findViewById(R.id.participate_release_candidate_text);
+        TextView rcView = findViewById(R.id.participate_release_candidate_text);
         rcView.setMovementMethod(LinkMovementMethod.getInstance());
 
-        TextView contributeIrcView = (TextView) findViewById(R.id.participate_contribute_irc_text);
+        TextView contributeIrcView = findViewById(R.id.participate_contribute_irc_text);
         contributeIrcView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeIrcView.setText(Html.fromHtml(getString(R.string.participate_contribute_irc_text) + " " +
                 getString(R.string.participate_contribute_irc_text_link,
-                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor()),
+                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this)),
                         getString(R.string.irc_weblink))));
 
-        TextView contributeForumView = (TextView) findViewById(R.id.participate_contribute_forum_text);
+        TextView contributeForumView = findViewById(R.id.participate_contribute_forum_text);
         contributeForumView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeForumView.setText(Html.fromHtml(getString(R.string.participate_contribute_forum_text) + " " +
                 getString(R.string.participate_contribute_forum_text_link,
-                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor()),
+                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this)),
                         getString(R.string.help_link), getString(R.string.participate_contribute_forum_forum))));
 
-        TextView contributeTranslationView = (TextView) findViewById(R.id.participate_contribute_translate_text);
+        TextView contributeTranslationView = findViewById(R.id.participate_contribute_translate_text);
         contributeTranslationView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeTranslationView.setText(Html.fromHtml(
                 getString(R.string.participate_contribute_translate_link,
-                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor()),
+                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this)),
                         getString(R.string.translation_link),
                         getString(R.string.participate_contribute_translate_translate)) + " " +
                         getString(R.string.participate_contribute_translate_text)));
 
-        TextView contributeGithubView = (TextView) findViewById(R.id.participate_contribute_github_text);
+        TextView contributeGithubView = findViewById(R.id.participate_contribute_github_text);
         contributeGithubView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeGithubView.setText(Html.fromHtml(
                 getString(R.string.participate_contribute_github_text,
                         getString(R.string.participate_contribute_github_text_link,
-                                ThemeUtils.colorToHexString(ThemeUtils.primaryColor()),
+                                ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this)),
                                 getString(R.string.contributing_link)))));
 
-        AppCompatButton reportButton = (AppCompatButton) findViewById(R.id.participate_testing_report);
-        reportButton.getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
-        reportButton.setTextColor(ThemeUtils.fontColor());
+        AppCompatButton reportButton = findViewById(R.id.participate_testing_report);
+        reportButton.getBackground().setColorFilter(ThemeUtils.primaryColor(this), PorterDuff.Mode.SRC_ATOP);
+        reportButton.setTextColor(ThemeUtils.fontColor(this));
         reportButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -92,31 +92,32 @@ public class PassCodeActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.passcodelock);
-        
-        mBCancel = (Button) findViewById(R.id.cancel);
-        mBCancel.getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
 
-        mPassCodeHdr = (TextView) findViewById(R.id.header);
-        mPassCodeHdrExplanation = (TextView) findViewById(R.id.explanation);
+        int primaryColor = ThemeUtils.primaryColor(this);
 
-        mPassCodeEditTexts[0] = (EditText) findViewById(R.id.txt0);
-        mPassCodeEditTexts[0].setTextColor(ThemeUtils.primaryColor());
-        mPassCodeEditTexts[0].getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
+        mBCancel = findViewById(R.id.cancel);
+        mBCancel.getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_ATOP);
+
+        mPassCodeHdr = findViewById(R.id.header);
+        mPassCodeHdrExplanation = findViewById(R.id.explanation);
+
+        mPassCodeEditTexts[0] = findViewById(R.id.txt0);
+        mPassCodeEditTexts[0].setTextColor(primaryColor);
+        mPassCodeEditTexts[0].getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_ATOP);
         mPassCodeEditTexts[0].requestFocus();
-        getWindow().setSoftInputMode(
-                android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        getWindow().setSoftInputMode(android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
 
-        mPassCodeEditTexts[1] = (EditText) findViewById(R.id.txt1);
-        mPassCodeEditTexts[1].setTextColor(ThemeUtils.primaryColor());
-        mPassCodeEditTexts[1].getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
+        mPassCodeEditTexts[1] = findViewById(R.id.txt1);
+        mPassCodeEditTexts[1].setTextColor(primaryColor);
+        mPassCodeEditTexts[1].getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_ATOP);
 
-        mPassCodeEditTexts[2] = (EditText) findViewById(R.id.txt2);
-        mPassCodeEditTexts[2].setTextColor(ThemeUtils.primaryColor());
-        mPassCodeEditTexts[2].getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
+        mPassCodeEditTexts[2] = findViewById(R.id.txt2);
+        mPassCodeEditTexts[2].setTextColor(primaryColor);
+        mPassCodeEditTexts[2].getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_ATOP);
 
-        mPassCodeEditTexts[3] = (EditText) findViewById(R.id.txt3);
-        mPassCodeEditTexts[3].setTextColor(ThemeUtils.primaryColor());
-        mPassCodeEditTexts[3].getBackground().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_ATOP);
+        mPassCodeEditTexts[3] = findViewById(R.id.txt3);
+        mPassCodeEditTexts[3].setTextColor(primaryColor);
+        mPassCodeEditTexts[3].getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_ATOP);
 
         if (ACTION_CHECK.equals(getIntent().getAction())) {
             /// this is a pass code request; the user has to input the right value

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -124,7 +124,7 @@ public class Preferences extends PreferenceActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
 
-        if (ThemeUtils.themingEnabled()) {
+        if (ThemeUtils.themingEnabled(this)) {
             setTheme(R.style.FallbackThemingTheme);
         }
 
@@ -141,7 +141,7 @@ public class Preferences extends PreferenceActivity
         // Register context menu for list of preferences.
         registerForContextMenu(getListView());
 
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(this);
         String appVersion = getAppVersion();
         PreferenceScreen preferenceScreen = (PreferenceScreen) findPreference("preference_screen");
 
@@ -748,17 +748,17 @@ public class Preferences extends PreferenceActivity
     private void setupActionBar() {
         ActionBar actionBar = getDelegate().getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
-        ThemeUtils.setColoredTitle(actionBar, getString(R.string.actionbar_settings));
-        actionBar.setBackgroundDrawable(new ColorDrawable(ThemeUtils.primaryColor()));
+        ThemeUtils.setColoredTitle(actionBar, getString(R.string.actionbar_settings), this);
+        actionBar.setBackgroundDrawable(new ColorDrawable(ThemeUtils.primaryColor(this)));
         getWindow().getDecorView().setBackgroundDrawable(new ColorDrawable(ResourcesCompat
                 .getColor(getResources(), R.color.background_color, null)));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().setStatusBarColor(ThemeUtils.primaryDarkColor());
+            getWindow().setStatusBarColor(ThemeUtils.primaryDarkColor(this));
         }
 
         Drawable backArrow = getResources().getDrawable(R.drawable.ic_arrow_back);
-        actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor()));
+        actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor(this)));
 
         // For adding content description tag to a title field in the action bar
         int actionBarTitleId = getResources().getIdentifier("action_bar_title", "id", "android");

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -291,7 +291,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
             mTintedCheck = DrawableCompat.wrap(ContextCompat.getDrawable(parent,
                     R.drawable.ic_account_circle_white_18dp));
-            int tint = ThemeUtils.primaryColor();
+            int tint = ThemeUtils.primaryColor(getContext());
             DrawableCompat.setTint(mTintedCheck, tint);
 
             mAccountListAdapter = new AccountListAdapter(parent, getAccountListItems(parent), mTintedCheck);
@@ -766,17 +766,17 @@ public class ReceiveExternalFilesActivity extends FileActivity
             }
             Button btnChooseFolder = findViewById(R.id.uploader_choose_folder);
                 btnChooseFolder.setOnClickListener(this);
-                btnChooseFolder.getBackground().setColorFilter(ThemeUtils.primaryColor(getAccount()),
+            btnChooseFolder.getBackground().setColorFilter(ThemeUtils.primaryColor(getAccount(), this),
                         PorterDuff.Mode.SRC_ATOP);
 
             if (getSupportActionBar() != null) {
                 getSupportActionBar().setBackgroundDrawable(new ColorDrawable(
-                        ThemeUtils.primaryColor(getAccount())));
+                        ThemeUtils.primaryColor(getAccount(), this)));
             }
 
-                ThemeUtils.colorStatusBar(this, ThemeUtils.primaryDarkColor(getAccount()));
+            ThemeUtils.colorStatusBar(this, ThemeUtils.primaryDarkColor(getAccount(), this));
 
-                ThemeUtils.colorToolbarProgressBar(this, ThemeUtils.primaryColor(getAccount()));
+            ThemeUtils.colorToolbarProgressBar(this, ThemeUtils.primaryColor(getAccount(), this));
 
             Button btnNewFolder = findViewById(R.id.uploader_cancel);
                 btnNewFolder.setOnClickListener(this);
@@ -791,7 +791,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         mEmptyListHeadline = findViewById(R.id.empty_list_view_headline);
         mEmptyListIcon = findViewById(R.id.empty_list_icon);
         mEmptyListProgress = findViewById(R.id.empty_list_progress);
-        mEmptyListProgress.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(),
+        mEmptyListProgress.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(this),
                 PorterDuff.Mode.SRC_IN);
     }
 
@@ -801,7 +801,9 @@ public class ReceiveExternalFilesActivity extends FileActivity
             if (mEmptyListContainer != null && mEmptyListMessage != null) {
                 mEmptyListHeadline.setText(headline);
                 mEmptyListMessage.setText(message);
-                mEmptyListIcon.setImageResource(icon);
+
+                mEmptyListIcon.setImageDrawable(ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(this)));
+
                 mEmptyListIcon.setVisibility(View.VISIBLE);
                 mEmptyListProgress.setVisibility(View.GONE);
                 mEmptyListMessage.setVisibility(View.VISIBLE);

--- a/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
@@ -151,11 +151,11 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            ThemeUtils.setColoredTitle(getSupportActionBar(), getString(R.string.drawer_synced_folders));
+            ThemeUtils.setColoredTitle(getSupportActionBar(), getString(R.string.drawer_synced_folders), this);
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        if (ThemeUtils.themingEnabled()) {
+        if (ThemeUtils.themingEnabled(this)) {
             setTheme(R.style.FallbackThemingTheme);
         }
     }

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -51,29 +51,33 @@ public abstract class ToolbarActivity extends BaseActivity {
      * want to use the toolbar.
      */
     protected void setupToolbar(boolean useBackgroundImage) {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        int primaryColor = ThemeUtils.primaryColor(this);
+        int primaryDarkColor = ThemeUtils.primaryDarkColor(this);
+        int fontColor = ThemeUtils.fontColor(this);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        mProgressBar = (ProgressBar) findViewById(R.id.progressBar);
+        mProgressBar = findViewById(R.id.progressBar);
         if (mProgressBar != null) {
             mProgressBar.setIndeterminateDrawable(
                     ContextCompat.getDrawable(this, R.drawable.actionbar_progress_indeterminate_horizontal));
 
-            ThemeUtils.colorToolbarProgressBar(this, ThemeUtils.primaryColor());
+            ThemeUtils.colorToolbarProgressBar(this, ThemeUtils.primaryColor(this));
         }
 
-        ThemeUtils.colorStatusBar(this, ThemeUtils.primaryDarkColor());
+        ThemeUtils.colorStatusBar(this, primaryDarkColor);
 
         if (toolbar.getOverflowIcon() != null) {
-            ThemeUtils.tintDrawable(toolbar.getOverflowIcon(), ThemeUtils.fontColor());
+            ThemeUtils.tintDrawable(toolbar.getOverflowIcon(), fontColor);
         }
 
         if (toolbar.getNavigationIcon() != null) {
-            ThemeUtils.tintDrawable(toolbar.getNavigationIcon(), ThemeUtils.fontColor());
+            ThemeUtils.tintDrawable(toolbar.getNavigationIcon(), fontColor);
         }
 
         if (!useBackgroundImage) {
-            toolbar.setBackgroundColor(ThemeUtils.primaryColor());
+            toolbar.setBackgroundColor(primaryColor);
         }
     }
 
@@ -85,7 +89,7 @@ public abstract class ToolbarActivity extends BaseActivity {
      * Updates title bar and home buttons (state and icon).
      */
     protected void updateActionBarTitleAndHomeButton(OCFile chosenFile) {
-        String title = ThemeUtils.getDefaultDisplayNameForRootFolder();    // default
+        String title = ThemeUtils.getDefaultDisplayNameForRootFolder(this);    // default
         boolean inRoot;
 
         // choose the appropriate title
@@ -112,7 +116,7 @@ public abstract class ToolbarActivity extends BaseActivity {
 
         // set & color the chosen title
         ActionBar actionBar = getSupportActionBar();
-        ThemeUtils.setColoredTitle(actionBar, titleToSet);
+        ThemeUtils.setColoredTitle(actionBar, titleToSet, this);
 
         // set home button properties
         if (actionBar != null) {
@@ -120,9 +124,9 @@ public abstract class ToolbarActivity extends BaseActivity {
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         if (toolbar != null && toolbar.getNavigationIcon() != null) {
-            ThemeUtils.tintDrawable(toolbar.getNavigationIcon(), ThemeUtils.fontColor());
+            ThemeUtils.tintDrawable(toolbar.getNavigationIcon(), ThemeUtils.fontColor(this));
         }
     }
 
@@ -133,8 +137,7 @@ public abstract class ToolbarActivity extends BaseActivity {
      * @return <code>true</code> if it is <code>null</code> or the root folder, else returns <code>false</code>
      */
     public boolean isRoot(OCFile file) {
-        return file == null ||
-                (file.isFolder() && file.getParentId() == FileDataStorageManager.ROOT_PARENT_ID);
+        return file == null || (file.isFolder() && file.getParentId() == FileDataStorageManager.ROOT_PARENT_ID);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -165,7 +165,7 @@ public class UploadFilesActivity extends FileActivity implements
 
         List<String> behaviours = new ArrayList<>();
         behaviours.add(getString(R.string.uploader_upload_files_behaviour_move_to_nextcloud_folder,
-                ThemeUtils.getDefaultDisplayNameForRootFolder()));
+                ThemeUtils.getDefaultDisplayNameForRootFolder(this)));
         behaviours.add(getString(R.string.uploader_upload_files_behaviour_only_upload));
         behaviours.add(getString(R.string.uploader_upload_files_behaviour_upload_and_delete_from_source));
 

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -155,7 +155,7 @@ public class UploadFilesActivity extends FileActivity implements
         findViewById(R.id.upload_files_btn_cancel).setOnClickListener(this);
 
         mUploadBtn = (AppCompatButton) findViewById(R.id.upload_files_btn_upload);
-        mUploadBtn.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+        mUploadBtn.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
         mUploadBtn.setOnClickListener(this);
 
         int localBehaviour = PreferenceManager.getUploaderBehaviour(this);
@@ -366,7 +366,7 @@ public class UploadFilesActivity extends FileActivity implements
         if(checked) {
             selectAll.setIcon(R.drawable.ic_select_none);
         } else {
-            selectAll.setIcon(ThemeUtils.tintDrawable(R.drawable.ic_select_all, ThemeUtils.primaryColor()));
+            selectAll.setIcon(ThemeUtils.tintDrawable(R.drawable.ic_select_all, ThemeUtils.primaryColor(this)));
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -342,7 +342,7 @@ public class UserInfoActivity extends FileActivity {
         public void onStart() {
             super.onStart();
 
-            int color = ThemeUtils.primaryAccentColor(getContext());
+            int color = ThemeUtils.primaryAccentColor(getActivity());
 
             AlertDialog alertDialog = (AlertDialog) getDialog();
 

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -147,7 +147,7 @@ public class UserInfoActivity extends FileActivity {
         setupToolbar(useBackgroundImage);
         updateActionBarTitleAndHomeButtonByString("");
 
-        mUserInfoList.setAdapter(new UserInfoAdapter(null, ThemeUtils.primaryColor(getAccount())));
+        mUserInfoList.setAdapter(new UserInfoAdapter(null, ThemeUtils.primaryColor(getAccount(), this)));
         mUserInfoList.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
 
         if (userInfo != null) {
@@ -197,7 +197,7 @@ public class UserInfoActivity extends FileActivity {
 
             emptyContentIcon.setVisibility(View.GONE);
             emptyContentMessage.setVisibility(View.GONE);
-            multiListProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(),
+            multiListProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(this),
                     PorterDuff.Mode.SRC_IN);
             multiListProgressBar.setVisibility(View.VISIBLE);
         }
@@ -223,7 +223,7 @@ public class UserInfoActivity extends FileActivity {
                 ImageView backgroundImageView = appBar.findViewById(R.id.drawer_header_background);
 
                 String background = getStorageManager().getCapability(account.name).getServerBackground();
-                int primaryColor = ThemeUtils.primaryColor(getAccount());
+                int primaryColor = ThemeUtils.primaryColor(getAccount(), this);
 
                 if (URLUtil.isValidUrl(background)) {
                     // background image
@@ -265,7 +265,7 @@ public class UserInfoActivity extends FileActivity {
         DisplayUtils.setAvatar(account, UserInfoActivity.this, mCurrentAccountAvatarRadiusDimension, getResources(),
                 getStorageManager(), avatar);
 
-        int tint = ThemeUtils.primaryColor(account);
+        int tint = ThemeUtils.primaryColor(account, this);
 
         if (!TextUtils.isEmpty(userInfo.getDisplayName())) {
             fullName.setText(userInfo.getDisplayName());
@@ -342,7 +342,7 @@ public class UserInfoActivity extends FileActivity {
         public void onStart() {
             super.onStart();
 
-            int color = ThemeUtils.primaryAccentColor();
+            int color = ThemeUtils.primaryAccentColor(getContext());
 
             AlertDialog alertDialog = (AlertDialog) getDialog();
 

--- a/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
@@ -82,7 +82,7 @@ public class WhatsNewActivity extends FragmentActivity implements ViewPager.OnPa
         super.onCreate(savedInstanceState);
         setContentView(R.layout.whats_new_activity);
 
-        int fontColor = ThemeUtils.fontColor();
+        int fontColor = ThemeUtils.fontColor(this);
 
         mProgress = findViewById(R.id.progressIndicator);
         mPager = findViewById(R.id.contentPanel);
@@ -336,7 +336,7 @@ public class WhatsNewActivity extends FragmentActivity implements ViewPager.OnPa
                                  @Nullable ViewGroup container,
                                  @Nullable Bundle savedInstanceState) {
             View v = inflater.inflate(R.layout.whats_new_element, container, false);
-            int fontColor = ThemeUtils.fontColor();
+            int fontColor = ThemeUtils.fontColor(getContext());
 
             ImageView iv = v.findViewById(R.id.whatsNewImage);
             if (mItem.shouldShowImage()) {

--- a/src/main/java/com/owncloud/android/ui/adapter/AccountListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/AccountListAdapter.java
@@ -72,11 +72,11 @@ public class AccountListAdapter extends ArrayAdapter<AccountListItem> implements
             view = inflater.inflate(R.layout.account_item, parent, false);
 
             viewHolder = new AccountViewHolderItem();
-            viewHolder.imageViewItem = (ImageView) view.findViewById(R.id.user_icon);
-            viewHolder.checkViewItem = (ImageView) view.findViewById(R.id.ticker);
+            viewHolder.imageViewItem = view.findViewById(R.id.user_icon);
+            viewHolder.checkViewItem = view.findViewById(R.id.ticker);
             viewHolder.checkViewItem.setImageDrawable(mTintedCheck);
-            viewHolder.usernameViewItem = (TextView) view.findViewById(R.id.user_name);
-            viewHolder.accountViewItem = (TextView) view.findViewById(R.id.account);
+            viewHolder.usernameViewItem = view.findViewById(R.id.user_name);
+            viewHolder.accountViewItem = view.findViewById(R.id.account);
 
             view.setTag(viewHolder);
         } else {
@@ -119,9 +119,9 @@ public class AccountListAdapter extends ArrayAdapter<AccountListItem> implements
         LayoutInflater inflater = mContext.getLayoutInflater();
         View actionView = inflater.inflate(R.layout.account_action, parent, false);
 
-        TextView userName = (TextView) actionView.findViewById(R.id.user_name);
+        TextView userName = actionView.findViewById(R.id.user_name);
         userName.setText(R.string.prefs_add_account);
-        userName.setTextColor(ThemeUtils.primaryColor());
+        userName.setTextColor(ThemeUtils.primaryColor(getContext()));
 
         ((ImageView) actionView.findViewById(R.id.user_icon)).setImageResource(R.drawable.ic_account_plus);
 

--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -260,7 +260,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             // Folder
             fileIcon.setImageDrawable(
                     MimeTypeUtil.getFolderTypeIcon(file.isSharedWithMe() || file.isSharedWithSharee(),
-                            file.isSharedViaLink(), file.isEncrypted(), file.getMountType()));
+                            file.isSharedViaLink(), file.isEncrypted(), file.getMountType(), context));
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -177,7 +177,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
                     gridViewHolder.itemLayout.setBackgroundColor(mContext.getResources()
                             .getColor(R.color.selected_item_background));
                     gridViewHolder.checkbox.setImageDrawable(ThemeUtils.tintDrawable(R.drawable.ic_checkbox_marked,
-                            ThemeUtils.primaryColor()));
+                            ThemeUtils.primaryColor(mContext)));
                 } else {
                     gridViewHolder.itemLayout.setBackgroundColor(Color.WHITE);
                     gridViewHolder.checkbox.setImageResource(R.drawable.ic_checkbox_blank_outline);
@@ -225,7 +225,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     private void setThumbnail(File file, ImageView thumbnailView) {
         if (file.isDirectory()) {
-            thumbnailView.setImageDrawable(MimeTypeUtil.getDefaultFolderIcon());
+            thumbnailView.setImageDrawable(MimeTypeUtil.getDefaultFolderIcon(mContext));
         } else {
             thumbnailView.setImageResource(R.drawable.file);
 

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -262,7 +262,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 gridViewHolder.itemLayout.setBackgroundColor(mContext.getResources()
                         .getColor(R.color.selected_item_background));
                 gridViewHolder.checkbox.setImageDrawable(ThemeUtils.tintDrawable(R.drawable.ic_checkbox_marked,
-                        ThemeUtils.primaryColor()));
+                        ThemeUtils.primaryColor(mContext)));
             } else {
                 gridViewHolder.itemLayout.setBackgroundColor(Color.WHITE);
                 gridViewHolder.checkbox.setImageResource(R.drawable.ic_checkbox_blank_outline);
@@ -354,7 +354,8 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private void setThumbnail(OCFile file, ImageView thumbnailView) {
         if (file.isFolder()) {
             thumbnailView.setImageDrawable(MimeTypeUtil.getFolderTypeIcon(file.isSharedWithMe() ||
-                    file.isSharedWithSharee(), file.isSharedViaLink(), file.isEncrypted(), file.getMountType()));
+                            file.isSharedWithSharee(), file.isSharedViaLink(), file.isEncrypted(), file.getMountType(),
+                    mContext));
         } else {
             if ((MimeTypeUtil.isImage(file) || MimeTypeUtil.isVideo(file)) && file.getRemoteId() != null) {
                 // Thumbnail in cache?
@@ -402,7 +403,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 }
             } else {
                 thumbnailView.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(),
-                        mAccount));
+                        mAccount, mContext));
             }
         }
     }

--- a/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.java
@@ -162,7 +162,7 @@ public class SyncedFolderAdapter extends SectionedRecyclerViewAdapter<SyncedFold
             File file = new File(mSyncFolderItems.get(section).getFilePaths().get(relativePosition));
 
             ThumbnailsCacheManager.MediaThumbnailGenerationTask task =
-                    new ThumbnailsCacheManager.MediaThumbnailGenerationTask(holder.image);
+                    new ThumbnailsCacheManager.MediaThumbnailGenerationTask(holder.image, mContext);
 
             ThumbnailsCacheManager.AsyncMediaThumbnailDrawable asyncDrawable =
                     new ThumbnailsCacheManager.AsyncMediaThumbnailDrawable(
@@ -249,7 +249,7 @@ public class SyncedFolderAdapter extends SectionedRecyclerViewAdapter<SyncedFold
     private void setSyncButtonActiveIcon(ImageButton syncStatusButton, boolean enabled) {
         if (enabled) {
             syncStatusButton.setImageDrawable(ThemeUtils.tintDrawable(R.drawable.ic_cloud_sync_on,
-                    ThemeUtils.primaryColor()));
+                    ThemeUtils.primaryColor(mContext)));
         } else {
             syncStatusButton.setImageResource(R.drawable.ic_cloud_sync_off);
         }

--- a/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -93,7 +93,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
         headerViewHolder.title.setText(String.format(mParentActivity.getString(R.string.uploads_view_group_header),
                 group.getGroupName(), group.getGroupItemCount()));
-        headerViewHolder.title.setTextColor(ThemeUtils.primaryAccentColor());
+        headerViewHolder.title.setTextColor(ThemeUtils.primaryAccentColor(mParentActivity));
     }
 
     @Override
@@ -190,7 +190,8 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         String status = getStatusText(item);
         switch (item.getUploadStatus()) {
             case UPLOAD_IN_PROGRESS:
-                ThemeUtils.colorHorizontalProgressBar(itemViewHolder.progressBar, ThemeUtils.primaryAccentColor());
+                ThemeUtils.colorHorizontalProgressBar(itemViewHolder.progressBar,
+                        ThemeUtils.primaryAccentColor(mParentActivity));
                 itemViewHolder.progressBar.setProgress(0);
                 itemViewHolder.progressBar.setVisibility(View.VISIBLE);
 
@@ -382,7 +383,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             }
         } else {
             itemViewHolder.thumbnail.setImageDrawable(MimeTypeUtil.getFileTypeIcon(item.getMimeType(), fileName,
-                    account));
+                    account, mParentActivity));
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/adapter/UploaderAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UploaderAdapter.java
@@ -94,7 +94,7 @@ public class UploaderAdapter extends SimpleAdapter {
         if (file.isFolder()) {
             fileIcon.setImageDrawable(MimeTypeUtil.getFolderTypeIcon(file.isSharedWithMe() ||
                             file.isSharedWithSharee(), file.isSharedViaLink(), file.isEncrypted(), mAccount,
-                    file.getMountType()));
+                    file.getMountType(), mContext));
         } else {
             // get Thumbnail if file is image
             if (MimeTypeUtil.isImage(file) && file.getRemoteId() != null) {
@@ -128,7 +128,7 @@ public class UploaderAdapter extends SimpleAdapter {
                 }
             } else {
                 fileIcon.setImageDrawable(
-                        MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), mAccount)
+                        MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), mAccount, mContext)
                 );
             }
         }

--- a/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -24,6 +24,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
@@ -72,25 +73,26 @@ public class CreateFolderDialogFragment
     public void onStart() {
         super.onStart();
 
-        int color = ThemeUtils.primaryAccentColor();
+        int color = ThemeUtils.primaryAccentColor(getContext());
 
         AlertDialog alertDialog = (AlertDialog) getDialog();
 
         alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(color);
         alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(color);
     }
-    
+
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
         mParentFolder = getArguments().getParcelable(ARG_PARENT_FOLDER);
-        
+
         // Inflate the layout for the dialog
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View v = inflater.inflate(R.layout.edit_box_dialog, null);
-        
+
         // Setup layout 
-        EditText inputText = ((EditText)v.findViewById(R.id.user_input));
+        EditText inputText = v.findViewById(R.id.user_input);
         inputText.setText("");
         inputText.requestFocus();
         inputText.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
@@ -98,8 +100,8 @@ public class CreateFolderDialogFragment
         // Build the dialog  
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setView(v)
-               .setPositiveButton(R.string.common_ok, this)
-               .setNegativeButton(R.string.common_cancel, this)
+                .setPositiveButton(R.string.common_ok, this)
+                .setNegativeButton(R.string.common_cancel, this)
                 .setTitle(ThemeUtils.getColoredTitle(getResources().getString(R.string.uploader_info_dirname),
                         accentColor));
         Dialog d = builder.create();

--- a/src/main/java/com/owncloud/android/ui/dialog/IndeterminateProgressDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/IndeterminateProgressDialog.java
@@ -24,6 +24,7 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnKeyListener;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.view.KeyEvent;
 import android.widget.ProgressBar;
@@ -59,6 +60,7 @@ public class IndeterminateProgressDialog extends DialogFragment {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         /// create indeterminate progress dialog
@@ -67,8 +69,8 @@ public class IndeterminateProgressDialog extends DialogFragment {
         progressDialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
             public void onShow(DialogInterface dialog) {
-                ProgressBar v = (ProgressBar) progressDialog.findViewById(android.R.id.progress);
-                v.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(),
+                ProgressBar v = progressDialog.findViewById(android.R.id.progress);
+                v.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
                         android.graphics.PorterDuff.Mode.MULTIPLY);
 
             }

--- a/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
@@ -21,6 +21,7 @@ package com.owncloud.android.ui.dialog;
 import android.app.Dialog;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -59,17 +60,18 @@ public class LoadingDialog extends DialogFragment {
         View v = inflater.inflate(R.layout.loading_dialog, container,  false);
         
         // set value
-        TextView tv  = (TextView) v.findViewById(R.id.loadingText);
+        TextView tv = v.findViewById(R.id.loadingText);
         tv.setText(mMessage);
 
         // set progress wheel color
-        ProgressBar progressBar  = (ProgressBar) v.findViewById(R.id.loadingBar);
-        progressBar.getIndeterminateDrawable().setColorFilter(
-                ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_IN);
+        ProgressBar progressBar = v.findViewById(R.id.loadingBar);
+        progressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
+                PorterDuff.Mode.SRC_IN);
         
         return v;
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         Dialog dialog = super.onCreateDialog(savedInstanceState);

--- a/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -30,6 +30,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
@@ -77,7 +78,7 @@ public class RenameFileDialogFragment
     public void onStart() {
         super.onStart();
 
-        int color = ThemeUtils.primaryAccentColor();
+        int color = ThemeUtils.primaryAccentColor(getContext());
 
         AlertDialog alertDialog = (AlertDialog) getDialog();
 
@@ -85,35 +86,36 @@ public class RenameFileDialogFragment
         alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(color);
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
         mTargetFile = getArguments().getParcelable(ARG_TARGET_FILE);
 
         // Inflate the layout for the dialog
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View v = inflater.inflate(R.layout.edit_box_dialog, null);
-        
+
         // Setup layout 
         String currentName = mTargetFile.getFileName();
-        EditText inputText = ((EditText)v.findViewById(R.id.user_input));
+        EditText inputText = v.findViewById(R.id.user_input);
         inputText.setText(currentName);
         int selectionStart = 0;
         int extensionStart = mTargetFile.isFolder() ? -1 : currentName.lastIndexOf('.');
         int selectionEnd = (extensionStart >= 0) ? extensionStart : currentName.length();
         if (selectionStart >= 0 && selectionEnd >= 0) {
             inputText.setSelection(
-                    Math.min(selectionStart, selectionEnd), 
+                    Math.min(selectionStart, selectionEnd),
                     Math.max(selectionStart, selectionEnd));
         }
         inputText.requestFocus();
         inputText.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
-        
+
         // Build the dialog  
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setView(v)
-               .setPositiveButton(R.string.common_ok, this)
-               .setNegativeButton(R.string.common_cancel, this)
+                .setPositiveButton(R.string.common_ok, this)
+                .setNegativeButton(R.string.common_cancel, this)
                 .setTitle(ThemeUtils.getColoredTitle(getResources().getString(R.string.rename_dialog_title),
                         accentColor));
         Dialog d = builder.create();

--- a/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.java
@@ -146,8 +146,9 @@ public class SendShareDialog extends BottomSheetDialogFragment {
     }
 
     private void themeShareButtonImage(ImageView shareImageView) {
-        shareImageView.getBackground().setColorFilter(ThemeUtils.elementColor(), PorterDuff.Mode.SRC_IN);
-        shareImageView.getDrawable().mutate().setColorFilter(ThemeUtils.fontColor(), PorterDuff.Mode.SRC_IN);
+        shareImageView.getBackground().setColorFilter(ThemeUtils.elementColor(getContext()), PorterDuff.Mode.SRC_IN);
+        shareImageView.getDrawable().mutate().setColorFilter(ThemeUtils.fontColor(getContext()),
+                PorterDuff.Mode.SRC_IN);
     }
 
     private void showResharingNotAllowedSnackbar() {

--- a/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -28,6 +28,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.AlertDialog;
@@ -106,7 +107,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
     public void onStart() {
         super.onStart();
 
-        int color = ThemeUtils.primaryAccentColor();
+        int color = ThemeUtils.primaryAccentColor(getContext());
 
         AlertDialog alertDialog = (AlertDialog) getDialog();
 
@@ -120,9 +121,10 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
         task.execute();
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
         account = getArguments().getParcelable(ARG_ACCOUNT);
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
@@ -207,12 +209,13 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
                                 positiveButton.setVisibility(View.GONE);
                                 negativeButton.setVisibility(View.GONE);
                                 getDialog().setTitle(ThemeUtils.getColoredTitle(getString(
-                                        R.string.end_to_end_encryption_storing_keys), ThemeUtils.primaryColor()));
+                                        R.string.end_to_end_encryption_storing_keys),
+                                        ThemeUtils.primaryColor(getContext())));
 
                                 GenerateNewKeysAsyncTask newKeysTask = new GenerateNewKeysAsyncTask();
                                 newKeysTask.execute();
                                 break;
-                            
+
                             default:
                                 dialog.dismiss();
                                 break;
@@ -292,7 +295,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
 
                     getDialog().setTitle(ThemeUtils.getColoredTitle(
                             getString(R.string.end_to_end_encryption_passphrase_title),
-                            ThemeUtils.primaryColor()));
+                            ThemeUtils.primaryColor(getContext())));
 
                     textView.setText(R.string.end_to_end_encryption_keywords_description);
 
@@ -418,7 +421,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
                 keyResult = KEY_FAILED;
 
                 getDialog().setTitle(ThemeUtils.getColoredTitle(
-                        getString(R.string.common_error), ThemeUtils.primaryColor()));
+                        getString(R.string.common_error), ThemeUtils.primaryColor(getContext())));
                 textView.setText(R.string.end_to_end_encryption_unsuccessful);
                 positiveButton.setText(R.string.end_to_end_encryption_dialog_close);
                 positiveButton.setVisibility(View.VISIBLE);

--- a/src/main/java/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.java
@@ -22,6 +22,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
@@ -57,8 +58,8 @@ public class SharePasswordDialogFragment extends DialogFragment
         super.onStart();
 
         AlertDialog alertDialog = (AlertDialog) getDialog();
-        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(ThemeUtils.primaryAccentColor());
-        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ThemeUtils.primaryAccentColor());
+        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(ThemeUtils.primaryAccentColor(getContext()));
+        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ThemeUtils.primaryAccentColor(getContext()));
     }
 
     /**
@@ -79,6 +80,7 @@ public class SharePasswordDialogFragment extends DialogFragment
         return frag;
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         mFile = getArguments().getParcelable(ARG_FILE);
@@ -89,8 +91,8 @@ public class SharePasswordDialogFragment extends DialogFragment
         View v = inflater.inflate(R.layout.password_dialog, null);
 
         // Setup layout
-        EditText inputText = ((EditText)v.findViewById(R.id.share_password));
-        inputText.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+        EditText inputText = v.findViewById(R.id.share_password);
+        inputText.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(getContext()), PorterDuff.Mode.SRC_ATOP);
         inputText.setText("");
         inputText.requestFocus();
 
@@ -98,9 +100,9 @@ public class SharePasswordDialogFragment extends DialogFragment
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(),
                 R.style.Theme_ownCloud_Dialog_NoButtonBarStyle);
         builder.setView(v)
-               .setPositiveButton(R.string.common_ok, this)
-               .setNegativeButton(R.string.common_cancel, this)
-               .setTitle(R.string.share_link_password_title);
+                .setPositiveButton(R.string.common_ok, this)
+                .setNegativeButton(R.string.common_cancel, this)
+                .setTitle(R.string.share_link_password_title);
         Dialog d = builder.create();
         d.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         return d;

--- a/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
@@ -94,7 +94,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
      */
     private void setupDialogElements(View view) {
         mCancel = view.findViewById(R.id.cancel);
-        mCancel.setTextColor(ThemeUtils.primaryAccentColor());
+        mCancel.setTextColor(ThemeUtils.primaryAccentColor(getContext()));
 
         mTaggedViews = new View[12];
         mTaggedViews[0] = view.findViewById(R.id.sortByNameAscending);
@@ -129,7 +129,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
      * tints the icon reflecting the actual sorting choice in the apps primary color.
      */
     private void setupActiveOrderSelection() {
-        final int color = ThemeUtils.primaryAccentColor();
+        final int color = ThemeUtils.primaryAccentColor(getContext());
         for (View view: mTaggedViews) {
             if (!((FileSortOrder)view.getTag()).mName.equals(mCurrentSortOrderName)) {
                 continue;

--- a/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -136,7 +136,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
      * @param view the parent view
      */
     private void setupDialogElements(View view) {
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
 
         if (mSyncedFolder.getType().getId() > MediaFolderType.CUSTOM.getId()) {
             // hide local folder chooser and delete for non-custom folders
@@ -164,12 +164,12 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         mEnabledSwitch = view.findViewById(R.id.sync_enabled);
         ThemeUtils.tintSwitch(mEnabledSwitch, accentColor);
 
-        mLocalFolderPath = (TextView) view.findViewById(R.id.synced_folders_settings_local_folder_path);
+        mLocalFolderPath = view.findViewById(R.id.synced_folders_settings_local_folder_path);
 
-        mLocalFolderSummary = (TextView) view.findViewById(R.id.local_folder_summary);
-        mRemoteFolderSummary = (TextView) view.findViewById(R.id.remote_folder_summary);
+        mLocalFolderSummary = view.findViewById(R.id.local_folder_summary);
+        mRemoteFolderSummary = view.findViewById(R.id.remote_folder_summary);
 
-        mUploadOnWifiCheckbox = (AppCompatCheckBox) view.findViewById(R.id.setting_instant_upload_on_wifi_checkbox);
+        mUploadOnWifiCheckbox = view.findViewById(R.id.setting_instant_upload_on_wifi_checkbox);
         ThemeUtils.tintCheckbox(mUploadOnWifiCheckbox, accentColor);
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
@@ -177,21 +177,21 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         } else {
             view.findViewById(R.id.setting_instant_upload_on_charging_container).setVisibility(View.VISIBLE);
 
-            mUploadOnChargingCheckbox = (AppCompatCheckBox) view.findViewById(
+            mUploadOnChargingCheckbox = view.findViewById(
                     R.id.setting_instant_upload_on_charging_checkbox);
             ThemeUtils.tintCheckbox(mUploadOnChargingCheckbox, accentColor);
         }
 
-        mUploadUseSubfoldersCheckbox = (AppCompatCheckBox) view.findViewById(
+        mUploadUseSubfoldersCheckbox = view.findViewById(
                 R.id.setting_instant_upload_path_use_subfolders_checkbox);
         ThemeUtils.tintCheckbox(mUploadUseSubfoldersCheckbox, accentColor);
 
-        mUploadBehaviorSummary = (TextView) view.findViewById(R.id.setting_instant_behaviour_summary);
+        mUploadBehaviorSummary = view.findViewById(R.id.setting_instant_behaviour_summary);
 
-        mCancel = (AppCompatButton) view.findViewById(R.id.cancel);
+        mCancel = view.findViewById(R.id.cancel);
         mCancel.setTextColor(accentColor);
 
-        mSave = (AppCompatButton) view.findViewById(R.id.save);
+        mSave = view.findViewById(R.id.save);
         mSave.setTextColor(accentColor);
 
         // Set values
@@ -393,7 +393,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(ThemeUtils.getColoredTitle(
                 getResources().getString(R.string.prefs_instant_behaviour_dialogTitle),
-                ThemeUtils.primaryAccentColor()))
+                ThemeUtils.primaryAccentColor(getContext())))
                 .setSingleChoiceItems(getResources().getTextArray(R.array.pref_behaviour_entries),
                         mSyncedFolder.getUploadActionInteger(),
                         new

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -144,7 +144,8 @@ public class EditShareFragment extends Fragment {
                 getResources().getString(R.string.share_with_edit_title, mShare.getSharedWithDisplayName()));
 
         View headerDivider = view.findViewById(R.id.share_header_divider);
-        headerDivider.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+        headerDivider.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
+                PorterDuff.Mode.SRC_ATOP);
 
         // Setup layout
         refreshUiFromState(view);
@@ -181,7 +182,7 @@ public class EditShareFragment extends Fragment {
             OwnCloudVersion serverVersion = AccountUtils.getServerVersion(mAccount);
             boolean isNotReshareableFederatedSupported = serverVersion.isNotReshareableFederatedSupported();
 
-            int accentColor = ThemeUtils.primaryAccentColor();
+            int accentColor = ThemeUtils.primaryAccentColor(getContext());
 
             SwitchCompat shareSwitch = editShareView.findViewById(R.id.canShareSwitch);
             ThemeUtils.tintSwitch(shareSwitch, accentColor, true);

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -370,7 +370,7 @@ public class ExtendedListFragment extends Fragment
         onCreateSwipeToRefresh(mRefreshListLayout);
 
         mFabMain = v.findViewById(R.id.fab_main);
-        ThemeUtils.tintFloatingActionButton(mFabMain, R.drawable.ic_plus);
+        ThemeUtils.tintFloatingActionButton(mFabMain, R.drawable.ic_plus, getContext());
 
         boolean searchSupported = AccountUtils.hasSearchSupport(AccountUtils.
                 getCurrentOwnCloudAccount(MainApp.getAppContext()));

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -250,7 +250,7 @@ public class ExtendedListFragment extends Fragment
             }
         });
 
-        int fontColor = ThemeUtils.fontColor();
+        int fontColor = ThemeUtils.fontColor(getContext());
 
         LinearLayout searchBar = searchView.findViewById(R.id.search_bar);
         TextView searchBadge = searchView.findViewById(R.id.search_badge);
@@ -423,7 +423,8 @@ public class ExtendedListFragment extends Fragment
         mEmptyListHeadline = view.findViewById(R.id.empty_list_view_headline);
         mEmptyListIcon = view.findViewById(R.id.empty_list_icon);
         mEmptyListProgress = view.findViewById(R.id.empty_list_progress);
-        mEmptyListProgress.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(), PorterDuff.Mode.SRC_IN);
+        mEmptyListProgress.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(getContext()),
+                PorterDuff.Mode.SRC_IN);
     }
 
     /**
@@ -596,6 +597,7 @@ public class ExtendedListFragment extends Fragment
     }
 
     /**
+    /**
      * Set message for empty list view.
      */
     public void setMessageForEmptyList(String message) {
@@ -635,7 +637,8 @@ public class ExtendedListFragment extends Fragment
                     mEmptyListMessage.setText(message);
 
                     if (tintIcon) {
-                        mEmptyListIcon.setImageDrawable(ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor()));
+                        mEmptyListIcon.setImageDrawable(ThemeUtils.tintDrawable(icon,
+                                ThemeUtils.primaryColor(getContext())));
                     } else {
                         mEmptyListIcon.setImageResource(icon);
                     }
@@ -732,9 +735,9 @@ public class ExtendedListFragment extends Fragment
     }
 
     protected void onCreateSwipeToRefresh(SwipeRefreshLayout refreshLayout) {
-        int primaryColor = ThemeUtils.primaryColor();
-        int darkColor = ThemeUtils.primaryDarkColor();
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int primaryColor = ThemeUtils.primaryColor(getContext());
+        int darkColor = ThemeUtils.primaryDarkColor(getContext());
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
 
         // Colors in animations
         // TODO change this to use darker and lighter color, again.

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -153,12 +153,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         mView = inflater.inflate(mLayout, null);
         
         if (mLayout == R.layout.file_details_fragment) {
-            int accentColor = ThemeUtils.primaryAccentColor();
+            int accentColor = ThemeUtils.primaryAccentColor(getContext());
             SwitchCompat favoriteToggle = mView.findViewById(R.id.fdFavorite);
             favoriteToggle.setOnCheckedChangeListener(this);
             ThemeUtils.tintSwitch(favoriteToggle, accentColor, false);
             ProgressBar progressBar = mView.findViewById(R.id.fdProgressBar);
-            ThemeUtils.colorHorizontalProgressBar(progressBar, ThemeUtils.primaryAccentColor());
+            ThemeUtils.colorHorizontalProgressBar(progressBar, ThemeUtils.primaryAccentColor(getContext()));
             mProgressListener = new ProgressListener(progressBar);
             mView.findViewById(R.id.fdCancelBtn).setOnClickListener(this);
             ((TextView)mView.findViewById(R.id.fdShareTitle)).setTextColor(accentColor);
@@ -295,7 +295,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
         item = menu.findItem(R.id.action_send_share_file);
         if (item != null) {
-            ThemeUtils.tintDrawable(item.getIcon(), ThemeUtils.fontColor());
+            ThemeUtils.tintDrawable(item.getIcon(), ThemeUtils.fontColor(getContext()));
             item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
             if (getFile().isSharedWithMe() && !getFile().canReshare()) {
                 // additional restriction for this fragment
@@ -483,7 +483,8 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         if (iv != null) {
             iv.setTag(file.getFileId());
             // Name of the file, to deduce the icon to use in case the MIME type is not precise enough
-            iv.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), mAccount));
+            iv.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), mAccount,
+                    getContext()));
 
             Bitmap thumbnail;
 
@@ -514,8 +515,9 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                     }
                 }
             } else {
-                iv.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), mAccount));
-			}
+                iv.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), mAccount,
+                        getContext()));
+            }
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.java
@@ -73,13 +73,13 @@ public class OCFileListBottomSheetDialog extends BottomSheetDialog {
 
         unbinder = ButterKnife.bind(this, view);
 
-        int primaryColor = ThemeUtils.primaryColor();
+        int primaryColor = ThemeUtils.primaryColor(getContext());
         ThemeUtils.tintDrawable(iconUploadFiles.getDrawable(), primaryColor);
         ThemeUtils.tintDrawable(iconUploadFromApp.getDrawable(), primaryColor);
         ThemeUtils.tintDrawable(iconMakeDir.getDrawable(), primaryColor);
 
         headline.setText(getContext().getResources().getString(R.string.add_to_cloud,
-                ThemeUtils.getDefaultDisplayNameForRootFolder()));
+                ThemeUtils.getDefaultDisplayNameForRootFolder(getContext())));
 
         setOnShowListener(d ->
                 BottomSheetBehavior.from((View) view.getParent()).setPeekHeight(view.getMeasuredHeight())

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -187,9 +187,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
         mSystemBarActionModeColor = getResources().getColor(R.color.action_mode_status_bar_background);
-        mSystemBarColor = ThemeUtils.primaryDarkColor();
+        mSystemBarColor = ThemeUtils.primaryDarkColor(getContext());
         mProgressBarActionModeColor = getResources().getColor(R.color.action_mode_background);
-        mProgressBarColor = ThemeUtils.primaryColor();
+        mProgressBarColor = ThemeUtils.primaryColor(getContext());
         mMultiChoiceModeListener = new MultiChoiceModeListener();
 
         if (savedInstanceState != null) {
@@ -1236,7 +1236,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     setTitle(R.string.drawer_item_shared);
                     break;
                 default:
-                    setTitle(ThemeUtils.getDefaultDisplayNameForRootFolder());
+                    setTitle(ThemeUtils.getDefaultDisplayNameForRootFolder(getContext()));
                     break;
             }
         }
@@ -1298,7 +1298,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         menuItemAddRemoveValue = MenuItemAddRemove.ADD_GRID_AND_SORT_WITH_SEARCH;
         if (getActivity() != null) {
             getActivity().invalidateOptionsMenu();
-            setTitle(ThemeUtils.getDefaultDisplayNameForRootFolder());
+            setTitle(ThemeUtils.getDefaultDisplayNameForRootFolder(getContext()));
         }
 
         getActivity().getIntent().removeExtra(OCFileListFragment.SEARCH_EVENT);
@@ -1521,7 +1521,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     ActionBar actionBar = ((FileDisplayActivity) getActivity()).getSupportActionBar();
 
                     if (actionBar != null) {
-                            ThemeUtils.setColoredTitle(actionBar, title);
+                        ThemeUtils.setColoredTitle(actionBar, title, getContext());
                     }
                 }
             }

--- a/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
@@ -188,20 +188,20 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
         Log_OC.d(TAG, "onCreateView");
 
         // use grey as fallback for elements where custom theming is not available
-        if (ThemeUtils.themingEnabled()) {
+        if (ThemeUtils.themingEnabled(getContext())) {
             getContext().getTheme().applyStyle(R.style.FallbackThemingTheme, true);
         }
 
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
 
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.share_file_layout, container, false);
 
         // Setup layout
         // Image
-        ImageView icon = (ImageView) view.findViewById(R.id.shareFileIcon);
+        ImageView icon = view.findViewById(R.id.shareFileIcon);
         icon.setImageDrawable(
-                MimeTypeUtil.getFileTypeIcon(mFile.getMimetype(), mFile.getFileName(), mAccount)
+                MimeTypeUtil.getFileTypeIcon(mFile.getMimetype(), mFile.getFileName(), mAccount, getContext())
         );
         if (MimeTypeUtil.isImage(mFile)) {
             String remoteId = String.valueOf(mFile.getRemoteId());
@@ -212,18 +212,19 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
         }
 
         // Title
-        TextView title = (TextView) view.findViewById(R.id.shareWithUsersSectionTitle);
+        TextView title = view.findViewById(R.id.shareWithUsersSectionTitle);
         title.setTextColor(accentColor);
 
         // Name
-        TextView fileNameHeader = (TextView) view.findViewById(R.id.shareFileName);
+        TextView fileNameHeader = view.findViewById(R.id.shareFileName);
         fileNameHeader.setText(getResources().getString(R.string.share_file, mFile.getFileName()));
 
         View headerDivider = view.findViewById(R.id.share_header_divider);
-        headerDivider.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+        headerDivider.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
+                PorterDuff.Mode.SRC_ATOP);
 
         // Size
-        TextView size = (TextView) view.findViewById(R.id.shareFileSize);
+        TextView size = view.findViewById(R.id.shareFileSize);
         if (mFile.isFolder()) {
             size.setVisibility(View.GONE);
         } else {
@@ -231,7 +232,7 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
         }
 
         //  Add User Button
-        Button addUserGroupButton = (Button) view.findViewById(R.id.addUserButton);
+        Button addUserGroupButton = view.findViewById(R.id.addUserButton);
         addUserGroupButton.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
         addUserGroupButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -280,8 +281,8 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
      */
     private void initShareViaLinkListener(View shareView) {
         mOnShareViaLinkSwitchCheckedChangeListener = new OnShareViaLinkListener();
-        SwitchCompat shareViaLinkSwitch = (SwitchCompat) shareView.findViewById(R.id.shareViaLinkSectionSwitch);
-        ThemeUtils.tintSwitch(shareViaLinkSwitch, ThemeUtils.primaryAccentColor(), true);
+        SwitchCompat shareViaLinkSwitch = shareView.findViewById(R.id.shareViaLinkSectionSwitch);
+        ThemeUtils.tintSwitch(shareViaLinkSwitch, ThemeUtils.primaryAccentColor(getContext()), true);
         shareViaLinkSwitch.setOnCheckedChangeListener(mOnShareViaLinkSwitchCheckedChangeListener);
     }
 
@@ -342,10 +343,10 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
     private void initExpirationListener(View shareView) {
         mOnExpirationDateInteractionListener = new OnExpirationDateInteractionListener();
 
-        SwitchCompat expirationSwitch = (SwitchCompat) shareView.findViewById(R.id.shareViaLinkExpirationSwitch);
+        SwitchCompat expirationSwitch = shareView.findViewById(R.id.shareViaLinkExpirationSwitch);
         expirationSwitch.setOnCheckedChangeListener(mOnExpirationDateInteractionListener);
 
-        ThemeUtils.tintSwitch(expirationSwitch, ThemeUtils.primaryAccentColor());
+        ThemeUtils.tintSwitch(expirationSwitch, ThemeUtils.primaryAccentColor(getContext()));
 
         shareView.findViewById(R.id.shareViaLinkExpirationLabel).
                 setOnClickListener(mOnExpirationDateInteractionListener);
@@ -422,9 +423,9 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
     private void initPasswordListener(View shareView) {
         mOnPasswordInteractionListener = new OnPasswordInteractionListener();
 
-        SwitchCompat passwordSwitch = (SwitchCompat) shareView.findViewById(R.id.shareViaLinkPasswordSwitch);
+        SwitchCompat passwordSwitch = shareView.findViewById(R.id.shareViaLinkPasswordSwitch);
         passwordSwitch.setOnCheckedChangeListener(mOnPasswordInteractionListener);
-        ThemeUtils.tintSwitch(passwordSwitch, ThemeUtils.primaryAccentColor());
+        ThemeUtils.tintSwitch(passwordSwitch, ThemeUtils.primaryAccentColor(getContext()));
 
         shareView.findViewById(R.id.shareViaLinkPasswordLabel).setOnClickListener(mOnPasswordInteractionListener);
 
@@ -487,9 +488,9 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
     private void initEditPermissionListener(View shareView) {
         mOnEditPermissionInteractionListener = new OnEditPermissionInteractionListener();
 
-        SwitchCompat permissionSwitch = (SwitchCompat) shareView.findViewById(R.id.shareViaLinkEditPermissionSwitch);
+        SwitchCompat permissionSwitch = shareView.findViewById(R.id.shareViaLinkEditPermissionSwitch);
         permissionSwitch.setOnCheckedChangeListener(mOnEditPermissionInteractionListener);
-        ThemeUtils.tintSwitch(permissionSwitch, ThemeUtils.primaryAccentColor());
+        ThemeUtils.tintSwitch(permissionSwitch, ThemeUtils.primaryAccentColor(getContext()));
     }
 
     /**
@@ -501,9 +502,9 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
     private void initHideFileListingListener(View shareView) {
         mOnHideFileListingPermissionInteractionListener = new OnHideFileListingPermissionInteractionListener();
 
-        SwitchCompat permissionSwitch = (SwitchCompat) shareView.findViewById(R.id.shareViaLinkFileListingPermissionSwitch);
+        SwitchCompat permissionSwitch = shareView.findViewById(R.id.shareViaLinkFileListingPermissionSwitch);
         permissionSwitch.setOnCheckedChangeListener(mOnHideFileListingPermissionInteractionListener);
-        ThemeUtils.tintSwitch(permissionSwitch, ThemeUtils.primaryAccentColor());
+        ThemeUtils.tintSwitch(permissionSwitch, ThemeUtils.primaryAccentColor(getContext()));
     }
 
     /**
@@ -654,8 +655,8 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
         );
 
         // Show data
-        TextView noShares = (TextView) getView().findViewById(R.id.shareNoUsers);
-        ListView usersList = (ListView) getView().findViewById(R.id.shareUsersList);
+        TextView noShares = getView().findViewById(R.id.shareNoUsers);
+        ListView usersList = getView().findViewById(R.id.shareUsersList);
 
         if (mPrivateShares.size() > 0) {
             noShares.setVisibility(View.GONE);
@@ -668,7 +669,7 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
         }
 
         // Set Scroll to initial position
-        ScrollView scrollView = (ScrollView) getView().findViewById(R.id.shareScroll);
+        ScrollView scrollView = getView().findViewById(R.id.shareScroll);
         scrollView.scrollTo(0, 0);
     }
 
@@ -747,7 +748,8 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
 
             // GetLink button
             AppCompatButton getLinkButton = getGetLinkButton();
-            getLinkButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+            getLinkButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
+                    PorterDuff.Mode.SRC_ATOP);
             getLinkButton.setVisibility(View.VISIBLE);
             getLinkButton.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -958,8 +960,8 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
      * @param view share file view
      */
     private void hideNotEnabledShareSections(View view) {
-        LinearLayout shareWithUsersSection = (LinearLayout) view.findViewById(R.id.shareWithUsersSection);
-        LinearLayout shareViaLinkSection = (LinearLayout) view.findViewById(R.id.shareViaLinkSection);
+        LinearLayout shareWithUsersSection = view.findViewById(R.id.shareWithUsersSection);
+        LinearLayout shareViaLinkSection = view.findViewById(R.id.shareViaLinkSection);
 
         boolean shareViaLinkAllowed = getActivity().getResources().getBoolean(R.bool.share_via_link_feature);
         boolean shareWithUsersAllowed = getActivity().getResources().getBoolean(R.bool.share_with_users_feature);

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
@@ -178,7 +178,7 @@ public class ContactListFragment extends FileFragment {
         }
         contactsPreferenceActivity.setDrawerIndicatorEnabled(false);
 
-        recyclerView = (RecyclerView) view.findViewById(R.id.contactlist_recyclerview);
+        recyclerView = view.findViewById(R.id.contactlist_recyclerview);
 
         if (savedInstanceState == null) {
             contactListAdapter = new ContactListAdapter(getContext(), vCards);
@@ -225,7 +225,7 @@ public class ContactListFragment extends FileFragment {
             }
         });
 
-        restoreContacts.setTextColor(ThemeUtils.primaryAccentColor());
+        restoreContacts.setTextColor(ThemeUtils.primaryAccentColor(getContext()));
 
         return view;
     }
@@ -320,8 +320,8 @@ public class ContactListFragment extends FileFragment {
         ContactItemViewHolder(View itemView) {
             super(itemView);
 
-            badge = (ImageView) itemView.findViewById(R.id.contactlist_item_icon);
-            name = (CheckedTextView) itemView.findViewById(R.id.contactlist_item_name);
+            badge = itemView.findViewById(R.id.contactlist_item_icon);
+            name = itemView.findViewById(R.id.contactlist_item_name);
 
 
             itemView.setTag(this);
@@ -629,7 +629,7 @@ class ContactListAdapter extends RecyclerView.Adapter<ContactListFragment.Contac
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                     holder.getName().getCheckMarkDrawable()
-                            .setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+                            .setColorFilter(ThemeUtils.primaryAccentColor(context), PorterDuff.Mode.SRC_ATOP);
                 }
             } else {
                 holder.getName().setChecked(false);
@@ -693,7 +693,7 @@ class ContactListAdapter extends RecyclerView.Adapter<ContactListFragment.Contac
                     if (holder.getName().isChecked()) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                             holder.getName().getCheckMarkDrawable()
-                                    .setColorFilter(ThemeUtils.primaryAccentColor(), PorterDuff.Mode.SRC_ATOP);
+                                    .setColorFilter(ThemeUtils.primaryAccentColor(context), PorterDuff.Mode.SRC_ATOP);
                         }
 
                         if (!checkedVCards.contains(verifiedPosition)) {

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -109,7 +109,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
     public View onCreateView(final LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
         // use grey as fallback for elements where custom theming is not available
-        if (ThemeUtils.themingEnabled()) {
+        if (ThemeUtils.themingEnabled(getContext())) {
             getContext().getTheme().applyStyle(R.style.FallbackThemingTheme, true);
         }
         View view = inflater.inflate(R.layout.contacts_backup_fragment, null);
@@ -137,7 +137,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
 
-        ThemeUtils.tintSwitch(backupSwitch, ThemeUtils.primaryAccentColor());
+        ThemeUtils.tintSwitch(backupSwitch, ThemeUtils.primaryAccentColor(getContext()));
         backupSwitch.setChecked(arbitraryDataProvider.getBooleanValue(account, PREFERENCE_CONTACTS_AUTOMATIC_BACKUP));
 
         onCheckedChangeListener = new CompoundButton.OnCheckedChangeListener() {
@@ -174,7 +174,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
             calendarPickerOpen = true;
         }
 
-        int accentColor = ThemeUtils.primaryAccentColor();
+        int accentColor = ThemeUtils.primaryAccentColor(getContext());
         int fontColor = ThemeUtils.fontColor();
 
         backupNow.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
@@ -182,6 +182,10 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
 
         contactsDatePickerBtn.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
         contactsDatePickerBtn.setTextColor(fontColor);
+
+        AppCompatButton chooseDate = view.findViewById(R.id.contacts_datepicker);
+        chooseDate.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
+        chooseDate.setTextColor(ThemeUtils.fontColor(getContext()));
 
         return view;
     }

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -128,11 +128,11 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
         ActionBar actionBar = contactsPreferenceActivity != null ? contactsPreferenceActivity.getSupportActionBar() : null;
 
         if (actionBar != null) {
-            ThemeUtils.setColoredTitle(actionBar, getString(R.string.actionbar_contacts));
+            ThemeUtils.setColoredTitle(actionBar, getString(R.string.actionbar_contacts), getContext());
             actionBar.setDisplayHomeAsUpEnabled(true);
 
             Drawable backArrow = getResources().getDrawable(R.drawable.ic_arrow_back);
-            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor()));
+            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor(getContext())));
         }
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
@@ -175,7 +175,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
         }
 
         int accentColor = ThemeUtils.primaryAccentColor(getContext());
-        int fontColor = ThemeUtils.fontColor();
+        int fontColor = ThemeUtils.fontColor(getContext());
 
         backupNow.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
         backupNow.setTextColor(fontColor);

--- a/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
+++ b/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
@@ -57,15 +57,12 @@ public class NotificationUtils {
      * @return              An instance of the regular {@link NotificationCompat.Builder}.
      */
     public static NotificationCompat.Builder newNotificationBuilder(Context context) {
-        return new NotificationCompat.Builder(context).
-                setColor(ThemeUtils.primaryColor());
+        return new NotificationCompat.Builder(context).setColor(ThemeUtils.primaryColor(context));
     }
 
     @SuppressFBWarnings("DMI")
-    public static void cancelWithDelay(
-            final NotificationManager notificationManager,
-            final int notificationId,
-            long delayInMillis) {
+    public static void cancelWithDelay(final NotificationManager notificationManager, final int notificationId,
+                                       long delayInMillis) {
     
         HandlerThread thread = new HandlerThread(
                 "NotificationDelayerThread_" + (new Random(System.currentTimeMillis())).nextInt(),

--- a/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -111,7 +111,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Bundle args = getArguments();
-        setFile((OCFile)args.getParcelable(ARG_FILE));
+        setFile(args.getParcelable(ARG_FILE));
             // TODO better in super, but needs to check ALL the class extending FileFragment; not right now
 
         mIgnoreFirstSavedState = args.getBoolean(ARG_IGNORE_FIRST);
@@ -136,9 +136,9 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
         }
 
         mView = inflater.inflate(R.layout.file_download_fragment, container, false);
-        
-        ProgressBar progressBar = (ProgressBar)mView.findViewById(R.id.progressBar);
-        ThemeUtils.colorHorizontalProgressBar(progressBar, ThemeUtils.primaryAccentColor());
+
+        ProgressBar progressBar = mView.findViewById(R.id.progressBar);
+        ThemeUtils.colorHorizontalProgressBar(progressBar, ThemeUtils.primaryAccentColor(getContext()));
         mProgressListener = new ProgressListener(progressBar);
 
         (mView.findViewById(R.id.cancelBtn)).setOnClickListener(this);
@@ -231,7 +231,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
 
         // show the progress bar for the transfer
         getView().findViewById(R.id.progressBar).setVisibility(View.VISIBLE);
-        TextView progressText = (TextView) getView().findViewById(R.id.progressText);
+        TextView progressText = getView().findViewById(R.id.progressText);
         progressText.setText(R.string.downloader_download_in_progress_ticker);
         progressText.setVisibility(View.VISIBLE);
 

--- a/src/main/java/com/owncloud/android/ui/whatsnew/ProgressIndicator.java
+++ b/src/main/java/com/owncloud/android/ui/whatsnew/ProgressIndicator.java
@@ -65,7 +65,7 @@ public class ProgressIndicator extends FrameLayout {
     }
 
     public void setNumberOfSteps(int steps) {
-        int fontColor = ThemeUtils.fontColor();
+        int fontColor = ThemeUtils.fontColor(getContext());
         mNumberOfSteps = steps;
         mDotsContainer.removeAllViews();
         for (int i = 0; i < steps; ++i) {

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -328,7 +328,7 @@ public class DisplayUtils {
      */
     public static int getRelativeInfoColor(Context context, int relative) {
         if (relative < RELATIVE_THRESHOLD_WARNING) {
-            if (ThemeUtils.colorToHexString(ThemeUtils.primaryColor()).equalsIgnoreCase(
+            if (ThemeUtils.colorToHexString(ThemeUtils.primaryColor(context)).equalsIgnoreCase(
                     ThemeUtils.colorToHexString(context.getResources().getColor(R.color.primary)))) {
                 return context.getResources().getColor(R.color.infolevel_info);
             } else {

--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -19,11 +19,11 @@
 package com.owncloud.android.utils;
 
 import android.accounts.Account;
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.webkit.MimeTypeMap;
 
-import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.network.WebdavEntry;
@@ -81,8 +81,8 @@ public class MimeTypeUtil {
      * @param filename Name, with extension.
      * @return Drawable of an image resource.
      */
-    public static Drawable getFileTypeIcon(String mimetype, String filename) {
-        return getFileTypeIcon(mimetype, filename, null);
+    public static Drawable getFileTypeIcon(String mimetype, String filename, Context context) {
+        return getFileTypeIcon(mimetype, filename, null, context);
     }
 
     /**
@@ -93,12 +93,12 @@ public class MimeTypeUtil {
      * @param account account which color should be used
      * @return Drawable of an image resource.
      */
-    public static Drawable getFileTypeIcon(String mimetype, String filename, Account account) {
+    public static Drawable getFileTypeIcon(String mimetype, String filename, Account account, Context context) {
         int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);
-        Drawable icon = MainApp.getAppContext().getResources().getDrawable(iconId);
+        Drawable icon = context.getResources().getDrawable(iconId);
 
         if(R.drawable.file_zip == iconId) {
-            ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(account));
+            ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(account, context));
         }
 
         return icon;
@@ -130,8 +130,8 @@ public class MimeTypeUtil {
      * @return Identifier of an image resource.
      */
     public static Drawable getFolderTypeIcon(boolean isSharedViaUsers, boolean isSharedViaLink, boolean isEncrypted,
-                                             WebdavEntry.MountType mountType) {
-        return getFolderTypeIcon(isSharedViaUsers, isSharedViaLink, isEncrypted, null, mountType);
+                                             WebdavEntry.MountType mountType, Context context) {
+        return getFolderTypeIcon(isSharedViaUsers, isSharedViaLink, isEncrypted, null, mountType, context);
     }
 
     /**
@@ -144,7 +144,8 @@ public class MimeTypeUtil {
      * @return Identifier of an image resource.
      */
     public static Drawable getFolderTypeIcon(boolean isSharedViaUsers, boolean isSharedViaLink,
-                                             boolean isEncrypted, Account account, WebdavEntry.MountType mountType) {
+                                             boolean isEncrypted, Account account, WebdavEntry.MountType mountType, 
+                                             Context context) {
         int drawableId;
 
         if (isSharedViaLink) {
@@ -159,11 +160,11 @@ public class MimeTypeUtil {
             drawableId = R.drawable.folder;
         }
 
-        return ThemeUtils.tintDrawable(drawableId, ThemeUtils.elementColor(account));
+        return ThemeUtils.tintDrawable(drawableId, ThemeUtils.elementColor(account, context));
     }
 
-    public static Drawable getDefaultFolderIcon() {
-        return getFolderTypeIcon(false, false, false, WebdavEntry.MountType.INTERNAL);
+    public static Drawable getDefaultFolderIcon(Context context) {
+        return getFolderTypeIcon(false, false, false, WebdavEntry.MountType.INTERNAL, context);
     }
 
 

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -380,11 +380,6 @@ public class ThemeUtils {
 
     private static OCCapability getCapability(Account acc, Context context) {
         Account account;
-        Context context = MainApp.getAppContext();
-
-        if (context == null) {
-            return new OCCapability();
-        }
 
         if (acc != null) {
             account = acc;

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -368,7 +368,8 @@ public class ThemeUtils {
         return String.format("#%06X", 0xFFFFFF & color);
     }
 
-    public static void tintFloatingActionButton(FloatingActionButton button, @DrawableRes int drawable) {
+    public static void tintFloatingActionButton(FloatingActionButton button, @DrawableRes int
+            drawable, Context context) {
         button.setBackgroundTintList(ColorStateList.valueOf(ThemeUtils.primaryColor(context)));
         button.setRippleColor(ThemeUtils.primaryDarkColor(context));
         button.setImageDrawable(ThemeUtils.tintDrawable(drawable, ThemeUtils.fontColor(context)));

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -60,57 +60,57 @@ import com.owncloud.android.ui.activity.ToolbarActivity;
  */
 public class ThemeUtils {
 
-    public static int primaryAccentColor() {
-        OCCapability capability = getCapability();
+    public static int primaryAccentColor(Context context) {
+        OCCapability capability = getCapability(context);
 
         try {
             float adjust;
-            if (darkTheme()) {
+            if (darkTheme(context)) {
                 adjust = +0.1f;
             } else {
                 adjust = -0.1f;
             }
             return adjustLightness(adjust, Color.parseColor(capability.getServerColor()), 0.35f);
         } catch (Exception e) {
-            return MainApp.getAppContext().getResources().getColor(R.color.color_accent);
+            return context.getResources().getColor(R.color.color_accent);
         }
     }
 
-    public static int primaryDarkColor() {
-        return primaryDarkColor(null);
+    public static int primaryDarkColor(Context context) {
+        return primaryDarkColor(null, context);
     }
 
-    public static int primaryDarkColor(Account account) {
-        OCCapability capability = getCapability(account);
+    public static int primaryDarkColor(Account account, Context context) {
+        OCCapability capability = getCapability(account, context);
 
         try {
             return adjustLightness(-0.2f, Color.parseColor(capability.getServerColor()), -1f);
         } catch (Exception e) {
-            return MainApp.getAppContext().getResources().getColor(R.color.primary_dark);
+            return context.getResources().getColor(R.color.primary_dark);
         }
     }
 
-    public static int primaryColor() {
-        return primaryColor(null);
+    public static int primaryColor(Context context) {
+        return primaryColor(null, context);
     }
 
-    public static int primaryColor(Account account) {
-        OCCapability capability = getCapability(account);
+    public static int primaryColor(Account account, Context context) {
+        OCCapability capability = getCapability(account, context);
 
         try {
             return Color.parseColor(capability.getServerColor());
         } catch (Exception e) {
-            return MainApp.getAppContext().getResources().getColor(R.color.primary);
+            return context.getResources().getColor(R.color.primary);
         }
     }
 
-    public static int elementColor() {
-        return elementColor(null);
+    public static int elementColor(Context context) {
+        return elementColor(null, context);
     }
 
     @NextcloudServer(max = 12)
-    public static int elementColor(Account account) {
-        OCCapability capability = getCapability(account);
+    public static int elementColor(Account account, Context context) {
+        OCCapability capability = getCapability(account, context);
 
         try {
             return Color.parseColor(capability.getServerElementColor());
@@ -120,32 +120,32 @@ public class ThemeUtils {
             try {
                 primaryColor = Color.parseColor(capability.getServerColor());
             } catch (Exception e1) {
-                primaryColor = MainApp.getAppContext().getResources().getColor(R.color.primary);
+                primaryColor = context.getResources().getColor(R.color.primary);
             }
 
             float[] hsl = colorToHSL(primaryColor);
 
             if (hsl[2] > 0.8) {
-                return MainApp.getAppContext().getResources().getColor(R.color.elementFallbackColor);
+                return context.getResources().getColor(R.color.elementFallbackColor);
             } else {
                 return primaryColor;
             }
         }
     }
 
-    public static boolean themingEnabled() {
-        return getCapability().getServerColor() != null && !getCapability().getServerColor().isEmpty();
+    public static boolean themingEnabled(Context context) {
+        return getCapability(context).getServerColor() != null && !getCapability(context).getServerColor().isEmpty();
     }
 
     /**
      * @return int font color to use
      * adapted from https://github.com/nextcloud/server/blob/master/apps/theming/lib/Util.php#L90-L102
      */
-    public static int fontColor() {
+    public static int fontColor(Context context) {
         try {
-            return Color.parseColor(getCapability().getServerTextColor());
+            return Color.parseColor(getCapability(context).getServerTextColor());
         } catch (Exception e) {
-            if (darkTheme()) {
+            if (darkTheme(context)) {
                 return Color.WHITE;
             } else {
                 return Color.BLACK;
@@ -157,8 +157,8 @@ public class ThemeUtils {
      * Tests if dark color is set
      * @return true if dark theme -> e.g.use light font color, darker accent color
      */
-    public static boolean darkTheme() {
-        int primaryColor = primaryColor();
+    public static boolean darkTheme(Context context) {
+        int primaryColor = primaryColor(context);
         float[] hsl = colorToHSL(primaryColor);
 
         return hsl[2] <= 0.55;
@@ -170,12 +170,12 @@ public class ThemeUtils {
      * @param actionBar actionBar to be used
      * @param title     title to be shown
      */
-    public static void setColoredTitle(ActionBar actionBar, String title) {
+    public static void setColoredTitle(ActionBar actionBar, String title, Context context) {
         if (actionBar != null) {
             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
                 actionBar.setTitle(title);
             } else {
-                String colorHex = colorToHexString(fontColor());
+                String colorHex = colorToHexString(fontColor(context));
                 actionBar.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + title + "</font>"));
             }
         }
@@ -196,14 +196,14 @@ public class ThemeUtils {
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
             actionBar.setTitle(titleId);
         } else {
-            String colorHex = colorToHexString(fontColor());
+            String colorHex = colorToHexString(fontColor(context));
             String title = context.getString(titleId);
             actionBar.setTitle(Html.fromHtml("<font color='" + colorHex + "'>" + title + "</font>"));
         }
     }
 
-    public static String getDefaultDisplayNameForRootFolder() {
-        OCCapability capability = getCapability();
+    public static String getDefaultDisplayNameForRootFolder(Context context) {
+        OCCapability capability = getCapability(context);
 
         if (capability.getServerName() == null || capability.getServerName().isEmpty()) {
             return MainApp.getAppContext().getResources().getString(R.string.default_display_name_for_root_folder);
@@ -268,8 +268,8 @@ public class ThemeUtils {
      *
      * @param seekBar the seek bar to be colored
      */
-    public static void colorHorizontalSeekBar(SeekBar seekBar) {
-        int color = ThemeUtils.primaryAccentColor();
+    public static void colorHorizontalSeekBar(SeekBar seekBar, Context context) {
+        int color = ThemeUtils.primaryAccentColor(context);
         colorHorizontalProgressBar(seekBar, color);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
@@ -369,16 +369,16 @@ public class ThemeUtils {
     }
 
     public static void tintFloatingActionButton(FloatingActionButton button, @DrawableRes int drawable) {
-        button.setBackgroundTintList(ColorStateList.valueOf(ThemeUtils.primaryColor()));
-        button.setRippleColor(ThemeUtils.primaryDarkColor());
-        button.setImageDrawable(ThemeUtils.tintDrawable(drawable, ThemeUtils.fontColor()));
+        button.setBackgroundTintList(ColorStateList.valueOf(ThemeUtils.primaryColor(context)));
+        button.setRippleColor(ThemeUtils.primaryDarkColor(context));
+        button.setImageDrawable(ThemeUtils.tintDrawable(drawable, ThemeUtils.fontColor(context)));
     }
 
-    private static OCCapability getCapability() {
-        return getCapability(null);
+    private static OCCapability getCapability(Context context) {
+        return getCapability(null, context);
     }
 
-    private static OCCapability getCapability(Account acc) {
+    private static OCCapability getCapability(Account acc, Context context) {
         Account account;
         Context context = MainApp.getAppContext();
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -643,7 +643,6 @@
     <string name="contacts_preferences_import_scheduled">Import scheduled and will start shortly</string>
 
     <!-- Notifications -->
-    <string name="new_notification_received">New notification received</string>
     <string name="drawer_logout">Log out</string>
     <string name="picture_set_as_no_app">No app found to set a picture with</string>
     <string name="privacy">Privacy</string>


### PR DESCRIPTION
With this any theming call uses now the context from the calling instance.
Only in both service (FileDownloader, FileUploader) getApplicationContext is used.

We are using theming on that many calls that the PR is such big :/

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>