### PR TITLE
Fix the removal of "select all" from the folder picker

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -122,7 +122,7 @@ public class LocalFileListFragment extends ExtendedListFragment implements Local
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         if (mContainerActivity.isFolderPickerMode()) {
-            menu.removeItem(R.id.action_select_all_action_menu);
+            menu.removeItem(R.id.action_select_all);
             menu.removeItem(R.id.action_search);
         } else {
             super.onCreateOptionsMenu(menu, inflater);


### PR DESCRIPTION
Before the wrong id for the menu entry was used