### PR TITLE
Fix double search

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -331,9 +331,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
         searchEvent = Parcels.unwrap(getArguments().getParcelable(OCFileListFragment.SEARCH_EVENT));
         prepareCurrentSearch(searchEvent);
-        if (searchEvent != null && savedInstanceState == null) {
-            onMessageEvent(searchEvent);
-        }
 
         if (isGridViewPreferred(getCurrentFile())) {
             switchToGridView();


### PR DESCRIPTION
Adding proposed fix by @AndyScherzinger (https://github.com/nextcloud/android/pull/1704#issuecomment-380098314)

Fixes #1908
Fixes #1704 
Fixes #2015
Fixes #1698 
Fixes #2100
Fixes #2198

`onViewStateRestored()` is executed directly after `onActivityCreated()` when starting the app / switching to e.g. favorite search from "all files". 
But after previewing a file from favorite search, only `onViewStateRestored()` is called, therefore we need to keep it there and thus remove it in `onActivityCreated()`.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>