### PR TITLE
ADD: [instantupload] setting to also upload existing files

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
@@ -42,6 +42,7 @@ public class SyncedFolder implements Serializable, Cloneable {
     private String remotePath;
     private Boolean wifiOnly;
     private Boolean chargingOnly;
+    private Boolean existing;
     private Boolean subfolderByDate;
     private String account;
     private Integer uploadAction;
@@ -62,12 +63,13 @@ public class SyncedFolder implements Serializable, Cloneable {
      * @param type            the type of the folder
      */
     public SyncedFolder(String localPath, String remotePath, Boolean wifiOnly, Boolean chargingOnly,
-                        Boolean subfolderByDate, String account, Integer uploadAction, Boolean enabled,
-                        MediaFolderType type) {
+                        Boolean existing, Boolean subfolderByDate, String account, Integer uploadAction,
+                        Boolean enabled,MediaFolderType type) {
         this.localPath = localPath;
         this.remotePath = remotePath;
         this.wifiOnly = wifiOnly;
         this.chargingOnly = chargingOnly;
+        this.existing = existing;
         this.subfolderByDate = subfolderByDate;
         this.account = account;
         this.uploadAction = uploadAction;

--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderDisplayItem.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderDisplayItem.java
@@ -45,6 +45,7 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
      * @param remotePath      remote path
      * @param wifiOnly        upload on wifi only flag
      * @param chargingOnly    upload on charging only
+     * @param existing        also upload existing
      * @param subfolderByDate create sub-folders by date (month)
      * @param account         the account owning the synced folder
      * @param uploadAction    the action to be done after the upload
@@ -55,19 +56,19 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
      * @param type            the type of the folder
      */
     public SyncedFolderDisplayItem(long id, String localPath, String remotePath, Boolean wifiOnly, Boolean chargingOnly,
-                                   Boolean subfolderByDate, String account, Integer uploadAction, Boolean enabled,
-                                   List<String> filePaths, String folderName, long numberOfFiles, MediaFolderType type)
+                                   Boolean existing, Boolean subfolderByDate, String account, Integer uploadAction,
+                                   Boolean enabled, List<String> filePaths, String folderName, long numberOfFiles, MediaFolderType type)
     {
-        super(id, localPath, remotePath, wifiOnly, chargingOnly, subfolderByDate, account, uploadAction, enabled, type);
+        super(id, localPath, remotePath, wifiOnly, chargingOnly, existing, subfolderByDate, account, uploadAction, enabled, type);
         this.filePaths = filePaths;
         this.folderName = folderName;
         this.numberOfFiles = numberOfFiles;
     }
 
     public SyncedFolderDisplayItem(long id, String localPath, String remotePath, Boolean wifiOnly, Boolean chargingOnly,
-                                   Boolean subfolderByDate, String account, Integer uploadAction, Boolean enabled,
-                                   String folderName, MediaFolderType type) {
-        super(id, localPath, remotePath, wifiOnly, chargingOnly, subfolderByDate, account, uploadAction, enabled, type);
+                                   Boolean existing, Boolean subfolderByDate, String account, Integer uploadAction,
+                                   Boolean enabled, String folderName, MediaFolderType type) {
+        super(id, localPath, remotePath, wifiOnly, chargingOnly, existing, subfolderByDate, account, uploadAction, enabled, type);
         this.folderName = folderName;
     }
 }

--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -339,6 +339,8 @@ public class SyncedFolderProvider extends Observable {
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_WIFI_ONLY)) == 1;
             Boolean chargingOnly = cursor.getInt(cursor.getColumnIndex(
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_CHARGING_ONLY)) == 1;
+            Boolean existing = cursor.getInt(cursor.getColumnIndex(
+                    ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_EXISTING)) == 1;
             Boolean subfolderByDate = cursor.getInt(cursor.getColumnIndex(
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE)) == 1;
             String accountName = cursor.getString(cursor.getColumnIndex(
@@ -350,8 +352,8 @@ public class SyncedFolderProvider extends Observable {
             MediaFolderType type = MediaFolderType.getById(cursor.getInt(cursor.getColumnIndex(
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_TYPE)));
 
-            syncedFolder = new SyncedFolder(id, localPath, remotePath, wifiOnly, chargingOnly, subfolderByDate,
-                    accountName, uploadAction, enabled, type);
+            syncedFolder = new SyncedFolder(id, localPath, remotePath, wifiOnly, chargingOnly, existing,
+                subfolderByDate,accountName, uploadAction, enabled, type);
         }
         return syncedFolder;
     }
@@ -369,6 +371,7 @@ public class SyncedFolderProvider extends Observable {
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_REMOTE_PATH, syncedFolder.getRemotePath());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_WIFI_ONLY, syncedFolder.getWifiOnly());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_CHARGING_ONLY, syncedFolder.getChargingOnly());
+        cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_EXISTING, syncedFolder.getExisting());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ENABLED, syncedFolder.isEnabled());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE, syncedFolder.getSubfolderByDate());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT, syncedFolder.getAccount());

--- a/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -31,7 +31,7 @@ import com.owncloud.android.MainApp;
  */
 public class ProviderMeta {
     public static final String DB_NAME = "filelist";
-    public static final int DB_VERSION = 49;
+    public static final int DB_VERSION = 50;
 
     private ProviderMeta() {
         // No instance
@@ -219,6 +219,7 @@ public class ProviderMeta {
         public static final String SYNCED_FOLDER_REMOTE_PATH = "remote_path";
         public static final String SYNCED_FOLDER_WIFI_ONLY = "wifi_only";
         public static final String SYNCED_FOLDER_CHARGING_ONLY = "charging_only";
+        public static final String SYNCED_FOLDER_EXISTING = "existing";
         public static final String SYNCED_FOLDER_ENABLED = "enabled";
         public static final String SYNCED_FOLDER_TYPE = "type";
         public static final String SYNCED_FOLDER_SUBFOLDER_BY_DATE = "subfolder_by_date";

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -821,6 +821,7 @@ public class FileContentProvider extends ContentProvider {
                        + ProviderTableMeta.SYNCED_FOLDER_REMOTE_PATH + " TEXT, "          // remote path
                        + ProviderTableMeta.SYNCED_FOLDER_WIFI_ONLY + " INTEGER, "         // wifi_only
                        + ProviderTableMeta.SYNCED_FOLDER_CHARGING_ONLY + " INTEGER, "     // charging only
+                       + ProviderTableMeta.SYNCED_FOLDER_EXISTING + " INTEGER, "          // existing
                        + ProviderTableMeta.SYNCED_FOLDER_ENABLED + " INTEGER, "           // enabled
                        + ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE + " INTEGER, " // subfolder by date
                        + ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + "  TEXT, "             // account

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -2013,6 +2013,24 @@ public class FileContentProvider extends ContentProvider {
             if (!upgraded) {
                 Log_OC.i(SQL, String.format(Locale.ENGLISH, UPGRADE_VERSION_MSG, oldVersion, newVersion));
             }
+
+            if (oldVersion < 50 && newVersion >= 50) {
+                Log_OC.i(SQL, "Entering in the #50 add syned.existing");
+                db.beginTransaction();
+                try {
+                    db.execSQL(ALTER_TABLE + ProviderTableMeta.SYNCED_FOLDERS_TABLE_NAME +
+                                   ADD_COLUMN + ProviderTableMeta.SYNCED_FOLDER_EXISTING + " INTEGER "); // boolean
+
+                    upgraded = true;
+                    db.setTransactionSuccessful();
+                } finally {
+                    db.endTransaction();
+                }
+            }
+
+            if (!upgraded) {
+                Log_OC.i(SQL, String.format(Locale.ENGLISH, UPGRADE_VERSION_MSG, oldVersion, newVersion));
+            }
         }
 
         @Override

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -2015,7 +2015,7 @@ public class FileContentProvider extends ContentProvider {
             }
 
             if (oldVersion < 50 && newVersion >= 50) {
-                Log_OC.i(SQL, "Entering in the #50 add syned.existing");
+                Log_OC.i(SQL, "Entering in the #50 add synced.existing");
                 db.beginTransaction();
                 try {
                     db.execSQL(ALTER_TABLE + ProviderTableMeta.SYNCED_FOLDERS_TABLE_NAME +

--- a/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -77,6 +77,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
     private SwitchCompat mEnabledSwitch;
     private AppCompatCheckBox mUploadOnWifiCheckbox;
     private AppCompatCheckBox mUploadOnChargingCheckbox;
+    private AppCompatCheckBox mUploadExistingCheckbox;
     private AppCompatCheckBox mUploadUseSubfoldersCheckbox;
     private TextView mUploadBehaviorSummary;
     private TextView mLocalFolderPath;
@@ -189,6 +190,9 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
             ThemeUtils.tintCheckbox(mUploadOnChargingCheckbox, accentColor);
         }
 
+        mUploadExistingCheckbox = view.findViewById(R.id.setting_instant_upload_existing_checkbox);
+        ThemeUtils.tintCheckbox(mUploadExistingCheckbox, accentColor);
+
         mUploadUseSubfoldersCheckbox = view.findViewById(
                 R.id.setting_instant_upload_path_use_subfolders_checkbox);
         ThemeUtils.tintCheckbox(mUploadUseSubfoldersCheckbox, accentColor);
@@ -227,6 +231,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             mUploadOnChargingCheckbox.setChecked(mSyncedFolder.getChargingOnly());
         }
+        mUploadExistingCheckbox.setChecked(mSyncedFolder.getExisting());
         mUploadUseSubfoldersCheckbox.setChecked(mSyncedFolder.getSubfolderByDate());
 
         mUploadBehaviorSummary.setText(mUploadBehaviorItemStrings[mSyncedFolder.getUploadActionInteger()]);
@@ -318,6 +323,9 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
             view.findViewById(R.id.setting_instant_upload_on_charging_container).setAlpha(alpha);
         }
 
+        view.findViewById(R.id.setting_instant_upload_existing_container).setEnabled(enable);
+        view.findViewById(R.id.setting_instant_upload_existing_container).setAlpha(alpha);
+
         view.findViewById(R.id.setting_instant_upload_path_use_subfolders_container).setEnabled(enable);
         view.findViewById(R.id.setting_instant_upload_path_use_subfolders_container).setAlpha(alpha);
 
@@ -360,6 +368,15 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
                         }
                     });
         }
+
+        view.findViewById(R.id.setting_instant_upload_existing_container).setOnClickListener(
+              new OnClickListener() {
+                  @Override
+                  public void onClick(View v) {
+                      mSyncedFolder.setExisting(!mSyncedFolder.getExisting());
+                      mUploadExistingCheckbox.toggle();
+                  }
+              });
 
         view.findViewById(R.id.setting_instant_upload_path_use_subfolders_container).setOnClickListener(
                 new OnClickListener() {

--- a/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
@@ -39,6 +39,7 @@ public class SyncedFolderParcelable implements Parcelable {
     private String mRemotePath;
     private Boolean mWifiOnly = false;
     private Boolean mChargingOnly = false;
+    private Boolean mExisting = false;
     private Boolean mEnabled = false;
     private Boolean mSubfolderByDate = false;
     private Integer mUploadAction;
@@ -54,6 +55,7 @@ public class SyncedFolderParcelable implements Parcelable {
         mRemotePath = syncedFolderDisplayItem.getRemotePath();
         mWifiOnly = syncedFolderDisplayItem.getWifiOnly();
         mChargingOnly = syncedFolderDisplayItem.getChargingOnly();
+        mExisting = syncedFolderDisplayItem.getExisting();
         mEnabled = syncedFolderDisplayItem.isEnabled();
         mSubfolderByDate = syncedFolderDisplayItem.getSubfolderByDate();
         mType = syncedFolderDisplayItem.getType();
@@ -69,6 +71,7 @@ public class SyncedFolderParcelable implements Parcelable {
         mRemotePath = read.readString();
         mWifiOnly = read.readInt()!= 0;
         mChargingOnly = read.readInt() != 0;
+        mExisting = read.readInt() != 0;
         mEnabled = read.readInt() != 0;
         mSubfolderByDate = read.readInt() != 0;
         mType = MediaFolderType.getById(read.readInt());
@@ -85,6 +88,7 @@ public class SyncedFolderParcelable implements Parcelable {
         dest.writeString(mRemotePath);
         dest.writeInt(mWifiOnly ? 1 : 0);
         dest.writeInt(mChargingOnly ? 1 : 0);
+        dest.writeInt(mExisting ? 1 : 0);
         dest.writeInt(mEnabled ? 1 : 0);
         dest.writeInt(mSubfolderByDate ? 1 : 0);
         dest.writeInt(mType.getId());
@@ -150,6 +154,14 @@ public class SyncedFolderParcelable implements Parcelable {
 
     public void setChargingOnly(Boolean mChargingOnly) {
         this.mChargingOnly = mChargingOnly;
+    }
+
+    public Boolean getExisting() {
+        return mExisting;
+    }
+
+    public void setExisting(Boolean mExisting) {
+        this.mExisting = mExisting;
     }
 
     public Boolean getEnabled() {

--- a/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -86,9 +86,13 @@ public final class FilesSyncHelper {
         final ContentResolver contentResolver = context.getContentResolver();
         ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(contentResolver);
 
-        Long currentTime = System.currentTimeMillis();
-        double currentTimeInSeconds = currentTime / 1000.0;
-        String currentTimeString = Long.toString((long) currentTimeInSeconds);
+        String currentTimeString = Long.toString(0);
+        if (!syncedFolder.getExisting())
+        {
+            Long currentTime = System.currentTimeMillis();
+            double currentTimeInSeconds = currentTime / 1000.0;
+            currentTimeString = Long.toString((long) currentTimeInSeconds);
+        }
 
         String syncedFolderInitiatedKey = SYNCEDFOLDERINITIATED + syncedFolder.getId();
         boolean dryRun = TextUtils.isEmpty(arbitraryDataProvider.getValue

--- a/src/main/res/layout/synced_folders_settings_layout.xml
+++ b/src/main/res/layout/synced_folders_settings_layout.xml
@@ -355,7 +355,7 @@
                     android:paddingRight="@dimen/zero"
                     android:paddingEnd="@dimen/zero">
 
-                    <android.support.v7.widget.AppCompatCheckBox
+                    <androidx.appcompat.widget.AppCompatCheckBox
                         android:id="@+id/setting_instant_upload_existing_checkbox"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/src/main/res/layout/synced_folders_settings_layout.xml
+++ b/src/main/res/layout/synced_folders_settings_layout.xml
@@ -318,6 +318,56 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/setting_instant_upload_existing_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:baselineAligned="false"
+                android:clipToPadding="false"
+                android:gravity="center_vertical"
+                android:minHeight="?attr/listPreferredItemHeightSmall">
+
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingBottom="@dimen/standard_padding"
+                    android:paddingTop="@dimen/standard_padding">
+
+                    <TextView
+                        android:id="@+id/setting_instant_upload_existing_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="marquee"
+                        android:singleLine="true"
+                        android:text="@string/instant_upload_existing"
+                        android:textAppearance="?attr/textAppearanceListItem"/>
+
+                </RelativeLayout>
+
+                <LinearLayout
+                    android:id="@+id/setting_instant_upload_existing"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="end|center_vertical"
+                    android:orientation="vertical"
+                    android:paddingLeft="@dimen/standard_padding"
+                    android:paddingStart="@dimen/standard_padding"
+                    android:paddingRight="@dimen/zero"
+                    android:paddingEnd="@dimen/zero">
+
+                    <android.support.v7.widget.AppCompatCheckBox
+                        android:id="@+id/setting_instant_upload_existing_checkbox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@null"
+                        android:clickable="false"
+                        android:focusable="false"/>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
                 android:id="@+id/setting_instant_upload_path_use_subfolders_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -322,6 +322,7 @@
 
     <string name="auto_upload_on_wifi">Only upload on unmetered Wi-Fi</string>
     <string name="instant_upload_on_charging">Only upload when charging</string>
+    <string name="instant_upload_existing">Also upload existing files</string>
     <string name="instant_upload_path">/InstantUpload</string>
     <string name="auto_upload_path">/AutoUpload</string>
     <string name="conflict_title">File conflict</string>


### PR DESCRIPTION
Please be kind, first time I put my nose into the code.

This adds a setting to the instant uploads to also upload files already present on the device at the time instant upload is setup.
Ref: https://help.nextcloud.com/t/why-doesnt-android-client-upload-existing-pictures/10365

95% of the PR is for handling of the setting itself.
It might be worth wondering whether this deserves a setting at all, really, ie whether *not* uploading existing files is worthwhile, as it's a bit counter-intuitive, imo