### PR TITLE
jobs: Use previously defined constants instead of hard coded values.

### DIFF
--- a/src/main/java/com/owncloud/android/jobs/MediaFoldersDetectionJob.java
+++ b/src/main/java/com/owncloud/android/jobs/MediaFoldersDetectionJob.java
@@ -134,7 +134,7 @@ public class MediaFoldersDetectionJob extends Job {
 
         } else {
             mediaFoldersModel = new MediaFoldersModel(imageMediaFolderPaths, videoMediaFolderPaths);
-            arbitraryDataProvider.storeOrUpdateKeyValue("global", "media_folders", gson.toJson(mediaFoldersModel));
+            arbitraryDataProvider.storeOrUpdateKeyValue(ACCOUNT_NAME_GLOBAL, KEY_MEDIA_FOLDERS, gson.toJson(mediaFoldersModel));
         }
 
         return Result.SUCCESS;


### PR DESCRIPTION
Use ACCOUNT_NAME_GLOBAL and KEY_MEDIA_FOLDERS constants where applicable.

Duplicated string literals make the process of refactoring error-prone.