### PR TITLE
Verify context before getting file type icon.

### DIFF
--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>Helper class for detecting the right icon for a file or folder,
  * based on its mime type and file extension.</p>
@@ -94,6 +96,7 @@ public class MimeTypeUtil {
      * @param account account which color should be used
      * @return Drawable of an image resource.
      */
+    @Nullable
     public static Drawable getFileTypeIcon(String mimetype, String filename, Account account, Context context) {
         if (context != null) {
             int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);

--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -22,6 +22,7 @@ import android.accounts.Account;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.support.v4.content.ContextCompat;
 import android.webkit.MimeTypeMap;
 
 import com.owncloud.android.R;
@@ -96,7 +97,7 @@ public class MimeTypeUtil {
     public static Drawable getFileTypeIcon(String mimetype, String filename, Account account, Context context) {
         if (context != null) {
             int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);
-            Drawable icon = context.getResources().getDrawable(iconId);
+            Drawable icon = ContextCompat.getDrawable(context, iconId);
 
             if (R.drawable.file_zip == iconId) {
                 ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(account, context));

--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -94,14 +94,18 @@ public class MimeTypeUtil {
      * @return Drawable of an image resource.
      */
     public static Drawable getFileTypeIcon(String mimetype, String filename, Account account, Context context) {
-        int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);
-        Drawable icon = context.getResources().getDrawable(iconId);
+        if (context != null) {
+            int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);
+            Drawable icon = context.getResources().getDrawable(iconId);
 
-        if(R.drawable.file_zip == iconId) {
-            ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(account, context));
+            if (R.drawable.file_zip == iconId) {
+                ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(account, context));
+            }
+
+            return icon;
+        } else {
+            return null;
         }
-
-        return icon;
     }
 
     /**


### PR DESCRIPTION
The context object passed to `getFileTypeIcon` can be null and we should therefore verify that it's not before calling `context.getResources()`. 

Furthermore, `context.getResources()` was deprecated in Marshmellow and we should be using the new theme aware equivalent.

This fixes #2569 