### PR TITLE
Do not process result of async task if activity is stopped

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -318,4 +318,11 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
         swipeListRefreshLayout.post(() -> swipeListRefreshLayout.setRefreshing(isActive));
 
     }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+
+        mActionListener.stopLoadingActivity();
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesContract.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesContract.java
@@ -40,5 +40,7 @@ public interface ActivitiesContract {
     interface ActionListener {
         void loadActivities(String pageUrl);
         void openActivity(String fileUrl, BaseActivity baseActivity, boolean isSharingSupported);
+
+        void stopLoadingActivity();
     }
 }

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesPresenter.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesPresenter.java
@@ -35,6 +35,7 @@ public class ActivitiesPresenter implements ActivitiesContract.ActionListener {
     private final ActivitiesContract.View activitiesView;
     private final ActivitiesRepository activitiesRepository;
     private final FilesRepository filesRepository;
+    private boolean activityStopped = false;
 
 
     ActivitiesPresenter(@NonNull ActivitiesRepository activitiesRepository,
@@ -52,14 +53,19 @@ public class ActivitiesPresenter implements ActivitiesContract.ActionListener {
             @Override
             public void onActivitiesLoaded(List<Object> activities, OwnCloudClient client,
                                            String nextPageUrl) {
-                activitiesView.setProgressIndicatorState(false);
-                activitiesView.showActivities(activities, client, nextPageUrl);
+
+                if (!activityStopped) {
+                    activitiesView.setProgressIndicatorState(false);
+                    activitiesView.showActivities(activities, client, nextPageUrl);
+                }
             }
 
             @Override
             public void onActivitiesLoadedError(String error) {
-                activitiesView.setProgressIndicatorState(false);
-                activitiesView.showActivitiesLoadError(error);
+                if (!activityStopped) {
+                    activitiesView.setProgressIndicatorState(false);
+                    activitiesView.showActivitiesLoadError(error);
+                }
             }
         });
     }
@@ -85,5 +91,10 @@ public class ActivitiesPresenter implements ActivitiesContract.ActionListener {
                         activitiesView.showActivityDetailError(error);
                     }
                 });
+    }
+
+    @Override
+    public void stopLoadingActivity() {
+        activityStopped = true;
     }
 }


### PR DESCRIPTION
Fix #2640 

This is quite a hacky way as it does not stop the async task.
There are lots of different approaches out there how to handle "long running" async tasks.
We should discuss this and take also in account how to cancel the tasks to prevent unneeded network calls.

But for now this is hopefully a "good" solution.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>