### PR TITLE
Add editor config to configure Android Studio 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# .editorconfig
+
+# see http://EditorConfig.org
+
+# This is the file in the root of the project.
+# For sub folders you can have other files that override only some settings. 
+# For these, this settings should be false.
+root=true
+
+[*]
+max_line_length=120
+# use spaces, not tabs.
+indent_style=space
+indent_size=4
+
+charset=utf-8
+
+# Trimming is good for consistency
+trim_trailing_whitespace=true
+# I've seen cases where a missing new_line was ignored on *nix systems.
+# Never again with this setting!
+insert_final_newline=true
+
+[*.properties]
+# Exception for Java properties files should be encoded latin1 (aka iso8859-1) 
+charset=latin1
+
+[*.{cmd,bat}]
+# batch files on Windows should stay with CRLF
+end_of_line=crlf
+
+[*.md]
+trim_trailing_whitespace=false

--- a/SETUP.md
+++ b/SETUP.md
@@ -52,6 +52,7 @@ To set up the project in Android Studio follow the next steps:
 * Make sure you have called ```git submodule update``` whenever you switched branches
 * Open Android Studio and select 'Import Project (Eclipse ADT, Gradle, etc)'. Browse through your file system to the folder 'android' where the project is located. Android Studio will then create the '.iml' files it needs. If you ever close the project but the files are still there, you just select 'Open Project…'. The file chooser will show an Android face as the folder icon, which you can select to reopen the project.
 * Android Studio will try to build the project directly after importing it. To build it manually, follow the menu path 'Build'/'Make Project', or just click the 'Play' button in the toolbar to build and run it in a mobile device or an emulator. The resulting APK file will be saved in the 'build/outputs/apk/' subdirectory in the project folder.
+* Setup Android Studio editor configurtation for the project: ```Settings``` → ```Editor``` → ```Code Style``` → ```Scheme: Project``` and ```Enable EditorConfig support```
 
 
 ### 3. Working in a terminal with Gradle:


### PR DESCRIPTION
...according to the project guidelines automatically

IntelliJ/Android Studio support `.editorcong` files out of the box. This way AS will be configured according to out guidelines :)