### PR TITLE
Pom: increase httpclient version

### DIFF
--- a/automationTest/pom.xml
+++ b/automationTest/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.6</version>
     </dependency>
     <dependency>
     	<groupId>com.google.android</groupId>


### PR DESCRIPTION
Though we do not use automationTest or pom right now, it is better to at least refer to a version without know security problems.

(was reported by Github)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>