### PR TITLE
Fix Avatar fetching for Nc14 server

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -870,7 +870,8 @@ public class ThumbnailsCacheManager {
                     // we are using eTag to download a new avatar only if it changed
                     switch (status) {
                         case HttpStatus.SC_OK:
-                            // new avatar
+                        case HttpStatus.SC_CREATED:
+						    // new avatar
                             InputStream inputStream = get.getResponseBodyAsStream();
 
                             String newETag = null;


### PR DESCRIPTION
Fixes #3015 - server sends a HTTP-201 (not 200) for a newly created avatar on Nc14

HTTP-201 (CREATED) is actually the correct HTTP code since the resource has just been created and is part of the body/reply (in case no other client has requested the avatar with the requested solution)