### PR TITLE
Explicitly allow gcm on gplay

### DIFF
--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -77,6 +77,17 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name="com.evernote.android.job.gcm.PlatformGcmService"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE"
+            tools:replace="android:enabled">
+            <intent-filter>
+                <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY"/>
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>


### PR DESCRIPTION
Fix #2643 
Fix #2639 

This happens due to a change on google side:
https://github.com/evernote/android-job/issues/415


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>