### PR TITLE
UI can already be non-existent

### DIFF
--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -279,7 +279,7 @@ public class TrashbinActivity extends FileActivity implements TrashbinActivityIn
             swipeListRefreshLayout.setRefreshing(false);
         }
 
-        if (emptyContentMessage != null) {
+        if (emptyContentMessage != null && emptyContentHeadline != null && emptyContentIcon != null) {
             emptyContentHeadline.setText(R.string.common_error);
             emptyContentIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_list_empty_error));
             emptyContentMessage.setText(message);

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -275,7 +275,9 @@ public class TrashbinActivity extends FileActivity implements TrashbinActivityIn
 
     @Override
     public void showError(int message) {
-        swipeListRefreshLayout.setRefreshing(false);
+        if (swipeListRefreshLayout != null) {
+            swipeListRefreshLayout.setRefreshing(false);
+        }
 
         if (emptyContentMessage != null) {
             emptyContentHeadline.setText(R.string.common_error);


### PR DESCRIPTION
Found via gplay console.

If async takes a bit and user already closed trashbin view, showing an error could lead to a NPE, as view is already destroyed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>