### PR TITLE
Lib refers always to master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,9 +194,9 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.3'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:filterActivities-SNAPSHOT"
-    gplayImplementation "com.github.nextcloud:android-library:filterActivities-SNAPSHOT"
-    versionDevImplementation 'com.github.nextcloud:android-library:filterActivities-SNAPSHOT' // use always latest master
+    genericImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
+    gplayImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
+    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'


### PR DESCRIPTION
- lib refers always to master
- only releases, in our release branch, target a specific library version

This way we can merge any PR to library without having to release inbetween version.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>