### PR TITLE
Search enhancements

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -2182,7 +2182,7 @@ public class FileDataStorageManager {
         if (onlyImages) {
             List<OCFile> temp = new ArrayList<>();
 
-            for (OCFile file : temp) {
+            for (OCFile file : ocFiles) {
                 if (MimeTypeUtil.isImage(file)) {
                     temp.add(file);
                 }

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -816,6 +816,11 @@ public class FileDisplayActivity extends HookActivity
                     setDrawerIndicatorEnabled(isDrawerIndicatorAvailable()); // order matters
                     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
                     mDrawerToggle.syncState();
+
+                    if (getListOfFilesFragment() != null) {
+                        getListOfFilesFragment().setSearchFragment(false);
+                        getListOfFilesFragment().refreshDirectory();
+                    }
                 } else {
                     searchView.post(new Runnable() {
                         @Override
@@ -1197,7 +1202,7 @@ public class FileDisplayActivity extends HookActivity
 
         if (searchView != null && !TextUtils.isEmpty(searchQuery)) {
             searchView.setQuery(searchQuery, true);
-        } else if (getListOfFilesFragment() != null && !getListOfFilesFragment().getIsSearchFragment()
+        } else if (getListOfFilesFragment() != null && !getListOfFilesFragment().isSearchFragment()
                 && startFile == null) {
             refreshListOfFilesFragment(false);
         } else {
@@ -1206,7 +1211,7 @@ public class FileDisplayActivity extends HookActivity
         }
 
         // Listen for sync messages
-        if (getListOfFilesFragment() != null && !getListOfFilesFragment().getIsSearchFragment()) {
+        if (getListOfFilesFragment() != null && !getListOfFilesFragment().isSearchFragment()) {
             IntentFilter syncIntentFilter = new IntentFilter(FileSyncAdapter.EVENT_FULL_SYNC_START);
             syncIntentFilter.addAction(FileSyncAdapter.EVENT_FULL_SYNC_END);
             syncIntentFilter.addAction(FileSyncAdapter.EVENT_FULL_SYNC_FOLDER_CONTENTS_SYNCED);
@@ -2425,11 +2430,9 @@ public class FileDisplayActivity extends HookActivity
 
     private void refreshList(boolean ignoreETag) {
         OCFileListFragment listOfFiles = getListOfFilesFragment();
-        if (listOfFiles != null && !listOfFiles.getIsSearchFragment()) {
+        if (listOfFiles != null && !listOfFiles.isSearchFragment()) {
             OCFile folder = listOfFiles.getCurrentFile();
             if (folder != null) {
-                /*mFile = mContainerActivity.getStorageManager().getFileById(mFile.getFileId());
-                listDirectory(mFile);*/
                 startSyncFolderOperation(folder, ignoreETag);
             }
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -198,7 +198,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
             mFile = savedInstanceState.getParcelable(KEY_FILE);
         }
 
-        searchFragment = currentSearchType != null;
+        searchFragment = currentSearchType != null && searchEvent != null;
     }
 
     /**
@@ -234,9 +234,11 @@ public class OCFileListFragment extends ExtendedListFragment implements
         bottomNavigationView = v.findViewById(R.id.bottom_navigation_view);
 
         if (savedInstanceState != null
-                && Parcels.unwrap(savedInstanceState.getParcelable(KEY_CURRENT_SEARCH_TYPE)) != null) {
-            currentSearchType = Parcels.unwrap(savedInstanceState.getParcelable(KEY_CURRENT_SEARCH_TYPE));
+                && Parcels.unwrap(savedInstanceState.getParcelable(KEY_CURRENT_SEARCH_TYPE)) != null &&
+                Parcels.unwrap(savedInstanceState.getParcelable(OCFileListFragment.SEARCH_EVENT)) != null) {
             searchFragment = true;
+            currentSearchType = Parcels.unwrap(savedInstanceState.getParcelable(KEY_CURRENT_SEARCH_TYPE));
+            searchEvent = Parcels.unwrap(savedInstanceState.getParcelable(OCFileListFragment.SEARCH_EVENT));
         } else {
             currentSearchType = SearchType.NO_SEARCH;
         }
@@ -1547,6 +1549,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
             mRefreshListLayout.setRefreshing(false);
         } else {
+            searchFragment = false;
             super.onRefresh();
         }
     }
@@ -1555,7 +1558,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         this.searchFragment = searchFragment;
     }
 
-    public boolean getIsSearchFragment() {
+    public boolean isSearchFragment() {
         return searchFragment;
     }
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/pull/2726

- correct filtering of images in favorites/shared
	- tag an image as favorite
	- drawer: favorites
	- click on image: previously no image, now you see the image

- sync folder on search
	- clean/fresh installed app
	- have a folder tagged as favorite
	- drawer -> favorites
	- click on folder: previously no content, now content
	(has the "downside" that every folder within result is synced (with eTag check)

- closing search
	- search for something
	- close search with "x"
	- see root folder, previously search result remained

- getting back from preview image
	- favorited image
	- drawer -> favorites
	- click on image
	- go back: now current dir, previously: endless loop
	(it should show favorites again, which will be solved via #2723)