### PR TITLE
Activity: use image url instead of generating previews by oneself

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -171,7 +171,7 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
                 PorterDuff.Mode.SRC_IN);
 
         FileDataStorageManager storageManager = new FileDataStorageManager(getAccount(), getContentResolver());
-        adapter = new ActivityListAdapter(this, this, storageManager, false);
+        adapter = new ActivityListAdapter(this, this, storageManager, getCapabilities(), false);
         recyclerView.setAdapter(adapter);
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);

--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityAndVersionListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityAndVersionListAdapter.java
@@ -13,6 +13,7 @@ import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.resources.activities.model.Activity;
 import com.owncloud.android.lib.resources.files.model.FileVersion;
+import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.ui.interfaces.ActivityListInterface;
 import com.owncloud.android.ui.interfaces.VersionListInterface;
 import com.owncloud.android.utils.DisplayUtils;
@@ -33,8 +34,8 @@ public class ActivityAndVersionListAdapter extends ActivityListAdapter {
 
     public ActivityAndVersionListAdapter(Context context, ActivityListInterface activityListInterface,
                                          VersionListInterface.View versionListInterface,
-                                         FileDataStorageManager storageManager) {
-        super(context, activityListInterface, storageManager, true);
+                                         FileDataStorageManager storageManager, OCCapability capability) {
+        super(context, activityListInterface, storageManager, capability, true);
 
         this.versionListInterface = versionListInterface;
     }

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.graphics.PorterDuff;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.Editable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -201,9 +202,16 @@ public class FileDetailActivitiesFragment extends Fragment implements ActivityLi
 
     @OnClick(R.id.submitComment)
     public void submitComment() {
-        if (commentInput.getText().toString().trim().length() > 0) {
-            new SubmitCommentTask(commentInput.getText().toString().trim(), userId, file.getLocalId(),
-                    callback, ownCloudClient).execute();
+        Editable commentField = commentInput.getText();
+
+        if (commentField == null) {
+            return;
+        }
+
+        String trimmedComment = commentField.toString().trim();
+
+        if (trimmedComment.length() > 0) {
+            new SubmitCommentTask(trimmedComment, userId, file.getLocalId(), callback, ownCloudClient).execute();
         }
     }
 
@@ -241,7 +249,7 @@ public class FileDetailActivitiesFragment extends Fragment implements ActivityLi
                 PorterDuff.Mode.SRC_IN);
         emptyContentIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_activity_light_grey));
 
-        adapter = new ActivityAndVersionListAdapter(getContext(), this, this, storageManager);
+        adapter = new ActivityAndVersionListAdapter(getContext(), this, this, storageManager, capability);
         recyclerView.setAdapter(adapter);
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());

--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -168,7 +168,7 @@ public final class MimeTypeUtil {
             drawableId = R.drawable.shared_with_me_folder;
         } else if (isEncrypted) {
             drawableId = R.drawable.ic_list_encrypted_folder;
-        } else if (WebdavEntry.MountType.EXTERNAL.equals(mountType)) {
+        } else if (WebdavEntry.MountType.EXTERNAL == mountType) {
             drawableId = R.drawable.folder_external;
         } else {
             drawableId = R.drawable.folder;
@@ -197,6 +197,10 @@ public final class MimeTypeUtil {
         return candidates.get(0);
     }
 
+    public static boolean isImageOrVideo(String mimeType) {
+        return isImage(mimeType) || isVideo(mimeType);
+    }
+
     /**
      * @return 'True' if the mime type defines image
      */
@@ -222,7 +226,7 @@ public final class MimeTypeUtil {
     /**
      * @return 'True' if mime type defines text
      */
-    public static boolean isText(String mimeType) {
+    private static boolean isText(String mimeType) {
         return mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("text/");
     }
 
@@ -297,6 +301,10 @@ public final class MimeTypeUtil {
      */
     public static boolean isVCard(OCFile file) {
         return isVCard(file.getMimeType()) || isVCard(getMimeTypeFromPath(file.getRemotePath()));
+    }
+
+    public static boolean isFolder(String mimeType) {
+        return MimeType.DIRECTORY.equalsIgnoreCase(mimeType);
     }
 
     /**


### PR DESCRIPTION
Needs https://github.com/nextcloud/android-library/pull/73 and https://github.com/nextcloud/activity/pull/300

Previously we tried to find a referenced file in our database and then generated a thumbnail out of it.
Now we rely on the server to get a preview url. This way we can have thumbnails for files we never had in our database before.

TODO
- [x] add backwards compatibility

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>