### PR TITLE
authentication: Fixed HTTPS prefixed URL normalization.

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorUrlUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorUrlUtils.java
@@ -78,7 +78,7 @@ public abstract class AuthenticatorUrlUtils {
             normalizedUrl = normalizedUrl.trim();
 
             if (!normalizedUrl.toLowerCase(Locale.ROOT).startsWith(HTTP_PROTOCOL) &&
-                    !normalizedUrl.toLowerCase(Locale.ROOT).startsWith(HTTP_PROTOCOL)) {
+                    !normalizedUrl.toLowerCase(Locale.ROOT).startsWith(HTTPS_PROTOCOL)) {
                 if (sslWhenUnprefixed) {
                     normalizedUrl = HTTPS_PROTOCOL + normalizedUrl;
                 } else {


### PR DESCRIPTION
I'm assuming here that the if statement is supposed to be checking whether the normalized URL starts with HTTP or HTTPS. The current version seemingly has a typo which this commit fixes.