### PR TITLE
Found via strictMode: missing close

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ArbitraryDataProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/ArbitraryDataProvider.java
@@ -178,6 +178,7 @@ public class ArbitraryDataProvider {
                 if (value == null) {
                     Log_OC.e(TAG, "Arbitrary value could not be created from cursor");
                 } else {
+                    cursor.close();
                     return value;
                 }
             }


### PR DESCRIPTION
Missing close on cursor, thus leads to memory leak

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>