### PR TITLE
Obey "can reshare" property

### DIFF
--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -44,7 +44,7 @@ import java.util.List;
 
 /**
  * Filters out the file actions available in a given {@link Menu} for a given {@link OCFile}
- * according to the current state of the latest. 
+ * according to the current state of the latest.
  */
 public class FileMenuFilter {
 
@@ -189,7 +189,8 @@ public class FileMenuFilter {
 
     private void filterShareFile(List<Integer> toShow, List<Integer> toHide, OCCapability capability) {
         if (containsEncryptedFile() || (!isShareViaLinkAllowed() && !isShareWithUsersAllowed()) ||
-                !isSingleSelection() || !isShareApiEnabled(capability) || mOverflowMenu) {
+            !isSingleSelection() || !isShareApiEnabled(capability) || !mFiles.iterator().next().canReshare()
+            || mOverflowMenu) {
             toHide.add(R.id.action_send_share_file);
         } else {
             toShow.add(R.id.action_send_share_file);

--- a/src/main/java/com/owncloud/android/ui/adapter/FileDetailTabAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/FileDetailTabAdapter.java
@@ -51,7 +51,7 @@ public class FileDetailTabAdapter extends FragmentStatePagerAdapter {
         switch (position) {
             case 0:
                 fileDetailActivitiesFragment = FileDetailActivitiesFragment.newInstance(file, account);
-                return fileDetailActivitiesFragment; 
+                return fileDetailActivitiesFragment;
             case 1:
                 fileDetailSharingFragment = FileDetailSharingFragment.newInstance(file, account);
                 return fileDetailSharingFragment;
@@ -70,6 +70,6 @@ public class FileDetailTabAdapter extends FragmentStatePagerAdapter {
 
     @Override
     public int getCount() {
-        return 2;
+        return file.canReshare() ? 2 : 1;
     }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -365,7 +365,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 }
             }
 
-            if (mHideItemOptions) {
+            if (mHideItemOptions || (file.isFolder() && !file.canReshare())) {
                 gridViewHolder.shared.setVisibility(View.GONE);
             } else {
                 showShareIcon(gridViewHolder, file);
@@ -487,7 +487,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private void showShareIcon(OCFileListGridImageViewHolder gridViewHolder, OCFile file) {
         ImageView sharedIconView = gridViewHolder.shared;
         sharedIconView.setVisibility(View.VISIBLE);
-        
+
         if (file.isSharedWithSharee() || file.isSharedWithMe()) {
             sharedIconView.setImageResource(R.drawable.shared_via_users);
             sharedIconView.setContentDescription(mContext.getString(R.string.shared_icon_shared));

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -163,7 +163,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
 
     /**
      * Creates an empty details fragment.
-     * 
+     *
      * It's necessary to keep a public constructor without parameters; the system uses it when tries
      * to reinstantiate a fragment automatically.
      */
@@ -267,13 +267,15 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
         tabLayout.removeAllTabs();
 
         tabLayout.addTab(tabLayout.newTab().setText(R.string.drawer_item_activities));
-        tabLayout.addTab(tabLayout.newTab().setText(R.string.share_dialog_title));
+
+        if (getFile().canReshare()) {
+            tabLayout.addTab(tabLayout.newTab().setText(R.string.share_dialog_title));
+        }
 
         tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
         tabLayout.setSelectedTabIndicatorColor(ThemeUtils.primaryAccentColor(getContext()));
 
-        final FileDetailTabAdapter adapter = new FileDetailTabAdapter
-                (getFragmentManager(), getFile(), account);
+        final FileDetailTabAdapter adapter = new FileDetailTabAdapter(getFragmentManager(), getFile(), account);
         viewPager.setAdapter(adapter);
         viewPager.addOnPageChangeListener(new TabLayout.TabLayoutOnPageChangeListener(tabLayout));
         tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
@@ -484,11 +486,11 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
     public void updateFileDetails(boolean transferring, boolean refresh) {
         if (readyToShow()) {
             FileDataStorageManager storageManager = mContainerActivity.getStorageManager();
-            
+
             if (storageManager == null) {
                 return;
             }
-            
+
             if (refresh) {
                 setFile(storageManager.getFileByPath(getFile().getRemotePath()));
             }
@@ -514,9 +516,9 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
                 setButtonsForTransferring();
 
             } else if (file.isDown()) {
-                
+
                 setButtonsForDown();
-                
+
             } else {
                 // TODO load default preview image; when the local file is removed, the preview
                 // remains there

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -7,16 +7,16 @@
  * @author Andy Scherzinger
  * Copyright (C) 2015 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -688,7 +688,7 @@ public class FileOperationsHelper {
     }
 
     public void sendShareFile(OCFile file) {
-        sendShareFile(file, false);
+        sendShareFile(file, !file.canReshare());
     }
 
     public void syncFiles(Collection<OCFile> files) {
@@ -709,7 +709,7 @@ public class FileOperationsHelper {
                     file.getRemotePath()));
             sendIntent.putExtra(Intent.ACTION_SEND, true);      // Send Action
 
-            mFileActivity.startActivity(Intent.createChooser(sendIntent, 
+            mFileActivity.startActivity(Intent.createChooser(sendIntent,
                     context.getString(R.string.actionbar_send_file)));
         } else {
             Log_OC.wtf(TAG, "Trying to send a NULL OCFile");


### PR DESCRIPTION
Fix #3160 

When resharing is not allowed, we hide share button on folders.
![2018-10-18-100018](https://user-images.githubusercontent.com/5836855/47139698-ba889d00-d2bc-11e8-844e-a111d3488ac3.png)

But not on files. As you can see button is there, but sharing is disabled in bottom sheet.
![2018-10-18-100026](https://user-images.githubusercontent.com/5836855/47139696-ba889d00-d2bc-11e8-9b7d-e9ff9662ccc6.png)

For files and folders, in details you cannot access sharing pane.
![2018-10-18-100037](https://user-images.githubusercontent.com/5836855/47139695-ba889d00-d2bc-11e8-85ac-0db718d54421.png)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>