### PR TITLE
Added a splash screen

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -80,7 +80,7 @@
             android:name=".ui.activity.FileDisplayActivity"
             android:label="@string/app_name"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/Theme.ownCloud.Toolbar.Drawer">
+            android:theme="@style/Theme.ownCloud.Launcher">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -182,7 +182,8 @@ public class FileDisplayActivity extends HookActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log_OC.v(TAG, "onCreate() start");
-
+        // Set the default theme to replace the launch screen theme.
+        setTheme(R.style.Theme_ownCloud_Toolbar_Drawer);
         super.onCreate(savedInstanceState); // this calls onAccountChanged() when ownCloud Account
         // is valid
 

--- a/src/main/res/drawable/launch_screen.xml
+++ b/src/main/res/drawable/launch_screen.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Nextcloud Android client application
+
+  Copyright (C) 2018 Edvard Holst
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item

--- a/src/main/res/drawable/launch_screen.xml
+++ b/src/main/res/drawable/launch_screen.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:drawable="@color/primary"/>
+
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/logo" />
+    </item>
+
+</layer-list>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -144,6 +144,12 @@
 		<item name="windowActionBarOverlay">true</item>
 	</style>
 
+	<!-- Launch screen -->
+	<style name="Theme.ownCloud.Launcher">
+		<item name="android:windowBackground">@drawable/launch_screen</item>
+	</style>
+
+
 	<!-- Progress bar -->
 	<style name="Widget.ownCloud.TopProgressBar" parent="style/Widget.AppCompat.ProgressBar.Horizontal">
 		<item name="android:progressDrawable">@drawable/actionbar_progress_horizontal</item>


### PR DESCRIPTION
Resolves #2444

Added a splash screen. This is done by defining a launch screen theme with an associated XML resource that configures the appearance. Then we associate the launch screen theme with the launcher activity (`FileDisplayActivity`) in the manifest. Finally, we set the default theme in `onCreate()` before super in `FileDisplayActivity` so that it's applied when the activity is ready to the view is set. 

This approach is better than implementing the launch screen as a separate activity since we dont get the negative performance impact of adding an additional activity transition every time the app is started.

I used the default logo drawable which I think looks fine but I'm sure the designers should chime in and give their input. Screenshot is attached.

![screenshot_20180409-220616](https://user-images.githubusercontent.com/366855/38520292-ac42efae-3c42-11e8-9fa7-2b26e5360c4b.png)

This fixes #2444 
