### PR TITLE
lint: ignore setJavaScriptEnabled

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -42,6 +42,7 @@ package com.owncloud.android.authentication;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.ComponentName;
 import android.content.Context;
@@ -355,6 +356,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 Build.MANUFACTURER.substring(1).toLowerCase(Locale.getDefault()) + " " + Build.MODEL;
     }
 
+    @SuppressLint("SetJavaScriptEnabled")
     private void initWebViewLogin(String baseURL) {
         mLoginWebView.setVisibility(View.GONE);
 

--- a/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
@@ -21,6 +21,7 @@
 
 package com.owncloud.android.ui.activity;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.widget.DrawerLayout;
@@ -42,7 +43,6 @@ import java.io.InputStream;
 /**
  * This activity shows an URL as a web view
  */
-
 public class ExternalSiteWebView extends FileActivity {
     public static final String EXTRA_TITLE = "TITLE";
     public static final String EXTRA_URL = "URL";
@@ -55,6 +55,7 @@ public class ExternalSiteWebView extends FileActivity {
     private int menuItemId;
     private WebView webview;
 
+    @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log_OC.v(TAG, "onCreate() start");

--- a/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
@@ -24,6 +24,7 @@ package com.owncloud.android.ui.activity;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -265,6 +266,7 @@ public class WhatsNewActivity extends FragmentActivity implements ViewPager.OnPa
             mWebUrl = getArguments() != null ? getArguments().getString("url") : null;
         }
 
+        @SuppressLint("SetJavaScriptEnabled")
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, 


### PR DESCRIPTION
we enable this for all our web views which is fine and lint just adds a warning so this is carefully reviewed. Thus the only way to then get rid of the warning is to suppress it.