### PR TITLE
enhance folder already exists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,9 +208,9 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.3'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    gplayImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
+    genericImplementation "com.github.nextcloud:android-library:createExistingFolder-SNAPSHOT"
+    gplayImplementation "com.github.nextcloud:android-library:createExistingFolder-SNAPSHOT"
+    versionDevImplementation 'com.github.nextcloud:android-library:createExistingFolder-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -208,9 +208,9 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.3'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:createExistingFolder-SNAPSHOT"
-    gplayImplementation "com.github.nextcloud:android-library:createExistingFolder-SNAPSHOT"
-    versionDevImplementation 'com.github.nextcloud:android-library:createExistingFolder-SNAPSHOT' // use always latest master
+    genericImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
+    gplayImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
+    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2109,10 +2109,12 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(false);
         } else {
             try {
-                DisplayUtils.showSnackMessage(
-                        this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
-                );
-
+                if (ResultCode.FOLDER_ALREADY_EXISTS == result.getCode()) {
+                    DisplayUtils.showSnackMessage(this, R.string.folder_already_exists);
+                } else {
+                    DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation,
+                            getResources()));
+                }
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
             }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -825,4 +825,5 @@
     <string name="stream">Stream with…</string>
     <string name="stream_not_possible_headline">Internal streaming not possible</string>
     <string name="stream_not_possible_message">Please download media instead or use external app.</string>
+    <string name="folder_already_exists">Folder already exists</string>
 </resources>


### PR DESCRIPTION
- [x] Needs: https://github.com/nextcloud/android-library/pull/156

Steps to test:
- create a folder whose name is already taken
- previously "method not allowed" as snackbar
- now: "Folder already exists"

![2018-07-05-142728](https://user-images.githubusercontent.com/5836855/42323190-949c9ce0-805f-11e8-9e88-49ca52df7e08.png)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>