### PR TITLE
res:styles: Don't use a translucent navigation bar in the Preview activity

### DIFF
--- a/src/main/res/values-v19/styles.xml
+++ b/src/main/res/values-v19/styles.xml
@@ -6,7 +6,6 @@
         <item name="android:windowActionBarOverlay">true</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:windowTranslucentNavigation">true</item>
         <!-- Support library compatibility -->
         <item name="actionBarStyle">@style/Theme.ownCloud.Overlay.ActionBar</item>
         <item name="windowActionBarOverlay">true</item>


### PR DESCRIPTION
This causes view elements at the bottom to overlap with the navigation bar which makes it impossible to interact with said elements. 

With a normal navigation bar the snackbar messages in the Preview fragment will appear correctly above the navigation bar and tapping the image will still hide the navigation bar just like before.

Unless anyone feels very strongly about the navigation bar having to be translucent I think this is a good solution to a pretty nasty bug.