### PR TITLE
Anonymous inner classes containing only one method should become lambdas

### DIFF
--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -511,20 +511,14 @@ public class MainApp extends MultiDexApplication {
                     new AlertDialog.Builder(context, R.style.Theme_ownCloud_Dialog)
                             .setTitle(R.string.drawer_synced_folders)
                             .setMessage(R.string.synced_folders_new_info)
-                            .setPositiveButton(R.string.drawer_open, new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int which) {
-                                    // show Auto Upload
-                                    Intent folderSyncIntent = new Intent(context,
-                                            SyncedFoldersActivity.class);
-                                    dialog.dismiss();
-                                    context.startActivity(folderSyncIntent);
-                                }
+                            .setPositiveButton(R.string.drawer_open, (dialog, which) -> {
+                                // show Auto Upload
+                                Intent folderSyncIntent = new Intent(context,
+                                        SyncedFoldersActivity.class);
+                                dialog.dismiss();
+                                context.startActivity(folderSyncIntent);
                             })
-                            .setNegativeButton(R.string.drawer_close, new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int which) {
-                                    dialog.dismiss();
-                                }
-                            })
+                            .setNegativeButton(R.string.drawer_close, (dialog, which) -> dialog.dismiss())
                             .setIcon(R.drawable.nav_synced_folders)
                             .show();
                 } catch (WindowManager.BadTokenException e) {

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -513,8 +513,7 @@ public class MainApp extends MultiDexApplication {
                             .setMessage(R.string.synced_folders_new_info)
                             .setPositiveButton(R.string.drawer_open, (dialog, which) -> {
                                 // show Auto Upload
-                                Intent folderSyncIntent = new Intent(context,
-                                        SyncedFoldersActivity.class);
+                                Intent folderSyncIntent = new Intent(context, SyncedFoldersActivity.class);
                                 dialog.dismiss();
                                 context.startActivity(folderSyncIntent);
                             })

--- a/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
@@ -112,13 +112,7 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
             final String message = String.format(mContext.getString(R.string.auth_unsupported_multiaccount), mContext.getString(R.string.app_name)); 
             bundle.putString(AccountManager.KEY_ERROR_MESSAGE, message);
            
-            mHandler.post(new Runnable() {
-
-                @Override
-                public void run() {
-                    Toast.makeText(mContext, message, Toast.LENGTH_SHORT).show();
-                }
-            });
+            mHandler.post(() -> Toast.makeText(mContext, message, Toast.LENGTH_SHORT).show());
             
         }
         

--- a/src/main/java/com/owncloud/android/authentication/SsoWebViewClient.java
+++ b/src/main/java/com/owncloud/android/authentication/SsoWebViewClient.java
@@ -125,14 +125,11 @@ public class SsoWebViewClient extends WebViewClient {
             //Log_OC.d(TAG, "Cookies: " + cookies);
             if (mListenerHandler != null && mListenerRef != null) {
                 // this is good idea because onPageFinished is not running in the UI thread
-                mListenerHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        SsoWebViewClientListener listener = mListenerRef.get();
-                        if (listener != null) {
-                        	// Send Cookies to the listener
-                            listener.onSsoFinished(cookies);
-                        }
+                mListenerHandler.post(() -> {
+                    SsoWebViewClientListener listener = mListenerRef.get();
+                    if (listener != null) {
+                        // Send Cookies to the listener
+                        listener.onSsoFinished(cookies);
                     }
                 });
             }

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -51,7 +51,6 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatDelegate;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.URLUtil;


### PR DESCRIPTION
Before Java 8, the only way to partially support closures in Java was by using anonymous inner classes. But the syntax of anonymous classes may seem unwieldy and unclear.

With Java 8, most uses of anonymous inner classes should be replaced by lambdas to highly increase the readability of the source code.