### PR TITLE
Clear file selection after performing various multi file selection actions - fix#2859

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -962,6 +962,7 @@ public class FileDisplayActivity extends HookActivity
             requestUploadOfFilesFromFileSystem(data, resultCode);
 
         } else if (requestCode == REQUEST_CODE__MOVE_FILES && resultCode == RESULT_OK) {
+            exitSelectionMode();
             final Intent fData = data;
             getHandler().postDelayed(
                     new Runnable() {
@@ -974,7 +975,7 @@ public class FileDisplayActivity extends HookActivity
             );
 
         } else if (requestCode == REQUEST_CODE__COPY_FILES && resultCode == RESULT_OK) {
-
+            exitSelectionMode();
             final Intent fData = data;
             getHandler().postDelayed(
                     new Runnable() {
@@ -990,6 +991,13 @@ public class FileDisplayActivity extends HookActivity
             super.onActivityResult(requestCode, resultCode, data);
         }
 
+    }
+
+    private void exitSelectionMode() {
+        OCFileListFragment ocFileListFragment = getListOfFilesFragment();
+        if (ocFileListFragment != null) {
+            ocFileListFragment.exitSelectionMode();
+        }
     }
 
     private void requestUploadOfFilesFromFileSystem(Intent data, int resultCode) {

--- a/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
@@ -158,13 +158,7 @@ public class RemoveFilesDialogFragment extends ConfirmationDialogFragment implem
     public void onConfirmation(String callerTag) {
         ComponentsGetter cg = (ComponentsGetter) getActivity();
         cg.getFileOperationsHelper().removeFiles(mTargetFiles, false, false);
-
-        // This is used when finishing an actionMode,
-        // for example if we want to exit the selection mode
-        // after deleting the target files.
-        if (actionMode != null) {
-            actionMode.finish();
-        }
+        finishActionMode();
     }
     
     /**
@@ -174,6 +168,7 @@ public class RemoveFilesDialogFragment extends ConfirmationDialogFragment implem
     public void onCancel(String callerTag) {
         ComponentsGetter cg = (ComponentsGetter) getActivity();
         cg.getFileOperationsHelper().removeFiles(mTargetFiles, true, false);
+        finishActionMode();
     }
 
     @Override
@@ -183,5 +178,16 @@ public class RemoveFilesDialogFragment extends ConfirmationDialogFragment implem
 
     private void setActionMode(ActionMode actionMode) {
         this.actionMode = actionMode;
+    }
+
+    /**
+     * This is used when finishing an actionMode,
+     * for example if we want to exit the selection mode
+     * after deleting the target files.
+     */
+    private void finishActionMode() {
+        if (actionMode != null) {
+            actionMode.finish();
+        }
     }
 }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -947,6 +947,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
             case R.id.action_download_file:
             case R.id.action_sync_file: {
                 mContainerActivity.getFileOperationsHelper().syncFiles(checkedFiles);
+                exitSelectionMode();
                 return true;
             }
             case R.id.action_cancel_sync: {
@@ -955,10 +956,12 @@ public class OCFileListFragment extends ExtendedListFragment implements
             }
             case R.id.action_keep_files_offline: {
                 mContainerActivity.getFileOperationsHelper().toggleOfflineFiles(checkedFiles, true);
+                exitSelectionMode();
                 return true;
             }
             case R.id.action_unset_keep_files_offline: {
                 mContainerActivity.getFileOperationsHelper().toggleOfflineFiles(checkedFiles, false);
+                exitSelectionMode();
                 return true;
             }
             case R.id.action_favorite: {
@@ -1578,5 +1581,12 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
 
         mActiveActionMode.invalidate();        
+    }
+
+    /**
+     * Exits the multi file selection mode.
+     */
+    public void exitSelectionMode() {
+        mActiveActionMode.finish();
     }
 }


### PR DESCRIPTION
As described in issue #2859, the selection was not deselected after performing copy/move/download/sync/set-available-offline for multiple files in selection mode.

This PR implements changes so we exit the selection mode after performing these actions, in addition to the afore mentioned actions the unset-available-offline action now also exits the selection mode.

Resolves #2859

Edit:
There is one more commit incoming for this PR.'

Edit2:
I noticed that deleting files locally did not clear the selection, the latest commit addresses this.