### PR TITLE
Resume activity crash due to grid view check

### DIFF
--- a/src/main/java/com/owncloud/android/db/PreferenceManager.java
+++ b/src/main/java/com/owncloud/android/db/PreferenceManager.java
@@ -254,6 +254,11 @@ public abstract class PreferenceManager {
         
         ArbitraryDataProvider dataProvider = new ArbitraryDataProvider(context.getContentResolver());
         FileDataStorageManager storageManager = ((ComponentsGetter)context).getStorageManager();
+
+        if (storageManager == null) {
+            storageManager = new FileDataStorageManager(account, context.getContentResolver());
+        }
+        
         String value = dataProvider.getValue(account.name, getKeyFromFolder(preferenceName, folder));
         while (folder != null && value.isEmpty()) {
             folder = storageManager.getFileById(folder.getParentId());

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -385,16 +385,6 @@ public class ExtendedListFragment extends Fragment
             return false;
         });
 
-        if (savedInstanceState != null) {
-            int referencePosition = savedInstanceState.getInt(KEY_SAVED_LIST_POSITION);
-
-            if (mRecyclerView != null) {
-                Log_OC.v(TAG, "Setting and centering around list position " + referencePosition);
-
-                mRecyclerView.getLayoutManager().scrollToPosition(referencePosition);
-            }
-        }
-
         // Pull-down to refresh layout
         mRefreshListLayout = v.findViewById(R.id.swipe_containing_list);
         onCreateSwipeToRefresh(mRefreshListLayout);
@@ -418,16 +408,6 @@ public class ExtendedListFragment extends Fragment
             // convert the DP into pixel
             int pixel = (int) (32 * scale + 0.5f);
             layoutParams.setMargins(0, 0, pixel / 2, bottomNavigationView.getMeasuredHeight() + pixel * 2);
-        }
-
-        if (savedInstanceState != null) {
-            if (savedInstanceState.getBoolean(KEY_IS_GRID_VISIBLE, false)) {
-                switchToGridView();
-            }
-            int referencePosition = savedInstanceState.getInt(KEY_SAVED_LIST_POSITION);
-
-            Log_OC.v(TAG, "Setting grid position " + referencePosition);
-            scrollToPosition(referencePosition);
         }
 
         return v;
@@ -483,6 +463,14 @@ public class ExtendedListFragment extends Fragment
             mTops = savedInstanceState.getIntegerArrayList(KEY_TOPS);
             mHeightCell = savedInstanceState.getInt(KEY_HEIGHT_CELL);
             setMessageForEmptyList(savedInstanceState.getString(KEY_EMPTY_LIST_MESSAGE));
+
+            if (savedInstanceState.getBoolean(KEY_IS_GRID_VISIBLE, false) && getRecyclerView().getAdapter() != null) {
+                switchToGridView();
+            }
+
+            int referencePosition = savedInstanceState.getInt(KEY_SAVED_LIST_POSITION);
+            Log_OC.v(TAG, "Setting grid position " + referencePosition);
+            scrollToPosition(referencePosition);
         } else {
             mIndexes = new ArrayList<>();
             mFirstPositions = new ArrayList<>();

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -200,10 +200,6 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
         }
 
         searchFragment = currentSearchType != null;
-
-        if (isGridViewPreferred(getCurrentFile())) {
-            switchToGridView();
-        }
     }
 
     /**
@@ -352,8 +348,11 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             onMessageEvent(searchEvent);
         }
 
-        setTitle();
+        if (isGridViewPreferred(getCurrentFile())) {
+            switchToGridView();
+        }
 
+        setTitle();
     }
 
     private void prepareCurrentSearch(SearchEvent event) {


### PR DESCRIPTION
If the app is suspended and re-activated, it crashed as it tries to use adapter when it was not set, therefore:
- move scroll/switchGrid/List to onActivityCreated
- check if adapter is already set
- fix npe on storage manager 

To check, this can be enabled in developer options:
![2018-03-27-093645](https://user-images.githubusercontent.com/5836855/37953188-6e14fee8-31a2-11e8-904c-073223573161.png)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>