### PR TITLE
datamodel: String function use should be optimized for single characters

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -237,9 +237,9 @@ public class SyncedFolderProvider extends Observable {
             if (!new File(syncedFolder.getLocalPath()).exists()) {
                 String localPath = syncedFolder.getLocalPath();
                 if (localPath.endsWith("/")) {
-                    localPath = localPath.substring(0, localPath.lastIndexOf("/"));
+                    localPath = localPath.substring(0, localPath.lastIndexOf('/'));
                 }
-                localPath = localPath.substring(0, localPath.lastIndexOf("/"));
+                localPath = localPath.substring(0, localPath.lastIndexOf('/'));
                 if (new File(localPath).exists()) {
                     syncedFolders.get(i).setLocalPath(localPath);
                     updateSyncFolder(syncedFolder);


### PR DESCRIPTION
An lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.