### PR TITLE
ThemeUtils: do not crash if context is null

### DIFF
--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -410,11 +410,11 @@ public class ThemeUtils {
     }
 
     private static OCCapability getCapability(Account acc, Context context) {
-        Account account;
+        Account account = null;
 
         if (acc != null) {
             account = acc;
-        } else {
+        } else if (context != null) {
             account = AccountUtils.getCurrentOwnCloudAccount(context);
         }
 


### PR DESCRIPTION
If context is null, then https://github.com/nextcloud/android/blob/b4b1790ef675db20cf436d510fa24e61c81d5eec/src/main/java/com/owncloud/android/authentication/AccountUtils.java#L99
will throw an IllegalArgumentException.

Context may be null due to starting/ending app on first login, though this is not consistently reproducible.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>