### PR TITLE
Upload IT: add non-zero uploads

### DIFF
--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 /**
@@ -29,7 +30,7 @@ import java.io.IOException;
 public abstract class AbstractIT {
 
     protected static OwnCloudClient client;
-    protected static Account account;
+    static Account account;
     protected static Context context;
 
     private static final String username = "test";
@@ -58,7 +59,7 @@ public abstract class AbstractIT {
             if (account == null) {
                 throw new ActivityNotFoundException();
             }
-            
+
             client = OwnCloudClientFactory.createOwnCloudClient(account, context);
 
             createDummyFiles();
@@ -73,14 +74,28 @@ public abstract class AbstractIT {
         }
     }
 
-    protected FileDataStorageManager getStorageManager() {
+    FileDataStorageManager getStorageManager() {
         return new FileDataStorageManager(account, context.getContentResolver());
     }
 
     private static void createDummyFiles() throws IOException {
         new File(FileStorageUtils.getSavePath(account.name)).mkdirs();
 
-        File file = new File(FileStorageUtils.getSavePath(account.name) + "/123.txt");
+        createFile("empty.txt", 0);
+        createFile("nonEmpty.txt", 100);
+        createFile("chunkedFile.txt", 500000);
+    }
+
+    private static void createFile(String name, int iteration) throws IOException {
+        File file = new File(FileStorageUtils.getSavePath(account.name) + File.separator + name);
         file.createNewFile();
+
+        FileWriter writer = new FileWriter(file);
+
+        for (int i = 0; i < iteration; i++) {
+            writer.write("123123123123123123123123123\n");
+        }
+        writer.flush();
+        writer.close();
     }
 }

--- a/src/androidTest/java/com/owncloud/android/UploadIT.java
+++ b/src/androidTest/java/com/owncloud/android/UploadIT.java
@@ -21,18 +21,45 @@ import static junit.framework.TestCase.assertTrue;
 public class UploadIT extends AbstractIT {
 
     @Test
-    public void testSimpleUpload() {
-        OCUpload ocUpload = new OCUpload(FileStorageUtils.getSavePath(account.name) + "/123.txt",
-                "/testUpload/1.txt", account.name);
+    public void testEmptyUpload() {
+        OCUpload ocUpload = new OCUpload(FileStorageUtils.getSavePath(account.name) + "/empty.txt",
+            "/testUpload/empty.txt", account.name);
+
+        RemoteOperationResult result = testUpload(ocUpload);
+
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    public void testNonEmptyUpload() {
+        OCUpload ocUpload = new OCUpload(FileStorageUtils.getSavePath(account.name) + "/nonEmpty.txt",
+            "/testUpload/nonEmpty.txt", account.name);
+
+        RemoteOperationResult result = testUpload(ocUpload);
+
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    public void testChunkedUpload() {
+        OCUpload ocUpload = new OCUpload(FileStorageUtils.getSavePath(account.name) + "/chunkedFile.txt",
+            "/testUpload/chunkedFile.txt", account.name);
+
+        RemoteOperationResult result = testUpload(ocUpload);
+
+        assertTrue(result.isSuccess());
+    }
+
+    public RemoteOperationResult testUpload(OCUpload ocUpload) {
         UploadFileOperation newUpload = new UploadFileOperation(
-                account,
-                null,
-                ocUpload,
-                false,
-                FileUploader.LOCAL_BEHAVIOUR_COPY,
-                context,
-                false,
-                false
+            account,
+            null,
+            ocUpload,
+            false,
+            FileUploader.LOCAL_BEHAVIOUR_COPY,
+            context,
+            false,
+            false
         );
         newUpload.addRenameUploadListener(() -> {
             // dummy
@@ -40,13 +67,12 @@ public class UploadIT extends AbstractIT {
 
         newUpload.setRemoteFolderToBeCreated();
 
-        RemoteOperationResult result = newUpload.execute(client, getStorageManager());
-        assertTrue(result.isSuccess());
+        return newUpload.execute(client, getStorageManager());
     }
 
     @Test
     public void testUploadInNonExistingFolder() {
-        OCUpload ocUpload = new OCUpload(FileStorageUtils.getSavePath(account.name) + "/123.txt",
+        OCUpload ocUpload = new OCUpload(FileStorageUtils.getSavePath(account.name) + "/empty.txt",
                 "/testUpload/2/3/4/1.txt", account.name);
         UploadFileOperation newUpload = new UploadFileOperation(
                 account,


### PR DESCRIPTION
Currently our IT tests against a master server are failing, due to a bug on their side with 0b files.
This adds tests to have also non-zero files, one ~100kb and one ~12Mb to also test chunked upload.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

