### PR TITLE
util: Added @Override annotation where applicable.

### DIFF
--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
@@ -63,6 +63,7 @@ public class FileSortOrderByDate extends FileSortOrder {
      *
      * @param files list of files to sort
      */
+    @Override
     public List<File> sortLocalFiles(List<File> files) {
         final int multiplier = mAscending ? 1 : -1;
 

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
@@ -70,6 +70,7 @@ public class FileSortOrderByName extends FileSortOrder {
      *
      * @param files files to sort
      */
+    @Override
     public List<File> sortLocalFiles(List<File> files) {
         final int multiplier = mAscending ? 1 : -1;
 

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
@@ -73,6 +73,7 @@ public class FileSortOrderBySize extends FileSortOrder {
      *
      * @param files list of files to sort
      */
+    @Override
     public List<File> sortLocalFiles(List<File> files) {
         final int multiplier = mAscending ? 1 : -1;
 


### PR DESCRIPTION
Using the @Override annotation is useful for two reasons :

It elicits a warning from the compiler if the annotated method doesn't actually override anything, as in the case of a misspelling.
It improves the readability of the source code by making it obvious that methods are overridden.