### PR TITLE
ortiz.touch: End switch case with an unconditional break.

### DIFF
--- a/src/main/java/com/ortiz/touch/TouchImageView.java
+++ b/src/main/java/com/ortiz/touch/TouchImageView.java
@@ -572,6 +572,7 @@ public class TouchImageView extends AppCompatImageView {
         	
         case CENTER_INSIDE:
         	scaleX = scaleY = Math.min(1, Math.min(scaleX, scaleY));
+        	break;
         	
         case FIT_CENTER:
         	scaleX = scaleY = Math.min(scaleX, scaleY);


### PR DESCRIPTION
No idea who maintains the TouchImageView class, but it seems like a bug to me that the switch case is missing a break.