### PR TITLE
Capabilities are queried too often

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AccountUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountUtils.java
@@ -30,12 +30,8 @@ import android.support.annotation.Nullable;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
-import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.accounts.AccountUtils.Constants;
-import com.owncloud.android.lib.common.operations.RemoteOperationResult;
-import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
-import com.owncloud.android.operations.GetCapabilitiesOperarion;
 import com.owncloud.android.ui.activity.ManageAccountsActivity;
 
 
@@ -163,18 +159,6 @@ public class AccountUtils {
                 if (found) {
                     SharedPreferences.Editor appPrefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
                     appPrefs.putString(PREF_SELECT_OC_ACCOUNT, accountName);
-
-                    // update credentials
-                    Thread t = new Thread(() -> {
-                        FileDataStorageManager storageManager = new FileDataStorageManager(account,
-                                context.getContentResolver());
-                        GetCapabilitiesOperarion getCapabilities = new GetCapabilitiesOperarion();
-                        RemoteOperationResult updateResult = getCapabilities.execute(storageManager, context);
-                        Log_OC.w(TAG, "Update Capabilities: " + updateResult.isSuccess());
-                    });
-
-                    t.start();
-
                     appPrefs.apply();
                     result = true;
                     break;


### PR DESCRIPTION
Before every time a new activity was created, the capabilities were queried.
We have this still, when 
- refreshing the root folder
- changing account (as we reload the app with different account and start with root folder --> point 1)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>