### PR TITLE
Do not sort on getFolderContent

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -851,8 +851,6 @@ public class FileDataStorageManager {
             c.close();
         }
 
-        Collections.sort(ret);
-
         return ret;
     }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -70,6 +70,7 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import third_parties.daveKoeller.AlphanumComparator;
 
 import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFERENCE_CONTACTS_AUTOMATIC_BACKUP;
 import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFERENCE_CONTACTS_LAST_BACKUP;
@@ -241,6 +242,8 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
 
                     List<OCFile> backupFiles = contactsPreferenceActivity.getStorageManager()
                             .getFolderContent(backupFolder, false);
+
+                    Collections.sort(backupFiles, new AlphanumComparator<>());
 
                     if (backupFiles == null || backupFiles.size() == 0) {
                         contactsDatePickerBtn.setVisibility(View.GONE);


### PR DESCRIPTION
~~Currently this is the only left occurrence I can find for our TimSort problem.~~
I went through all calling methods and either sorting order is not important, or it is done afterwards anyway (like in OCFileListFragment).

At the only occurrence where it is import, I added our AlphaNumComparator.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>