### PR TITLE
Brander with white primary color

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -433,6 +433,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             @Override
             public void run() {
                 Snackbar.make(mLoginWebView, R.string.fallback_weblogin_text, Snackbar.LENGTH_INDEFINITE)
+                        .setActionTextColor(getResources().getColor(R.color.primary_dark))
                         .setAction(R.string.fallback_weblogin_back, new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {

--- a/src/main/res/layout/account_setup.xml
+++ b/src/main/res/layout/account_setup.xml
@@ -81,6 +81,7 @@
 
             <android.support.design.widget.TextInputLayout
                 android:id="@+id/input_layout_hostUrl"
+                android:theme="@style/EditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -114,7 +115,7 @@
                 android:padding="@dimen/zero"
                 android:scaleType="fitCenter"
                 android:src="@drawable/arrow_right"
-                android:tint="@color/white"
+                android:tint="@color/login_text_color"
                 android:background="@android:color/transparent"
                 android:onClick="onTestServerConnectionClick"
                 android:contentDescription="@string/test_server_button"
@@ -158,7 +159,7 @@
             android:onClick="onCheckClick"
             android:text="@string/oauth_check_onoff"
             android:textAppearance="?android:attr/textAppearanceSmall"
-            android:textColor="@color/white"
+            android:textColor="@color/login_text_hint_color"
             android:contentDescription="@string/oauth_check_onoff"
             />
 
@@ -206,6 +207,7 @@
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/input_layout_account_username"
+            android:theme="@style/EditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone">
@@ -226,9 +228,10 @@
             android:id="@+id/input_layout_account_password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:theme="@style/EditText"
             android:visibility="gone"
             app:passwordToggleDrawable="@drawable/password_visibility_selector"
-            app:passwordToggleTint="@color/white">
+            app:passwordToggleTint="@color/login_text_hint_color">
 
             <EditText
                 android:id="@+id/account_password"

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -110,7 +110,7 @@
 
 	<style name="Button.Login" parent="Button">
 		<item name="colorButtonNormal">@color/white</item>
-		<item name="android:textColor">@color/primary</item>
+		<item name="android:textColor">@color/primary_dark</item>
 	</style>
 
 	<style name="Button.Borderless" parent="Base.Widget.AppCompat.Button.Borderless">
@@ -243,5 +243,11 @@
 		<item name="android:textColor">#000000</item>
 	</style>
 	<style name="NextcloudTextAppearanceMedium" parent="@style/TextAppearance.AppCompat.Medium">
+	</style>
+
+	<style name="EditText" parent="Theme.AppCompat.Light">
+		<item name="colorControlActivated">@color/login_text_color</item>
+		<item name="colorControlNormal">@color/login_text_color</item>
+		<item name="android:textColorHint">@color/login_text_color</item>
 	</style>
 </resources>


### PR DESCRIPTION
If in setup.xml white is chosen as primary color, this will now show login screen.

To test use in setup.xml:
< color name="primary">#ffffff</color>
< color name="login_text_color">@color/black</color>

![2018-05-03-182339](https://user-images.githubusercontent.com/5836855/39589738-4faa3674-4eff-11e8-94dd-97808c72e08a.png)

TODO
- [x] do the same for old login method
- [x] revert button on snackbar not correct tinted

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>