### PR TITLE
FileDisplayActivity: Replaced duplicate subexpression in if statement with instantVideoUploadEnabled preference.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -288,7 +288,8 @@ public class FileDisplayActivity extends HookActivity
      */
     private void upgradeNotificationForInstantUpload() {
         // check for Android 6+ if legacy instant upload is activated --> disable + show info
-        if (PreferenceManager.instantPictureUploadEnabled(this)) {
+        if (PreferenceManager.instantPictureUploadEnabled(this) ||
+                PreferenceManager.instantVideoUploadEnabled(this)) {
 
             // remove legacy shared preferences
             SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -288,8 +288,7 @@ public class FileDisplayActivity extends HookActivity
      */
     private void upgradeNotificationForInstantUpload() {
         // check for Android 6+ if legacy instant upload is activated --> disable + show info
-        if (PreferenceManager.instantPictureUploadEnabled(this) ||
-                PreferenceManager.instantPictureUploadEnabled(this)) {
+        if (PreferenceManager.instantPictureUploadEnabled(this)) {
 
             // remove legacy shared preferences
             SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();


### PR DESCRIPTION
It makes no sense to have identical expressions on both side of the binary operator, but I guess this is pretty self explanatory.