### PR TITLE
after download: update file via remote id

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -141,6 +141,17 @@ public class FileDataStorageManager {
         return file;
     }
 
+    public @Nullable
+    OCFile getFileByRemoteId(String remoteId) {
+        Cursor c = getFileCursorForValue(ProviderTableMeta.FILE_REMOTE_ID, remoteId);
+        OCFile file = null;
+        if (c.moveToFirst()) {
+            file = createFileInstance(c);
+        }
+        c.close();
+        return file;
+    }
+
     public boolean fileExists(long id) {
         return fileExists(ProviderTableMeta._ID, String.valueOf(id));
     }

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1521,8 +1521,9 @@ public class FileDisplayActivity extends HookActivity
                 }
 
                 if (mWaitingToSend != null) {
-                    mWaitingToSend = getStorageManager().getFileByPath(mWaitingToSend.getRemotePath());
-                    if (mWaitingToSend.isDown() && downloadBehaviour != null) {
+                    // update file after downloading
+                    mWaitingToSend = getStorageManager().getFileByRemoteId(mWaitingToSend.getRemoteId());
+                    if (mWaitingToSend != null && mWaitingToSend.isDown() && downloadBehaviour != null) {
                         switch (downloadBehaviour) {
                             case OCFileListFragment.DOWNLOAD_SEND:
                                 String packageName = intent.getStringExtra(SendShareDialog.PACKAGE_NAME);


### PR DESCRIPTION
Found via google play console:
```
Caused by: java.lang.NullPointerException: 
  at com.owncloud.android.ui.activity.FileDisplayActivity$DownloadFinishReceiver.onReceive (FileDisplayActivity.java:1493)
  at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$-android_app_LoadedApk$ReceiverDispatcher$Args_52225 (LoadedApk.java:1319)
```

https://github.com/nextcloud/android/blob/f8801115f2f9a27b6da52aaf5b1c36940b1f2652/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java#L1518-L1520

The file gets refreshed because metadata could have changed.
Somehow then storageManager cannot find it anylonger.
(mWaitingToSend is *not* null, as this would produce an IllegalArgumentException).
So my assumption is that somehow the the remote path is changed and thus the file cannot be found anymore.
--> remoteId stays the same, so it is better to use.

Additionally, I added a null check, so that in doubt nothing happens, but at least also do not crash.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>