### PR TITLE
Media streaming with NC14 endpoint

### DIFF
--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -27,6 +27,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import com.owncloud.android.R;
+import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;
@@ -345,6 +346,16 @@ public class FileMenuFilter {
             toShow.add(R.id.action_download_file);
         }
     }
+    
+    private void filterStream() {
+        // STREAM
+        if (mFiles.isEmpty() || !isSingleFile() || !isSingleMedia() ||
+                !AccountUtils.getServerVersion(mAccount).isMediaStreamingSupported()) {
+            toHide.add(R.id.action_stream_media);
+        } else {
+            toShow.add(R.id.action_stream_media);
+        }
+    }
 
     private boolean anyFileSynchronizing() {
         boolean synchronizing = false;
@@ -428,6 +439,11 @@ public class FileMenuFilter {
 
     private boolean isSingleImage() {
         return isSingleSelection() && MimeTypeUtil.isImage(mFiles.iterator().next());
+    }
+
+    private boolean isSingleMedia() {
+        OCFile file = mFiles.iterator().next();
+        return isSingleSelection() && (MimeTypeUtil.isVideo(file) || MimeTypeUtil.isAudio(file));
     }
 
     private boolean allFiles() {

--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -184,6 +184,7 @@ public class FileMenuFilter {
         filterEncrypt(toShow, toHide, endToEndEncryptionEnabled);
         filterUnsetEncrypted(toShow, toHide, endToEndEncryptionEnabled);
         filterSetPictureAs(toShow, toHide);
+        filterStream(toShow, toHide);
     }
 
     private void filterShareFile(List<Integer> toShow, List<Integer> toHide, OCCapability capability) {
@@ -346,9 +347,8 @@ public class FileMenuFilter {
             toShow.add(R.id.action_download_file);
         }
     }
-    
-    private void filterStream() {
-        // STREAM
+
+    private void filterStream(List<Integer> toShow, List<Integer> toHide) {
         if (mFiles.isEmpty() || !isSingleFile() || !isSingleMedia() ||
                 !AccountUtils.getServerVersion(mAccount).isMediaStreamingSupported()) {
             toHide.add(R.id.action_stream_media);

--- a/src/main/java/com/owncloud/android/files/StreamMediaFileOperation.java
+++ b/src/main/java/com/owncloud/android/files/StreamMediaFileOperation.java
@@ -1,0 +1,90 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2018 Tobias Kaminsky
+ * Copyright (C) 2018 Nextcloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.files;
+
+import com.owncloud.android.lib.common.OwnCloudClient;
+import com.owncloud.android.lib.common.operations.RemoteOperation;
+import com.owncloud.android.lib.common.operations.RemoteOperationResult;
+import com.owncloud.android.lib.common.utils.Log_OC;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+public class StreamMediaFileOperation extends RemoteOperation {
+    private static final String TAG = StreamMediaFileOperation.class.getSimpleName();
+    private static final int SYNC_READ_TIMEOUT = 40000;
+    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
+    private static final String STREAM_MEDIA_URL = "/ocs/v2.php/apps/dav/api/v1/direct";
+    
+    private String fileID;
+
+    // JSON node names
+    private static final String NODE_OCS = "ocs";
+    private static final String NODE_DATA = "data";
+    private static final String NODE_URL = "url";
+    private static final String JSON_FORMAT = "?format=json";
+
+    public StreamMediaFileOperation(String fileID) {
+        this.fileID = fileID;
+    }
+
+    protected RemoteOperationResult run(OwnCloudClient client) {
+        RemoteOperationResult result;
+        PostMethod postMethod = null;
+
+        try {
+            postMethod = new PostMethod(client.getBaseUri() + STREAM_MEDIA_URL + JSON_FORMAT);
+            postMethod.setParameter("fileId", fileID);
+
+            // remote request
+            postMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
+
+            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+
+            if (status == HttpStatus.SC_OK) {
+                String response = postMethod.getResponseBodyAsString();
+
+                // Parse the response
+                JSONObject respJSON = new JSONObject(response);
+                String url = (String) respJSON.getJSONObject(NODE_OCS).getJSONObject(NODE_DATA).get(NODE_URL);
+
+                result = new RemoteOperationResult(true, postMethod);
+                ArrayList<Object> urlArray = new ArrayList<>();
+                urlArray.add(url);
+                result.setData(urlArray);
+            } else {
+                result = new RemoteOperationResult(false, postMethod);
+                client.exhaustResponse(postMethod.getResponseBodyAsStream());
+            }
+        } catch (Exception e) {
+            result = new RemoteOperationResult(e);
+            Log_OC.e(TAG, "Get stream url for file with id " + fileID + " failed: " + result.getLogMessage(),
+                    result.getException());
+        } finally {
+            if (postMethod != null)
+                postMethod.releaseConnection();
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/owncloud/android/files/StreamMediaFileOperation.java
+++ b/src/main/java/com/owncloud/android/files/StreamMediaFileOperation.java
@@ -67,7 +67,7 @@ public class StreamMediaFileOperation extends RemoteOperation {
 
                 // Parse the response
                 JSONObject respJSON = new JSONObject(response);
-                String url = (String) respJSON.getJSONObject(NODE_OCS).getJSONObject(NODE_DATA).get(NODE_URL);
+                String url = respJSON.getJSONObject(NODE_OCS).getJSONObject(NODE_DATA).getString(NODE_URL);
 
                 result = new RemoteOperationResult(true, postMethod);
                 ArrayList<Object> urlArray = new ArrayList<>();

--- a/src/main/java/com/owncloud/android/files/StreamMediaFileOperation.java
+++ b/src/main/java/com/owncloud/android/files/StreamMediaFileOperation.java
@@ -82,8 +82,9 @@ public class StreamMediaFileOperation extends RemoteOperation {
             Log_OC.e(TAG, "Get stream url for file with id " + fileID + " failed: " + result.getLogMessage(),
                     result.getException());
         } finally {
-            if (postMethod != null)
+            if (postMethod != null) {
                 postMethod.releaseConnection();
+            }
         }
         return result;
     }

--- a/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/src/main/java/com/owncloud/android/media/MediaService.java
@@ -1,8 +1,12 @@
-/**
+/*
  * ownCloud Android client application
  *
  * @author David A. Velasco
  * Copyright (C) 2016 ownCloud Inc.
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2018 Tobias Kaminsky
+ * Copyright (C) 2018 Nextcloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -20,6 +24,8 @@
 package com.owncloud.android.media;
 
 import android.accounts.Account;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -32,6 +38,7 @@ import android.media.MediaPlayer.OnErrorListener;
 import android.media.MediaPlayer.OnPreparedListener;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.WifiLock;
+import android.os.AsyncTask;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.support.v4.app.NotificationCompat;
@@ -39,6 +46,12 @@ import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.files.StreamMediaFileOperation;
+import com.owncloud.android.lib.common.OwnCloudAccount;
+import com.owncloud.android.lib.common.OwnCloudClient;
+import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
+import com.owncloud.android.lib.common.accounts.AccountUtils;
+import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
@@ -46,6 +59,7 @@ import com.owncloud.android.ui.notifications.NotificationUtils;
 import com.owncloud.android.utils.ThemeUtils;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 
 /**
@@ -365,7 +379,6 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
         }
     }
 
-
     /**
      * Fully releases the audio focus.
      */
@@ -443,33 +456,19 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
 
             createMediaPlayerIfNeeded();
             mPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
-            String url = mFile.getStoragePath();
 
-            /* Streaming is not possible right now
-            if (url == null || url.length() <= 0) {
-                url = AccountUtils.constructFullURLForAccount(this, mAccount) + mFile.getRemotePath();
+            if (mFile.isDown()) {
+                mPlayer.setDataSource(mFile.getStoragePath());
+                preparePlayer();
+            } else {
+                OwnCloudAccount ocAccount = new OwnCloudAccount(mAccount, getBaseContext());
+                OwnCloudClient client = OwnCloudClientManagerFactory.getDefaultSingleton().
+                        getClientFor(ocAccount, getBaseContext());
+
+                new LoadStreamUrl(this, client).execute(mFile.getLocalId());
             }
-            mIsStreaming = url.startsWith("http:") || url.startsWith("https:");
-            */
-            //mIsStreaming = false;
-            mPlayer.setDataSource(url);
-
-            mState = State.PREPARING;
-            setUpAsForeground(String.format(getString(R.string.media_state_loading), mFile.getFileName()));
-
-            // starts preparing the media player in background
-            mPlayer.prepareAsync();
-
-            // prevent the Wifi from going to sleep when streaming
-            /*
-            if (mIsStreaming) {
-                mWifiLock.acquire();
-            } else
-            */
-            if (mWifiLock.isHeld()) {
-                mWifiLock.release();
-            }
-
+        } catch (AccountUtils.AccountNotFoundException | OperationCanceledException | AuthenticatorException e) {
+            Log_OC.e(TAG, "Loading stream url not possible: " + e.getMessage());
         } catch (SecurityException | IOException | IllegalStateException | IllegalArgumentException e) {
             Log_OC.e(TAG, e.getClass().getSimpleName() + " playing " + mAccount.name + mFile.getRemotePath(), e);
             Toast.makeText(this, String.format(getString(R.string.media_err_playing), mFile.getFileName()),
@@ -478,6 +477,13 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
         }
     }
 
+    private void preparePlayer() {
+        mState = State.PREPARING;
+        setUpAsForeground(String.format(getString(R.string.media_state_loading), mFile.getFileName()));
+
+        // starts preparing the media player in background
+        mPlayer.prepareAsync();
+    }
 
     /** Called when media player is done playing current song. */
     public void onCompletion(MediaPlayer player) {
@@ -702,4 +708,48 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
         return mMediaController;
     }
 
+    private static class LoadStreamUrl extends AsyncTask<String, Void, String> {
+
+        private OwnCloudClient client;
+        private WeakReference<MediaService> mediaServiceWeakReference;
+
+        public LoadStreamUrl(MediaService mediaService, OwnCloudClient client) {
+            this.client = client;
+            this.mediaServiceWeakReference = new WeakReference<>(mediaService);
+        }
+
+        @Override
+        protected String doInBackground(String... fileId) {
+            StreamMediaFileOperation sfo = new StreamMediaFileOperation(fileId[0]);
+            RemoteOperationResult result = sfo.execute(client);
+
+            if (!result.isSuccess()) {
+                return null;
+            }
+
+            return (String) result.getData().get(0);
+        }
+
+        @Override
+        protected void onPostExecute(String url) {
+            MediaService mediaService = mediaServiceWeakReference.get();
+
+            if (mediaService != null) {
+                if (url != null) {
+                    try {
+                        mediaService.mPlayer.setDataSource(url);
+
+                        // prevent the Wifi from going to sleep when streaming
+                        mediaService.mWifiLock.acquire();
+                        mediaService.preparePlayer();
+                    } catch (IOException e) {
+                        Log_OC.e(TAG, "Streaming not possible: " + e.getMessage());
+                    }
+                } else {
+                    // we already show a toast with error from media player
+                    mediaService.processStopRequest(true);
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -70,7 +70,6 @@ import android.widget.ImageView;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
@@ -730,7 +729,8 @@ public class FileDisplayActivity extends HookActivity
                         mWaitingToPreview = getStorageManager().getFileById(mWaitingToPreview.getFileId());
                         
                         if (PreviewMediaFragment.canBePreviewed(mWaitingToPreview)) {
-                            boolean streaming = AccountUtils.getServerVersion(getAccount()).isMediaStreamingSupported();
+                            boolean streaming = AccountUtils.getServerVersionForAccount(getAccount(), this)
+                                    .isMediaStreamingSupported();
                             startMediaPreview(mWaitingToPreview, 0, true, true, streaming);
                             detailsFragmentChanged = true;
                         } else if (MimeTypeUtil.isVCard(mWaitingToPreview.getMimeType())) {
@@ -2052,7 +2052,8 @@ public class FileDisplayActivity extends HookActivity
                     ((PreviewMediaFragment) details).updateFile(renamedFile);
                     if (PreviewMediaFragment.canBePreviewed(renamedFile)) {
                         int position = ((PreviewMediaFragment) details).getPosition();
-                        boolean streaming = AccountUtils.getServerVersion(getAccount()).isMediaStreamingSupported();
+                        boolean streaming = AccountUtils.getServerVersionForAccount(getAccount(), this)
+                                .isMediaStreamingSupported();
                         startMediaPreview(renamedFile, position, true, true, streaming);
                     } else {
                         getFileOperationsHelper().openFile(renamedFile);
@@ -2463,7 +2464,8 @@ public class FileDisplayActivity extends HookActivity
         if (event.getIntent().getBooleanExtra(TEXT_PREVIEW, false)) {
             startTextPreview((OCFile) bundle.get(EXTRA_FILE), true);
         } else if (bundle.containsKey(PreviewVideoActivity.EXTRA_START_POSITION)) {
-            boolean streaming = AccountUtils.getServerVersion(getAccount()).isMediaStreamingSupported();
+            boolean streaming = AccountUtils.getServerVersionForAccount(getAccount(), this)
+                    .isMediaStreamingSupported();
             startMediaPreview((OCFile)bundle.get(EXTRA_FILE),
                     (int)bundle.get(PreviewVideoActivity.EXTRA_START_POSITION),
                     (boolean) bundle.get(PreviewVideoActivity.EXTRA_AUTOPLAY), true, streaming);

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2329,7 +2329,7 @@ public class FileDisplayActivity extends HookActivity
      */
     public void startMediaPreview(OCFile file, int startPlaybackPosition, boolean autoplay, boolean showPreview,
                                   boolean streamMedia) {
-        if ((showPreview && file.isDown() && !file.isDownloading()) || streamMedia) {
+        if (showPreview && file.isDown() && !file.isDownloading() || streamMedia) {
             Fragment mediaFragment = PreviewMediaFragment.newInstance(file, getAccount(), startPlaybackPosition, autoplay);
             setSecondFragment(mediaFragment);
             updateFragmentsVisibility(true);

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -70,6 +70,7 @@ import android.widget.ImageView;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
+import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
@@ -725,11 +726,12 @@ public class FileDisplayActivity extends HookActivity
                 boolean detailsFragmentChanged = false;
                 if (waitedPreview) {
                     if (success) {
-                        mWaitingToPreview = getStorageManager().getFileById(
-                                mWaitingToPreview.getFileId());   // update the file from database,
-                        // for the local storage path
+                        // update the file from database, for the local storage path
+                        mWaitingToPreview = getStorageManager().getFileById(mWaitingToPreview.getFileId());
+                        
                         if (PreviewMediaFragment.canBePreviewed(mWaitingToPreview)) {
-                            startMediaPreview(mWaitingToPreview, 0, true, true);
+                            boolean streaming = AccountUtils.getServerVersion(getAccount()).isMediaStreamingSupported();
+                            startMediaPreview(mWaitingToPreview, 0, true, true, streaming);
                             detailsFragmentChanged = true;
                         } else if (MimeTypeUtil.isVCard(mWaitingToPreview.getMimeType())) {
                             startContactListFragment(mWaitingToPreview);
@@ -2050,7 +2052,8 @@ public class FileDisplayActivity extends HookActivity
                     ((PreviewMediaFragment) details).updateFile(renamedFile);
                     if (PreviewMediaFragment.canBePreviewed(renamedFile)) {
                         int position = ((PreviewMediaFragment) details).getPosition();
-                        startMediaPreview(renamedFile, position, true, true);
+                        boolean streaming = AccountUtils.getServerVersion(getAccount()).isMediaStreamingSupported();
+                        startMediaPreview(renamedFile, position, true, true, streaming);
                     } else {
                         getFileOperationsHelper().openFile(renamedFile);
                     }
@@ -2323,8 +2326,9 @@ public class FileDisplayActivity extends HookActivity
      * @param autoplay              When 'true', the playback will start without user
      *                              interactions.
      */
-    public void startMediaPreview(OCFile file, int startPlaybackPosition, boolean autoplay, boolean showPreview) {
-        if (showPreview && file.isDown() && !file.isDownloading()) {
+    public void startMediaPreview(OCFile file, int startPlaybackPosition, boolean autoplay, boolean showPreview,
+                                  boolean streamMedia) {
+        if ((showPreview && file.isDown() && !file.isDownloading()) || streamMedia) {
             Fragment mediaFragment = PreviewMediaFragment.newInstance(file, getAccount(), startPlaybackPosition, autoplay);
             setSecondFragment(mediaFragment);
             updateFragmentsVisibility(true);
@@ -2459,9 +2463,10 @@ public class FileDisplayActivity extends HookActivity
         if (event.getIntent().getBooleanExtra(TEXT_PREVIEW, false)) {
             startTextPreview((OCFile) bundle.get(EXTRA_FILE), true);
         } else if (bundle.containsKey(PreviewVideoActivity.EXTRA_START_POSITION)) {
+            boolean streaming = AccountUtils.getServerVersion(getAccount()).isMediaStreamingSupported();
             startMediaPreview((OCFile)bundle.get(EXTRA_FILE),
                     (int)bundle.get(PreviewVideoActivity.EXTRA_START_POSITION),
-                    (boolean)bundle.get(PreviewVideoActivity.EXTRA_AUTOPLAY), true);
+                    (boolean) bundle.get(PreviewVideoActivity.EXTRA_AUTOPLAY), true, streaming);
         } else if (bundle.containsKey(PreviewImageActivity.EXTRA_VIRTUAL_TYPE)) {
             startImagePreview((OCFile)bundle.get(EXTRA_FILE),
                     (VirtualFolderType)bundle.get(PreviewImageActivity.EXTRA_VIRTUAL_TYPE),

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -367,7 +367,7 @@ public class FileOperationsHelper {
             Intent openFileWithIntent = new Intent(Intent.ACTION_VIEW);
             Uri uri = Uri.parse((String) result.getData().get(0));
 
-            openFileWithIntent.setDataAndType(uri, file.getMimetype());
+            openFileWithIntent.setDataAndType(uri, file.getMimeType());
 
             mFileActivity.startActivity(Intent.createChooser(openFileWithIntent,
                     mFileActivity.getString(R.string.stream)));

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -352,28 +352,25 @@ public class FileOperationsHelper {
     public void streamMediaFile(OCFile file) {
         mFileActivity.showLoadingDialog(mFileActivity.getString(R.string.wait_a_moment));
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Account account = AccountUtils.getCurrentOwnCloudAccount(mFileActivity);
-                StreamMediaFileOperation sfo = new StreamMediaFileOperation(file.getLocalId());
-                RemoteOperationResult result = sfo.execute(account, mFileActivity);
+        new Thread(() -> {
+            Account account = AccountUtils.getCurrentOwnCloudAccount(mFileActivity);
+            StreamMediaFileOperation sfo = new StreamMediaFileOperation(file.getLocalId());
+            RemoteOperationResult result = sfo.execute(account, mFileActivity);
 
-                mFileActivity.dismissLoadingDialog();
+            mFileActivity.dismissLoadingDialog();
 
-                if (!result.isSuccess()) {
-                    DisplayUtils.showSnackMessage(mFileActivity, R.string.stream_not_possible_headline);
-                    return;
-                }
-
-                Intent openFileWithIntent = new Intent(Intent.ACTION_VIEW);
-                Uri uri = Uri.parse((String) result.getData().get(0));
-
-                openFileWithIntent.setDataAndType(uri, file.getMimetype());
-
-                mFileActivity.startActivity(Intent.createChooser(openFileWithIntent,
-                        mFileActivity.getString(R.string.stream)));
+            if (!result.isSuccess()) {
+                DisplayUtils.showSnackMessage(mFileActivity, R.string.stream_not_possible_headline);
+                return;
             }
+
+            Intent openFileWithIntent = new Intent(Intent.ACTION_VIEW);
+            Uri uri = Uri.parse((String) result.getData().get(0));
+
+            openFileWithIntent.setDataAndType(uri, file.getMimetype());
+
+            mFileActivity.startActivity(Intent.createChooser(openFileWithIntent,
+                    mFileActivity.getString(R.string.stream)));
         }).start();
     }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -512,7 +512,7 @@ public class PreviewMediaFragment extends FileFragment implements
 
                 new LoadStreamUrl(this, client).execute(getFile().getLocalId());
             } catch (Exception e) {
-                Log_OC.e(TAG, "Loading stream url not possible: " + e.getMessage());
+                Log_OC.e(TAG, "Loading stream url not possible: " + e);
             }
         }
     }

--- a/src/main/res/layout/empty_list.xml
+++ b/src/main/res/layout/empty_list.xml
@@ -62,7 +62,6 @@
         android:layout_gravity="center_horizontal"
         android:ellipsize="end"
         android:gravity="center"
-        android:maxLines="3"
         android:text="@string/file_list_empty"
         android:visibility="gone"/>
 

--- a/src/main/res/menu/file_actions_menu.xml
+++ b/src/main/res/menu/file_actions_menu.xml
@@ -65,6 +65,13 @@
         android:showAsAction="never" />
 
     <item
+        android:id="@+id/action_stream_media"
+        android:title="@string/stream"
+        app:showAsAction="never"
+        android:showAsAction="never"
+        android:orderInCategory="1"/>
+    
+    <item
         android:id="@+id/action_send_share_file"
         android:title="@string/action_send_share"
         app:showAsAction="never"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -223,7 +223,6 @@
     <string name="media_state_loading">%1$s (loading)</string>
     <string name="media_event_done">%1$s playback finished</string>
     <string name="media_err_nothing_to_play">No media file found</string>
-    <string name="media_err_no_account">No account provided</string>
     <string name="media_err_not_in_owncloud">The file is not in a valid account</string>
     <string name="media_err_unsupported">Unsupported media codec</string>
     <string name="media_err_io">Could not read the media file</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -814,4 +814,7 @@
     <string name="trashbin_file_not_deleted">File %1$s could not be deleted!</string>
     <string name="trashbin_file_not_restored">File %1$s could not be restored!</string>
     <string name="trashbin_not_emptied">Files could not be deleted permanently!</string>
+    <string name="stream">Stream with…</string>
+    <string name="stream_not_possible_headline">Internal streaming not possible</string>
+    <string name="stream_not_possible_message">Please download media instead or use external app.</string>
 </resources>


### PR DESCRIPTION
Needs: 
- [x] https://github.com/nextcloud/android-library/pull/142
- [x] https://github.com/nextcloud/server/pull/9178

Fixes: #379 

This enables video/audio streaming without exposing any credentials.

Test cases:
NC14
- non downloaded file
    - stream video internally
		- toggle to fullscreen
    - stream audio internally
    - stream video with external app
    - stream audio with external app
- downloaded file
    - play video/audio directly

NC13
- no option to stream
- non downloaded file
    - download media, then play
- downloaded file
    - play video/audio directly


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>