### PR TITLE
Prevent NPE on media stream

### DIFF
--- a/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/src/main/java/com/owncloud/android/media/MediaService.java
@@ -700,7 +700,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
     }
 
 
-    protected void setMediaContoller(MediaControlView mediaController) {
+    protected void setMediaController(MediaControlView mediaController) {
         mMediaController = mediaController;
     }
 
@@ -734,7 +734,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
         protected void onPostExecute(String url) {
             MediaService mediaService = mediaServiceWeakReference.get();
 
-            if (mediaService != null) {
+            if (mediaService != null && mediaService.getCurrentFile() != null) {
                 if (url != null) {
                     try {
                         mediaService.mPlayer.setDataSource(url);

--- a/src/main/java/com/owncloud/android/media/MediaServiceBinder.java
+++ b/src/main/java/com/owncloud/android/media/MediaServiceBinder.java
@@ -157,12 +157,12 @@ public class MediaServiceBinder extends Binder implements MediaController.MediaP
 
 
     public void registerMediaController(MediaControlView mediaController) {
-        mService.setMediaContoller(mediaController);
+        mService.setMediaController(mediaController);
     }
 
     public void unregisterMediaController(MediaControlView mediaController) {
         if (mediaController != null && mediaController == mService.getMediaController()) {
-            mService.setMediaContoller(null);
+            mService.setMediaController(null);
         }
 
     }


### PR DESCRIPTION
- fix typo
- if load stream url takes too long, media player is already destroyed, so a NPE on file can occur -> this does not fix streaming, but only prevent app from crashing


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>