### PR TITLE
authentication: Added @Override annotations to applicable methods.

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AccountAuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountAuthenticatorActivity.java
@@ -53,6 +53,7 @@ public class AccountAuthenticatorActivity extends AppCompatActivity {
      * icicle is non-zero.
      * @param icicle the save instance data of this Activity, may be null
      */
+    @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
 
@@ -67,6 +68,7 @@ public class AccountAuthenticatorActivity extends AppCompatActivity {
     /**
      * Sends the result or a Constants.ERROR_CODE_CANCELED error if a result isn't present.
      */
+    @Override
     public void finish() {
         if (mAccountAuthenticatorResponse != null) {
             // send the result bundle back if set, otherwise send an error.

--- a/src/main/java/com/owncloud/android/authentication/AccountAuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountAuthenticatorActivity.java
@@ -49,13 +49,13 @@ public class AccountAuthenticatorActivity extends AppCompatActivity {
     }
 
     /**
-     * Retreives the AccountAuthenticatorResponse from either the intent of the icicle, if the
+     * Retrieves the AccountAuthenticatorResponse from either the intent of the icicle, if the
      * icicle is non-zero.
-     * @param icicle the save instance data of this Activity, may be null
+     * @param savedInstanceState the save instance data of this Activity, may be null
      */
     @Override
-    protected void onCreate(Bundle icicle) {
-        super.onCreate(icicle);
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
         mAccountAuthenticatorResponse =
                 getIntent().getParcelableExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE);


### PR DESCRIPTION
Using the @Override annotation is useful for two reasons :

It elicits a warning from the compiler if the annotated method doesn't actually override anything, as in the case of a misspelling.
It improves the readability of the source code by making it obvious that methods are overridden.