### PR TITLE
MainApp: Fixed auto upload state check.

### DIFF
--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -488,7 +488,8 @@ public class MainApp extends MultiDexApplication {
 
     private static void updateToAutoUpload() {
             Context context = getAppContext();
-            if (PreferenceManager.instantPictureUploadEnabled(context)) {
+            if (PreferenceManager.instantPictureUploadEnabled(context) ||
+                    PreferenceManager.instantVideoUploadEnabled(context)){
 
                 // remove legacy shared preferences
                 SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -488,8 +488,7 @@ public class MainApp extends MultiDexApplication {
 
     private static void updateToAutoUpload() {
             Context context = getAppContext();
-            if (PreferenceManager.instantPictureUploadEnabled(context) ||
-                            PreferenceManager.instantPictureUploadEnabled(context)) {
+            if (PreferenceManager.instantPictureUploadEnabled(context)) {
 
                 // remove legacy shared preferences
                 SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();


### PR DESCRIPTION
This is almost certainly a mistake. Using the same value on either side of a binary operator makes no sense. It should check whether photo uploads or video uploads are enabled.