### PR TITLE
ui: Corrected '&' to '&&' in boolean if statement.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -272,7 +272,7 @@ public class UserInfoActivity extends FileActivity {
         }
         
         if (userInfo.getPhone() == null && userInfo.getEmail() == null && userInfo.getAddress() == null
-                && userInfo.getTwitter() == null & userInfo.getWebsite() == null) {
+                && userInfo.getTwitter() == null && userInfo.getWebsite() == null) {
 
             setErrorMessageForMultiList(getString(R.string.userinfo_no_info_headline),
                     getString(R.string.userinfo_no_info_text), R.drawable.ic_user);


### PR DESCRIPTION
The use of non-short-circuit logic in a boolean context is likely a mistake - one that could cause serious program errors as conditions are evaluated under the wrong circumstances.