### PR TITLE
Add specific sort order for upload/local/trashbin

### DIFF
--- a/src/main/java/com/owncloud/android/db/PreferenceManager.java
+++ b/src/main/java/com/owncloud/android/db/PreferenceManager.java
@@ -258,19 +258,57 @@ public final class PreferenceManager {
      * @param context Caller {@link Context}, used to access to shared preferences manager.
      * @return sort order     the sort order, default is {@link FileSortOrder#sort_a_to_z} (sort by name)
      */
-    public static FileSortOrder getSortOrder(Context context, OCFile folder) {
+    public static FileSortOrder getSortOrderByFolder(Context context, OCFile folder) {
         return FileSortOrder.sortOrders.get(getFolderPreference(context, PREF__FOLDER_SORT_ORDER, folder,
-                FileSortOrder.sort_a_to_z.mName));
+            FileSortOrder.sort_a_to_z.name));
     }
 
     /**
      * Set preferred folder sort order.
      *
-     * @param context Caller {@link Context}, used to access to shared preferences manager.
-     * @param sortOrder   the sort order
+     * @param context   Caller {@link Context}, used to access to shared preferences manager.
+     * @param sortOrder the sort order
      */
     public static void setSortOrder(Context context, OCFile folder, FileSortOrder sortOrder) {
-        setFolderPreference(context, PREF__FOLDER_SORT_ORDER, folder, sortOrder.mName);
+        setFolderPreference(context, PREF__FOLDER_SORT_ORDER, folder, sortOrder.name);
+    }
+
+    public static FileSortOrder getSortOrderByType(Context context, FileSortOrder.Type type) {
+        return getSortOrderByType(context, type, FileSortOrder.sort_a_to_z);
+    }
+
+    /**
+     * Get preferred folder sort order.
+     *
+     * @param context Caller {@link Context}, used to access to shared preferences manager.
+     * @return sort order     the sort order, default is {@link FileSortOrder#sort_a_to_z} (sort by name)
+     */
+    public static FileSortOrder getSortOrderByType(Context context, FileSortOrder.Type type,
+                                                   FileSortOrder defaultOrder) {
+        Account account = AccountUtils.getCurrentOwnCloudAccount(context);
+
+        if (account == null) {
+            return defaultOrder;
+        }
+
+        ArbitraryDataProvider dataProvider = new ArbitraryDataProvider(context.getContentResolver());
+
+        String value = dataProvider.getValue(account.name, PREF__FOLDER_SORT_ORDER + "_" + type);
+
+        return value.isEmpty() ? defaultOrder : FileSortOrder.sortOrders.get(value);
+    }
+
+    /**
+     * Set preferred folder sort order.
+     *
+     * @param context   Caller {@link Context}, used to access to shared preferences manager.
+     * @param sortOrder the sort order
+     */
+    public static void setSortOrder(Context context, FileSortOrder.Type type, FileSortOrder sortOrder) {
+        Account account = AccountUtils.getCurrentOwnCloudAccount(context);
+        ArbitraryDataProvider dataProvider = new ArbitraryDataProvider(context.getContentResolver());
+
+        dataProvider.storeOrUpdateKeyValue(account.name, PREF__FOLDER_SORT_ORDER + "_" + type, sortOrder.name);
     }
 
     /**
@@ -303,6 +341,29 @@ public final class PreferenceManager {
             folder = storageManager.getFileById(folder.getParentId());
             value = dataProvider.getValue(account.name, getKeyFromFolder(preferenceName, folder));
         }
+        return value.isEmpty() ? defaultValue : value;
+    }
+
+    /**
+     * Get preference value for a view.
+     *
+     * @param context        Context object.
+     * @param preferenceName Name of the preference to lookup.
+     * @param type           view which view
+     * @param defaultValue   Fallback value in case nothing is set.
+     * @return Preference value
+     */
+    public static String getTypePreference(Context context, String preferenceName, String type, String defaultValue) {
+        Account account = AccountUtils.getCurrentOwnCloudAccount(context);
+
+        if (account == null) {
+            return defaultValue;
+        }
+
+        ArbitraryDataProvider dataProvider = new ArbitraryDataProvider(context.getContentResolver());
+
+        String value = dataProvider.getValue(account.name, preferenceName + "_" + type);
+
         return value.isEmpty() ? defaultValue : value;
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -144,8 +144,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static com.owncloud.android.db.PreferenceManager.getSortOrder;
-
 /**
  * Displays, what files the user has available in his ownCloud. This is the main view.
  */
@@ -890,7 +888,7 @@ public class FileDisplayActivity extends HookActivity
                 ft.addToBackStack(null);
 
                 SortingOrderDialogFragment mSortingOrderDialogFragment = SortingOrderDialogFragment.newInstance(
-                        getSortOrder(this, getListOfFilesFragment().getCurrentFile()));
+                    PreferenceManager.getSortOrderByFolder(this, getListOfFilesFragment().getCurrentFile()));
                 mSortingOrderDialogFragment.show(ft, SortingOrderDialogFragment.SORTING_ORDER_FRAGMENT);
 
                 break;

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -115,9 +115,6 @@ import java.util.List;
 import java.util.Stack;
 import java.util.Vector;
 
-import static com.owncloud.android.db.PreferenceManager.getSortOrder;
-
-
 /**
  * This can be used to upload things to an ownCloud instance.
  */
@@ -170,7 +167,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
             if (parentPath != null) {
                 mParents.addAll(Arrays.asList(parentPath.split("/")));
             }
-            
+
             mFile = savedInstanceState.getParcelable(KEY_FILE);
         }
         mAccountManager = (AccountManager) getSystemService(Context.ACCOUNT_SERVICE);
@@ -264,7 +261,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
             AlertDialog.Builder builder = new Builder(getActivity());
             builder.setIcon(R.drawable.ic_warning);
             builder.setTitle(R.string.uploader_wrn_no_account_title);
-            builder.setMessage(String.format(getString(R.string.uploader_wrn_no_account_text), 
+            builder.setMessage(String.format(getString(R.string.uploader_wrn_no_account_text),
                     getString(R.string.app_name)));
             builder.setCancelable(false);
             builder.setPositiveButton(R.string.uploader_wrn_no_account_setup_btn_text, (dialog, which) -> {
@@ -653,7 +650,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         // filter on dirtype
         Vector<OCFile> files = new Vector<>();
         files.addAll(tmpFiles);
-        
+
         if (files.size() < position) {
             throw new IndexOutOfBoundsException("Incorrect item selected");
         }
@@ -800,7 +797,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
             if (actionBar != null) {
                 actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor(this)));
             }
-            
+
             Button btnNewFolder = findViewById(R.id.uploader_cancel);
                 btnNewFolder.setOnClickListener(this);
 
@@ -857,7 +854,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private List<OCFile> sortFileList(List<OCFile> files) {
-        FileSortOrder sortOrder = getSortOrder(this, mFile);
+        FileSortOrder sortOrder = PreferenceManager.getSortOrderByFolder(this, mFile);
         return sortOrder.sortCloudFiles(files);
     }
 
@@ -1079,7 +1076,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 break;
             case R.id.action_sort:
                 SortingOrderDialogFragment mSortingOrderDialogFragment = SortingOrderDialogFragment.newInstance(
-                        getSortOrder(this, mFile));
+                    PreferenceManager.getSortOrderByFolder(this, mFile));
                 mSortingOrderDialogFragment.show(getSupportFragmentManager(),
                         SortingOrderDialogFragment.SORTING_ORDER_FRAGMENT);
                 break;

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -70,9 +70,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.owncloud.android.db.PreferenceManager.getSortOrder;
-
-
 /**
  * Displays local files and let the user choose what of them wants to upload
  * to the current ownCloud account.
@@ -143,12 +140,12 @@ public class UploadFilesActivity extends FileActivity implements
                 mCurrentDir = Environment.getExternalStorageDirectory();
             }
         }
-        
+
         mAccountOnCreation = getAccount();
-                
+
         /// USER INTERFACE
-            
-        // Drop-down navigation 
+
+        // Drop-down navigation
         mDirectories = new CustomArrayAdapter<>(this, R.layout.support_simple_spinner_dropdown_item);
         File currDir = mCurrentDir;
         while(currDir != null && currDir.getParentFile() != null) {
@@ -167,7 +164,7 @@ public class UploadFilesActivity extends FileActivity implements
         }
 
         mFileListFragment = (LocalFileListFragment) getSupportFragmentManager().findFragmentById(R.id.local_files_list);
-        
+
         // Set input controllers
         findViewById(R.id.upload_files_btn_cancel).setOnClickListener(this);
 
@@ -194,7 +191,7 @@ public class UploadFilesActivity extends FileActivity implements
 
         // setup the toolbar
         setupToolbar();
-            
+
         // Action bar setup
         ActionBar actionBar = getSupportActionBar();
         actionBar.setHomeButtonEnabled(true);   // mandatory since Android ICS, according to the
@@ -215,7 +212,7 @@ public class UploadFilesActivity extends FileActivity implements
             mCurrentDialog.dismiss();
             mCurrentDialog = null;
         }
-            
+
         Log_OC.d(TAG, "onCreate() end");
     }
 
@@ -266,7 +263,7 @@ public class UploadFilesActivity extends FileActivity implements
         switch (item.getItemId()) {
             case android.R.id.home: {
                 if(mCurrentDir != null && mCurrentDir.getParentFile() != null){
-                    onBackPressed(); 
+                    onBackPressed();
                 }
                 break;
             }
@@ -283,7 +280,7 @@ public class UploadFilesActivity extends FileActivity implements
                 ft.addToBackStack(null);
 
                 SortingOrderDialogFragment mSortingOrderDialogFragment = SortingOrderDialogFragment.newInstance(
-                        getSortOrder(this, null));
+                    PreferenceManager.getSortOrderByType(this, FileSortOrder.Type.uploadFilesView));
                 mSortingOrderDialogFragment.show(ft, SORT_ORDER_DIALOG_TAG);
 
                 break;
@@ -311,15 +308,15 @@ public class UploadFilesActivity extends FileActivity implements
     public void onSortingOrderChosen(FileSortOrder selection) {
         mFileListFragment.sortFiles(selection);
     }
-    
+
     @Override
     public boolean onNavigationItemSelected(int itemPosition, long itemId) {
         int i = itemPosition;
         while (i-- != 0) {
             onBackPressed();
         }
-        // the next operation triggers a new call to this method, but it's necessary to 
-        // ensure that the name exposed in the action bar is the current directory when the 
+        // the next operation triggers a new call to this method, but it's necessary to
+        // ensure that the name exposed in the action bar is the current directory when the
         // user selected it in the navigation list
         if (itemPosition != 0) {
             getSupportActionBar().setSelectedNavigationItem(0);
@@ -335,7 +332,7 @@ public class UploadFilesActivity extends FileActivity implements
             return mSearchEditFrame != null && mSearchEditFrame.getVisibility() == View.VISIBLE;
         }
     }
-    
+
     @Override
     public void onBackPressed() {
         if (isSearchOpen() && mSearchView != null) {
@@ -365,7 +362,7 @@ public class UploadFilesActivity extends FileActivity implements
             }
         }
     }
-    
+
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         // responsibility of restore is preferred in onCreate() before than in
@@ -417,7 +414,7 @@ public class UploadFilesActivity extends FileActivity implements
      * Custom array adapter to override text colors
      */
     private class CustomArrayAdapter<T> extends ArrayAdapter<T> {
-    
+
         public CustomArrayAdapter(UploadFilesActivity ctx, int view) {
             super(ctx, view);
         }
@@ -433,13 +430,13 @@ public class UploadFilesActivity extends FileActivity implements
             ((TextView) v).setTextColor(colorStateList);
             return v;
         }
-    
+
         public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent) {
             View v = super.getDropDownView(position, convertView, parent);
-    
+
             ((TextView) v).setTextColor(getResources().getColorStateList(
                     android.R.color.white));
-    
+
             return v;
         }
     }
@@ -467,7 +464,7 @@ public class UploadFilesActivity extends FileActivity implements
     public void onFileClick(File file) {
         // nothing to do
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -486,8 +483,8 @@ public class UploadFilesActivity extends FileActivity implements
 
     /**
      * Performs corresponding action when user presses 'Cancel' or 'Upload' button
-     * 
-     * TODO Make here the real request to the Upload service ; will require to receive the account and 
+     *
+     * TODO Make here the real request to the Upload service ; will require to receive the account and
      * target folder where the upload must be done in the received intent.
      */
     @Override
@@ -516,7 +513,7 @@ public class UploadFilesActivity extends FileActivity implements
     /**
      * Asynchronous task checking if there is space enough to copy all the files chosen
      * to upload into the ownCloud local folder.
-     * 
+     *
      * Maybe an AsyncTask is not strictly necessary, but who really knows.
      */
     private class CheckAvailableSpaceTask extends AsyncTask<Boolean, Void, Boolean> {
@@ -567,7 +564,7 @@ public class UploadFilesActivity extends FileActivity implements
                 mCurrentDialog.dismiss();
                 mCurrentDialog = null;
             }
-            
+
             if (result) {
                 // return the list of selected files (success)
                 Intent data = new Intent();
@@ -639,7 +636,7 @@ public class UploadFilesActivity extends FileActivity implements
                 setResult(RESULT_CANCELED);
                 finish();
             }
-            
+
         } else {
             setResult(RESULT_CANCELED);
             finish();

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -294,7 +294,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
             }
         }
 
-        FileSortOrder sortOrder = PreferenceManager.getSortOrder(mContext, null);
+        FileSortOrder sortOrder = PreferenceManager.getSortOrderByType(mContext, FileSortOrder.Type.localFileListView);
         mFiles = sortOrder.sortLocalFiles(mFiles);
 
         // Fetch preferences for showing hidden files
@@ -310,7 +310,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public void setSortOrder(FileSortOrder sortOrder) {
-        PreferenceManager.setSortOrder(mContext, null, sortOrder);
+        PreferenceManager.setSortOrder(mContext, FileSortOrder.Type.localFileListView, sortOrder);
         mFiles = sortOrder.sortLocalFiles(mFiles);
         notifyDataSetChanged();
     }

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -529,7 +529,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             if (!PreferenceManager.showHiddenFilesEnabled(mContext)) {
                 mFiles = filterHiddenFiles(mFiles);
             }
-            FileSortOrder sortOrder = PreferenceManager.getSortOrder(mContext, directory);
+            FileSortOrder sortOrder = PreferenceManager.getSortOrderByFolder(mContext, directory);
             mFiles = sortOrder.sortCloudFiles(mFiles);
             mFilesAll.clear();
             mFilesAll.addAll(mFiles);
@@ -573,7 +573,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 !searchType.equals(ExtendedListFragment.SearchType.PHOTOS_SEARCH_FILTER) &&
                 !searchType.equals(ExtendedListFragment.SearchType.RECENTLY_MODIFIED_SEARCH) &&
                 !searchType.equals(ExtendedListFragment.SearchType.RECENTLY_MODIFIED_SEARCH_FILTER)) {
-            FileSortOrder sortOrder = PreferenceManager.getSortOrder(mContext, folder);
+            FileSortOrder sortOrder = PreferenceManager.getSortOrderByFolder(mContext, folder);
             mFiles = sortOrder.sortCloudFiles(mFiles);
         } else {
             mFiles = FileStorageUtils.sortOcFolderDescDateModified(mFiles);
@@ -764,7 +764,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 if (!PreferenceManager.showHiddenFilesEnabled(mContext)) {
                     mFiles = filterHiddenFiles(mFiles);
                 }
-                FileSortOrder sortOrder = PreferenceManager.getSortOrder(mContext, null);
+                FileSortOrder sortOrder = PreferenceManager.getSortOrderByFolder(mContext, currentDirectory);
                 mFiles = sortOrder.sortCloudFiles(mFiles);
             }
 

--- a/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
@@ -86,7 +86,8 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             files.add((TrashbinFile) file);
         }
 
-        files = PreferenceManager.getSortOrder(context, null).sortTrashbinFiles(files);
+        files = PreferenceManager.getSortOrderByType(context, FileSortOrder.Type.trashBinView,
+            FileSortOrder.sort_new_to_old).sortTrashbinFiles(files);
 
         notifyDataSetChanged();
     }
@@ -281,7 +282,7 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     }
 
     public void setSortOrder(FileSortOrder sortOrder) {
-        PreferenceManager.setSortOrder(context, null, sortOrder);
+        PreferenceManager.setSortOrder(context, FileSortOrder.Type.trashBinView, sortOrder);
         files = sortOrder.sortTrashbinFiles(files);
         notifyDataSetChanged();
     }

--- a/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
@@ -57,7 +57,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
         SortingOrderDialogFragment dialogFragment = new SortingOrderDialogFragment();
 
         Bundle args = new Bundle();
-        args.putString(KEY_SORT_ORDER, sortOrder.mName);
+        args.putString(KEY_SORT_ORDER, sortOrder.name);
         dialogFragment.setArguments(args);
 
         dialogFragment.setStyle(STYLE_NORMAL, R.style.Theme_ownCloud_Dialog);
@@ -72,7 +72,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
         setRetainInstance(true);
 
         mView = null;
-        mCurrentSortOrderName = getArguments().getString(KEY_SORT_ORDER, FileSortOrder.sort_a_to_z.mName);
+        mCurrentSortOrderName = getArguments().getString(KEY_SORT_ORDER, FileSortOrder.sort_a_to_z.name);
     }
 
     @Override
@@ -131,7 +131,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
     private void setupActiveOrderSelection() {
         final int color = ThemeUtils.primaryAccentColor(getContext());
         for (View view: mTaggedViews) {
-            if (!((FileSortOrder)view.getTag()).mName.equals(mCurrentSortOrderName)) {
+            if (!((FileSortOrder) view.getTag()).name.equals(mCurrentSortOrderName)) {
                 continue;
             }
             if (view instanceof ImageButton) {

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -22,6 +22,7 @@ package com.owncloud.android.ui.preview;
 import android.accounts.Account;
 import android.content.Context;
 import android.graphics.Matrix;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -57,7 +58,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
 
     /**
      * Constructor
-     * 
+     *
      * @param fragmentManager   {@link FragmentManager} instance that will handle
      *                          the {@link Fragment}s provided by the adapter.
      * @param parentFolder      Folder where images will be searched for.
@@ -67,13 +68,13 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
                                     Account account, FileDataStorageManager storageManager,
                                     boolean onlyOnDevice, Context context) {
         super(fragmentManager);
-        
+
         if (fragmentManager == null) {
             throw new IllegalArgumentException("NULL FragmentManager instance");
         }
         if (parentFolder == null) {
             throw new IllegalArgumentException("NULL parent folder");
-        } 
+        }
         if (storageManager == null) {
             throw new IllegalArgumentException("NULL storage manager");
         }
@@ -82,9 +83,9 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         mStorageManager = storageManager;
         mImageFiles = mStorageManager.getFolderImages(parentFolder, onlyOnDevice);
 
-        FileSortOrder sortOrder = PreferenceManager.getSortOrder(context, parentFolder);
+        FileSortOrder sortOrder = PreferenceManager.getSortOrderByFolder(context, parentFolder);
         mImageFiles = sortOrder.sortCloudFiles(mImageFiles);
-        
+
         mObsoleteFragments = new HashSet<>();
         mObsoletePositions = new HashSet<>();
         mDownloadErrors = new HashSet<>();
@@ -141,7 +142,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         }
     }
 
-    
+
     public Fragment getItem(int i) {
         OCFile file = getFileAt(i);
         Fragment fragment;
@@ -172,7 +173,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
     public int getFilePosition(OCFile file) {
         return mImageFiles.indexOf(file);
     }
-    
+
     @Override
     public int getCount() {
         return mImageFiles.size();
@@ -189,7 +190,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         }
     }
 
-    
+
     public void updateFile(int position, OCFile file) {
         FileFragment fragmentToUpdate = mCachedFragments.get(position);
         if (fragmentToUpdate != null) {
@@ -198,8 +199,8 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         mObsoletePositions.add(position);
         mImageFiles.set(position, file);
     }
-    
-    
+
+
     public void updateWithDownloadError(int position) {
         FileFragment fragmentToUpdate = mCachedFragments.get(position);
         if (fragmentToUpdate != null) {
@@ -207,9 +208,9 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         }
         mDownloadErrors.add(position);
     }
-    
+
     @Override
-    public int getItemPosition(Object object) {
+    public int getItemPosition(@NonNull Object object) {
         if (mObsoleteFragments.contains(object)) {
             mObsoleteFragments.remove(object);
             return POSITION_NONE;
@@ -217,15 +218,16 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         return super.getItemPosition(object);
     }
 
+    @NonNull
     @Override
-    public Object instantiateItem(ViewGroup container, int position) {
+    public Object instantiateItem(@NonNull ViewGroup container, int position) {
         Object fragment = super.instantiateItem(container, position);
         mCachedFragments.put(position, (FileFragment) fragment);
         return fragment;
     }
-    
+
     @Override
-    public void destroyItem(ViewGroup container, int position, Object object) {
+    public void destroyItem(@NonNull ViewGroup container, int position, @NonNull Object object) {
         mCachedFragments.remove(position);
        super.destroyItem(container, position, object);
     }

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -36,6 +36,7 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.lib.resources.files.TrashbinFile;
 import com.owncloud.android.ui.EmptyRecyclerView;
 import com.owncloud.android.ui.activity.FileActivity;
@@ -52,8 +53,6 @@ import butterknife.BindString;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
-
-import static com.owncloud.android.db.PreferenceManager.getSortOrder;
 
 /**
  * Presenting trashbin data, received from presenter
@@ -164,7 +163,8 @@ public class TrashbinActivity extends FileActivity implements TrashbinActivityIn
                 ft.addToBackStack(null);
 
                 SortingOrderDialogFragment mSortingOrderDialogFragment = SortingOrderDialogFragment.newInstance(
-                        getSortOrder(this, null));
+                    PreferenceManager.getSortOrderByType(this, FileSortOrder.Type.trashBinView,
+                        FileSortOrder.sort_new_to_old));
                 mSortingOrderDialogFragment.show(ft, SortingOrderDialogFragment.SORTING_ORDER_FRAGMENT);
 
                 break;
@@ -276,7 +276,7 @@ public class TrashbinActivity extends FileActivity implements TrashbinActivityIn
     @Override
     public void showError(int message) {
         swipeListRefreshLayout.setRefreshing(false);
-        
+
         if (emptyContentMessage != null) {
             emptyContentHeadline.setText(R.string.common_error);
             emptyContentIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_list_empty_error));

--- a/src/main/java/com/owncloud/android/utils/FileSortOrder.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrder.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Sort order 
+ * Sort order
  */
 
 public class FileSortOrder {
@@ -42,22 +42,27 @@ public class FileSortOrder {
     public static final FileSortOrder sort_big_to_small = new FileSortOrderBySize("sort_big_to_small", false);
 
     public static final Map<String, FileSortOrder> sortOrders;
+
+    public enum Type {
+        trashBinView, localFileListView, uploadFilesView
+
+    }
     static {
         sortOrders = new HashMap<>();
-        sortOrders.put(sort_a_to_z.mName, sort_a_to_z);
-        sortOrders.put(sort_z_to_a.mName, sort_z_to_a);
-        sortOrders.put(sort_old_to_new.mName, sort_old_to_new);
-        sortOrders.put(sort_new_to_old.mName, sort_new_to_old);
-        sortOrders.put(sort_small_to_big.mName, sort_small_to_big);
-        sortOrders.put(sort_big_to_small.mName, sort_big_to_small);
+        sortOrders.put(sort_a_to_z.name, sort_a_to_z);
+        sortOrders.put(sort_z_to_a.name, sort_z_to_a);
+        sortOrders.put(sort_old_to_new.name, sort_old_to_new);
+        sortOrders.put(sort_new_to_old.name, sort_new_to_old);
+        sortOrders.put(sort_small_to_big.name, sort_small_to_big);
+        sortOrders.put(sort_big_to_small.name, sort_big_to_small);
     }
 
-    public String mName;
-    public boolean mAscending;
+    public String name;
+    public boolean isAscending;
 
     public FileSortOrder(String name, boolean ascending) {
-        mName = name;
-        mAscending = ascending;
+        this.name = name;
+        isAscending = ascending;
     }
 
     public List<OCFile> sortCloudFiles(List<OCFile> files) {

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
@@ -42,7 +42,7 @@ public class FileSortOrderByDate extends FileSortOrder {
      * @param files list of files to sort
      */
     public List<OCFile> sortCloudFiles(List<OCFile> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) ->
                 multiplier * Long.compare(o1.getModificationTimestamp(), o2.getModificationTimestamp()));
@@ -57,7 +57,7 @@ public class FileSortOrderByDate extends FileSortOrder {
      */
     @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             Long obj1 = o1.getDeletionTimestamp();
@@ -74,7 +74,7 @@ public class FileSortOrderByDate extends FileSortOrder {
      */
     @Override
     public List<File> sortLocalFiles(List<File> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> multiplier * Long.compare(o1.lastModified(),o2.lastModified()));
 

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByName.java
@@ -47,7 +47,7 @@ public class FileSortOrderByName extends FileSortOrder {
      */
     @SuppressFBWarnings("Bx")
     public List<OCFile> sortCloudFiles(List<OCFile> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             if (o1.isFolder() && o2.isFolder()) {
@@ -71,7 +71,7 @@ public class FileSortOrderByName extends FileSortOrder {
     @SuppressFBWarnings("Bx")
     @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             if (o1.isFolder() && o2.isFolder()) {
@@ -94,7 +94,7 @@ public class FileSortOrderByName extends FileSortOrder {
      */
     @Override
     public List<File> sortLocalFiles(List<File> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             if (o1.isDirectory() && o2.isDirectory()) {

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
@@ -43,7 +43,7 @@ public class FileSortOrderBySize extends FileSortOrder {
      * @param files list of files to sort
      */
     public List<OCFile> sortCloudFiles(List<OCFile> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             if (o1.isFolder() && o2.isFolder()) {
@@ -70,7 +70,7 @@ public class FileSortOrderBySize extends FileSortOrder {
      */
     @Override
     public List<TrashbinFile> sortTrashbinFiles(List<TrashbinFile> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             if (o1.isFolder() && o2.isFolder()) {
@@ -97,7 +97,7 @@ public class FileSortOrderBySize extends FileSortOrder {
      */
     @Override
     public List<File> sortLocalFiles(List<File> files) {
-        final int multiplier = mAscending ? 1 : -1;
+        final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
             if (o1.isDirectory() && o2.isDirectory()) {


### PR DESCRIPTION
Fix #2919 

Trashbin: new->old by default

We previously had one setting for all three above. There is no good transition in my opinion, so it starts for upload/local a->z and trashbin: new->old

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>