### PR TITLE
bump to 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.4 (August, 21, 2018)
+## 3.2.4 (September, 04, 2018)
 fix push notification on gplay release
 
 ## 3.2.3 (August, 21, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 3.2.2 (August, 21, 2018)
+## 3.2.4 (August, 21, 2018)
+fix push notification on gplay release
+
+## 3.2.3 (August, 21, 2018)
 fix crash on Android 4.x
 
 ## 3.2.2 (August, 20, 2018)

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ repositories {
 // semantic versioning for version code
 def versionMajor = 3
 def versionMinor = 2
-def versionPatch = 3
+def versionPatch = 4
 def versionBuild = 99 // 0-49=Alpha / 50-98=RC / 99=stable
 
 android {

--- a/fastlane/metadata/android/en-US/changelogs/30020399.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30020399.txt
@@ -1,2 +1,2 @@
-## 3.2.2 (August, 21, 2018)
+## 3.2.3 (August, 21, 2018)
 fix crash on Android 4.x

--- a/fastlane/metadata/android/en-US/changelogs/30020499.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30020499.txt
@@ -1,0 +1,2 @@
+## 3.2.4 (August, 21, 2018)
+fix push notification on gplay release

--- a/fastlane/metadata/android/en-US/changelogs/30020499.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30020499.txt
@@ -1,2 +1,2 @@
-## 3.2.4 (August, 21, 2018)
+## 3.2.4 (September, 04, 2018)
 fix push notification on gplay release


### PR DESCRIPTION
There is no code change from 3.2.3 -> 3.2.4 except of the version number as the missing push notification came from a wrong build chain.

Resolves #2931

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>