### PR TITLE
Account may be null

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -111,9 +111,14 @@ public class ManageAccountsActivity extends FileActivity
 
         Account[] accountList = AccountManager.get(this).getAccountsByType(MainApp.getAccountType(this));
         mOriginalAccounts = DisplayUtils.toAccountNameSet(Arrays.asList(accountList));
-        mOriginalCurrentAccount = AccountUtils.getCurrentOwnCloudAccount(this).name;
 
-        setAccount(AccountUtils.getCurrentOwnCloudAccount(this));
+        Account currentAccount = AccountUtils.getCurrentOwnCloudAccount(this);
+
+        if (currentAccount != null) {
+            mOriginalCurrentAccount = currentAccount.name;
+        }
+
+        setAccount(currentAccount);
         onAccountSet(false);
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());

--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -212,7 +212,7 @@ public class ManageAccountsActivity extends FileActivity
         if (account == null) {
             return true;
         } else {
-            return !mOriginalCurrentAccount.equals(account.name);
+            return !account.name.equals(mOriginalCurrentAccount);
         }
     }
 


### PR DESCRIPTION
Found via google play console.

I have no steps to reproduce and I do not understand how we can have no valid account, when opening manageAccountActivity, but this should help to prevent a crash.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>