### PR TITLE
FileContentProvider: limit calling package check

### DIFF
--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -1010,7 +1010,7 @@ public class FileContentProvider extends ContentProvider {
 
     private boolean isCallerNotAllowed() {
         String callingPackage = mContext.getPackageManager().getNameForUid(Binder.getCallingUid());
-        return callingPackage == null || !callingPackage.contains(mContext.getPackageName());
+        return callingPackage == null || !callingPackage.equals(mContext.getPackageName());
     }
 
     class DataBaseHelper extends SQLiteOpenHelper {


### PR DESCRIPTION
As calling package is only the package name, we can use equals instead of contains, so we can prevent other apps like com.nextcloud.client2

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>