### PR TITLE
Do not show first run activity for brander

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -455,9 +455,16 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 UserInfoActivity.openAccountRemovalConfirmationDialog(getAccount(), getFragmentManager(), true);
                 break;
             case R.id.drawer_menu_account_add:
-                Intent firstRunIntent = new Intent(getApplicationContext(), FirstRunActivity.class);
-                firstRunIntent.putExtra(FirstRunActivity.EXTRA_ALLOW_CLOSE, true);
-                startActivity(firstRunIntent);
+                boolean isProviderOrOwnInstallationVisible = getResources()
+                        .getBoolean(R.bool.show_provider_or_own_installation);
+
+                if (isProviderOrOwnInstallationVisible) {
+                    Intent firstRunIntent = new Intent(getApplicationContext(), FirstRunActivity.class);
+                    firstRunIntent.putExtra(FirstRunActivity.EXTRA_ALLOW_CLOSE, true);
+                    startActivity(firstRunIntent);
+                } else {
+                    createAccount(false);
+                }
                 break;
             case R.id.drawer_menu_account_manage:
                 Intent manageAccountsIntent = new Intent(getApplicationContext(), ManageAccountsActivity.class);

--- a/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
@@ -168,6 +168,13 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
     }
 
     public static boolean runIfNeeded(Context context) {
+        boolean isProviderOrOwnInstallationVisible = context.getResources()
+                .getBoolean(R.bool.show_provider_or_own_installation);
+
+        if (!isProviderOrOwnInstallationVisible) {
+            return false;
+        }
+        
         if (context instanceof FirstRunActivity) {
             return false;
         }

--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -276,7 +276,7 @@ public class ManageAccountsActivity extends FileActivity
         startActivity(firstRunIntent);
     }
 
-    //    @Override
+    @Override
     public void createAccount() {
         AccountManager am = AccountManager.get(getApplicationContext());
         am.addAccount(MainApp.getAccountType(this),

--- a/src/main/java/com/owncloud/android/ui/adapter/AccountListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/AccountListAdapter.java
@@ -127,7 +127,15 @@ public class AccountListAdapter extends ArrayAdapter<AccountListItem> implements
         ((ImageView) actionView.findViewById(R.id.user_icon)).setImageResource(R.drawable.ic_account_plus);
 
         // bind action listener
-        actionView.setOnClickListener(v -> mListener.showFirstRunActivity());
+        boolean isProviderOrOwnInstallationVisible = mContext.getResources()
+                .getBoolean(R.bool.show_provider_or_own_installation);
+
+        if (isProviderOrOwnInstallationVisible) {
+            actionView.setOnClickListener(v -> mListener.showFirstRunActivity());
+        } else {
+            actionView.setOnClickListener(v -> mListener.createAccount());
+        }
+        
         return actionView;
     }
 
@@ -185,6 +193,8 @@ public class AccountListAdapter extends ArrayAdapter<AccountListItem> implements
     public interface AccountListAdapterListener {
 
         void showFirstRunActivity();
+
+        void createAccount();
     }
 
     /**


### PR DESCRIPTION
On brander, the first run activity should not be shown, but directly the login screen.
Can be toggled via: show_provider_or_own_installation in setup.xml

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>