### PR TITLE
Show offline info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,9 +208,9 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.3'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    gplayImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
+    genericImplementation "com.github.nextcloud:android-library:offlineSupport-SNAPSHOT"
+    gplayImplementation "com.github.nextcloud:android-library:offlineSupport-SNAPSHOT"
+    versionDevImplementation 'com.github.nextcloud:android-library:offlineSupport-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -289,13 +289,6 @@ public class RefreshFolderOperation extends RemoteOperation {
             if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
                 removeLocalFolder();
             }
-            if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
-                return result;
-            }
-            if (result.getCode() == ResultCode.HOST_NOT_AVAILABLE ||
-                    result.getCode() == ResultCode.NO_NETWORK_CONNECTION) {
-                return result;
-            }
             if (result.isException()) {
                 Log_OC.e(TAG, "Checked " + mAccount.name + remotePath + " : " +
                         result.getLogMessage(), result.getException());

--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -292,6 +292,10 @@ public class RefreshFolderOperation extends RemoteOperation {
             if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
                 return result;
             }
+            if (result.getCode() == ResultCode.HOST_NOT_AVAILABLE ||
+                    result.getCode() == ResultCode.NO_NETWORK_CONNECTION) {
+                return result;
+            }
             if (result.isException()) {
                 Log_OC.e(TAG, "Checked " + mAccount.name + remotePath + " : " +
                         result.getLogMessage(), result.getException());

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1339,6 +1339,9 @@ public class FileDisplayActivity extends HookActivity
                                     showUntrustedCertDialog(synchResult);
                                 } else if (ResultCode.MAINTENANCE_MODE.equals(synchResult.getCode())) {
                                     showInfoBox(R.string.maintenance_mode);
+                                } else if (ResultCode.NO_NETWORK_CONNECTION.equals(synchResult.getCode()) ||
+                                        ResultCode.HOST_NOT_AVAILABLE.equals(synchResult.getCode())) {
+                                    showInfoBox(R.string.offline_mode);
                                 }
                             }
                         }


### PR DESCRIPTION
When on remote operation offline/no connection is detected, this will be shown on top, until the next successful refresh is done.

Needs https://github.com/nextcloud/android-library/pull/155

![2018-07-05-131950](https://user-images.githubusercontent.com/5836855/42320817-fd2a3492-8056-11e8-8395-f140d711ffc2.png)
