### PR TITLE
Ignore translations files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,6 @@ coverage:
 comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default
+
+ignore:
+  - "src/main/res/values*/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,3 +14,4 @@ comment:
 
 ignore:
   - "src/main/res/values*/*"
+  


### PR DESCRIPTION
Should ignore all translations files, otherwise if new translations in a language are added, coverage will be reduced, but this is not meaningful for us.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>