### PR TITLE
As async, it can happen that list already changed

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -234,8 +234,11 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
         protected void onPostExecute(Boolean success) {
             if (success) {
                 int position = holder.getAdapterPosition();
-                notificationsList.remove(position);
-                notifyItemRemoved(position);
+
+                if (position > 0 && position < notificationsList.size()) {
+                    notificationsList.remove(position);
+                    notifyItemRemoved(position);
+                }
             } else {
                 setButtonEnabled(holder, true);
                 DisplayUtils.showSnackMessage(notificationsActivity, "Failed to execute action!");

--- a/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -235,7 +235,7 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
             if (success) {
                 int position = holder.getAdapterPosition();
 
-                if (position > 0 && position < notificationsList.size()) {
+                if (position >= 0 && position < notificationsList.size()) {
                     notificationsList.remove(position);
                     notifyItemRemoved(position);
                 }


### PR DESCRIPTION
As action handling on notification is done async, it can happen that when clicking multiple actions at once, the list changed and thus it crashed with OutOfBounds.

When using this one by one or with a fast enough connection, this does not happen as the list internally gets refreshed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>