### PR TITLE
TimSort, first fix values, then sort

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -79,7 +79,7 @@ public class UploadsStorageManager extends Observable {
         cv.put(ProviderTableMeta.UPLOADS_FORCE_OVERWRITE, ocUpload.isForceOverwrite() ? 1 : 0);
         cv.put(ProviderTableMeta.UPLOADS_IS_CREATE_REMOTE_FOLDER, ocUpload.isCreateRemoteFolder() ? 1 : 0);
         cv.put(ProviderTableMeta.UPLOADS_LAST_RESULT, ocUpload.getLastResult().getValue());
-        cv.put(ProviderTableMeta.UPLOADS_CREATED_BY, ocUpload.getCreadtedBy());
+        cv.put(ProviderTableMeta.UPLOADS_CREATED_BY, ocUpload.getCreatedBy());
         cv.put(ProviderTableMeta.UPLOADS_IS_WHILE_CHARGING_ONLY, ocUpload.isWhileChargingOnly() ? 1 : 0);
         cv.put(ProviderTableMeta.UPLOADS_IS_WIFI_ONLY, ocUpload.isUseWifiOnly() ? 1 : 0);
         cv.put(ProviderTableMeta.UPLOADS_FOLDER_UNLOCK_TOKEN, ocUpload.getFolderUnlockToken());

--- a/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -82,7 +82,7 @@ public class OCUpload implements Parcelable {
     /**
      * Create destination folder?
      */
-    private boolean isCreateRemoteFolder;
+    private boolean createRemoteFolder;
 
     /**
      * Status of upload (later, in_progress, ...).
@@ -107,12 +107,12 @@ public class OCUpload implements Parcelable {
     /**
      * Upload only via wifi?
      */
-    private boolean isUseWifiOnly;
+    private boolean useWifiOnly;
 
     /**
      * Upload only if phone being charged?
      */
-    private boolean isWhileChargingOnly;
+    private boolean whileChargingOnly;
 
     /**
      * Token to unlock E2E folder
@@ -151,7 +151,7 @@ public class OCUpload implements Parcelable {
     }
 
     /**
-     * Convenience constructor to reupload already existing {@link OCFile}s.
+     * Convenience constructor to re-upload already existing {@link OCFile}s.
      *
      * @param  ocFile           {@link OCFile} instance to update in the remote server.
      * @param  account          ownCloud {@link Account} where ocFile is contained.
@@ -171,12 +171,12 @@ public class OCUpload implements Parcelable {
         id = -1;
         localAction = FileUploader.LOCAL_BEHAVIOUR_COPY;
         forceOverwrite = false;
-        isCreateRemoteFolder = false;
+        createRemoteFolder = false;
         uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS;
         lastResult = UploadResult.UNKNOWN;
         createdBy = UploadFileOperation.CREATED_BY_USER;
-        isUseWifiOnly = true;
-        isWhileChargingOnly = false;
+        useWifiOnly = true;
+        whileChargingOnly = false;
         folderUnlockToken = "";
     }
 
@@ -223,7 +223,7 @@ public class OCUpload implements Parcelable {
      * @param lastResult the lastResult to set
      */
     public void setLastResult(UploadResult lastResult) {
-        this.lastResult = ((lastResult != null) ? lastResult : UploadResult.UNKNOWN);
+        this.lastResult = lastResult != null ? lastResult : UploadResult.UNKNOWN;
     }
 
 
@@ -303,14 +303,14 @@ public class OCUpload implements Parcelable {
      * @return the isCreateRemoteFolder
      */
     public boolean isCreateRemoteFolder() {
-        return isCreateRemoteFolder;
+        return createRemoteFolder;
     }
 
     /**
-     * @param isCreateRemoteFolder the isCreateRemoteFolder to set
+     * @param createRemoteFolder the createRemoteFolder to set
      */
-    public void setCreateRemoteFolder(boolean isCreateRemoteFolder) {
-        this.isCreateRemoteFolder = isCreateRemoteFolder;
+    public void setCreateRemoteFolder(boolean createRemoteFolder) {
+        this.createRemoteFolder = createRemoteFolder;
     }
 
     /**
@@ -331,7 +331,7 @@ public class OCUpload implements Parcelable {
         this.createdBy = createdBy;
     }
 
-    public int getCreadtedBy() {
+    public int getCreatedBy() {
         return createdBy;
     }
 
@@ -377,22 +377,22 @@ public class OCUpload implements Parcelable {
      * @return the isUseWifiOnly
      */
     public boolean isUseWifiOnly() {
-        return isUseWifiOnly;
+        return useWifiOnly;
     }
 
     /**
-     * @param isUseWifiOnly the isUseWifiOnly to set
+     * @param useWifiOnly the useWifiOnly to set
      */
-    public void setUseWifiOnly(boolean isUseWifiOnly) {
-        this.isUseWifiOnly = isUseWifiOnly;
+    public void setUseWifiOnly(boolean useWifiOnly) {
+        this.useWifiOnly = useWifiOnly;
     }
 
-    public void setWhileChargingOnly(boolean isWhileChargingOnly) {
-        this.isWhileChargingOnly = isWhileChargingOnly;
+    public void setWhileChargingOnly(boolean whileChargingOnly) {
+        this.whileChargingOnly = whileChargingOnly;
     }
 
     public boolean isWhileChargingOnly() {
-        return isWhileChargingOnly;
+        return whileChargingOnly;
     }
 
     public void setFolderUnlockToken(String token) {
@@ -419,7 +419,7 @@ public class OCUpload implements Parcelable {
         accountName = source.readString();
         localAction = source.readInt();
         forceOverwrite = source.readInt() == 1;
-        isCreateRemoteFolder = source.readInt() == 1;
+        createRemoteFolder = source.readInt() == 1;
         try {
             uploadStatus = UploadStatus.valueOf(source.readString());
         } catch (IllegalArgumentException x) {
@@ -432,8 +432,8 @@ public class OCUpload implements Parcelable {
             lastResult = UploadResult.UNKNOWN;
         }
         createdBy = source.readInt();
-        isUseWifiOnly = source.readInt() == 1;
-        isWhileChargingOnly = source.readInt() == 1;
+        useWifiOnly = source.readInt() == 1;
+        whileChargingOnly = source.readInt() == 1;
         folderUnlockToken = source.readString();
     }
 
@@ -450,13 +450,13 @@ public class OCUpload implements Parcelable {
         dest.writeString(accountName);
         dest.writeInt(localAction);
         dest.writeInt(forceOverwrite ? 1 : 0);
-        dest.writeInt(isCreateRemoteFolder ? 1 : 0);
+        dest.writeInt(createRemoteFolder ? 1 : 0);
         dest.writeString(uploadStatus.name());
         dest.writeLong(uploadEndTimeStamp);
-        dest.writeString(((lastResult == null) ? "" : lastResult.name()));
+        dest.writeString(lastResult == null ? "" : lastResult.name());
         dest.writeInt(createdBy);
-        dest.writeInt(isUseWifiOnly ? 1 : 0);
-        dest.writeInt(isWhileChargingOnly ? 1 : 0);
+        dest.writeInt(useWifiOnly ? 1 : 0);
+        dest.writeInt(whileChargingOnly ? 1 : 0);
         dest.writeString(folderUnlockToken);
     }
 

--- a/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -47,85 +47,85 @@ public class OCUpload implements Parcelable {
 
     private static final String TAG = OCUpload.class.getSimpleName();
 
-    private long mId;
+    private long id;
 
     /**
      * Absolute path in the local file system to the file to be uploaded.
      */
-    private String mLocalPath;
+    private String localPath;
 
     /**
      * Absolute path in the remote account to set to the uploaded file (not for its parent folder!)
      */
-    private String mRemotePath;
+    private String remotePath;
 
     /**
      * Name of Owncloud account to upload file to.
      */
-    private String mAccountName;
+    private String accountName;
 
     /**
      * File size.
      */
-    private long mFileSize;
+    private long fileSize;
 
     /**
      * Local action for upload. (0 - COPY, 1 - MOVE, 2 - FORGET)
      */
-    private int mLocalAction;
+    private int localAction;
 
     /**
      * Overwrite destination file?
      */
-    private boolean mForceOverwrite;
+    private boolean forceOverwrite;
 
     /**
      * Create destination folder?
      */
-    private boolean mIsCreateRemoteFolder;
+    private boolean isCreateRemoteFolder;
 
     /**
      * Status of upload (later, in_progress, ...).
      */
-    private UploadStatus mUploadStatus;
+    private UploadStatus uploadStatus;
 
     /**
      * Result from last upload operation. Can be null.
      */
-    private UploadResult mLastResult;
+    private UploadResult lastResult;
 
     /**
      * Defines the origin of the upload; see constants CREATED_ in {@link UploadFileOperation}
      */
-    private int mCreatedBy;
+    private int createdBy;
 
     /**
      * When the upload ended
      */
-    private long mUploadEndTimeStamp;
+    private long uploadEndTimeStamp;
 
     /**
      * Upload only via wifi?
      */
-    private boolean mIsUseWifiOnly;
+    private boolean isUseWifiOnly;
 
     /**
      * Upload only if phone being charged?
      */
-    private boolean mIsWhileChargingOnly;
+    private boolean isWhileChargingOnly;
 
     /**
      * Token to unlock E2E folder
      */
-    private String mFolderUnlockToken;
+    private String folderUnlockToken;
 
     /**
      * temporary values, used for sorting
      */
-    private UploadStatus mFixedUploadStatus;
-    private boolean mFixedUploadingNow;
-    private long mFixedUploadEndTimeStamp;
-    private long mFixedId;
+    private UploadStatus fixedUploadStatus;
+    private boolean fixedUploadingNow;
+    private long fixedUploadEndTimeStamp;
+    private long fixedId;
 
     /**
      * Main constructor.
@@ -145,9 +145,9 @@ public class OCUpload implements Parcelable {
             throw new IllegalArgumentException("Invalid account name");
         }
         resetData();
-        mLocalPath = localPath;
-        mRemotePath = remotePath;
-        mAccountName = accountName;
+        this.localPath = localPath;
+        this.remotePath = remotePath;
+        this.accountName = accountName;
     }
 
     /**
@@ -164,43 +164,43 @@ public class OCUpload implements Parcelable {
      * Reset all the fields to default values.
      */
     private void resetData() {
-        mRemotePath = "";
-        mLocalPath = "";
-        mAccountName = "";
-        mFileSize = -1;
-        mId = -1;
-        mLocalAction = FileUploader.LOCAL_BEHAVIOUR_COPY;
-        mForceOverwrite = false;
-        mIsCreateRemoteFolder = false;
-        mUploadStatus = UploadStatus.UPLOAD_IN_PROGRESS;
-        mLastResult = UploadResult.UNKNOWN;
-        mCreatedBy = UploadFileOperation.CREATED_BY_USER;
-        mIsUseWifiOnly = true;
-        mIsWhileChargingOnly = false;
-        mFolderUnlockToken = "";
+        remotePath = "";
+        localPath = "";
+        accountName = "";
+        fileSize = -1;
+        id = -1;
+        localAction = FileUploader.LOCAL_BEHAVIOUR_COPY;
+        forceOverwrite = false;
+        isCreateRemoteFolder = false;
+        uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS;
+        lastResult = UploadResult.UNKNOWN;
+        createdBy = UploadFileOperation.CREATED_BY_USER;
+        isUseWifiOnly = true;
+        isWhileChargingOnly = false;
+        folderUnlockToken = "";
     }
 
     public void setDataFixed(FileUploader.FileUploaderBinder binder) {
-        mFixedUploadStatus = mUploadStatus;
-        mFixedUploadingNow = binder != null && binder.isUploadingNow(this);
-        mFixedUploadEndTimeStamp = mUploadEndTimeStamp;
-        mFixedId = mId;
+        fixedUploadStatus = uploadStatus;
+        fixedUploadingNow = binder != null && binder.isUploadingNow(this);
+        fixedUploadEndTimeStamp = uploadEndTimeStamp;
+        fixedId = id;
     }
 
     // Getters & Setters
     public void setUploadId(long id) {
-        mId = id;
+        this.id = id;
     }
 
     public long getUploadId() {
-        return mId;
+        return id;
     }
 
     /**
      * @return the uploadStatus
      */
     public UploadStatus getUploadStatus() {
-        return mUploadStatus;
+        return uploadStatus;
     }
 
     /**
@@ -208,7 +208,7 @@ public class OCUpload implements Parcelable {
      * @param uploadStatus the uploadStatus to set
      */
     public void setUploadStatus(UploadStatus uploadStatus) {
-        this.mUploadStatus = uploadStatus;
+        this.uploadStatus = uploadStatus;
         setLastResult(UploadResult.UNKNOWN);
     }
 
@@ -216,14 +216,14 @@ public class OCUpload implements Parcelable {
      * @return the lastResult
      */
     public UploadResult getLastResult() {
-        return mLastResult;
+        return lastResult;
     }
 
     /**
      * @param lastResult the lastResult to set
      */
     public void setLastResult(UploadResult lastResult) {
-        this.mLastResult = ((lastResult != null) ? lastResult : UploadResult.UNKNOWN);
+        this.lastResult = ((lastResult != null) ? lastResult : UploadResult.UNKNOWN);
     }
 
 
@@ -231,25 +231,25 @@ public class OCUpload implements Parcelable {
      * @return the localPath
      */
     public String getLocalPath() {
-        return mLocalPath;
+        return localPath;
     }
 
     public void setLocalPath(String localPath) {
-        mLocalPath = localPath;
+        this.localPath = localPath;
     }
 
     /**
      * @return the remotePath
      */
     public String getRemotePath() {
-        return mRemotePath;
+        return remotePath;
     }
 
     /**
      * @param remotePath the remotePath
      */
     public void setRemotePath(String remotePath) {
-        mRemotePath = remotePath;
+        this.remotePath = remotePath;
     }
 
 
@@ -257,67 +257,67 @@ public class OCUpload implements Parcelable {
      * @return File size
      */
     public long getFileSize() {
-        return mFileSize;
+        return fileSize;
     }
 
     public void setFileSize(long fileSize) {
-        mFileSize = fileSize;
+        this.fileSize = fileSize;
     }
 
     /**
      * @return the mimeType
      */
     public String getMimeType() {
-        return MimeTypeUtil.getBestMimeTypeByFilename(mLocalPath);
+        return MimeTypeUtil.getBestMimeTypeByFilename(localPath);
     }
 
     /**
      * @return the localAction
      */
     public int getLocalAction() {
-        return mLocalAction;
+        return localAction;
     }
 
     /**
      * @param localAction the localAction to set
      */
     public void setLocalAction(int localAction) {
-        this.mLocalAction = localAction;
+        this.localAction = localAction;
     }
 
     /**
      * @return the forceOverwrite
      */
     public boolean isForceOverwrite() {
-        return mForceOverwrite;
+        return forceOverwrite;
     }
 
     /**
      * @param forceOverwrite the forceOverwrite to set
      */
     public void setForceOverwrite(boolean forceOverwrite) {
-        this.mForceOverwrite = forceOverwrite;
+        this.forceOverwrite = forceOverwrite;
     }
 
     /**
      * @return the isCreateRemoteFolder
      */
     public boolean isCreateRemoteFolder() {
-        return mIsCreateRemoteFolder;
+        return isCreateRemoteFolder;
     }
 
     /**
      * @param isCreateRemoteFolder the isCreateRemoteFolder to set
      */
     public void setCreateRemoteFolder(boolean isCreateRemoteFolder) {
-        this.mIsCreateRemoteFolder = isCreateRemoteFolder;
+        this.isCreateRemoteFolder = isCreateRemoteFolder;
     }
 
     /**
      * @return the accountName
      */
     public String getAccountName() {
-        return mAccountName;
+        return accountName;
     }
 
     /**
@@ -328,19 +328,19 @@ public class OCUpload implements Parcelable {
     }
 
     public void setCreatedBy(int createdBy) {
-        mCreatedBy = createdBy;
+        this.createdBy = createdBy;
     }
 
     public int getCreadtedBy() {
-        return mCreatedBy;
+        return createdBy;
     }
 
     public void setUploadEndTimestamp(long uploadEndTimestamp) {
-        mUploadEndTimeStamp = uploadEndTimestamp;
+        uploadEndTimeStamp = uploadEndTimestamp;
     }
 
     public long getUploadEndTimestamp() {
-        return mUploadEndTimeStamp;
+        return uploadEndTimeStamp;
     }
 
     /**
@@ -377,30 +377,30 @@ public class OCUpload implements Parcelable {
      * @return the isUseWifiOnly
      */
     public boolean isUseWifiOnly() {
-        return mIsUseWifiOnly;
+        return isUseWifiOnly;
     }
 
     /**
      * @param isUseWifiOnly the isUseWifiOnly to set
      */
     public void setUseWifiOnly(boolean isUseWifiOnly) {
-        this.mIsUseWifiOnly = isUseWifiOnly;
+        this.isUseWifiOnly = isUseWifiOnly;
     }
 
     public void setWhileChargingOnly(boolean isWhileChargingOnly) {
-        this.mIsWhileChargingOnly = isWhileChargingOnly;
+        this.isWhileChargingOnly = isWhileChargingOnly;
     }
 
     public boolean isWhileChargingOnly() {
-        return mIsWhileChargingOnly;
+        return isWhileChargingOnly;
     }
 
     public void setFolderUnlockToken(String token) {
-        mFolderUnlockToken = token;
+        folderUnlockToken = token;
     }
 
     public String getFolderUnlockToken() {
-        return mFolderUnlockToken;
+        return folderUnlockToken;
     }
 
     /**
@@ -413,28 +413,28 @@ public class OCUpload implements Parcelable {
     }
 
     private void readFromParcel(Parcel source) {
-        mId = source.readLong();
-        mLocalPath = source.readString();
-        mRemotePath = source.readString();
-        mAccountName = source.readString();
-        mLocalAction = source.readInt();
-        mForceOverwrite = source.readInt() == 1;
-        mIsCreateRemoteFolder = source.readInt() == 1;
+        id = source.readLong();
+        localPath = source.readString();
+        remotePath = source.readString();
+        accountName = source.readString();
+        localAction = source.readInt();
+        forceOverwrite = source.readInt() == 1;
+        isCreateRemoteFolder = source.readInt() == 1;
         try {
-            mUploadStatus = UploadStatus.valueOf(source.readString());
+            uploadStatus = UploadStatus.valueOf(source.readString());
         } catch (IllegalArgumentException x) {
-            mUploadStatus = UploadStatus.UPLOAD_IN_PROGRESS;
+            uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS;
         }
-        mUploadEndTimeStamp = source.readLong();
+        uploadEndTimeStamp = source.readLong();
         try {
-            mLastResult = UploadResult.valueOf(source.readString());
+            lastResult = UploadResult.valueOf(source.readString());
         } catch (IllegalArgumentException x) {
-            mLastResult = UploadResult.UNKNOWN;
+            lastResult = UploadResult.UNKNOWN;
         }
-        mCreatedBy = source.readInt();
-        mIsUseWifiOnly = source.readInt() == 1;
-        mIsWhileChargingOnly = source.readInt() == 1;
-        mFolderUnlockToken = source.readString();
+        createdBy = source.readInt();
+        isUseWifiOnly = source.readInt() == 1;
+        isWhileChargingOnly = source.readInt() == 1;
+        folderUnlockToken = source.readString();
     }
 
     @Override
@@ -444,36 +444,36 @@ public class OCUpload implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeLong(mId);
-        dest.writeString(mLocalPath);
-        dest.writeString(mRemotePath);
-        dest.writeString(mAccountName);
-        dest.writeInt(mLocalAction);
-        dest.writeInt(mForceOverwrite ? 1 : 0);
-        dest.writeInt(mIsCreateRemoteFolder ? 1 : 0);
-        dest.writeString(mUploadStatus.name());
-        dest.writeLong(mUploadEndTimeStamp);
-        dest.writeString(((mLastResult == null) ? "" : mLastResult.name()));
-        dest.writeInt(mCreatedBy);
-        dest.writeInt(mIsUseWifiOnly ? 1 : 0);
-        dest.writeInt(mIsWhileChargingOnly ? 1 : 0);
-        dest.writeString(mFolderUnlockToken);
+        dest.writeLong(id);
+        dest.writeString(localPath);
+        dest.writeString(remotePath);
+        dest.writeString(accountName);
+        dest.writeInt(localAction);
+        dest.writeInt(forceOverwrite ? 1 : 0);
+        dest.writeInt(isCreateRemoteFolder ? 1 : 0);
+        dest.writeString(uploadStatus.name());
+        dest.writeLong(uploadEndTimeStamp);
+        dest.writeString(((lastResult == null) ? "" : lastResult.name()));
+        dest.writeInt(createdBy);
+        dest.writeInt(isUseWifiOnly ? 1 : 0);
+        dest.writeInt(isWhileChargingOnly ? 1 : 0);
+        dest.writeString(folderUnlockToken);
     }
 
     public UploadStatus getFixedUploadStatus() {
-        return mFixedUploadStatus;
+        return fixedUploadStatus;
     }
 
     public boolean isFixedUploadingNow() {
-        return mFixedUploadingNow;
+        return fixedUploadingNow;
     }
 
     public long getFixedUploadEndTimestamp() {
-        return mFixedUploadEndTimeStamp;
+        return fixedUploadEndTimeStamp;
     }
 
     public Long getFixedUploadId() {
-        return mFixedId;
+        return fixedId;
     }
 
     enum CanUploadFileNowStatus {NOW, LATER, FILE_GONE, ERROR}

--- a/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -4,7 +4,9 @@
  * @author LukeOwncloud
  * @author masensio
  * @author David A. Velasco
+ * @author Tobias Kaminsky
  * Copyright (C) 2016 ownCloud Inc.
+ * Copyright (C) 2018 Nextcloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -118,6 +120,14 @@ public class OCUpload implements Parcelable {
     private String mFolderUnlockToken;
 
     /**
+     * temporary values, used for sorting
+     */
+    private UploadStatus mFixedUploadStatus;
+    private boolean mFixedUploadingNow;
+    private long mFixedUploadEndTimeStamp;
+    private long mFixedId;
+
+    /**
      * Main constructor.
      *
      * @param localPath         Absolute path in the local file system to the file to be uploaded.
@@ -168,6 +178,13 @@ public class OCUpload implements Parcelable {
         mIsUseWifiOnly = true;
         mIsWhileChargingOnly = false;
         mFolderUnlockToken = "";
+    }
+
+    public void setDataFixed(FileUploader.FileUploaderBinder binder) {
+        mFixedUploadStatus = mUploadStatus;
+        mFixedUploadingNow = binder != null && binder.isUploadingNow(this);
+        mFixedUploadEndTimeStamp = mUploadEndTimeStamp;
+        mFixedId = mId;
     }
 
     // Getters & Setters
@@ -229,7 +246,7 @@ public class OCUpload implements Parcelable {
     }
 
     /**
-     * @param remotePath
+     * @param remotePath the remotePath
      */
     public void setRemotePath(String remotePath) {
         mRemotePath = remotePath;
@@ -391,11 +408,11 @@ public class OCUpload implements Parcelable {
      *
      * @param source The source parcel
      */
-    protected OCUpload(Parcel source) {
+    private OCUpload(Parcel source) {
         readFromParcel(source);
     }
 
-    public void readFromParcel(Parcel source) {
+    private void readFromParcel(Parcel source) {
         mId = source.readLong();
         mLocalPath = source.readString();
         mRemotePath = source.readString();
@@ -441,6 +458,22 @@ public class OCUpload implements Parcelable {
         dest.writeInt(mIsUseWifiOnly ? 1 : 0);
         dest.writeInt(mIsWhileChargingOnly ? 1 : 0);
         dest.writeString(mFolderUnlockToken);
+    }
+
+    public UploadStatus getFixedUploadStatus() {
+        return mFixedUploadStatus;
+    }
+
+    public boolean isFixedUploadingNow() {
+        return mFixedUploadingNow;
+    }
+
+    public long getFixedUploadEndTimestamp() {
+        return mFixedUploadEndTimeStamp;
+    }
+
+    public Long getFixedUploadId() {
+        return mFixedId;
     }
 
     enum CanUploadFileNowStatus {NOW, LATER, FILE_GONE, ERROR}

--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -870,11 +870,11 @@ public class FileUploader extends Service
 
         public boolean isUploadingNow(OCUpload upload) {
             return (
-                upload != null  &&
-                mCurrentAccount != null &&
-                mCurrentUpload != null &&
-                upload.getAccountName().equals(mCurrentAccount.name) &&
-                upload.getRemotePath().equals(mCurrentUpload.getRemotePath())
+                    upload != null &&
+                            mCurrentAccount != null &&
+                            mCurrentUpload != null &&
+                            upload.getAccountName().equals(mCurrentAccount.name) &&
+                            upload.getRemotePath().equals(mCurrentUpload.getRemotePath())
             );
         }
 

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -211,7 +211,7 @@ public class UploadFileOperation extends SyncOperation {
         mOriginalStoragePath = mFile.getStoragePath();
         mContext = context;
         mOCUploadId = upload.getUploadId();
-        mCreatedBy = upload.getCreadtedBy();
+        mCreatedBy = upload.getCreatedBy();
         mRemoteFolderToBeCreated = upload.isCreateRemoteFolder();
         // Ignore power save mode only if user explicitly created this upload
         mIgnoringPowerSaveMode = (mCreatedBy == CREATED_BY_USER);

--- a/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -609,7 +609,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             this.items = items;
         }
 
-        void fixAndSortItems(OCUpload[] array) {
+        void fixAndSortItems(OCUpload... array) {
             FileUploader.FileUploaderBinder binder = mParentActivity.getFileUploaderBinder();
 
             for (OCUpload upload : array) {


### PR DESCRIPTION
TimSort is crashing because values (e.g. upload status) is changing while sorting.
Therefore the idea is to "fix" these values for sorting.
Drawback is that it can happen that sorting is already outdated, once sorting is done.
But we refresh after each upload and also a manual refresh can be triggered.

This is currently #1 bug on google play console.

For developing, I set each value of OCUpload to random and had a crash on nearly every sorting/refresh.
With this enhancement, I had no crash at all, although every value changed at any time.

We are using these fixedValues only for sorting and read-only.
So a changing status, e.g. because upload failed, will still be reflected on next sort.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>