### PR TITLE
Notification: move client creation to thread

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -233,20 +233,6 @@ public class NotificationsActivity extends FileActivity {
                 PorterDuff.Mode.SRC_IN);
         setLoadingMessage();
 
-        try {
-            OwnCloudAccount ocAccount = new OwnCloudAccount(currentAccount, this);
-            client = OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount, this);
-            client.setOwnCloudVersion(AccountUtils.getServerVersion(currentAccount));
-
-            hideRefreshLayoutLoader();
-        } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException |
-                IOException | OperationCanceledException | AuthenticatorException e) {
-            Log_OC.e(TAG, "Error initializing client", e);
-        }
-
-        adapter = new NotificationListAdapter(client, this);
-        recyclerView.setAdapter(adapter);
-
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
 
         recyclerView.setLayoutManager(layoutManager);
@@ -267,6 +253,22 @@ public class NotificationsActivity extends FileActivity {
 
     private void fetchAndSetData() {
         Thread t = new Thread(() -> {
+            if (client == null) {
+                try {
+                    OwnCloudAccount ocAccount = new OwnCloudAccount(currentAccount, this);
+                    client = OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount, this);
+                    client.setOwnCloudVersion(AccountUtils.getServerVersion(currentAccount));
+                } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException |
+                    IOException | OperationCanceledException | AuthenticatorException e) {
+                    Log_OC.e(TAG, "Error initializing client", e);
+                }
+            }
+
+            if (adapter == null) {
+                adapter = new NotificationListAdapter(client, this);
+                recyclerView.setAdapter(adapter);
+            }
+
             RemoteOperation getRemoteNotificationOperation = new GetRemoteNotificationsOperation();
             final RemoteOperationResult result = getRemoteNotificationOperation.execute(client);
 


### PR DESCRIPTION
Though I cannot reproduce it, it is good to have client creation in a thread.

Error message was:
```
0-08 15:43:05.598 22330-22330/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.nextcloud.client, PID: 22330
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.nextcloud.client/com.owncloud.android.ui.activity.NotificationsActivity}: java.lang.IllegalStateException: calling this from your main thread can lead to deadlock
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2792)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2870)
        at android.app.ActivityThread.-wrap11(Unknown Source:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1601)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:172)
        at android.app.ActivityThread.main(ActivityThread.java:6590)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
     Caused by: java.lang.IllegalStateException: calling this from your main thread can lead to deadlock
        at android.accounts.AccountManager.ensureNotOnMainThread(AccountManager.java:2188)
        at android.accounts.AccountManager.-wrap1(Unknown Source:0)
        at android.accounts.AccountManager$AmsTask.internalGetResult(AccountManager.java:2291)
        at android.accounts.AccountManager$AmsTask.getResult(AccountManager.java:2329)
        at android.accounts.AccountManager$AmsTask.getResult(AccountManager.java:2326)
        at android.accounts.AccountManager.blockingGetAuthToken(AccountManager.java:1514)
        at com.owncloud.android.lib.common.accounts.AccountUtils.getCredentialsForAccount(AccountUtils.java:209)
        at com.owncloud.android.lib.common.OwnCloudAccount.loadCredentials(OwnCloudAccount.java:126)
        at com.owncloud.android.lib.common.SingleSessionManager.getClientFor(SingleSessionManager.java:127)
        at com.owncloud.android.lib.common.DynamicSessionManager.getClientFor(DynamicSessionManager.java:38)
        at com.owncloud.android.lib.common.DynamicSessionManager.getClientFor(DynamicSessionManager.java:30)
        at com.owncloud.android.ui.activity.NotificationsActivity.setupContent(NotificationsActivity.java:239)
        at com.owncloud.android.ui.activity.NotificationsActivity.onCreate(NotificationsActivity.java:160)
        at android.app.Activity.performCreate(Activity.java:7023)
        at android.app.Activity.performCreate(Activity.java:7014)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1215)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2745)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2870) 
        at android.app.ActivityThread.-wrap11(Unknown Source:0) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1601) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:172) 
        at android.app.ActivityThread.main(ActivityThread.java:6590) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807) 
```
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>