### PR TITLE
Bump supportLibraryVersion from 27.1.1 to 28.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ configurations.all {
 }
 
 ext {
-    supportLibraryVersion = '27.1.1'
+    supportLibraryVersion = '28.0.0'
     jacocoVersion = "0.8.2"
 
     travisBuild = System.getenv("TRAVIS") == "true"

--- a/build.gradle
+++ b/build.gradle
@@ -79,11 +79,11 @@ android {
         javaMaxHeapSize "4g"
     }
 
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -6,6 +6,7 @@ import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -38,7 +39,7 @@ public abstract class AbstractIT {
     @BeforeClass
     public static void beforeAll() {
         try {
-            context = MainApp.getAppContext();
+            context = InstrumentationRegistry.getTargetContext();
 
             Account temp = new Account(username + "@" + baseUrl, MainApp.getAccountType(context));
 

--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -7,7 +7,6 @@ import android.accounts.OperationCanceledException;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.ApplicationTestCase;
 
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.OwnCloudClient;
@@ -26,7 +25,7 @@ import java.io.IOException;
  */
 
 @RunWith(AndroidJUnit4.class)
-public abstract class AbstractIT extends ApplicationTestCase<MainApp> {
+public abstract class AbstractIT {
 
     protected static OwnCloudClient client;
     protected static Account account;
@@ -35,10 +34,6 @@ public abstract class AbstractIT extends ApplicationTestCase<MainApp> {
     private static final String username = "test";
     private static final String password = "test";
     private static final String baseUrl = "server";
-
-    public AbstractIT() {
-        super(MainApp.class);
-    }
 
     @BeforeClass
     public static void beforeAll() {

--- a/src/androidTest/java/com/owncloud/android/FileIT.java
+++ b/src/androidTest/java/com/owncloud/android/FileIT.java
@@ -9,10 +9,12 @@ import com.owncloud.android.operations.common.SyncOperation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNull;
+
 /**
  * Tests related to file operations
  */
-
 @RunWith(AndroidJUnit4.class)
 public class FileIT extends AbstractIT {
 

--- a/src/androidTest/java/com/owncloud/android/UploadIT.java
+++ b/src/androidTest/java/com/owncloud/android/UploadIT.java
@@ -11,6 +11,8 @@ import com.owncloud.android.utils.FileStorageUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static junit.framework.TestCase.assertTrue;
+
 /**
  * Tests related to file uploads
  */

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -598,10 +598,10 @@ public class ExtendedListFragment extends Fragment
         if (getActivity() != null) {
             getActivity().runOnUiThread(() -> {
                 if (visible) {
-                    mFabMain.setVisibility(View.VISIBLE);
+                    mFabMain.show();
                     ThemeUtils.tintDrawable(mFabMain.getBackground(), ThemeUtils.primaryColor(getContext()));
                 } else {
-                    mFabMain.setVisibility(View.GONE);
+                    mFabMain.hide();
                 }
             });
         }
@@ -617,7 +617,7 @@ public class ExtendedListFragment extends Fragment
     public void setFabEnabled(final boolean enabled) {
         if (getActivity() != null) {
             getActivity().runOnUiThread(() -> {
-                mFabMain.setVisibility(View.VISIBLE);
+                mFabMain.show();
 
                 if (enabled) {
                     mFabMain.setEnabled(true);


### PR DESCRIPTION
Successor of #3078

Bumps `supportLibraryVersion` from 27.1.1 to 28.0.0. and fixes any compile/lint errors/warnings

Updates `support-v4` from 27.1.1 to 28.0.0

Updates `design` from 27.1.1 to 28.0.0
<details>
<summary>Commits</summary>

- See full diff in [compare view](https://github.com/material-components/material-components-android/commits)
</details>
<br />

Updates `appcompat-v7` from 27.1.1 to 28.0.0

Updates `cardview-v7` from 27.1.1 to 28.0.0

Updates `exifinterface` from 27.1.1 to 28.0.0

Updates `support-annotations` from 27.1.1 to 28.0.0