### PR TITLE
added more information on initial connection error

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1562,8 +1562,8 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = getResources().getString(R.string.auth_unknown_error_http_title);
                 break;
             case UNKNOWN_ERROR:
-                if (result.getException() != null && result.getException().getMessage() != null
-                        && !"".equals(result.getException().getMessage())) {
+                if (result.getException() != null &&
+                        !TextUtils.isEmpty(result.getException().getMessage())) {
                     mServerStatusText = getResources().getString(
                             R.string.auth_unknown_error_exception_title,
                             result.getException().getMessage()

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1562,7 +1562,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = getResources().getString(R.string.auth_unknown_error_http_title);
                 break;
             case UNKNOWN_ERROR:
-                if(result.getException() != null) {
+                if (result.getException() != null) {
                     mServerStatusText = getResources().getString(
                             R.string.auth_unknown_error_exception_title,
                             result.getException().getMessage()

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1562,7 +1562,8 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = getResources().getString(R.string.auth_unknown_error_http_title);
                 break;
             case UNKNOWN_ERROR:
-                if (result.getException() != null) {
+                if (result.getException() != null && result.getException().getMessage() != null
+                        && !"".equals(result.getException().getMessage())) {
                     mServerStatusText = getResources().getString(
                             R.string.auth_unknown_error_exception_title,
                             result.getException().getMessage()

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1559,8 +1559,17 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerStatusText = getResources().getString(R.string.auth_oauth_error_access_denied);
                 break;
             case UNHANDLED_HTTP_CODE:
+                mServerStatusText = getResources().getString(R.string.auth_unknown_error_http_title);
+                break;
             case UNKNOWN_ERROR:
-                mServerStatusText = getResources().getString(R.string.auth_unknown_error_title);
+                if(result.getException() != null) {
+                    mServerStatusText = getResources().getString(
+                            R.string.auth_unknown_error_exception_title,
+                            result.getException().getMessage()
+                    );
+                } else {
+                    mServerStatusText = getResources().getString(R.string.auth_unknown_error_title);
+                }
                 break;
             case OK_REDIRECT_TO_NON_SECURE_CONNECTION:
                 mServerStatusIcon = R.drawable.ic_lock_open_white;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -239,7 +239,9 @@
 	<string name="auth_not_configured_title">Malformed server configuration</string>
 	<string name="auth_account_not_new">An account for the same user and server already exists on the device</string>
 	<string name="auth_account_not_the_same">The entered user does not match the user of this account</string>
-	<string name="auth_unknown_error_title">Unknown error occurred!</string>
+    <string name="auth_unknown_error_http_title">Unknown HTTP error occurred!</string>
+    <string name="auth_unknown_error_title">Unknown error occurred!</string>
+    <string name="auth_unknown_error_exception_title">Unknown error: %1$s</string>
 	<string name="auth_unknown_host_title">Could not find host</string>
 	<string name="auth_incorrect_path_title">Server not found</string>
 	<string name="auth_timeout_title">The server took too long to respond</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -239,9 +239,9 @@
 	<string name="auth_not_configured_title">Malformed server configuration</string>
 	<string name="auth_account_not_new">An account for the same user and server already exists on the device</string>
 	<string name="auth_account_not_the_same">The entered user does not match the user of this account</string>
-    <string name="auth_unknown_error_http_title">Unknown HTTP error occurred!</string>
-    <string name="auth_unknown_error_title">Unknown error occurred!</string>
-    <string name="auth_unknown_error_exception_title">Unknown error: %1$s</string>
+	<string name="auth_unknown_error_http_title">Unknown HTTP error occurred!</string>
+	<string name="auth_unknown_error_title">Unknown error occurred!</string>
+	<string name="auth_unknown_error_exception_title">Unknown error: %1$s</string>
 	<string name="auth_unknown_host_title">Could not find host</string>
 	<string name="auth_incorrect_path_title">Server not found</string>
 	<string name="auth_timeout_title">The server took too long to respond</string>


### PR DESCRIPTION
for issues like #2510 provide the exception message to make reporting/analyzing of connection issue during login easier for server-admins and the client devs

*before*
![device-2018-04-24-122940](https://user-images.githubusercontent.com/1315170/39182448-40583a84-47bd-11e8-820d-bcfc4a9caded.png)

*after*
![device-2018-04-24-123111](https://user-images.githubusercontent.com/1315170/39182455-45aac876-47bd-11e8-9aca-80a5be5c2b31.png)

I wouldn't do any string manipulation on exception message since in this case I guess the chunk size is "" and we don't know what message we might get back from the exceptions in general.