### PR TITLE
ui:preview Simplified generateCheckerboardLayeredDrawable()

### DIFF
--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -703,18 +703,21 @@ public class PreviewImageFragment extends FileFragment {
         LayerDrawable layerDrawable = new LayerDrawable(layers);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (result.ocFile.getMimetype().equalsIgnoreCase(MIME_TYPE_PNG)) {
-                layerDrawable.setLayerSize(0, convertDpToPixel(bitmap.getWidth(),
-                        getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
-                layerDrawable.setLayerSize(1, convertDpToPixel(bitmap.getWidth(),
-                        getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
-            } else {
-                layerDrawable.setLayerSize(0,
-                        convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
-                        convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
-                layerDrawable.setLayerSize(1,
-                        convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
-                        convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
+            Activity activity = getActivity();
+            if (activity != null) {
+                if (result.ocFile.getMimetype().equalsIgnoreCase(MIME_TYPE_PNG)) {
+                    layerDrawable.setLayerSize(0, convertDpToPixel(bitmap.getWidth(),
+                            getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
+                    layerDrawable.setLayerSize(1, convertDpToPixel(bitmap.getWidth(),
+                            getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
+                } else {
+                    layerDrawable.setLayerSize(0,
+                            convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
+                            convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
+                    layerDrawable.setLayerSize(1,
+                            convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
+                            convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
+                }
             }
         }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -706,17 +706,21 @@ public class PreviewImageFragment extends FileFragment {
             Activity activity = getActivity();
             if (activity != null) {
                 if (result.ocFile.getMimetype().equalsIgnoreCase(MIME_TYPE_PNG)) {
-                    layerDrawable.setLayerSize(0, convertDpToPixel(bitmap.getWidth(),
-                            getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
-                    layerDrawable.setLayerSize(1, convertDpToPixel(bitmap.getWidth(),
-                            getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
+                    int bitmapWidth = convertDpToPixel(bitmap.getWidth(),
+                            getActivity());
+                    int bitmapHeight = convertDpToPixel(bitmap.getHeight(),
+                            getActivity());
+                    layerDrawable.setLayerSize(0, bitmapWidth, bitmapHeight);
+                    layerDrawable.setLayerSize(1, bitmapWidth, bitmapHeight);
                 } else {
-                    layerDrawable.setLayerSize(0,
-                            convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
-                            convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
-                    layerDrawable.setLayerSize(1,
-                            convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
-                            convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
+                    int bitmapIntrinsicWidth = convertDpToPixel(bitmapDrawable.getIntrinsicWidth(),
+                            getActivity());
+                    int bitmapIntrinsicHeight = convertDpToPixel(bitmapDrawable.getIntrinsicHeight(),
+                            getActivity());
+                    layerDrawable.setLayerSize(0, bitmapIntrinsicWidth,
+                            bitmapIntrinsicHeight);
+                    layerDrawable.setLayerSize(1, bitmapIntrinsicWidth,
+                            bitmapIntrinsicHeight);
                 }
             }
         }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -704,19 +704,17 @@ public class PreviewImageFragment extends FileFragment {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (result.ocFile.getMimetype().equalsIgnoreCase(MIME_TYPE_PNG)) {
-                layerDrawable.setLayerHeight(0, convertDpToPixel(bitmap.getHeight(), getActivity()));
-                layerDrawable.setLayerHeight(1, convertDpToPixel(bitmap.getHeight(), getActivity()));
-                layerDrawable.setLayerWidth(0, convertDpToPixel(bitmap.getWidth(), getActivity()));
-                layerDrawable.setLayerWidth(1, convertDpToPixel(bitmap.getWidth(), getActivity()));
+                layerDrawable.setLayerSize(0, convertDpToPixel(bitmap.getWidth(),
+                        getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
+                layerDrawable.setLayerSize(1, convertDpToPixel(bitmap.getWidth(),
+                        getActivity()), convertDpToPixel(bitmap.getHeight(), getActivity()));
             } else {
-                layerDrawable.setLayerHeight(0, convertDpToPixel(bitmapDrawable.getIntrinsicHeight(),
-                        getActivity()));
-                layerDrawable.setLayerHeight(1, convertDpToPixel(bitmapDrawable.getIntrinsicHeight(),
-                        getActivity()));
-                layerDrawable.setLayerWidth(0, convertDpToPixel(bitmapDrawable.getIntrinsicWidth(),
-                        getActivity()));
-                layerDrawable.setLayerWidth(1, convertDpToPixel(bitmapDrawable.getIntrinsicWidth(),
-                        getActivity()));
+                layerDrawable.setLayerSize(0,
+                        convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
+                        convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
+                layerDrawable.setLayerSize(1,
+                        convertDpToPixel(bitmapDrawable.getIntrinsicHeight(), getActivity()),
+                        convertDpToPixel(bitmapDrawable.getIntrinsicWidth(), getActivity()));
             }
         }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -705,22 +705,25 @@ public class PreviewImageFragment extends FileFragment {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             Activity activity = getActivity();
             if (activity != null) {
+                int bitmapWidth;
+                int bitmapHeight;
+
                 if (result.ocFile.getMimetype().equalsIgnoreCase(MIME_TYPE_PNG)) {
-                    int bitmapWidth = convertDpToPixel(bitmap.getWidth(),
+                    bitmapWidth = convertDpToPixel(bitmap.getWidth(),
                             getActivity());
-                    int bitmapHeight = convertDpToPixel(bitmap.getHeight(),
+                    bitmapHeight = convertDpToPixel(bitmap.getHeight(),
                             getActivity());
                     layerDrawable.setLayerSize(0, bitmapWidth, bitmapHeight);
                     layerDrawable.setLayerSize(1, bitmapWidth, bitmapHeight);
                 } else {
-                    int bitmapIntrinsicWidth = convertDpToPixel(bitmapDrawable.getIntrinsicWidth(),
+                    bitmapWidth = convertDpToPixel(bitmapDrawable.getIntrinsicWidth(),
                             getActivity());
-                    int bitmapIntrinsicHeight = convertDpToPixel(bitmapDrawable.getIntrinsicHeight(),
+                    bitmapHeight = convertDpToPixel(bitmapDrawable.getIntrinsicHeight(),
                             getActivity());
-                    layerDrawable.setLayerSize(0, bitmapIntrinsicWidth,
-                            bitmapIntrinsicHeight);
-                    layerDrawable.setLayerSize(1, bitmapIntrinsicWidth,
-                            bitmapIntrinsicHeight);
+                    layerDrawable.setLayerSize(0, bitmapWidth,
+                            bitmapHeight);
+                    layerDrawable.setLayerSize(1, bitmapWidth,
+                            bitmapHeight);
                 }
             }
         }


### PR DESCRIPTION
Simplified `generateCheckerboardLayeredDrawable() `by replacing the separate calls to `setLayerWidth` and `setLayerHeight` with `setLayerSize()`. Also added a check to verify that `getActivity() `is not null before generating the `layerDrawable`.