### PR TITLE
fix wrong access to mFilesAll

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -139,7 +139,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public int getItemPosition(File file) {
-        return mFilesAll.indexOf(file);
+        return mFiles.indexOf(file);
     }
 
     public String[] getCheckedFilesPath() {


### PR DESCRIPTION
Fix #2729 

mFilesAll is only used to restore after ending filtering.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>