### PR TITLE
backport: Tint drawable according to login color #3025

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/FeatureFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FeatureFragment.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 
 import com.owncloud.android.R;
 import com.owncloud.android.features.FeatureItem;
+import com.owncloud.android.utils.ThemeUtils;
 
 
 public class FeatureFragment extends Fragment {
@@ -46,7 +47,7 @@ public class FeatureFragment extends Fragment {
 
         ImageView whatsNewImage = view.findViewById(R.id.whatsNewImage);
         if (item.shouldShowImage()) {
-            whatsNewImage.setImageResource(item.getImage());
+            whatsNewImage.setImageDrawable(ThemeUtils.tintDrawable(item.getImage(), fontColor));
         }
 
         TextView whatsNewTitle = view.findViewById(R.id.whatsNewTitle);


### PR DESCRIPTION
(e.g. black on white background, white on blue background)

As this is needed for brander, and we want to release branded 3.3 version, this should be backported.

Signed-off-by: tobiasKaminsky tobias@kaminsky.me

backport of #3025