### PR TITLE
Wrong behaviour on privacy tab

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
@@ -97,7 +97,12 @@ public class ExternalSiteWebView extends FileActivity {
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             ThemeUtils.setColoredTitle(actionBar, title, this);
-            actionBar.setDisplayHomeAsUpEnabled(true);
+
+            if (showSidebar) {
+                actionBar.setDisplayHomeAsUpEnabled(true);
+            } else {
+                setDrawerIndicatorEnabled(false);
+            }
         }
 
         // enable zoom
@@ -157,8 +162,7 @@ public class ExternalSiteWebView extends FileActivity {
                         openDrawer();
                     }
                 } else {
-                    Intent settingsIntent = new Intent(getApplicationContext(), Preferences.class);
-                    startActivity(settingsIntent);
+                    finish();
                 }
             retval = true;
             break;


### PR DESCRIPTION
Fix #2721 
- show correct drawer icon
- do not start preferences on "back"

Steps to test:
- open up privacy, go back
- open up an external site in drawer

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>