### PR TITLE
Preferences: Don't start FileDisplayActivity when pressing the back button

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -839,24 +839,6 @@ public class Preferences extends PreferenceActivity
     }
 
     @Override
-    public boolean onMenuItemSelected(int featureId, MenuItem item) {
-        super.onMenuItemSelected(featureId, item);
-        Intent intent;
-
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                intent = new Intent(getBaseContext(), FileDisplayActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                startActivity(intent);
-                break;
-            default:
-                Log_OC.w(TAG, "Unknown menu item triggered");
-                return false;
-        }
-        return true;
-    }
-
-    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 


### PR DESCRIPTION
Since the `FileDisplayActivity` has its launch mode set to '`multiple`' (the default) and `FLAG_ACTIVITY_SINGLE_TOP` is not being used, using `FLAG_ACTIVITY_CLEAR_TOP` will effectively [finish any existing activity and then re-create it](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_TOP). This will cause the launch screen to be showed again. This is probably not the behavior we want.

We could consider declaring the FileDisplayActivity with `android:launchMode="singleTask"` if you want to prevent duplicate entries in the back stack.

This fixes #2507 