### PR TITLE
add checksum for gradle release

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionSha256Sum=7a2c66d1a78f811d5f37d14630ad21cec5e77a2a4dc61e787e2257a6341016ce


### PR DESCRIPTION
see https://github.com/nextcloud/passman-android/pull/52 or https://gitlab.com/fdroid/rfp/issues/199 respectively. 

So for security reasons it makes sense to have the checksum added to the wrapper properties.