### PR TITLE
Prevent IllegalArgumentException on generating preview

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -405,7 +405,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     public void updateFileDetails(boolean transferring, boolean refresh) {
         if (readyToShow()) {
             FileDataStorageManager storageManager = mContainerActivity.getStorageManager();
-            if (refresh && storageManager != null) {
+            
+            if (storageManager == null) {
+                return;
+            }
+            
+            if (refresh) {
                 setFile(storageManager.getFileByPath(getFile().getRemotePath()));
             }
             OCFile file = getFile();


### PR DESCRIPTION
- enable "don't keep activities" on developer settings, otherwise you would have to wait long
- open detail view on image
- minimize app
- restore app
-> crash on generating preview due to nullable storage manager

FileDetailFragment is called twice
- once via onStart, which is too early
- once via regular cycle, where everything is setup

(reported via google play console, but not a regression, so only for next version, not requiring a new RC)