### PR TITLE
"dependencies" label do not need a pull approve

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -20,6 +20,10 @@ group_defaults:
     enabled: false
   reset_on_reopened:
     enabled: true
+  conditions:
+    labels:
+      exclude:
+        - dependencies
 
 groups:
   code-review:


### PR DESCRIPTION
As we discussed in one issue (I hope I recall it correctly), we want to merge new deps as soon as possible.
Therefore we added dependabot. If one of those PRs turn green, we can directly merge.
This PR should trigger pullapprove to ignore those PRs.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>