### PR TITLE
Correct menu highlighting

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -229,6 +229,8 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
     protected void onResume() {
         super.onResume();
 
+        setDrawerMenuItemChecked(R.id.nav_activity);
+        
         setupContent();
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1012,6 +1012,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
 
                 DisplayUtils.downloadIcon(this, link.iconUrl, target, R.drawable.ic_link_grey, size, size);
             }
+
+            setDrawerMenuItemChecked(mCheckedMenuItem);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -240,7 +240,6 @@ public class FileDisplayActivity extends HookActivity
             setupDrawer(R.id.nav_all_files);
         }
 
-
         mDualPane = getResources().getBoolean(R.bool.large_land_layout);
         mLeftFragmentContainer = findViewById(R.id.left_fragment_container);
         mRightFragmentContainer = findViewById(R.id.right_fragment_container);
@@ -1198,8 +1197,8 @@ public class FileDisplayActivity extends HookActivity
         }
 
         revertBottomNavigationBarToAllFiles();
-        // refresh list of files
 
+        // refresh list of files
         if (searchView != null && !TextUtils.isEmpty(searchQuery)) {
             searchView.setQuery(searchQuery, true);
         } else if (getListOfFilesFragment() != null && !getListOfFilesFragment().isSearchFragment()
@@ -1235,8 +1234,14 @@ public class FileDisplayActivity extends HookActivity
         mDownloadFinishReceiver = new DownloadFinishReceiver();
         registerReceiver(mDownloadFinishReceiver, downloadIntentFilter);
 
+        // setup drawer
+        if (MainApp.isOnlyOnDevice()) {
+            setDrawerMenuItemChecked(R.id.nav_on_device);
+        } else {
+            setDrawerMenuItemChecked(R.id.nav_all_files);
+        }
+        
         Log_OC.v(TAG, "onResume() end");
-
     }
 
 

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -356,4 +356,11 @@ public class NotificationsActivity extends FileActivity {
             emptyContentIcon.setVisibility(View.VISIBLE);
         }
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        setDrawerMenuItemChecked(R.id.nav_notifications);
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
@@ -146,4 +146,11 @@ public class ParticipateActivity extends FileActivity {
         fileDisplayActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(fileDisplayActivity);
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        setDrawerMenuItemChecked(R.id.nav_participate);
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
@@ -665,4 +665,11 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
                 FileUploader.LOCAL_BEHAVIOUR_FORGET, false, null, MediaFolderType.CUSTOM);
         onSyncFolderSettingsClick(0, emptyCustomFolder);
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        setDrawerMenuItemChecked(R.id.nav_synced_folders);
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -196,6 +196,8 @@ public class UploadListActivity extends FileActivity {
         Log_OC.v(TAG, "onResume() start");
         super.onResume();
 
+        setDrawerMenuItemChecked(R.id.nav_uploads);
+
         // Listen for upload messages
         mUploadMessagesReceiver = new UploadMessagesReceiver();
         IntentFilter uploadIntentFilter = new IntentFilter();


### PR DESCRIPTION
Now every combination (as far as I tested) should work, e.g.
- on device
- settings
- on device

Please note that this does not work
- favorites
- settings
- back
-> it shows "all files" as also the "search" vanished.
So the menu highlighting is correct, but the behaviour is not ;-)
This is true for all other "search"-related menus.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>