### PR TITLE
Shorten code and improve readability via a menu helper

### DIFF
--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -124,7 +124,12 @@ public class FileMenuFilter {
         }
     }
 
-    private static void hideMenuItem(MenuItem item) {
+    /**
+     * hides a given {@link MenuItem}.
+     *
+     * @param item the {@link MenuItem} to be hidden
+     */
+    public static void hideMenuItem(MenuItem item) {
         if (item != null) {
             item.setVisible(false);
             item.setEnabled(false);

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -333,64 +333,20 @@ public class PreviewImageFragment extends FileFragment {
 
         // additional restriction for this fragment 
         // TODO allow renaming in PreviewImageFragment
-        MenuItem item = menu.findItem(R.id.action_rename_file);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment 
         // TODO allow refresh file in PreviewImageFragment
-        item = menu.findItem(R.id.action_sync_file);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_select_all);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_move);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_copy);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_favorite);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_unset_favorite);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
+        FileMenuFilter.hideMenuItems(
+                menu.findItem(R.id.action_rename_file),
+                menu.findItem(R.id.action_sync_file),
+                menu.findItem(R.id.action_select_all),
+                menu.findItem(R.id.action_move),
+                menu.findItem(R.id.action_copy),
+                menu.findItem(R.id.action_favorite),
+                menu.findItem(R.id.action_unset_favorite)
+        );
 
         if (getFile().isSharedWithMe() && !getFile().canReshare()) {
-            // additional restriction for this fragment
-            item = menu.findItem(R.id.action_send_share_file);
-            if (item != null) {
-                item.setVisible(false);
-                item.setEnabled(false);
-            }
+            FileMenuFilter.hideMenuItem(menu.findItem(R.id.action_send_share_file));
         }
-
     }
 
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -78,10 +78,10 @@ public class PreviewTextFragment extends FileFragment {
 
     /**
      * Creates an empty fragment for previews.
-     * <p/>
+     *
      * MUST BE KEPT: the system uses it when tries to re-instantiate a fragment automatically
      * (for instance, when the device is turned a aside).
-     * <p/>
+     *
      * DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful
      * construction
      */
@@ -169,7 +169,7 @@ public class PreviewTextFragment extends FileFragment {
      * {@inheritDoc}
      */
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(PreviewTextFragment.EXTRA_FILE, getFile());
         outState.putParcelable(PreviewTextFragment.EXTRA_ACCOUNT, mAccount);
@@ -296,82 +296,28 @@ public class PreviewTextFragment extends FileFragment {
         }
 
         // additional restriction for this fragment
-        MenuItem item = menu.findItem(R.id.action_rename_file);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_select_all);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_move);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // this one doesn't make sense since the file has to be down in order to be previewed
-        item = menu.findItem(R.id.action_download_file);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        item = menu.findItem(R.id.action_sync_file);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        item = menu.findItem(R.id.action_sync_account);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
+        FileMenuFilter.hideMenuItems(
+                menu.findItem(R.id.action_rename_file),
+                menu.findItem(R.id.action_select_all),
+                menu.findItem(R.id.action_move),
+                menu.findItem(R.id.action_download_file),
+                menu.findItem(R.id.action_sync_file),
+                menu.findItem(R.id.action_sync_account),
+                menu.findItem(R.id.action_favorite),
+                menu.findItem(R.id.action_unset_favorite)
+        );
 
         Boolean dualPane = getResources().getBoolean(R.bool.large_land_layout);
 
-        item = menu.findItem(R.id.action_switch_view);
-        if (item != null && !dualPane){
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        item = menu.findItem(R.id.action_sort);
-        if (item != null && !dualPane) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_favorite);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
-        // additional restriction for this fragment
-        item = menu.findItem(R.id.action_unset_favorite);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
+        if (!dualPane) {
+            FileMenuFilter.hideMenuItems(menu.findItem(R.id.action_switch_view),
+                    menu.findItem(R.id.action_sort)
+            );
         }
 
         if(getFile().isSharedWithMe() && !getFile().canReshare()){
-            // additional restriction for this fragment
-            item = menu.findItem(R.id.action_send_share_file);
-            if(item != null){
-                item.setVisible(false);
-                item.setEnabled(false);
-            }
+            FileMenuFilter.hideMenuItem(menu.findItem(R.id.action_send_share_file));
         }
-
     }
 
     /**


### PR DESCRIPTION
Preview*Fragment hides a lot of menu items thus I use the helper implementation to reduce the code and improve the readablity. To be further utilized e.g. for sharing fragments, but only after this PR has been merged to reduce the risk of large merge conflicts.

cc @ardevd @tobiasKaminsky @mario for review :)