### PR TITLE
Add 3.2.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.1 (June, 10, 2018)
+## 3.2.1 (June, 11, 2018)
 - Enhanced file detail/sharing screen for mail-shares
 - Fix local sorting and file selection
 - Fix local filtering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.2.1 (June, 10, 2018)
+- Enhanced file detail/sharing screen for mail-shares
+- Fix local sorting and file selection
+- Fix local filtering
+- Fix back navigation on privacy screen
+- Fix bug on searching
+- Fix crash on sorting
+- Fix wrong menu highlighting
+- various bug fixes
+
 ## 3.2.0 (May, 13, 2018)
 - Revamped details screen & sharing
 - minor UI/UX improvements

--- a/fastlane/metadata/android/en-US/changelogs/30020199.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30020199.txt
@@ -1,4 +1,4 @@
-3.2.1 (June, 10, 2018)
+3.2.1 (June, 11, 2018)
 
 Enhanced file detail/sharing screen for mail-shares
 Fix local sorting and file selection

--- a/fastlane/metadata/android/en-US/changelogs/30020199.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30020199.txt
@@ -1,0 +1,10 @@
+3.2.1 (June, 10, 2018)
+
+Enhanced file detail/sharing screen for mail-shares
+Fix local sorting and file selection
+Fix local filtering
+Fix back navigation on privacy screen
+Fix bug on searching
+Fix crash on sorting
+Fix wrong menu highlighting
+various bug fixes


### PR DESCRIPTION
This also creates a folder structure needed by fastlane.
Fastlane then can automatically pick the changelog and uploads it to play store.
(background: this allows to tag, create signed generic/gplay version and upload gplay to play store completely automatically).

I would like to keep changelog.md and additionally have these version text files. Although it is a bit of c&p I think it is better to also have it in one central place.

This is targeting master branch, so that it will be in upcoming stable-3.3.x branch.
(I do not expect to have any 3.2.x)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>