### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.1
+## 3.2.1 (June, 10, 2018)
 - Enhanced file detail/sharing screen for mail-shares
 - Fix local sorting and file selection
 - Fix local filtering

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ repositories {
 def versionMajor = 3
 def versionMinor = 2
 def versionPatch = 1
-def versionBuild = 50 // 0-49=Alpha / 50-98=RC / 99=stable
+def versionBuild = 99 // 0-49=Alpha / 50-98=RC / 99=stable
 
 android {
     lintOptions {


### PR DESCRIPTION
Our RC1 of 3.2.1 was really stable, so we can release 3.2.1.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>