### PR TITLE
Feedback: test if any email app is available

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -384,7 +384,12 @@ public class Preferences extends PreferenceActivity
 
                         intent.setData(Uri.parse(feedbackMail));
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        startActivity(intent);
+
+                        if (intent.resolveActivity(getPackageManager()) != null) {
+                            startActivity(intent);
+                        } else {
+                            DisplayUtils.showSnackMessage(Preferences.this, R.string.feedback_no_mail_app);
+                        }
 
                         return true;
                     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -806,4 +806,5 @@
     <string name="file_version_restored_error">Error restoring file version!</string>
     <string name="outdated_server">The server has reached end of life, please upgrade!</string>
     <string name="dismiss">Dismiss</string>
+    <string name="feedback_no_mail_app">No app available to send mails!</string>
 </resources>


### PR DESCRIPTION
Found via google play console:
- disable any email app
- click on preferences -> feedback
-> crash: android.content.ActivityNotFoundException

Now we are testing this, and if no app is available, show a snackbar.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>