### PR TITLE
Ignore "unused quantity"

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -16,6 +16,12 @@
         <ignore path="**/values-ka-rGE/strings.xml"/>
     </issue>
 
+    <issue id="UnusedQuantity">
+        <ignore path="**/values-sk-rSK/strings.xml"/>
+        <ignore path="**/values-cs-rCZ/strings.xml"/>
+        <ignore path="**/values-lt-rLT/strings.xml"/>
+    </issue>
+
     <issue id="ExtraTranslation">
         <ignore path="**/strings.xml"/>
         <ignore path="**/values-b+en+001/strings.xml"/>


### PR DESCRIPTION
> Android defines a number of different quantity strings, such as zero, one, few and many. However, many languages do not distinguish grammatically between all these different quantities.
>
>This lint check looks at the quantity strings defined for each translation and flags any quantity strings that are unused (because the language does not make that quantity distinction, and Android will therefore not look it up).
>
>For example, in Chinese, only the other quantity is used, so even if you provide translations for zero and one, these strings will not be returned when getQuantityString() is called, even with 0 or 1.


As transifex is not that smart to prevent translation of those languages that not have all quantities, we simply ignore lint.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>