### PR TITLE
App crashes when uploading files to Nextcloud

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -65,6 +65,8 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!-- Apps that target Android 9 (API level 28) or higher and use foreground services must request the FOREGROUND_SERVICE permission -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
 
     <application
@@ -109,7 +111,7 @@
         <activity android:name=".ui.activity.ContactsPreferenceActivity"
             android:launchMode="singleInstance"/>
         <activity android:name=".ui.activity.ReceiveExternalFilesActivity"
-                  
+
                   android:taskAffinity=""
                   android:excludeFromRecents="true"
                   android:theme="@style/Theme.ownCloud.NoActionBar">
@@ -245,7 +247,7 @@
         <activity android:name=".ui.activity.RequestCredentialsActivity" />
         <activity android:name=".ui.activity.ConflictsResolveActivity"/>
         <activity android:name=".ui.activity.ErrorsWhileCopyingHandlerActivity"/>
-        
+
         <activity android:name=".ui.activity.LogHistoryActivity"/>
 
         <activity android:name=".ui.errorhandling.ErrorShowActivity" />

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
-    <!-- Apps that target Android 9 (API level 28) or higher and use foreground services must request the FOREGROUND_SERVICE permission -->
+    <!-- Apps that target Android 9 (API level 28) or higher and use foreground services
+    must request the FOREGROUND_SERVICE permission -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
 


### PR DESCRIPTION
- In Android Pie(API 28) if user tries to upload a files to nextcloud it will crash with below errors.

**Logcat error:**

Process: com.nextcloud.client, PID: 30549 java.lang.RuntimeException: Unable to start service com.owncloud.android.files.services.FileUploader@6fd73c0 with Intent { cmp=com.nextcloud.client/com.owncloud.android.files.services.FileUploader (has extras) }: java.lang.SecurityException: **Permission Denial: startForeground from pid=30549, uid=10278 requires android.permission.FOREGROUND_SERVICE**

Reason:
Apps that target Android 9 (API level 28) or higher and use foreground services must request the FOREGROUND_SERVICE permission.
https://developer.android.com/guide/components/services#Foreground

- Added **android.permission.FOREGROUND_SERVICE** permission in android manifest.