### PR TITLE
Fix CanvasTooLargeException

### DIFF
--- a/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -104,8 +104,7 @@ public final class BitmapUtils {
 
             // calculates the largest inSampleSize value (for smallest sample) that is a power of 2 and keeps both
             // height and width **larger** than the requested height and width.
-            while ((halfHeight / inSampleSize) > reqHeight
-                    && (halfWidth / inSampleSize) > reqWidth) {
+            while ((halfHeight / inSampleSize) > reqHeight || (halfWidth / inSampleSize) > reqWidth) {
                 inSampleSize *= 2;
             }
         }


### PR DESCRIPTION
Fix #3049 

The sample factor is copied from [Android developer's guide](https://developer.android.com/topic/performance/graphics/load-bitmap), so I am unsure if we want to change this.
But for very large landscape images this is maybe necessary.

For "regular" images this should make no difference, e.g. 1024x768 other 4:3 image formats.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>