### PR TITLE
Intent may be null

### DIFF
--- a/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -182,7 +182,7 @@ public class OperationsService extends Service {
 
         // WIP: for the moment, only SYNC_FOLDER is expected here;
         // the rest of the operations are requested through the Binder
-        if (ACTION_SYNC_FOLDER.equals(intent.getAction())) {
+        if (intent != null && ACTION_SYNC_FOLDER.equals(intent.getAction())) {
 
             if (!intent.hasExtra(EXTRA_ACCOUNT) || !intent.hasExtra(EXTRA_REMOTE_PATH)) {
                 Log_OC.e(TAG, "Not enough information provided in intent");


### PR DESCRIPTION
Found via google play console.

> The Intent supplied to Context.startService, as given. This may be null if the service is being restarted after its process has gone away, and it had previously returned anything except START_STICKY_COMPATIBILITY.


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>