### PR TITLE
ui:activity: Removed @NonNull annotation for method where null can be returned

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
@@ -153,7 +153,6 @@ public class ErrorsWhileCopyingHandlerActivity  extends AppCompatActivity implem
         /**
          * {@inheritDoc}
          */
-        @NonNull
         @Override
         public View getView (int position, View convertView, @NonNull ViewGroup parent) {
             View view = convertView;


### PR DESCRIPTION
The return value is marked @NonNull and is therefore assumed to only return non-null values. Therefore setting one of these values to null, or failing to set such a class field in a constructor, could cause NullPointerExceptions at runtime. In this case, view might be null.