### PR TITLE
tint zip icon same as folder icon

### DIFF
--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -103,7 +103,7 @@ public class MimeTypeUtil {
             Drawable icon = ContextCompat.getDrawable(context, iconId);
 
             if (R.drawable.file_zip == iconId) {
-                ThemeUtils.tintDrawable(icon, ThemeUtils.primaryColor(account, context));
+                ThemeUtils.tintDrawable(icon, ThemeUtils.elementColor(account, context));
             }
 
             return icon;


### PR DESCRIPTION
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>
![2018-05-28-142825](https://user-images.githubusercontent.com/5836855/40614531-673a18bc-6283-11e8-95ce-7330d67f825b.png)

This is now same as we use in folderTypeIcon:
https://github.com/nextcloud/android/blob/364c92cfcc92b1f8201c855d9d2aa5cc1334802b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java#L154-L172