### PR TITLE
Add divider for local/oc file list again

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -122,6 +122,8 @@ public class ExtendedListFragment extends Fragment
 
     private EmptyRecyclerView mRecyclerView;
 
+    private DividerItemDecoration dividerItemDecoration;
+
     protected SearchView searchView;
     private Handler handler = new Handler();
 
@@ -154,6 +156,11 @@ public class ExtendedListFragment extends Fragment
         return mRecyclerView;
     }
 
+    protected DividerItemDecoration getDividerItemDecoration() {
+        return dividerItemDecoration;
+    }
+
+
     public FloatingActionButton getFabMain() {
         return mFabMain;
     }
@@ -161,12 +168,14 @@ public class ExtendedListFragment extends Fragment
     public void switchToGridView() {
         if (!isGridEnabled()) {
             getRecyclerView().setLayoutManager(new GridLayoutManager(getContext(), getColumnSize()));
+            getRecyclerView().removeItemDecoration(dividerItemDecoration);
         }
     }
 
     public void switchToListView() {
         if (isGridEnabled()) {
             getRecyclerView().setLayoutManager(new LinearLayoutManager(getContext()));
+            getRecyclerView().addItemDecoration(dividerItemDecoration);
         }
     }
 
@@ -363,8 +372,12 @@ public class ExtendedListFragment extends Fragment
         mRecyclerView.setHasFixedSize(true);
         LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
         mRecyclerView.setLayoutManager(layoutManager);
-        DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(getContext(), layoutManager.getOrientation());
-        mRecyclerView.addItemDecoration(dividerItemDecoration);
+        dividerItemDecoration = new DividerItemDecoration(getContext(), layoutManager.getOrientation());
+        dividerItemDecoration.setDrawable(getResources().getDrawable(R.drawable.vertical_divider));
+
+        if(!isGridEnabled()){
+            mRecyclerView.addItemDecoration(dividerItemDecoration);
+        }
 
         mScale = PreferenceManager.getGridColumns(getContext());
         setGridViewColumns(1f);

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -36,6 +36,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -360,7 +361,10 @@ public class ExtendedListFragment extends Fragment
         mRecyclerView.setHasFooter(true);
         mRecyclerView.setEmptyView(v.findViewById(R.id.empty_list_view));
         mRecyclerView.setHasFixedSize(true);
-        mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
+        mRecyclerView.setLayoutManager(layoutManager);
+        DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(getContext(), layoutManager.getOrientation());
+        mRecyclerView.addItemDecoration(dividerItemDecoration);
 
         mScale = PreferenceManager.getGridColumns(getContext());
         setGridViewColumns(1f);

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1164,9 +1164,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     }
                 }
             });
-            
+            getRecyclerView().removeItemDecoration(getDividerItemDecoration());
         } else {
             layoutManager = new LinearLayoutManager(getContext());
+            getRecyclerView().addItemDecoration(getDividerItemDecoration());
         }
 
         getRecyclerView().setLayoutManager(layoutManager);

--- a/src/main/res/drawable/vertical_divider.xml
+++ b/src/main/res/drawable/vertical_divider.xml
@@ -1,0 +1,28 @@
+<!--
+    Nextcloud Android client application
+
+    @author Andy Scherzinger
+    Copyright (C) 2018 Andy Scherzinger
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:left="72dp">
+
+        <shape>
+            <size android:height="1px" />
+            <solid android:color="#1f000000" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
![2018-08-29-180806](https://user-images.githubusercontent.com/5836855/44800363-89da9000-abb6-11e8-9584-9039c0902869.png) ![2018-08-29-180817](https://user-images.githubusercontent.com/5836855/44800365-89da9000-abb6-11e8-9a55-d136bb4fe047.png)

It looks a bit too heavy. I will have a chat with Jan tomorrow.
The old value seems to be "#eee".
Also somehow the divider is on grid view much more narrow than I have it in my mind, before RecyclerView.

@AndyScherzinger thanks for this finding on irc :+1: 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>