### PR TITLE
Show local size when switching to "on device" view

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -108,6 +108,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private static final int VIEWTYPE_IMAGE = 2;
 
     private List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks = new ArrayList<>();
+    private boolean onlyOnDevice = false;
 
     public OCFileListAdapter(Context context, ComponentsGetter transferServiceGetter,
                              OCFileListFragmentInterface ocFileListFragmentInterface, boolean argHideItemOptions,
@@ -283,7 +284,21 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             if (holder instanceof OCFileListItemViewHolder) {
                 OCFileListItemViewHolder itemViewHolder = (OCFileListItemViewHolder) holder;
-                itemViewHolder.fileSize.setText(DisplayUtils.bytesToHumanReadable(file.getFileLength()));
+
+                if (onlyOnDevice) {
+                    File localFile = new File(file.getStoragePath());
+
+                    long localSize;
+                    if (localFile.isDirectory()) {
+                        localSize = FileStorageUtils.getFolderSize(localFile);
+                    } else {
+                        localSize = localFile.length();
+                    }
+
+                    itemViewHolder.fileSize.setText(DisplayUtils.bytesToHumanReadable(localSize));
+                } else {
+                    itemViewHolder.fileSize.setText(DisplayUtils.bytesToHumanReadable(file.getFileLength()));
+                }
                 itemViewHolder.lastModification.setText(DisplayUtils.getRelativeTimestamp(mContext,
                         file.getModificationTimestamp()));
 
@@ -499,6 +514,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
      */
     public void swapDirectory(OCFile directory, FileDataStorageManager updatedStorageManager,
                               boolean onlyOnDevice) {
+        this.onlyOnDevice = onlyOnDevice;
         if (updatedStorageManager != null && !updatedStorageManager.equals(mStorageManager)) {
             mStorageManager = updatedStorageManager;
             mAccount = AccountUtils.getCurrentOwnCloudAccount(mContext);


### PR DESCRIPTION
When switching to "on device" view, you see how much space a directory consumes, making it simplier to delete big folders/files.

![2018-09-20-151129](https://user-images.githubusercontent.com/5836855/45820613-78813100-bce7-11e8-94ef-cb04c9b9c8d1.png) ![2018-09-20-151001](https://user-images.githubusercontent.com/5836855/45820540-47086580-bce7-11e8-89f1-efddd1dc28e1.png)

(in this case only 12mb of folder size are locally available)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>	