### PR TITLE
Store mnemonic as typed in

### DIFF
--- a/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -185,6 +185,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
 
                                 try {
                                     String privateKey = task.get();
+                                    String mnemonicUnchanged = passwordField.getText().toString();
                                     String mnemonic = passwordField.getText().toString().replaceAll("\\s", "")
                                             .toLowerCase(Locale.ROOT);
                                     String decryptedPrivateKey = EncryptionUtils.decryptPrivateKey(privateKey,
@@ -197,7 +198,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
                                     Log_OC.d(TAG, "Private key successfully decrypted and stored");
 
                                     arbitraryDataProvider.storeOrUpdateKeyValue(account.name, EncryptionUtils.MNEMONIC,
-                                            mnemonic);
+                                            mnemonicUnchanged);
 
                                     Intent intentExisting = new Intent();
                                     intentExisting.putExtra(SUCCESS, true);


### PR DESCRIPTION
Ref: https://github.com/nextcloud/android/pull/2381#issuecomment-399385582

We have to distinguish two cases:
- first setup e2e on user, then also currently the mnemonic is stored with withespaces
- setup client with existing e2e: this now stores the mnemonic as the user types it.

We cannot automagically split the words, but I guess it is ok if the user gets back what he/she typed in before.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>