### PR TITLE
ui:activity: Check if OCFileListFragment is null before calling onItemClicked().

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2110,7 +2110,7 @@ public class FileDisplayActivity extends HookActivity
         if (result.isSuccess()) {
             OCFileListFragment fileListFragment = getListOfFilesFragment();
             if (fileListFragment != null) {
-                getListOfFilesFragment().onItemClicked(getStorageManager().getFileByPath(operation.getRemotePath()));
+                fileListFragment.onItemClicked(getStorageManager().getFileByPath(operation.getRemotePath()));
             }
         } else {
             try {

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2108,7 +2108,10 @@ public class FileDisplayActivity extends HookActivity
     private void onCreateFolderOperationFinish(CreateFolderOperation operation,
                                                RemoteOperationResult result) {
         if (result.isSuccess()) {
-            getListOfFilesFragment().onItemClicked(getStorageManager().getFileByPath(operation.getRemotePath()));
+            OCFileListFragment fileListFragment = getListOfFilesFragment();
+            if (fileListFragment != null) {
+                getListOfFilesFragment().onItemClicked(getStorageManager().getFileByPath(operation.getRemotePath()));
+            }
         } else {
             try {
                 if (ResultCode.FOLDER_ALREADY_EXISTS == result.getCode()) {


### PR DESCRIPTION
A reference to null should never be dereferenced/accessed