### PR TITLE
Show outdated server warning for server <NC12

### DIFF
--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -59,6 +59,7 @@ import com.owncloud.android.jobs.NCJobCreator;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory.Policy;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.activity.ContactsPreferenceActivity;
 import com.owncloud.android.ui.activity.Preferences;
 import com.owncloud.android.ui.activity.SyncedFoldersActivity;
@@ -88,6 +89,8 @@ import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFER
  * classes
  */
 public class MainApp extends MultiDexApplication {
+
+    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = OwnCloudVersion.nextcloud_12;
 
     private static final String TAG = MainApp.class.getSimpleName();
 

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1419,7 +1419,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             mServerInfo = (GetServerInfoOperation.ServerInfo) (result.getData().get(0));
 
             // show outdated warning
-            if (mServerInfo.mVersion.compareTo(OwnCloudVersion.nextcloud_12) < 0) {
+            if (mServerInfo.mVersion.compareTo(MainApp.OUTDATED_SERVER_VERSION) < 0) {
                 DisplayUtils.showServerOutdatedSnackbar(this);
             }
 

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1418,6 +1418,11 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             //      4. we got the authentication method required by the server 
             mServerInfo = (GetServerInfoOperation.ServerInfo) (result.getData().get(0));
 
+            // show outdated warning
+            if (mServerInfo.mVersion.compareTo(OwnCloudVersion.nextcloud_12) < 0) {
+                DisplayUtils.showServerOutdatedSnackbar(this);
+            }
+
             webViewLoginMethod = mServerInfo.mVersion.isWebLoginSupported() && !forceOldLoginMethod;
 
             if (webViewUser != null && !webViewUser.isEmpty() &&

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -365,7 +365,7 @@ public class FileDisplayActivity extends HookActivity
         if (MainApp.getVersionCode() > lastSeenVersion) {
             OwnCloudVersion serverVersion = AccountUtils.getServerVersionForAccount(account, this);
 
-            if (serverVersion.compareTo(OwnCloudVersion.nextcloud_12) < 0) {
+            if (serverVersion.compareTo(MainApp.OUTDATED_SERVER_VERSION) < 0) {
                 DisplayUtils.showServerOutdatedSnackbar(this);
             }
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -69,6 +69,7 @@ import android.widget.ImageView;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
+import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
@@ -85,6 +86,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCo
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
+import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.media.MediaService;
 import com.owncloud.android.media.MediaServiceBinder;
 import com.owncloud.android.operations.CopyFileOperation;
@@ -301,6 +303,7 @@ public class FileDisplayActivity extends HookActivity
         // always AFTER setContentView(...) in onCreate(); to work around bug in its implementation
 
         upgradeNotificationForInstantUpload();
+        checkOutdatedServer();
     }
 
     private Activity getActivity() {
@@ -350,6 +353,24 @@ public class FileDisplayActivity extends HookActivity
                     })
                     .setIcon(R.drawable.nav_synced_folders)
                     .show();
+        }
+    }
+
+    private void checkOutdatedServer() {
+        ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
+        Account account = getAccount();
+
+        int lastSeenVersion = arbitraryDataProvider.getIntegerValue(account, WhatsNewActivity.KEY_LAST_SEEN_VERSION_CODE);
+
+        if (MainApp.getVersionCode() > lastSeenVersion) {
+            OwnCloudVersion serverVersion = AccountUtils.getServerVersionForAccount(account, this);
+
+            if (serverVersion.compareTo(OwnCloudVersion.nextcloud_12) < 0) {
+                DisplayUtils.showServerOutdatedSnackbar(this);
+            }
+
+            arbitraryDataProvider.storeOrUpdateKeyValue(account.name, WhatsNewActivity.KEY_LAST_SEEN_VERSION_CODE,
+                    String.valueOf(MainApp.getVersionCode()));
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
@@ -182,7 +182,7 @@ public class WhatsNewActivity extends FragmentActivity implements ViewPager.OnPa
         editor.apply();
     }
 
-    static private int getLastSeenVersionCode() {
+    static public int getLastSeenVersionCode() {
         SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(MainApp.getAppContext());
         return pref.getInt(KEY_LAST_SEEN_VERSION_CODE, 0);
     }

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -767,4 +767,11 @@ public class DisplayUtils {
         }
     }
 
+    static public void showServerOutdatedSnackbar(Activity activity) {
+        Snackbar.make(activity.findViewById(android.R.id.content),
+                R.string.outdated_server, Snackbar.LENGTH_INDEFINITE)
+                .setAction(R.string.dismiss, v -> {
+                })
+                .show();
+    }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -801,4 +801,6 @@
     <string name="new_version_was_created">New version was created</string>
     <string name="file_version_restored_successfully">Successfully restored file version.</string>
     <string name="file_version_restored_error">Error restoring file version!</string>
+    <string name="outdated_server">The server has reached end of life, please upgrade!</string>
+    <string name="dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
Fix #2240 

On new account / new installation:

legacy login:
![2018-06-19-135629](https://user-images.githubusercontent.com/5836855/41595860-998e19d4-73c8-11e8-930f-ae0535326710.png)

weblogin:
![2018-06-19-135815](https://user-images.githubusercontent.com/5836855/41595922-df758d9c-73c8-11e8-8817-89e9db1fafa5.png)

This is on app upgrade:

![2018-06-19-143713](https://user-images.githubusercontent.com/5836855/41597630-47124d1e-73ce-11e8-8e7b-9ffe510a4712.png)

It is shown/checked once for each account.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>