### PR TITLE
WIP: Overlapping fab with snackbar

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2109,9 +2109,13 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(false);
         } else {
             try {
-                DisplayUtils.showSnackMessage(
-                        this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
-                );
+                if (getListOfFilesFragment() != null) {
+                    DisplayUtils.showSnackMessage(getListOfFilesFragment().getListLayout(),
+                            ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
+                } else {
+                    DisplayUtils.showSnackMessage(this,
+                            ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
+                }
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -32,6 +32,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.design.widget.BottomNavigationView;
+import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.MenuItemCompat;
@@ -104,6 +105,7 @@ public class ExtendedListFragment extends Fragment
     private ScaleGestureDetector mScaleGestureDetector = null;
     protected SwipeRefreshLayout mRefreshListLayout;
     protected LinearLayout mEmptyListContainer;
+    protected CoordinatorLayout mListFragmentLayout;
     protected TextView mEmptyListMessage;
     protected TextView mEmptyListHeadline;
     protected ImageView mEmptyListIcon;
@@ -364,6 +366,8 @@ public class ExtendedListFragment extends Fragment
 
         mScale = PreferenceManager.getGridColumns(getContext());
         setGridViewColumns(1f);
+
+        mListFragmentLayout = v.findViewById(R.id.list_fragment_layout);
 
         mScaleGestureDetector = new ScaleGestureDetector(MainApp.getAppContext(),new ScaleListener());
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -39,6 +39,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.design.widget.BottomNavigationView;
+import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.widget.DrawerLayout;
@@ -1483,6 +1484,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
         } catch (OperationCanceledException e) {
             Log_OC.e(TAG, "Operation has been canceled", e);
         }
+    }
+
+    public CoordinatorLayout getListLayout() {
+        return mListFragmentLayout;
     }
 
     private void setTitle(@StringRes final int title) {

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -57,7 +57,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
 import android.widget.PopupMenu;
-import android.widget.RelativeLayout;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -246,22 +245,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
         if (getResources().getBoolean(R.bool.bottom_toolbar_enabled)) {
             bottomNavigationView.setVisibility(View.VISIBLE);
             DisplayUtils.setupBottomBar(bottomNavigationView, getResources(), getActivity(), R.id.nav_bar_files);
-        }
-
-        if (!getResources().getBoolean(R.bool.bottom_toolbar_enabled) || savedInstanceState != null) {
-
-            final View fabView = v.findViewById(R.id.fab_main);
-            final RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams)
-                    fabView.getLayoutParams();
-            layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, 1);
-            Handler handler = new Handler();
-            handler.post(new Runnable() {
-                @Override
-                public void run() {
-                    fabView.setLayoutParams(layoutParams);
-                    fabView.invalidate();
-                }
-            });
         }
 
         Bundle args = getArguments();
@@ -755,7 +738,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     if (file.isEncrypted()) {
                         // check if API >= 19
                         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
-                            Snackbar.make(getRecyclerView(), R.string.end_to_end_encryption_not_supported,
+                            Snackbar.make(mListFragmentLayout, R.string.end_to_end_encryption_not_supported,
                                     Snackbar.LENGTH_LONG).show();
                             return;
                         }
@@ -767,7 +750,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
                     if (ocCapability.getEndToEndEncryption().isFalse() ||
                             ocCapability.getEndToEndEncryption().isUnknown()) {
-                        Snackbar.make(getRecyclerView(), R.string.end_to_end_encryption_not_enabled,
+                        Snackbar.make(mListFragmentLayout, R.string.end_to_end_encryption_not_enabled,
                                 Snackbar.LENGTH_LONG).show();
                         return;
                     }// check if keys are stored
@@ -792,7 +775,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                         if (mContainerActivity instanceof FolderPickerActivity &&
                                 ((FolderPickerActivity) mContainerActivity)
                                         .isDoNotEnterEncryptedFolder()) {
-                            Snackbar.make(getRecyclerView(),
+                            Snackbar.make(mListFragmentLayout,
                                     R.string.copy_move_to_encrypted_folder_not_supported,
                                     Snackbar.LENGTH_LONG).show();
                         } else {
@@ -1486,9 +1469,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
             if (remoteOperationResult.isSuccess()) {
                 mAdapter.setEncryptionAttributeForItemID(event.remoteId, event.shouldBeEncrypted);
             } else if (remoteOperationResult.getHttpCode() == HttpStatus.SC_FORBIDDEN) {
-                Snackbar.make(getRecyclerView(), R.string.end_to_end_encryption_folder_not_empty, Snackbar.LENGTH_LONG).show();
+                Snackbar.make(mListFragmentLayout, R.string.end_to_end_encryption_folder_not_empty, Snackbar.LENGTH_LONG).show();
             } else {
-                Snackbar.make(getRecyclerView(), R.string.common_error_unknown, Snackbar.LENGTH_LONG).show();
+                Snackbar.make(mListFragmentLayout, R.string.common_error_unknown, Snackbar.LENGTH_LONG).show();
             }
 
         } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {

--- a/src/main/res/layout/list_fragment.xml
+++ b/src/main/res/layout/list_fragment.xml
@@ -44,15 +44,12 @@
 
         <include layout="@layout/empty_list"/>
 
-    </android.support.design.widget.CoordinatorLayout>
-
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab_main"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_above="@+id/bottom_navigation_view"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
+        android:layout_gravity="end|bottom"
         android:layout_marginBottom="@dimen/standard_margin"
         android:layout_marginEnd="@dimen/standard_margin"
         android:layout_marginRight="@dimen/standard_margin"
@@ -70,5 +67,6 @@
         app:itemTextColor="@color/primary_button_text_color"
         app:menu="@menu/navigation_bar_menu"/>
 
+    </android.support.design.widget.CoordinatorLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
For FAB behaving correctly, we need to use a reference to CoordinatorLayout 
https://github.com/nextcloud/android/blob/3e6a782af8cc26f434bc287d7230aa15b4fe7507/src/main/res/layout/list_fragment.xml#L26-L29.

We used to have this for any Snackbar calling an activity/used in FDA:
```
DisplayUtils.showSnackMessage(this,
                            ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
```

Now we would have to check if OCFileListFragment is available and if so, use the CoordinatorLayout, else use the previous way.

Or do you have a nicer approach @mario, @AndyScherzinger?