### PR TITLE
Backport: fix wrong access to mFilesAll

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -139,7 +139,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public int getItemPosition(File file) {
-        return mFilesAll.indexOf(file);
+        return mFiles.indexOf(file);
     }
 
     public String[] getCheckedFilesPath() {


### PR DESCRIPTION
Backport of #2734 / #2729