### PR TITLE
ContactBackup: use always account of calling activity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
@@ -93,7 +93,6 @@ public class ContactsPreferenceActivity extends FileActivity implements FileFrag
                     intent.getParcelableExtra(ContactListFragment.ACCOUNT) == null) {
                 ContactsBackupFragment fragment = new ContactsBackupFragment();
                 Bundle bundle = new Bundle();
-                bundle.putParcelable(ContactListFragment.ACCOUNT, getAccount());
                 bundle.putBoolean(EXTRA_SHOW_SIDEBAR, showSidebar);
                 fragment.setArguments(bundle);
                 transaction.add(R.id.frame_container, fragment);

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -118,7 +118,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
 
         final ContactsPreferenceActivity contactsPreferenceActivity = (ContactsPreferenceActivity) getActivity();
 
-        account = (Account) getArguments().get(ContactListFragment.ACCOUNT);
+        account = contactsPreferenceActivity.getAccount();
 
         contactsPreferenceActivity.getSupportActionBar().setTitle(R.string.actionbar_contacts);
         contactsPreferenceActivity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
Fix #2484 
Fix #2327 

Previously we used account of savedInstance. This could have been an outdated account, if meanwhile the user switched the account.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>