### PR TITLE
Use capability to check if activity app is enabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ def versionMinor = 3
 def versionPatch = 0
 def versionBuild = 0 // 0-49=Alpha / 50-98=RC / 99=stable
 
-def taskRequest = getGradle().getStartParameter().getTaskRequests().toString();
+def taskRequest = getGradle().getStartParameter().getTaskRequests().toString()
 if (taskRequest.contains("Gplay") || taskRequest.contains("findbugs") || taskRequest.contains("lint")) {
     apply from: 'gplay.gradle'
 }
@@ -211,9 +211,9 @@ dependencies {
     // dependencies for app building
     implementation 'com.android.support:multidex:1.0.3'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    gplayImplementation "com.github.nextcloud:android-library:master-SNAPSHOT"
-    versionDevImplementation 'com.github.nextcloud:android-library:master-SNAPSHOT' // use always latest master
+    genericImplementation "com.github.nextcloud:android-library:activityCapability-SNAPSHOT"
+    gplayImplementation "com.github.nextcloud:android-library:activityCapability-SNAPSHOT"
+    versionDevImplementation 'com.github.nextcloud:android-library:activityCapability-SNAPSHOT' // use always latest master
     implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation 'com.jakewharton:disklrucache:2.0.2'

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1949,6 +1949,7 @@ public class FileDataStorageManager {
                 .getValue());
         cv.put(ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_PLAIN, capability.getServerBackgroundPlain()
                 .getValue());
+        cv.put(ProviderTableMeta.CAPABILITIES_ACTIVITY, capability.isActivityEnabled().getValue());
 
         if (capabilityExists(mAccount.name)) {
             if (getContentResolver() != null) {
@@ -2102,6 +2103,8 @@ public class FileDataStorageManager {
                     c.getInt(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_DEFAULT))));
             capability.setServerBackgroundPlain(CapabilityBooleanType.fromValue(
                     c.getInt(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_PLAIN))));
+            capability.setActivity(CapabilityBooleanType.fromValue(
+                    c.getInt(c.getColumnIndex(ProviderTableMeta.CAPABILITIES_ACTIVITY))));
         }
         return capability;
     }

--- a/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -32,7 +32,7 @@ import com.owncloud.android.MainApp;
 public class ProviderMeta {
 
     public static final String DB_NAME = "filelist";
-    public static final int DB_VERSION = 32;
+    public static final int DB_VERSION = 33;
 
     private ProviderMeta() {
     }
@@ -171,6 +171,7 @@ public class ProviderMeta {
         public static final String CAPABILITIES_SERVER_BACKGROUND_PLAIN = "background_plain";
         
         public static final String CAPABILITIES_END_TO_END_ENCRYPTION = "end_to_end_encryption";
+        public static final String CAPABILITIES_ACTIVITY = "activity";
 
         public static final String CAPABILITIES_DEFAULT_SORT_ORDER = CAPABILITIES_ACCOUNT_NAME
                 + " collate nocase asc";

--- a/src/main/java/com/owncloud/android/operations/GetCapabilitiesOperation.java
+++ b/src/main/java/com/owncloud/android/operations/GetCapabilitiesOperation.java
@@ -28,7 +28,7 @@ import com.owncloud.android.operations.common.SyncOperation;
 /**
  * Get and save capabilities from the server
  */
-public class GetCapabilitiesOperarion extends SyncOperation {
+public class GetCapabilitiesOperation extends SyncOperation {
 
     @Override
     protected RemoteOperationResult run(OwnCloudClient client) {

--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -247,7 +247,7 @@ public class RefreshFolderOperation extends RemoteOperation {
     }
 
     private void updateCapabilities() {
-        GetCapabilitiesOperarion getCapabilities = new GetCapabilitiesOperarion();
+        GetCapabilitiesOperation getCapabilities = new GetCapabilitiesOperation();
         RemoteOperationResult result = getCapabilities.execute(mStorageManager, mContext);
         if (!result.isSuccess()) {
             Log_OC.w(TAG, "Update Capabilities unsuccessfully");

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -804,6 +804,7 @@ public class FileContentProvider extends ContentProvider {
                 + ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN + TEXT
                 + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL + TEXT
                 + ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION + INTEGER
+                + ProviderTableMeta.CAPABILITIES_ACTIVITY + INTEGER
                 + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_DEFAULT + INTEGER
                 + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_PLAIN + " INTEGER );");
     }
@@ -1694,6 +1695,23 @@ public class FileContentProvider extends ContentProvider {
                     db.execSQL(ALTER_TABLE + ProviderTableMeta.OCSHARES_TABLE_NAME +
                             ADD_COLUMN + ProviderTableMeta.OCSHARES_IS_PASSWORD_PROTECTED + " INTEGER "); // boolean
 
+                    upgraded = true;
+                    db.setTransactionSuccessful();
+                } finally {
+                    db.endTransaction();
+                }
+            }
+
+            if (!upgraded) {
+                Log_OC.i(SQL, String.format(Locale.ENGLISH, UPGRADE_VERSION_MSG, oldVersion, newVersion));
+            }
+
+            if (oldVersion < 33 && newVersion >= 33) {
+                Log_OC.i(SQL, "Entering in the #3 Adding activity to capability");
+                db.beginTransaction();
+                try {
+                    db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                            ADD_COLUMN + ProviderTableMeta.CAPABILITIES_ACTIVITY + " INTEGER ");
                     upgraded = true;
                     db.setTransactionSuccessful();
                 } finally {

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -346,7 +346,8 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
     private void filterDrawerMenu(Menu menu, Account account) {
         DrawerMenuUtil.filterForBottomToolbarMenuItems(menu, getResources());
         DrawerMenuUtil.filterSearchMenuItems(menu, account, getResources());
-        DrawerMenuUtil.filterTrashbinMenuItems(menu, account, getContentResolver());
+        DrawerMenuUtil.filterTrashbinMenuItem(menu, account, getContentResolver());
+        DrawerMenuUtil.filterActivityMenuItem(menu, account, getContentResolver());
 
         DrawerMenuUtil.setupHomeMenuItem(menu, getResources());
 

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -79,7 +79,7 @@ import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.lib.resources.users.GetRemoteUserInfoOperation;
-import com.owncloud.android.operations.GetCapabilitiesOperarion;
+import com.owncloud.android.operations.GetCapabilitiesOperation;
 import com.owncloud.android.ui.TextDrawable;
 import com.owncloud.android.ui.activities.ActivitiesActivity;
 import com.owncloud.android.ui.events.AccountRemovedEvent;
@@ -1356,7 +1356,7 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 // fetch capabilities as early as possible
                 if ((getCapabilities() == null || getCapabilities().getAccountName().isEmpty())
                         && getStorageManager() != null) {
-                    GetCapabilitiesOperarion getCapabilities = new GetCapabilitiesOperarion();
+                    GetCapabilitiesOperation getCapabilities = new GetCapabilitiesOperation();
                     getCapabilities.execute(getStorageManager(), getBaseContext());
                 }
 

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -64,6 +64,7 @@ import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.authentication.PassCodeManager;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.ExternalLinksProvider;
+import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.ExternalLink;
 import com.owncloud.android.lib.common.ExternalLinkType;
@@ -344,10 +345,16 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
     }
 
     private void filterDrawerMenu(Menu menu, Account account) {
+        OCCapability capability = null;
+        if (account != null) {
+            FileDataStorageManager storageManager = new FileDataStorageManager(account, getContentResolver());
+            capability = storageManager.getCapability(account.name);
+        }
+        
         DrawerMenuUtil.filterForBottomToolbarMenuItems(menu, getResources());
         DrawerMenuUtil.filterSearchMenuItems(menu, account, getResources());
-        DrawerMenuUtil.filterTrashbinMenuItem(menu, account, getContentResolver());
-        DrawerMenuUtil.filterActivityMenuItem(menu, account, getContentResolver());
+        DrawerMenuUtil.filterTrashbinMenuItem(menu, account, capability);
+        DrawerMenuUtil.filterActivityMenuItem(menu, capability);
 
         DrawerMenuUtil.setupHomeMenuItem(menu, getResources());
 

--- a/src/main/java/com/owncloud/android/utils/DrawerMenuUtil.java
+++ b/src/main/java/com/owncloud/android/utils/DrawerMenuUtil.java
@@ -21,13 +21,12 @@
 package com.owncloud.android.utils;
 
 import android.accounts.Account;
-import android.content.ContentResolver;
 import android.content.res.Resources;
+import android.support.annotation.Nullable;
 import android.view.Menu;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
-import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 
@@ -67,11 +66,8 @@ public class DrawerMenuUtil {
         }
     }
 
-    public static void filterTrashbinMenuItem(Menu menu, Account account, ContentResolver contentResolver) {
-        if (account != null) {
-            FileDataStorageManager storageManager = new FileDataStorageManager(account, contentResolver);
-            OCCapability capability = storageManager.getCapability(account.name);
-
+    public static void filterTrashbinMenuItem(Menu menu, @Nullable Account account, @Nullable OCCapability capability) {
+        if (account != null && capability != null) {
             if (AccountUtils.getServerVersion(account).compareTo(OwnCloudVersion.nextcloud_14) < 0 ||
                     capability.getFilesUndelete().isFalse() || capability.getFilesUndelete().isUnknown()) {
                 filterMenuItems(menu, R.id.nav_trashbin);
@@ -79,15 +75,10 @@ public class DrawerMenuUtil {
         }
     }
 
-    public static void filterActivityMenuItem(Menu menu, Account account, ContentResolver contentResolver) {
-        if (account != null) {
-            FileDataStorageManager storageManager = new FileDataStorageManager(account, contentResolver);
-            OCCapability capability = storageManager.getCapability(account.name);
-
-            if (capability.isActivityEnabled().isFalse() || capability.isActivityEnabled().isUnknown()) {
+    public static void filterActivityMenuItem(Menu menu, @Nullable OCCapability capability) {
+        if (capability != null && capability.isActivityEnabled().isFalse()) {
                 filterMenuItems(menu, R.id.nav_activity);
             }
-        }
     }
 
     public static void removeMenuItem(Menu menu, int id, boolean remove) {

--- a/src/main/java/com/owncloud/android/utils/DrawerMenuUtil.java
+++ b/src/main/java/com/owncloud/android/utils/DrawerMenuUtil.java
@@ -67,7 +67,7 @@ public class DrawerMenuUtil {
         }
     }
 
-    public static void filterTrashbinMenuItems(Menu menu, Account account, ContentResolver contentResolver) {
+    public static void filterTrashbinMenuItem(Menu menu, Account account, ContentResolver contentResolver) {
         if (account != null) {
             FileDataStorageManager storageManager = new FileDataStorageManager(account, contentResolver);
             OCCapability capability = storageManager.getCapability(account.name);
@@ -75,6 +75,17 @@ public class DrawerMenuUtil {
             if (AccountUtils.getServerVersion(account).compareTo(OwnCloudVersion.nextcloud_14) < 0 ||
                     capability.getFilesUndelete().isFalse() || capability.getFilesUndelete().isUnknown()) {
                 filterMenuItems(menu, R.id.nav_trashbin);
+            }
+        }
+    }
+
+    public static void filterActivityMenuItem(Menu menu, Account account, ContentResolver contentResolver) {
+        if (account != null) {
+            FileDataStorageManager storageManager = new FileDataStorageManager(account, contentResolver);
+            OCCapability capability = storageManager.getCapability(account.name);
+
+            if (capability.isActivityEnabled().isFalse() || capability.isActivityEnabled().isUnknown()) {
+                filterMenuItems(menu, R.id.nav_activity);
             }
         }
     }


### PR DESCRIPTION
This uses capability to check if activity app is enabled and if not remove it from drawer.

Only problem is, that right after adding an new account, we do not have capability in place and thus we do not know if activity app is enabled.
So what to do? Show the menu entry and maybe later hide it?
(on Trashbin this is the same problem, there I chose to hide it first, and then show it if it is supported).

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>