### PR TITLE
ui:activity Removed unused override method in ManageAccountsActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -148,11 +148,6 @@ public class ManageAccountsActivity extends FileActivity
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
-    }
-
-    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         switch (resultCode) {


### PR DESCRIPTION
Overriding a method just to call the same method from the super class without performing any other actions is useless and misleading.