### PR TITLE
Codacy fixes

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -455,7 +455,7 @@ public class FileDataStorageManager {
         cv.put(ProviderTableMeta.FILE_PUBLIC_LINK, folder.getPublicLink());
         cv.put(ProviderTableMeta.FILE_PERMISSIONS, folder.getPermissions());
         cv.put(ProviderTableMeta.FILE_REMOTE_ID, folder.getRemoteId());
-        cv.put(ProviderTableMeta.FILE_FAVORITE, folder.getIsFavorite());
+        cv.put(ProviderTableMeta.FILE_FAVORITE, folder.isFavorite());
         cv.put(ProviderTableMeta.FILE_IS_ENCRYPTED, folder.isEncrypted());
         return cv;
     }
@@ -487,7 +487,7 @@ public class FileDataStorageManager {
         cv.put(ProviderTableMeta.FILE_UPDATE_THUMBNAIL, file.needsUpdateThumbnail());
         cv.put(ProviderTableMeta.FILE_IS_DOWNLOADING, file.isDownloading());
         cv.put(ProviderTableMeta.FILE_ETAG_IN_CONFLICT, file.getEtagInConflict());
-        cv.put(ProviderTableMeta.FILE_FAVORITE, file.getIsFavorite());
+        cv.put(ProviderTableMeta.FILE_FAVORITE, file.isFavorite());
         cv.put(ProviderTableMeta.FILE_IS_ENCRYPTED, file.isEncrypted());
         cv.put(ProviderTableMeta.FILE_MOUNT_TYPE, file.getMountType().ordinal());
         return cv;
@@ -1399,7 +1399,7 @@ public class FileDataStorageManager {
                 cv.put(ProviderTableMeta.FILE_PUBLIC_LINK, file.getPublicLink());
                 cv.put(ProviderTableMeta.FILE_PERMISSIONS, file.getPermissions());
                 cv.put(ProviderTableMeta.FILE_REMOTE_ID, file.getRemoteId());
-                cv.put(ProviderTableMeta.FILE_FAVORITE, file.getIsFavorite());
+                cv.put(ProviderTableMeta.FILE_FAVORITE, file.isFavorite());
                 cv.put(
                         ProviderTableMeta.FILE_UPDATE_THUMBNAIL,
                         file.needsUpdateThumbnail() ? 1 : 0

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -557,7 +557,7 @@ public class FileDataStorageManager {
     }
 
     private boolean removeFolderInDb(OCFile folder) {
-        Uri folder_uri = Uri.withAppendedPath(ProviderTableMeta.CONTENT_URI_DIR, "" + folder.getFileId()); // URI
+        Uri folder_uri = Uri.withAppendedPath(ProviderTableMeta.CONTENT_URI_DIR, String.valueOf(folder.getFileId())); // URI
         // for recursive deletion
         String where = ProviderTableMeta.FILE_ACCOUNT_OWNER + AND + ProviderTableMeta.FILE_PATH + "=?";
         String[] whereArgs = new String[]{mAccount.name, folder.getRemotePath()};

--- a/src/main/java/com/owncloud/android/datamodel/MediaProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/MediaProvider.java
@@ -223,7 +223,7 @@ public final class MediaProvider {
 
                         if (filePath != null) {
                             mediaFolder.filePaths.add(filePath);
-                            mediaFolder.absolutePath = filePath.substring(0, filePath.lastIndexOf("/"));
+                            mediaFolder.absolutePath = filePath.substring(0, filePath.lastIndexOf('/'));
                         }
                     }
                     cursorVideos.close();

--- a/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -198,7 +198,7 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
         dest.writeSerializable(mMountType);
     }
 
-    public boolean getIsFavorite() {
+    public boolean isFavorite() {
         return mIsFavorite;
     }
 

--- a/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -714,7 +714,7 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
      * @return 'True' if the file is hidden
      */
     public boolean isHidden() {
-        return getFileName().startsWith(".");
+        return getFileName().charAt(0) == '.';
     }
 
     public String getPermissions() {

--- a/src/main/java/com/owncloud/android/datastorage/providers/MountCommandStoragePointProvider.java
+++ b/src/main/java/com/owncloud/android/datastorage/providers/MountCommandStoragePointProvider.java
@@ -62,7 +62,7 @@ public class MountCommandStoragePointProvider extends AbstractCommandLineStorage
             if (!line.toLowerCase(Locale.US).contains("asec") && sPattern.matcher(line).matches()) {
                 String parts[] = line.split(" ");
                 for (String path : parts) {
-                    if (path.startsWith("/") && !path.toLowerCase(Locale.US).contains("vold")) {
+                    if (path.charAt(0) == '/' && !path.toLowerCase(Locale.US).contains("vold")) {
                         result.add(path);
                     }
                 }

--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -495,7 +495,7 @@ public class FileMenuFilter {
 
     private boolean allFavorites() {
         for (OCFile file : mFiles) {
-            if (!file.getIsFavorite()) {
+            if (!file.isFavorite()) {
                 return false;
             }
         }
@@ -504,7 +504,7 @@ public class FileMenuFilter {
 
     private boolean allNotFavorites() {
         for (OCFile file : mFiles) {
-            if (file.getIsFavorite()) {
+            if (file.isFavorite()) {
                 return false;
             }
         }

--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -961,15 +961,15 @@ public class FileUploader extends Service
                         totalToTransfer, fileName);
 
                 if (MainApp.getAppContext() != null) {
-                    if (mCurrentUpload.getIsWifiRequired() && !Device.getNetworkType(MainApp.getAppContext()).
+                    if (mCurrentUpload.isWifiRequired() && !Device.getNetworkType(MainApp.getAppContext()).
                             equals(JobRequest.NetworkType.UNMETERED)) {
                         cancel(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath()
                                 , ResultCode.DELAYED_FOR_WIFI);
-                    } else if (mCurrentUpload.getIsChargingRequired() &&
+                    } else if (mCurrentUpload.isChargingRequired() &&
                             !Device.getBatteryStatus(MainApp.getAppContext()).isCharging()) {
                         cancel(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath()
                                 , ResultCode.DELAYED_FOR_CHARGING);
-                    } else if (!mCurrentUpload.getIsIgnoringPowerSaveMode() &&
+                    } else if (!mCurrentUpload.isIgnoringPowerSaveMode() &&
                             PowerUtils.isPowerSaveMode(MainApp.getAppContext())) {
                         cancel(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath()
                                 , ResultCode.DELAYED_IN_POWER_SAVE_MODE);

--- a/src/main/java/com/owncloud/android/jobs/ContactsImportJob.java
+++ b/src/main/java/com/owncloud/android/jobs/ContactsImportJob.java
@@ -88,8 +88,8 @@ public class ContactsImportJob extends Job {
             }
 
 
-            for (int i = 0; i < intArray.length; i++) {
-                VCard vCard = vCards.get(intArray[i]);
+            for (int checkedItem : intArray) {
+                VCard vCard = vCards.get(checkedItem);
                 if (ContactListFragment.getDisplayName(vCard).length() != 0) {
                     if (!ownContactList.containsKey(vCard)) {
                         operations.insertContact(vCard);

--- a/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
@@ -144,8 +144,7 @@ public class DownloadFileOperation extends RemoteOperation {
     }
     
     public long getModificationTimestamp() {
-        return (mModificationTimestamp > 0) ? mModificationTimestamp :
-                mFile.getModificationTimestamp();
+        return mModificationTimestamp > 0 ? mModificationTimestamp : mFile.getModificationTimestamp();
     }
 
     public String getEtag() {

--- a/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -245,7 +245,7 @@ public class SynchronizeFileOperation extends SyncOperation {
                         // service when the upload finishes
                     } else {
                         // TODO CHECK: is this really useful in some point in the code?
-                        mServerFile.setFavorite(mLocalFile.getIsFavorite());
+                        mServerFile.setFavorite(mLocalFile.isFavorite());
                         mServerFile.setAvailableOffline(mLocalFile.isAvailableOffline());
                         mServerFile.setLastSyncDateForData(mLocalFile.getLastSyncDateForData());
                         mServerFile.setStoragePath(mLocalFile.getStoragePath());

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -219,15 +219,15 @@ public class UploadFileOperation extends SyncOperation {
         mFolderUnlockToken = upload.getFolderUnlockToken();
     }
 
-    public boolean getIsWifiRequired() {
+    public boolean isWifiRequired() {
         return mOnWifiOnly;
     }
 
-    public boolean getIsChargingRequired() {
+    public boolean isChargingRequired() {
         return mWhileChargingOnly;
     }
 
-    public boolean getIsIgnoringPowerSaveMode() { return mIgnoringPowerSaveMode; }
+    public boolean isIgnoringPowerSaveMode() { return mIgnoringPowerSaveMode; }
 
     public Account getAccount() {
         return mAccount;

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2020,7 +2020,7 @@ public class FileDisplayActivity extends HookActivity
             snackbar.show();
         }
 
-        if (fileDetailFragment != null && fileDetailFragment instanceof FileDetailFragment) {
+        if (fileDetailFragment instanceof FileDetailFragment) {
             ((FileDetailFragment) fileDetailFragment).getFileDetailSharingFragment()
                     .onUpdateShareInformation(result, getFile());
         }

--- a/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -40,7 +40,6 @@ import java.io.File;
 public class ManageSpaceActivity extends AppCompatActivity {
 
     private static final String TAG = ManageSpaceActivity.class.getSimpleName();
-
     private static final String LIB_FOLDER = "lib";
 
     @Override
@@ -167,13 +166,13 @@ public class ManageSpaceActivity extends AppCompatActivity {
             if (dir != null && dir.isDirectory()) {
                 String[] children = dir.list();
                 if (children != null) {
-                    for (int i = 0; i < children.length; i++) {
-                        boolean success = deleteDir(new File(dir, children[i]));
+                    for (String child : children) {
+                        boolean success = deleteDir(new File(dir, child));
                         if (!success) {
-                            Log_OC.w(TAG, "File NOT deleted " + children[i]);
+                            Log_OC.w(TAG, "File NOT deleted " + child);
                             return false;
                         } else {
-                            Log_OC.d(TAG, "File deleted " + children[i]);
+                            Log_OC.d(TAG, "File deleted " + child);
                         }
                     }
                 } else {
@@ -181,7 +180,11 @@ public class ManageSpaceActivity extends AppCompatActivity {
                 }
             }
 
-            return dir.delete();
+            if (dir != null) {
+                return dir.delete();
+            } else {
+                return false;
+            }
         }
     }
 }

--- a/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
+++ b/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
@@ -251,14 +251,14 @@ public class StorageMigration {
         }
 
         protected void stopAccountsSyncing() {
-            for (int i = 0; i < mOcAccounts.length; ++i) {
-                ContentResolver.setSyncAutomatically(mOcAccounts[i], mAuthority, false);
+            for (Account ocAccount : mOcAccounts) {
+                ContentResolver.setSyncAutomatically(ocAccount, mAuthority, false);
             }
         }
 
         protected void waitForUnfinishedSynchronizations() {
-            for (int i = 0; i < mOcAccounts.length; ++i) {
-                while (ContentResolver.isSyncActive(mOcAccounts[i], mAuthority)) {
+            for (Account ocAccount : mOcAccounts) {
+                while (ContentResolver.isSyncActive(ocAccount, mAuthority)) {
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException e) {

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -461,8 +461,8 @@ public class UserInfoActivity extends FileActivity {
 
         public class ViewHolder extends RecyclerView.ViewHolder {
 
-            @BindView(R.id.icon) protected ImageView icon = null;
-            @BindView(R.id.text) protected TextView text = null;
+            @BindView(R.id.icon) protected ImageView icon;
+            @BindView(R.id.text) protected TextView text;
 
             public ViewHolder(View itemView) {
                 super(itemView);

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -248,7 +248,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
             if (MimeTypeUtil.isImage(file)) {
                 // Thumbnail in Cache?
                 Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                        ThumbnailsCacheManager.PREFIX_THUMBNAIL + String.valueOf(file.hashCode())
+                        ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.hashCode()
                 );
                 if (thumbnail != null) {
                     thumbnailView.setImageBitmap(thumbnail);

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -338,7 +338,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 gridViewHolder.localFileIndicator.setVisibility(View.VISIBLE);
             }
 
-            gridViewHolder.favorite.setVisibility(file.getIsFavorite() ? View.VISIBLE : View.GONE);
+            gridViewHolder.favorite.setVisibility(file.isFavorite() ? View.VISIBLE : View.GONE);
             gridViewHolder.offlineIcon.setVisibility(file.isAvailableOffline() ? View.VISIBLE : View.GONE);
 
             if (multiSelect) {

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -380,7 +380,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             if ((MimeTypeUtil.isImage(file) || MimeTypeUtil.isVideo(file)) && file.getRemoteId() != null) {
                 // Thumbnail in cache?
                 Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                        ThumbnailsCacheManager.PREFIX_THUMBNAIL + String.valueOf(file.getRemoteId())
+                        ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.getRemoteId()
                 );
 
                 if (thumbnail != null && !file.needsUpdateThumbnail()) {

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -163,14 +163,16 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     public void setFavoriteAttributeForItemID(String fileId, boolean favorite) {
-        for (int i = 0; i < mFiles.size(); i++) {
+        int filesSize = mFiles.size();
+        for (int i = 0; i < filesSize; i++) {
             if (mFiles.get(i).getRemoteId().equals(fileId)) {
                 mFiles.get(i).setFavorite(favorite);
                 break;
             }
         }
 
-        for (int i = 0; i < mFilesAll.size(); i++) {
+        filesSize = mFilesAll.size();
+        for (int i = 0; i < filesSize; i++) {
             if (mFilesAll.get(i).getRemoteId().equals(fileId)) {
                 mFilesAll.get(i).setFavorite(favorite);
                 break;

--- a/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
@@ -211,7 +211,7 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             if ((MimeTypeUtil.isImage(file) || MimeTypeUtil.isVideo(file)) && file.getRemoteId() != null) {
                 // Thumbnail in cache?
                 Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                        ThumbnailsCacheManager.PREFIX_THUMBNAIL + String.valueOf(file.getRemoteId())
+                        ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.getRemoteId()
                 );
 
                 if (thumbnail != null) {

--- a/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  *   ownCloud Android client application
  *
  *   Copyright (C) 2015 ownCloud Inc.
@@ -36,10 +36,6 @@ import com.owncloud.android.utils.ThemeUtils;
 public class LoadingDialog extends DialogFragment {
 
     private String mMessage;
-    
-    public LoadingDialog() {
-        super();
-    }
     
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/src/main/java/com/owncloud/android/ui/dialog/SslValidatorDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SslValidatorDialog.java
@@ -321,11 +321,11 @@ public class SslValidatorDialog extends Dialog {
         Map<String, String> result = new HashMap<>();
         String toParse = principal.getName();
         String[] pieces = toParse.split(",");
-        String[] tokens = {"CN", "O", "OU", "C", "ST", "L"}; 
-        for (int i=0; i < pieces.length ; i++) {
-            for (int j=0; j<tokens.length; j++) {
-                if (pieces[i].startsWith(tokens[j] + "=")) {
-                    result.put(tokens[j], pieces[i].substring(tokens[j].length()+1));
+        String[] tokens = {"CN", "O", "OU", "C", "ST", "L"};
+        for (String piece : pieces) {
+            for (String token : tokens) {
+                if (piece.startsWith(token + "=")) {
+                    result.put(token, piece.substring(token.length() + 1));
                 }
             }
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -290,12 +290,11 @@ public class EditShareFragment extends Fragment {
                         if (isChecked) {
                             if (!isFederated) {
                                 /// not federated shares -> enable all the subpermisions
-                                for (int i = 0; i < sSubordinateCheckBoxIds.length; i++) {
+                                for (int subordinateCheckBoxId : sSubordinateCheckBoxIds) {
                                     //noinspection ConstantConditions, prevented in the method beginning
-                                    subordinate = getView().findViewById(sSubordinateCheckBoxIds[i]);
+                                    subordinate = getView().findViewById(subordinateCheckBoxId);
                                     subordinate.setVisibility(View.VISIBLE);
-                                    if (!subordinate.isChecked() &&
-                                            !mFile.isSharedWithMe()) {          // see (1)
+                                    if (!subordinate.isChecked() && !mFile.isSharedWithMe()) { // see (1)
                                         toggleDisablingListener(subordinate);
                                     }
                                 }

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -299,7 +299,7 @@ public class ExtendedListFragment extends Fragment
                 delay = 0;
             }
 
-            if (adapter != null && adapter instanceof OCFileListAdapter) {
+            if (adapter instanceof OCFileListAdapter) {
                 handler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
@@ -313,7 +313,7 @@ public class ExtendedListFragment extends Fragment
                         }
                     }
                 }, delay);
-            } else if (adapter != null && adapter instanceof LocalFileListAdapter) {
+            } else if (adapter instanceof LocalFileListAdapter) {
                 handler.postDelayed(new Runnable() {
                     @Override
                     public void run() {

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -433,12 +433,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
                 break;
             }
             case R.id.favorite: {
-                if (getFile().getIsFavorite()) {
+                if (getFile().isFavorite()) {
                     mContainerActivity.getFileOperationsHelper().toggleFavoriteFile(getFile(), false);
                 } else {
                     mContainerActivity.getFileOperationsHelper().toggleFavoriteFile(getFile(), true);
                 }
-                setFavoriteIconStatus(!getFile().getIsFavorite());
+                setFavoriteIconStatus(!getFile().isFavorite());
                 break;
             }
             case R.id.overflow_menu: {
@@ -503,7 +503,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
             fileSize.setText(DisplayUtils.bytesToHumanReadable(file.getFileLength()));
             fileModifiedTimestamp.setText(DisplayUtils.getRelativeTimestamp(getContext(), file.getModificationTimestamp()));
             setFilePreview(file);
-            setFavoriteIconStatus(file.getIsFavorite());
+            setFavoriteIconStatus(file.isFavorite());
 
             // configure UI for depending upon local state of the file
             FileDownloaderBinder downloaderBinder = mContainerActivity.getFileDownloaderBinder();

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
@@ -188,8 +188,10 @@ public class ContactListFragment extends FileFragment {
         } else {
             Set<Integer> checkedItems = new HashSet<>();
             int[] itemsArray = savedInstanceState.getIntArray(CHECKED_ITEMS_ARRAY_KEY);
-            for (int i = 0; i < itemsArray.length; i++) {
-                checkedItems.add(itemsArray[i]);
+            if (itemsArray != null) {
+                for (int checkedItem : itemsArray) {
+                    checkedItems.add(checkedItem);
+                }
             }
             if (checkedItems.size() > 0) {
                 onMessageEvent(new VCardToggleEvent(true));

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -780,7 +780,7 @@ public class FileOperationsHelper {
     public void toggleFavoriteFiles(Collection<OCFile> files, boolean shouldBeFavorite) {
         List<OCFile> alreadyRightStateList = new ArrayList<>();
         for (OCFile file : files) {
-            if (file.getIsFavorite() == shouldBeFavorite) {
+            if (file.isFavorite() == shouldBeFavorite) {
                 alreadyRightStateList.add(file);
             }
         }
@@ -793,7 +793,7 @@ public class FileOperationsHelper {
     }
 
     public void toggleFavoriteFile(OCFile file, boolean shouldBeFavorite) {
-        if (file.getIsFavorite() != shouldBeFavorite) {
+        if (file.isFavorite() != shouldBeFavorite) {
             EventBus.getDefault().post(new FavoriteEvent(file.getRemotePath(), shouldBeFavorite, file.getRemoteId()));
         }
     }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -167,7 +167,7 @@ public class PreviewImageActivity extends FileActivity implements
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(KEY_WAITING_FOR_BINDER, mRequestWaitingForBinder);
-        outState.putBoolean(KEY_SYSTEM_VISIBLE, getSystemUIVisible());
+        outState.putBoolean(KEY_SYSTEM_VISIBLE, isSystemUIVisible());
     }
 
     @Override
@@ -426,7 +426,7 @@ public class PreviewImageActivity extends FileActivity implements
         }
     }
 
-    public boolean getSystemUIVisible() {
+    public boolean isSystemUIVisible() {
         return getSupportActionBar() == null || getSupportActionBar().isShowing();
     }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -728,7 +728,7 @@ public class PreviewImageFragment extends FileFragment {
                 LayerDrawable layerDrawable = (LayerDrawable) mImageView.getDrawable();
                 Drawable layerOne;
 
-                if (previewImageActivity.getSystemUIVisible()) {
+                if (previewImageActivity.isSystemUIVisible()) {
                     layerOne = getResources().getDrawable(R.color.white);
                 } else {
                     layerOne = getResources().getDrawable(R.drawable.backrepeat);

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -53,7 +53,6 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
     private Set<Integer> mObsoletePositions;
     private Set<Integer> mDownloadErrors;
     private FileDataStorageManager mStorageManager;
-
     private SparseArray<FileFragment> mCachedFragments;
 
     /**
@@ -240,12 +239,13 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
      * Reset the image zoom to default value for each CachedFragments
      */
     public void resetZoom() {
+        Matrix matrix = new Matrix();
         for (int i = 0; i < mCachedFragments.size(); i++) {
             FileFragment fileFragment = mCachedFragments.valueAt(i);
 
             if (fileFragment instanceof PreviewImageFragment) {
-                ((PreviewImageFragment) fileFragment).getImageView().setDisplayMatrix(new Matrix());
-                ((PreviewImageFragment) fileFragment).getImageView().setSuppMatrix(new Matrix());
+                ((PreviewImageFragment) fileFragment).getImageView().setDisplayMatrix(matrix);
+                ((PreviewImageFragment) fileFragment).getImageView().setSuppMatrix(matrix);
             }
         }
     }

--- a/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -289,7 +289,7 @@ public final class BitmapUtils {
 
         // Splitting evenly the string
         for (int i = 0; i < hash.length(); i++) {
-            result[i % modulo] = result[i % modulo] + String.valueOf(Integer.parseInt(hash.substring(i, i + 1), 16));
+            result[i % modulo] = result[i % modulo] + Integer.parseInt(hash.substring(i, i + 1), 16);
         }
 
         // Converting our data into a usable rgb format

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -252,7 +252,7 @@ public final class DisplayUtils {
 
         String urlNoDots = url;
         String dots = "";
-        while (urlNoDots.startsWith(".")) {
+        while (urlNoDots.charAt(0) == '.') {
             urlNoDots = url.substring(1);
             dots = dots + ".";
         }

--- a/src/main/java/com/owncloud/android/utils/FileSortOrder.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrder.java
@@ -79,11 +79,11 @@ public class FileSortOrder {
      */
     public static List<OCFile> sortCloudFilesByFavourite(List<OCFile> files) {
         Collections.sort(files, (o1, o2) -> {
-            if (o1.getIsFavorite() && o2.getIsFavorite()) {
+            if (o1.isFavorite() && o2.isFavorite()) {
                 return 0;
-            } else if (o1.getIsFavorite()) {
+            } else if (o1.isFavorite()) {
                 return -1;
-            } else if (o2.getIsFavorite()) {
+            } else if (o2.isFavorite()) {
                 return 1;
             }
             return 0;

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
@@ -68,7 +68,7 @@ public class FileSortOrderByName extends FileSortOrder {
      *
      * @param files files to sort
      */
-    @SuppressFBWarnings(value = "Bx")
+    @SuppressFBWarnings("Bx")
     @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
         final int multiplier = mAscending ? 1 : -1;

--- a/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -195,7 +195,7 @@ public final class FileStorageUtils {
         file.setEtag(ocFile.getEtag());
         file.setPermissions(ocFile.getPermissions());
         file.setRemoteId(ocFile.getRemoteId());
-        file.setFavorite(ocFile.getIsFavorite());
+        file.setFavorite(ocFile.isFavorite());
         return file;
     }
 


### PR DESCRIPTION
needs https://github.com/nextcloud/android-library/pull/180

fixing several codacy warning categories, while for the for-loop I am respecting https://developer.android.com/training/articles/perf-tips :
> With an ArrayList, a hand-written counted loop is about 3x faster (with or without JIT), but for other collections the enhanced for loop syntax will be exactly equivalent to explicit iterator usage.

* codacy: String.indexOf(char) is faster than String.indexOf(String).
* codacy: Do not add empty strings
* codacy: Avoid the use of value in annotations when its the only element
* codacy: Avoid unnecessary constructors - the compiler will generate t…
* codacy: No need to check for null before an instanceof
* codacy: String.startsWith can be rewritten using String.charAt(0)
* codacy: A getX() method which returns a boolean should be named isX()
* codacy: No need to call String.valueOf to append to a string.
* codacy: Avoid using redundant field initializer
* codacy: This for loop can be replaced by a foreach loop 