### PR TITLE
adapter: Pass valid context to setImageDrawable()-call.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -254,7 +254,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         .error(placeholder).into(fileIcon); // using custom fetcher
 
             } else {
-                fileIcon.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), null));
+                fileIcon.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimetype(), file.getFileName(), context));
             }
         } else {
             // Folder


### PR DESCRIPTION
Pass a valid `Context` to the call to setImageDrawable(). With the recently refactored theming syntax introduced in 5b432b3ed0a608d50388768f0503e47b1504afe8 the null `Context` passed here seemingly results in an NPE crash.

Fixes #2502.

