### PR TITLE
Correct theming for contacts backup fragment: actionbar, buttons

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -26,12 +26,14 @@ import android.app.DatePickerDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.SwitchCompat;
 import android.view.LayoutInflater;
@@ -84,6 +86,9 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
     @BindView(R.id.contacts_last_backup_timestamp)
     public TextView lastBackup;
 
+    @BindView(R.id.contacts_backup_now)
+    public AppCompatButton backupNow;
+
     private Date selectedDate = null;
     private boolean calendarPickerOpen;
 
@@ -120,8 +125,15 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
 
         account = (Account) getArguments().get(ContactListFragment.ACCOUNT);
 
-        contactsPreferenceActivity.getSupportActionBar().setTitle(R.string.actionbar_contacts);
-        contactsPreferenceActivity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        ActionBar actionBar = contactsPreferenceActivity != null ? contactsPreferenceActivity.getSupportActionBar() : null;
+
+        if (actionBar != null) {
+            ThemeUtils.setColoredTitle(actionBar, getString(R.string.actionbar_contacts));
+            actionBar.setDisplayHomeAsUpEnabled(true);
+
+            Drawable backArrow = getResources().getDrawable(R.drawable.ic_arrow_back);
+            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor()));
+        }
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
 
@@ -163,13 +175,13 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
         }
 
         int accentColor = ThemeUtils.primaryAccentColor();
-        contactsDatePickerBtn.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
-        view.findViewById(R.id.contacts_backup_now).getBackground()
-                .setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
+        int fontColor = ThemeUtils.fontColor();
 
-        AppCompatButton chooseDate = view.findViewById(R.id.contacts_datepicker);
-        chooseDate.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
-        chooseDate.setTextColor(ThemeUtils.fontColor());
+        backupNow.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
+        backupNow.setTextColor(fontColor);
+
+        contactsDatePickerBtn.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
+        contactsDatePickerBtn.setTextColor(fontColor);
 
         return view;
     }


### PR DESCRIPTION
Fix #2484 

Actionbar and buttons now have correct font color.
![2018-04-18-133555](https://user-images.githubusercontent.com/5836855/38930051-c41b3654-430e-11e8-99a9-b34ed89a99e9.png) ![2018-04-18-133539](https://user-images.githubusercontent.com/5836855/38930052-c438c228-430e-11e8-9cbe-36b6f2fa320c.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>