### PR TITLE
fragment:util: Added private constructor to hide the inherit public one

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/util/FileDetailSharingFragmentHelper.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/util/FileDetailSharingFragmentHelper.java
@@ -39,6 +39,10 @@ import java.util.Date;
  */
 public class FileDetailSharingFragmentHelper {
 
+    private FileDetailSharingFragmentHelper() {
+        // Private empty constructor
+    }
+
     /**
      * Sets checked/visiblity state on the given {@link MenuItem} based on the given criteria.
      *


### PR DESCRIPTION
Utility classes, which are collections of static members, are not meant to be instantiated.

Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.