### PR TITLE
backport: Fix account switching: After adding an account, the app restart and uses the new account #3037

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
@@ -216,10 +216,21 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (FIRST_RUN_RESULT_CODE == requestCode && RESULT_OK == resultCode) {
-            setAccount(AccountUtils.getCurrentOwnCloudAccount(this));
+
+            String accountName = data.getStringExtra(AccountManager.KEY_ACCOUNT_NAME);
+            Account account = AccountUtils.getOwnCloudAccountByName(this, accountName);
+
+            if (account == null) {
+                DisplayUtils.showSnackMessage(this, R.string.account_creation_failed);
+                return;
+            }
+            
+            setAccount(account);
+            AccountUtils.setCurrentOwnCloudAccount(this, account.name);
             onAccountSet(false);
 
             Intent i = new Intent(this, FileDisplayActivity.class);
+            i.setAction(FileDisplayActivity.RESTART);
             i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(i);
         }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -816,4 +816,5 @@
     <string name="file_keep">Keep</string>
     <string name="file_rename">Rename</string>
     <string name="fab_label">Add or upload</string>
+    <string name="account_creation_failed">Account creation failed</string>
 </resources>


### PR DESCRIPTION
backport for #3037