### PR TITLE
Clear selection after deleting files - issue#2463

### DIFF
--- a/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  *   ownCloud Android client application
  *
  *   @author David A. Velasco
@@ -15,16 +15,9 @@
  *
  *   You should have received a copy of the GNU General Public License
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 package com.owncloud.android.ui.dialog;
-
-/**
- *  Dialog requiring confirmation before removing a collection of given OCFiles.
- * 
- *  Triggers the removal according to the user response.
- */
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -41,8 +34,13 @@ import com.owncloud.android.utils.ThemeUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class RemoveFilesDialogFragment extends ConfirmationDialogFragment
-implements ConfirmationDialogFragmentListener {
+/**
+ *  Dialog requiring confirmation before removing a collection of given OCFiles.
+ *
+ *  Triggers the removal according to the user response.
+ */
+public class RemoveFilesDialogFragment extends ConfirmationDialogFragment implements
+        ConfirmationDialogFragmentListener {
 
     private Collection<OCFile> mTargetFiles;
 

--- a/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
@@ -30,6 +30,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.view.ActionMode;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -46,6 +47,21 @@ implements ConfirmationDialogFragmentListener {
     private Collection<OCFile> mTargetFiles;
 
     private static final String ARG_TARGET_FILES = "TARGET_FILES";
+
+    private ActionMode actionMode;
+
+    /**
+     * Public factory method to create new RemoveFilesDialogFragment instances.
+     *
+     * @param files           Files to remove.
+     * @param actionMode      ActionMode to finish on confirmation
+     * @return                Dialog ready to show.
+     */
+    public static RemoveFilesDialogFragment newInstance(ArrayList<OCFile> files, ActionMode actionMode) {
+        RemoveFilesDialogFragment dialogFragment = newInstance(files);
+        dialogFragment.setActionMode(actionMode);
+        return dialogFragment;
+    }
 
     /**
      * Public factory method to create new RemoveFilesDialogFragment instances.
@@ -137,12 +153,20 @@ implements ConfirmationDialogFragmentListener {
     }    
 
     /**
-     * Performs the removal of the target file, both locally and in the server.
+     * Performs the removal of the target file, both locally and in the server and
+     * finishes the supplied ActionMode if one was given.
      */
     @Override
     public void onConfirmation(String callerTag) {
         ComponentsGetter cg = (ComponentsGetter) getActivity();
         cg.getFileOperationsHelper().removeFiles(mTargetFiles, false, false);
+
+        // This is used when finishing an actionMode,
+        // for example if we want to exit the selection mode
+        // after deleting the target files.
+        if (actionMode != null) {
+            actionMode.finish();
+        }
     }
     
     /**
@@ -157,5 +181,9 @@ implements ConfirmationDialogFragmentListener {
     @Override
     public void onNeutral(String callerTag) {
         // nothing to do here
+    }
+
+    private void setActionMode(ActionMode actionMode) {
+        this.actionMode = actionMode;
     }
 }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -940,7 +940,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         /// actions possible on a batch of files
         switch (menuId) {
             case R.id.action_remove_file: {
-                RemoveFilesDialogFragment dialog = RemoveFilesDialogFragment.newInstance(new ArrayList<>(checkedFiles));
+                RemoveFilesDialogFragment dialog = RemoveFilesDialogFragment.newInstance(new ArrayList<>(checkedFiles), mActiveActionMode);
                 dialog.show(getFragmentManager(), ConfirmationDialogFragment.FTAG_CONFIRMATION);
                 return true;
             }


### PR DESCRIPTION
As described in issue #2463, the selection was not deselected after deleting multiple files in selection mode.
This PR implements a fix, that exits selection mode after deleting multiple files.

Resolves #2463