### PR TITLE
Added missing @Override annotations above applicable method signatures.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -181,6 +181,7 @@ public class TrashbinActivity extends FileActivity implements TrashbinActivityIn
         return retval;
     }
 
+    @Override
     public void onDestroy() {
         super.onDestroy();
         unbinder.unbind();

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
@@ -55,6 +55,7 @@ public class FileSortOrderByDate extends FileSortOrder {
      *
      * @param files list of files to sort
      */
+    @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
         final int multiplier = mAscending ? 1 : -1;
 

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
@@ -69,6 +69,7 @@ public class FileSortOrderByName extends FileSortOrder {
      * @param files files to sort
      */
     @SuppressFBWarnings(value = "Bx")
+    @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
         final int multiplier = mAscending ? 1 : -1;
 

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
@@ -68,6 +68,7 @@ public class FileSortOrderBySize extends FileSortOrder {
      *
      * @param files list of files to sort
      */
+    @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
         final int multiplier = mAscending ? 1 : -1;
 


### PR DESCRIPTION
Using the @Override annotation is useful for two reasons:

- It elicits a warning from the compiler if the annotated method doesn't actually override anything, as in the case of a misspelling.
- It improves the readability of the source code by making it obvious that methods are overridden.