### PR TITLE
Fix e2e: file input stream overwrote tmpFile

### DIFF
--- a/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
@@ -201,9 +201,10 @@ public class DownloadFileOperation extends RemoteOperation {
                 byte[] authenticationTag = EncryptionUtils.decodeStringToBase64Bytes(metadata.getFiles()
                         .get(mFile.getEncryptedFileName()).getAuthenticationTag());
 
-                try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)){
+                try {
                     byte[] decryptedBytes = EncryptionUtils.decryptFile(tmpFile, key, iv, authenticationTag);
 
+                    FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
                     fileOutputStream.write(decryptedBytes);
                 } catch (Exception e) {
                     return new RemoteOperationResult(e);


### PR DESCRIPTION
tmpFile was overwritten with the latest change by @ardevd.
This was a bit confusing written code as tmpFile already contained data and I re-used tmpFile.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>