### PR TITLE
Use userId for webdav search

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1514,6 +1514,8 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
             new Handler(Looper.getMainLooper()).post(switchViewsRunnable);
         }
 
+        final Account currentAccount = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext());
+
         final RemoteOperation remoteOperation;
         if (!currentSearchType.equals(SearchType.SHARED_FILTER)) {
             boolean searchOnlyFolders = false;
@@ -1521,12 +1523,14 @@ public class OCFileListFragment extends ExtendedListFragment implements OCFileLi
                 searchOnlyFolders = true;
             }
 
-            remoteOperation = new SearchOperation(event.getSearchQuery(), event.getSearchType(), searchOnlyFolders);
+            String userId = AccountManager.get(MainApp.getAppContext()).getUserData(currentAccount,
+                    com.owncloud.android.lib.common.accounts.AccountUtils.Constants.KEY_USER_ID);
+
+            remoteOperation = new SearchOperation(event.getSearchQuery(), event.getSearchType(), searchOnlyFolders,
+                    userId);
         } else {
             remoteOperation = new GetRemoteSharesOperation();
         }
-
-        final Account currentAccount = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext());
 
         remoteOperationAsyncTask = new AsyncTask() {
             @Override


### PR DESCRIPTION
Fix #2400 
* [x] Needs https://github.com/nextcloud/android-library/pull/141

We have two different things:
- loginname (username in our app): 
	- this is what you use to authenticate with, eg. on web ui or very first login on android app
	- it is used for re-authenticate once our token is expired
	- it can be different than userId on certain backends
- userID:
	- this is used for all new dav endpoints
	- it is a unique id for each server

The problem in #2400 was that loginname was used instead of userId.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>