### PR TITLE
Material design revamp

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -73,7 +73,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     public static final String EXTRA_FILES = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_FILES";
     public static final String EXTRA_ACTION = FolderPickerActivity.class.getCanonicalName() + ".EXTRA_ACTION";
     public static final String EXTRA_CURRENT_FOLDER = FolderPickerActivity.class.getCanonicalName() +
-            ".EXTRA_CURRENT_FOLDER";
+        ".EXTRA_CURRENT_FOLDER";
     public static final String MOVE = "MOVE";
     public static final String COPY = "COPY";
 
@@ -158,7 +158,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     }
 
     /**
-     *  Called when the ownCloud {@link Account} associated to the Activity was just updated.
+     * Called when the ownCloud {@link Account} associated to the Activity was just updated.
      */
     @Override
     protected void onAccountSet(boolean stateWasRecovered) {
@@ -211,10 +211,10 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         if (listFragment != null) {
             if (!mSyncInProgress) {
                 listFragment.setMessageForEmptyList(
-                        R.string.file_list_empty_headline,
-                        R.string.file_list_empty_moving,
-                        R.drawable.ic_list_empty_create_folder,
-                        true
+                    R.string.file_list_empty_headline,
+                    R.string.file_list_empty_moving,
+                    R.drawable.ic_list_empty_create_folder,
+                    true
                 );
             } else {
                 listFragment.setEmptyListLoadingMessage();
@@ -227,7 +227,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     protected OCFileListFragment getListOfFilesFragment() {
         Fragment listOfFiles = getSupportFragmentManager().findFragmentByTag(FolderPickerActivity.TAG_LIST_OF_FOLDERS);
         if (listOfFiles != null) {
-            return (OCFileListFragment)listOfFiles;
+            return (OCFileListFragment) listOfFiles;
         }
         Log_OC.e(TAG, "Access to non existing list of files fragment!!");
         return null;
@@ -235,7 +235,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
 
     /**
      * {@inheritDoc}
-     *
+     * <p>
      * Updates action bar and second fragment, if in dual pane mode.
      */
     @Override
@@ -258,7 +258,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
 
         // perform folder synchronization
         RemoteOperation refreshFolderOperation = new RefreshFolderOperation(folder, currentSyncTime, false,
-                ignoreETag, getStorageManager(), getAccount(), getApplicationContext());
+            ignoreETag, getStorageManager(), getAccount(), getApplicationContext());
 
         refreshFolderOperation.execute(getAccount(), this, null, null);
         setIndeterminate(true);
@@ -313,18 +313,18 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean retval = true;
         switch (item.getItemId()) {
-        case R.id.action_create_dir: {
-            CreateFolderDialogFragment dialog = CreateFolderDialogFragment.newInstance(getCurrentFolder());
-            dialog.show(getSupportFragmentManager(), CreateFolderDialogFragment.CREATE_FOLDER_FRAGMENT);
-            break;
-        }
-        case android.R.id.home: {
-            OCFile currentDir = getCurrentFolder();
-            if(currentDir != null && currentDir.getParentId() != 0) {
-                onBackPressed();
+            case R.id.action_create_dir: {
+                CreateFolderDialogFragment dialog = CreateFolderDialogFragment.newInstance(getCurrentFolder());
+                dialog.show(getSupportFragmentManager(), CreateFolderDialogFragment.CREATE_FOLDER_FRAGMENT);
+                break;
             }
-            break;
-        }
+            case android.R.id.home: {
+                OCFile currentDir = getCurrentFolder();
+                if (currentDir != null && currentDir.getParentId() != 0) {
+                    onBackPressed();
+                }
+                break;
+            }
             case R.id.action_sort: {
                 FragmentManager fm = getSupportFragmentManager();
                 FragmentTransaction ft = fm.beginTransaction();
@@ -336,9 +336,9 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
 
                 break;
             }
-        default:
-            retval = super.onOptionsItemSelected(item);
-            break;
+            default:
+                retval = super.onOptionsItemSelected(item);
+                break;
         }
 
         return retval;
@@ -409,7 +409,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     /**
      * Set per-view controllers
      */
-    private void initControls(){
+    private void initControls() {
         mCancelBtn = findViewById(R.id.folder_picker_btn_cancel);
         mCancelBtn.setOnClickListener(this);
         mChooseBtn = findViewById(R.id.folder_picker_btn_choose);
@@ -417,6 +417,10 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         if (mChooseBtn != null) {
             mChooseBtn.getBackground().setColorFilter(ThemeUtils.primaryColor(this, true), PorterDuff.Mode.SRC_ATOP);
             mChooseBtn.setOnClickListener(this);
+        }
+
+        if (mCancelBtn != null) {
+            mCancelBtn.setTextColor(ThemeUtils.primaryColor(this, true));
         }
     }
 
@@ -453,23 +457,23 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
      * Updates the view associated to the activity after the finish of an operation trying
      * to create a new folder.
      *
-     * @param operation     Creation operation performed.
-     * @param result        Result of the creation.
+     * @param operation Creation operation performed.
+     * @param result    Result of the creation.
      */
     private void onCreateFolderOperationFinish(
-            CreateFolderOperation operation, RemoteOperationResult result
-            ) {
+        CreateFolderOperation operation, RemoteOperationResult result
+    ) {
 
         if (result.isSuccess()) {
             refreshListOfFilesFragment(false);
         } else {
             try {
                 DisplayUtils.showSnackMessage(
-                        this,ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
+                    this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
 
             } catch (NotFoundException e) {
-                Log_OC.e(TAG, "Error while trying to show fail message " , e);
+                Log_OC.e(TAG, "Error while trying to show fail message ", e);
             }
         }
     }
@@ -487,23 +491,23 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                 String accountName = intent.getStringExtra(FileSyncAdapter.EXTRA_ACCOUNT_NAME);
                 String syncFolderRemotePath = intent.getStringExtra(FileSyncAdapter.EXTRA_FOLDER_PATH);
                 RemoteOperationResult syncResult = (RemoteOperationResult)
-                        DataHolderUtil.getInstance().retrieve(intent.getStringExtra(FileSyncAdapter.EXTRA_RESULT));
+                    DataHolderUtil.getInstance().retrieve(intent.getStringExtra(FileSyncAdapter.EXTRA_RESULT));
                 boolean sameAccount = getAccount() != null && accountName.equals(getAccount().name)
-                        && getStorageManager() != null;
+                    && getStorageManager() != null;
 
                 if (sameAccount) {
                     if (FileSyncAdapter.EVENT_FULL_SYNC_START.equals(event)) {
                         mSyncInProgress = true;
                     } else {
                         OCFile currentFile = (getFile() == null) ? null :
-                                getStorageManager().getFileByPath(getFile().getRemotePath());
+                            getStorageManager().getFileByPath(getFile().getRemotePath());
                         OCFile currentDir = (getCurrentFolder() == null) ? null :
                             getStorageManager().getFileByPath(getCurrentFolder().getRemotePath());
 
                         if (currentDir == null) {
                             // current folder was removed from the server
                             DisplayUtils.showSnackMessage(getActivity(), R.string.sync_current_folder_was_removed,
-                                    getCurrentFolder().getFileName());
+                                getCurrentFolder().getFileName());
                             browseToRoot();
                         } else {
                             if (currentFile == null && !getFile().isFolder()) {
@@ -521,17 +525,17 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                         }
 
                         mSyncInProgress = (!FileSyncAdapter.EVENT_FULL_SYNC_END.equals(event) &&
-                                !RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED.equals(event));
+                            !RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED.equals(event));
 
                         if (RefreshFolderOperation.EVENT_SINGLE_FOLDER_CONTENTS_SYNCED.equals(event) &&
-                                /// TODO refactor and make common
-                                syncResult != null && !syncResult.isSuccess()) {
+                            /// TODO refactor and make common
+                            syncResult != null && !syncResult.isSuccess()) {
 
                             if (ResultCode.UNAUTHORIZED.equals(syncResult.getCode()) || (syncResult.isException()
-                                    && syncResult.getException() instanceof AuthenticatorException)) {
+                                && syncResult.getException() instanceof AuthenticatorException)) {
                                 requestCredentialsUpdate(context);
                             } else if (RemoteOperationResult.ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED
-                                    .equals(syncResult.getCode())) {
+                                .equals(syncResult.getCode())) {
                                 showUntrustedCertDialog(syncResult);
                             }
 

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -411,7 +411,6 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
      */
     private void initControls() {
         mCancelBtn = findViewById(R.id.folder_picker_btn_cancel);
-        mCancelBtn.setOnClickListener(this);
         mChooseBtn = findViewById(R.id.folder_picker_btn_choose);
 
         if (mChooseBtn != null) {
@@ -421,6 +420,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
 
         if (mCancelBtn != null) {
             mCancelBtn.setTextColor(ThemeUtils.primaryColor(this, true));
+            mCancelBtn.setOnClickListener(this);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -82,6 +82,7 @@ public class LogHistoryActivity extends ToolbarActivity {
         Button deleteHistoryButton = findViewById(R.id.deleteLogHistoryButton);
         Button sendHistoryButton = findViewById(R.id.sendLogHistoryButton);
         sendHistoryButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
+        deleteHistoryButton.setTextColor(ThemeUtils.primaryColor(this, true));
         TextView logTV = findViewById(R.id.logTV);
 
         deleteHistoryButton.setOnClickListener(new OnClickListener() {

--- a/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -81,7 +81,7 @@ public class LogHistoryActivity extends ToolbarActivity {
         }
         Button deleteHistoryButton = findViewById(R.id.deleteLogHistoryButton);
         Button sendHistoryButton = findViewById(R.id.sendLogHistoryButton);
-        sendHistoryButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
+        sendHistoryButton.getBackground().setColorFilter(ThemeUtils.primaryColor(this), PorterDuff.Mode.SRC_ATOP);
         deleteHistoryButton.setTextColor(ThemeUtils.primaryColor(this, true));
         TextView logTV = findViewById(R.id.logTV);
 

--- a/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
@@ -30,11 +30,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.google.android.material.button.MaterialButton;
 import com.owncloud.android.R;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.ThemeUtils;
-
-import androidx.appcompat.widget.AppCompatButton;
 
 /**
  * Activity providing information about ways to participate in the app's development.
@@ -93,7 +92,7 @@ public class ParticipateActivity extends FileActivity {
                                 ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this, true)),
                                 getString(R.string.contributing_link)))));
 
-        AppCompatButton reportButton = findViewById(R.id.participate_testing_report);
+        MaterialButton reportButton = findViewById(R.id.participate_testing_report);
         reportButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
         reportButton.setOnClickListener(v -> DisplayUtils.startLinkIntent(this, R.string.report_issue_link));
     }

--- a/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ParticipateActivity.java
@@ -93,7 +93,7 @@ public class ParticipateActivity extends FileActivity {
                                 getString(R.string.contributing_link)))));
 
         MaterialButton reportButton = findViewById(R.id.participate_testing_report);
-        reportButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
+        reportButton.getBackground().setColorFilter(ThemeUtils.primaryColor(this), PorterDuff.Mode.SRC_ATOP);
         reportButton.setOnClickListener(v -> DisplayUtils.startLinkIntent(this, R.string.report_issue_link));
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -761,7 +761,7 @@ public class Preferences extends PreferenceActivity
                     .getColor(getResources(), R.color.background_color, null)));
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                window.setStatusBarColor(ThemeUtils.primaryDarkColor(this));
+                window.setStatusBarColor(ThemeUtils.primaryColor(this));
             }
 
             // For adding content description tag to a title field in the action bar

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -800,11 +800,12 @@ public class ReceiveExternalFilesActivity extends FileActivity
             }
 
             Button btnNewFolder = findViewById(R.id.uploader_cancel);
-                btnNewFolder.setOnClickListener(this);
+            btnNewFolder.setTextColor(ThemeUtils.primaryColor(this, true));
+            btnNewFolder.setOnClickListener(this);
 
-                mListView.setOnItemClickListener(this);
-            }
+            mListView.setOnItemClickListener(this);
         }
+    }
 
     protected void setupEmptyList() {
         mEmptyListContainer = findViewById(R.id.empty_list_view);

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -789,7 +789,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                         ThemeUtils.primaryColor(getAccount(), false, this)));
             }
 
-            ThemeUtils.colorStatusBar(this, ThemeUtils.primaryDarkColor(getAccount(), this));
+            ThemeUtils.colorStatusBar(this, ThemeUtils.primaryColor(getAccount(), false, this));
 
             ThemeUtils.colorToolbarProgressBar(this, ThemeUtils.primaryColor(getAccount(), false, this));
 

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -81,7 +81,7 @@ public abstract class ToolbarActivity extends BaseActivity {
 
         mPreviewImage = findViewById(R.id.preview_image);
 
-        ThemeUtils.colorStatusBar(this, primaryDarkColor);
+        ThemeUtils.colorStatusBar(this, primaryColor);
 
         if (toolbar.getOverflowIcon() != null) {
             ThemeUtils.tintDrawable(toolbar.getOverflowIcon(), fontColor);

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -63,7 +63,6 @@ public abstract class ToolbarActivity extends BaseActivity {
      */
     protected void setupToolbar(boolean useBackgroundImage) {
         int primaryColor = ThemeUtils.primaryColor(this, false);
-        int primaryDarkColor = ThemeUtils.primaryDarkColor(this);
         int fontColor = ThemeUtils.fontColor(this);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
@@ -74,7 +73,7 @@ public abstract class ToolbarActivity extends BaseActivity {
             mProgressBar.setIndeterminateDrawable(
                     ContextCompat.getDrawable(this, R.drawable.actionbar_progress_indeterminate_horizontal));
 
-            ThemeUtils.colorToolbarProgressBar(this, ThemeUtils.primaryColor(this, false));
+            ThemeUtils.colorToolbarProgressBar(this, primaryColor);
         }
         mInfoBox = findViewById(R.id.info_box);
         mInfoBoxMessage = findViewById(R.id.info_box_message);

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -167,9 +167,11 @@ public class UploadFilesActivity extends FileActivity implements
         mFileListFragment = (LocalFileListFragment) getSupportFragmentManager().findFragmentById(R.id.local_files_list);
 
         // Set input controllers
-        findViewById(R.id.upload_files_btn_cancel).setOnClickListener(this);
+        MaterialButton mCancelButton = findViewById(R.id.upload_files_btn_cancel);
+        mCancelButton.setTextColor(ThemeUtils.primaryColor(this, true));
+        mCancelButton.setOnClickListener(this);
 
-        mUploadBtn = (MaterialButton) findViewById(R.id.upload_files_btn_upload);
+        mUploadBtn = findViewById(R.id.upload_files_btn_upload);
         mUploadBtn.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
         mUploadBtn.setOnClickListener(this);
 

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -42,6 +42,7 @@ import android.widget.ImageView;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import com.google.android.material.button.MaterialButton;
 import com.owncloud.android.R;
 import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -62,7 +63,6 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatSpinner;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.MenuItemCompat;
@@ -160,7 +160,7 @@ public class UploadFilesActivity extends FileActivity implements
 
         if (mLocalFolderPickerMode) {
             findViewById(R.id.upload_options).setVisibility(View.GONE);
-            ((AppCompatButton) findViewById(R.id.upload_files_btn_upload))
+            ((MaterialButton) findViewById(R.id.upload_files_btn_upload))
                     .setText(R.string.uploader_btn_alternative_text);
         }
 
@@ -169,7 +169,7 @@ public class UploadFilesActivity extends FileActivity implements
         // Set input controllers
         findViewById(R.id.upload_files_btn_cancel).setOnClickListener(this);
 
-        mUploadBtn = (AppCompatButton) findViewById(R.id.upload_files_btn_upload);
+        mUploadBtn = (MaterialButton) findViewById(R.id.upload_files_btn_upload);
         mUploadBtn.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
         mUploadBtn.setOnClickListener(this);
 

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -172,7 +172,7 @@ public class UploadFilesActivity extends FileActivity implements
         mCancelButton.setOnClickListener(this);
 
         mUploadBtn = findViewById(R.id.upload_files_btn_upload);
-        mUploadBtn.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(this), PorterDuff.Mode.SRC_ATOP);
+        mUploadBtn.getBackground().setColorFilter(ThemeUtils.primaryColor(this, true), PorterDuff.Mode.SRC_ATOP);
         mUploadBtn.setOnClickListener(this);
 
         int localBehaviour = PreferenceManager.getUploaderBehaviour(this);

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -338,7 +338,7 @@ public class UserInfoActivity extends FileActivity {
         public void onStart() {
             super.onStart();
 
-            int color = ThemeUtils.primaryAccentColor(getActivity());
+            int color = ThemeUtils.primaryColor(getActivity());
 
             AlertDialog alertDialog = (AlertDialog) getDialog();
 

--- a/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -34,7 +34,6 @@ import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;

--- a/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -45,6 +45,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.model.StreamEncoder;
 import com.bumptech.glide.load.resource.file.FileToStreamDecoder;
 import com.caverock.androidsvg.SVG;
+import com.google.android.material.button.MaterialButton;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
@@ -135,12 +136,13 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
 
         // add action buttons
         holder.buttons.removeAllViews();
-        Button button;
+        MaterialButton button;
 
 
         for (Action action : notification.getActions()) {
-            button = new Button(notificationsActivity);
+            button = new MaterialButton(notificationsActivity);
             button.setText(action.label);
+            button.setCornerRadiusResource(R.dimen.button_corner_radius);
 
             if (action.primary) {
                 button.getBackground().setColorFilter(ThemeUtils.primaryColor(notificationsActivity, true),

--- a/src/main/java/com/owncloud/android/ui/components/CustomEditText.java
+++ b/src/main/java/com/owncloud/android/ui/components/CustomEditText.java
@@ -26,13 +26,14 @@ import android.graphics.Rect;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import com.google.android.material.textfield.TextInputEditText;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AuthenticatorActivity;
 
 /**
  * Custom edit text to support fixed suffix or prefix
  */
-public class CustomEditText extends androidx.appcompat.widget.AppCompatEditText {
+public class CustomEditText extends TextInputEditText {
     private Rect fixedRect = new Rect();
     private String fixedText = "";
     private boolean isPrefixFixed;

--- a/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
@@ -24,6 +24,8 @@ package com.owncloud.android.ui.dialog;
 import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -32,6 +34,8 @@ import android.view.Window;
 import android.view.WindowManager.LayoutParams;
 import android.widget.EditText;
 
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.ui.activity.ComponentsGetter;
@@ -58,8 +62,11 @@ public class NoteDialogFragment extends DialogFragment implements DialogInterfac
     private OCShare share;
     private Unbinder unbinder;
 
+    @BindView(R.id.user_input_container)
+    TextInputLayout noteEditTextInputLayout;
+
     @BindView(R.id.user_input)
-    EditText noteEditText;
+    TextInputEditText noteEditText;
 
     public static NoteDialogFragment newInstance(OCShare share) {
         NoteDialogFragment frag = new NoteDialogFragment();
@@ -107,7 +114,7 @@ public class NoteDialogFragment extends DialogFragment implements DialogInterfac
         // Setup layout
         noteEditText.setText(share.getNote());
         noteEditText.requestFocus();
-        noteEditText.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
+        ThemeUtils.colorTextInputLayout(noteEditTextInputLayout, accentColor);
 
         // Build the dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());

--- a/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
@@ -24,15 +24,11 @@ package com.owncloud.android.ui.dialog;
 import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
-import android.content.res.ColorStateList;
-import android.graphics.Color;
-import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager.LayoutParams;
-import android.widget.EditText;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;

--- a/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
@@ -59,10 +59,10 @@ public class NoteDialogFragment extends DialogFragment implements DialogInterfac
     private Unbinder unbinder;
 
     @BindView(R.id.user_input_container)
-    TextInputLayout noteEditTextInputLayout;
+    public TextInputLayout noteEditTextInputLayout;
 
     @BindView(R.id.user_input)
-    TextInputEditText noteEditText;
+    public TextInputEditText noteEditText;
 
     public static NoteDialogFragment newInstance(OCShare share) {
         NoteDialogFragment frag = new NoteDialogFragment();

--- a/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -124,7 +124,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        int accentColor = ThemeUtils.primaryAccentColor(getContext());
+        int primaryColor = ThemeUtils.primaryColor(getContext());
         account = getArguments().getParcelable(ARG_ACCOUNT);
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
@@ -137,13 +137,13 @@ public class SetupEncryptionDialogFragment extends DialogFragment {
         textView = v.findViewById(R.id.encryption_status);
         passphraseTextView = v.findViewById(R.id.encryption_passphrase);
         passwordField = v.findViewById(R.id.encryption_passwordInput);
-        passwordField.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
+        passwordField.getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_ATOP);
 
         Drawable wrappedDrawable = DrawableCompat.wrap(passwordField.getBackground());
-        DrawableCompat.setTint(wrappedDrawable, accentColor);
+        DrawableCompat.setTint(wrappedDrawable, primaryColor);
         passwordField.setBackgroundDrawable(wrappedDrawable);
 
-        return createDialog(accentColor, v);
+        return createDialog(primaryColor, v);
     }
 
     @NonNull

--- a/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
@@ -30,13 +30,13 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
+import com.google.android.material.button.MaterialButton;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.FileSortOrder;
 import com.owncloud.android.utils.ThemeUtils;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.widget.AppCompatButton;
 import androidx.fragment.app.DialogFragment;
 
 /**
@@ -51,7 +51,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
 
     private View mView;
     private View[] mTaggedViews;
-    private AppCompatButton mCancel;
+    private MaterialButton mCancel;
     private String mCurrentSortOrderName;
 
     public static SortingOrderDialogFragment newInstance(FileSortOrder sortOrder) {

--- a/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -34,6 +34,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.google.android.material.button.MaterialButton;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.MediaFolderType;
 import com.owncloud.android.datamodel.SyncedFolderDisplayItem;
@@ -49,7 +50,6 @@ import java.io.File;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.DialogFragment;
@@ -78,8 +78,8 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
     private TextView mRemoteFolderSummary;
 
     private SyncedFolderParcelable mSyncedFolder;
-    private AppCompatButton mCancel;
-    private AppCompatButton mSave;
+    private MaterialButton mCancel;
+    private MaterialButton mSave;
     private boolean behaviourDialogShown;
     private AlertDialog behaviourDialog;
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -199,7 +199,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
         mSystemBarActionModeColor = getResources().getColor(R.color.action_mode_status_bar_background);
-        mSystemBarColor = ThemeUtils.primaryDarkColor(getContext());
+        mSystemBarColor = ThemeUtils.primaryColor(getContext());
         mProgressBarActionModeColor = getResources().getColor(R.color.action_mode_background);
         mProgressBarColor = ThemeUtils.primaryColor(getContext());
         mMultiChoiceModeListener = new MultiChoiceModeListener();
@@ -444,7 +444,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
     public void showActivityDetailView(OCFile file) {
         mContainerActivity.showDetails(file, 0);
     }
-    
+
     @Override
     public void onOverflowIconClicked(OCFile file, View view) {
         PopupMenu popup = new PopupMenu(getActivity(), view);

--- a/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
@@ -39,6 +39,7 @@ import android.widget.ListView;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -60,7 +61,6 @@ import java.util.Date;
 import java.util.List;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.Fragment;
 
@@ -717,7 +717,7 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
             }
 
             // GetLink button
-            AppCompatButton getLinkButton = getGetLinkButton();
+            MaterialButton getLinkButton = getGetLinkButton();
             getLinkButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
                     PorterDuff.Mode.SRC_ATOP);
             getLinkButton.setVisibility(View.VISIBLE);
@@ -873,8 +873,8 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
         return getView().findViewById(R.id.shareViaLinkHideFileListingPermissionSection);
     }
 
-    private AppCompatButton getGetLinkButton() {
-        return (AppCompatButton) getView().findViewById(R.id.shareViaLinkGetLinkButton);
+    private MaterialButton getGetLinkButton() {
+        return (MaterialButton) getView().findViewById(R.id.shareViaLinkGetLinkButton);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
@@ -718,7 +718,7 @@ public class ShareFileFragment extends Fragment implements ShareUserListAdapter.
 
             // GetLink button
             MaterialButton getLinkButton = getGetLinkButton();
-            getLinkButton.getBackground().setColorFilter(ThemeUtils.primaryAccentColor(getContext()),
+            getLinkButton.getBackground().setColorFilter(ThemeUtils.primaryColor(getContext()),
                     PorterDuff.Mode.SRC_ATOP);
             getLinkButton.setVisibility(View.VISIBLE);
             getLinkButton.setOnClickListener(new View.OnClickListener() {

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
@@ -690,7 +690,7 @@ class ContactListAdapter extends RecyclerView.Adapter<ContactListFragment.Contac
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             if (checked) {
                 checkedTextView.getCheckMarkDrawable()
-                        .setColorFilter(ThemeUtils.primaryAccentColor(context), PorterDuff.Mode.SRC_ATOP);
+                        .setColorFilter(ThemeUtils.primaryColor(context), PorterDuff.Mode.SRC_ATOP);
             } else {
                 checkedTextView.getCheckMarkDrawable().clearColorFilter();
             }
@@ -703,7 +703,7 @@ class ContactListAdapter extends RecyclerView.Adapter<ContactListFragment.Contac
         if (holder.getName().isChecked()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                 holder.getName().getCheckMarkDrawable()
-                        .setColorFilter(ThemeUtils.primaryAccentColor(context), PorterDuff.Mode.SRC_ATOP);
+                        .setColorFilter(ThemeUtils.primaryColor(context), PorterDuff.Mode.SRC_ATOP);
             }
 
             checkedVCards.add(verifiedPosition);

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -39,6 +39,7 @@ import android.widget.TextView;
 
 import com.evernote.android.job.JobRequest;
 import com.evernote.android.job.util.support.PersistableBundleCompat;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
@@ -63,7 +64,6 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.Fragment;
 import butterknife.BindView;
@@ -81,13 +81,13 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
     public SwitchCompat backupSwitch;
 
     @BindView(R.id.contacts_datepicker)
-    public AppCompatButton contactsDatePickerBtn;
+    public MaterialButton contactsDatePickerBtn;
 
     @BindView(R.id.contacts_last_backup_timestamp)
     public TextView lastBackup;
 
     @BindView(R.id.contacts_backup_now)
-    public AppCompatButton backupNow;
+    public MaterialButton backupNow;
 
     private Date selectedDate;
     private boolean calendarPickerOpen;
@@ -183,7 +183,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
         contactsDatePickerBtn.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
         contactsDatePickerBtn.setTextColor(fontColor);
 
-        AppCompatButton chooseDate = view.findViewById(R.id.contacts_datepicker);
+        MaterialButton chooseDate = view.findViewById(R.id.contacts_datepicker);
         chooseDate.getBackground().setColorFilter(accentColor, PorterDuff.Mode.SRC_ATOP);
         chooseDate.setTextColor(ThemeUtils.fontColor(getContext()));
 

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -40,6 +40,7 @@ import android.widget.SeekBar;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.textfield.TextInputLayout;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -365,6 +366,26 @@ public final class ThemeUtils {
         if (activity instanceof ToolbarActivity) {
             ((ToolbarActivity) activity).setProgressBarBackgroundColor(progressBarColor);
         }
+    }
+
+    /**
+     * Sets the color of the  TextInputLayout to {@code color} for hint text and box stroke.
+     *
+     * @param textInputLayout the TextInputLayout instance
+     * @param color the color to be used for the hint text and box stroke
+     */
+    public static void colorTextInputLayout(TextInputLayout textInputLayout, int color) {
+        textInputLayout.setBoxStrokeColor(color);
+        textInputLayout.setDefaultHintTextColor(new ColorStateList(
+            new int[][]{
+                new int[]{-android.R.attr.state_focused},
+                new int[]{android.R.attr.state_focused},
+            },
+            new int[]{
+                Color.GRAY,
+                color
+            }
+        ));
     }
 
     public static void tintCheckbox(AppCompatCheckBox checkBox, int color) {

--- a/src/main/res/layout-land/account_setup.xml
+++ b/src/main/res/layout-land/account_setup.xml
@@ -58,7 +58,7 @@
 			    android:orientation="vertical"
 			    android:padding="@dimen/standard_half_padding" >
 
-                <androidx.appcompat.widget.AppCompatButton
+                <com.google.android.material.button.MaterialButton
 					android:id="@+id/centeredRefreshButton"
 					style="@style/ownCloud.Button"
 					android:layout_width="wrap_content"
@@ -281,7 +281,7 @@
         android:orientation="vertical"
         android:paddingTop="@dimen/standard_half_padding">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
 			android:id="@+id/buttonOK"
 			android:theme="@style/Button.Login"
 			style="@style/Button.Login"

--- a/src/main/res/layout-land/account_setup.xml
+++ b/src/main/res/layout-land/account_setup.xml
@@ -175,7 +175,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
-					<EditText
+					<com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/oAuthEntryPoint_1"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -197,7 +197,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
-					<EditText
+					<com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/oAuthEntryPoint_2"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -220,7 +220,7 @@
 					android:layout_height="wrap_content"
 					android:visibility="gone">
 
-				<EditText
+				<com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/account_username"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -241,7 +241,7 @@
 					app:passwordToggleDrawable="@drawable/password_visibility_selector"
 					app:passwordToggleTint="@color/white">
 
-                    <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/account_password"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/src/main/res/layout-land/account_setup.xml
+++ b/src/main/res/layout-land/account_setup.xml
@@ -60,7 +60,6 @@
 
                 <com.google.android.material.button.MaterialButton
 					android:id="@+id/centeredRefreshButton"
-					style="@style/ownCloud.Button"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
 					android:layout_gravity="center_horizontal"
@@ -68,7 +67,8 @@
 					android:theme="@style/Button"
 					android:text="@string/auth_check_server"
 					android:visibility="gone"
-					android:contentDescription="@string/auth_check_server"/>
+					android:contentDescription="@string/auth_check_server"
+                    app:cornerRadius="@dimen/button_corner_radius"/>
 
 				<TextView
                     android:id="@+id/instructions_message"
@@ -292,7 +292,8 @@
 			android:enabled="false"
 			android:text="@string/setup_btn_connect"
 			android:contentDescription="@string/setup_btn_connect"
-			android:visibility="gone"/>
+			android:visibility="visible"
+            app:cornerRadius="@dimen/button_corner_radius"/>
 	</LinearLayout>
 
 </RelativeLayout>

--- a/src/main/res/layout/account_setup.xml
+++ b/src/main/res/layout/account_setup.xml
@@ -81,7 +81,7 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/input_layout_hostUrl"
-                android:theme="@style/EditText"
+                android:theme="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -168,7 +168,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/oAuthEntryPoint_1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -190,7 +190,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/oAuthEntryPoint_2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -209,12 +209,12 @@
 
             <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/input_layout_account_username"
-            android:theme="@style/EditText"
+            android:theme="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone">
 
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/account_username"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -231,12 +231,12 @@
             android:id="@+id/input_layout_account_password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:theme="@style/EditText"
+            android:theme="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:visibility="gone"
             app:passwordToggleDrawable="@drawable/password_visibility_selector"
             app:passwordToggleTint="@color/login_text_hint_color">
 
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/account_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/src/main/res/layout/account_setup.xml
+++ b/src/main/res/layout/account_setup.xml
@@ -50,7 +50,7 @@
             android:orientation="vertical"
             android:padding="@dimen/standard_half_padding">
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
             android:id="@+id/centeredRefreshButton"
             style="@style/ownCloud.Button"
             android:layout_width="wrap_content"
@@ -262,7 +262,7 @@
             android:textColor="@color/login_text_color"
             android:contentDescription="@string/auth_unauthorized"/>
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonOK"
             android:theme="@style/Button.Login"
             style="@style/Button.Login"

--- a/src/main/res/layout/account_setup.xml
+++ b/src/main/res/layout/account_setup.xml
@@ -52,7 +52,6 @@
 
             <com.google.android.material.button.MaterialButton
             android:id="@+id/centeredRefreshButton"
-            style="@style/ownCloud.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
@@ -60,7 +59,8 @@
             android:theme="@style/Button"
             android:text="@string/auth_check_server"
             android:visibility="gone"
-            android:contentDescription="@string/auth_check_server"/>
+            android:contentDescription="@string/auth_check_server"
+            app:cornerRadius="@dimen/button_corner_radius"/>
 
         <TextView
             android:id="@+id/instructions_message"
@@ -273,7 +273,8 @@
             android:enabled="false"
             android:text="@string/setup_btn_connect"
             android:contentDescription="@string/setup_btn_connect"
-            android:visibility="gone"/>
+            android:visibility="gone"
+            app:cornerRadius="@dimen/button_corner_radius"/>
         </LinearLayout>
 
     </LinearLayout>

--- a/src/main/res/layout/activity_manage_space.xml
+++ b/src/main/res/layout/activity_manage_space.xml
@@ -31,7 +31,7 @@
         android:text="@string/manage_space_description"
         />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/manage_space_clear_data"

--- a/src/main/res/layout/activity_manage_space.xml
+++ b/src/main/res/layout/activity_manage_space.xml
@@ -17,9 +17,10 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/general_description"
@@ -40,6 +41,7 @@
         android:layout_margin="@dimen/standard_margin"
         android:theme="@style/Button.Primary"
         style="@style/Button.Primary"
-        android:contentDescription="@string/manage_space_clear_data"/>
+        android:contentDescription="@string/manage_space_clear_data"
+        app:cornerRadius="@dimen/button_corner_radius" />
 
 </LinearLayout>

--- a/src/main/res/layout/activity_sso_grant_permission.xml
+++ b/src/main/res/layout/activity_sso_grant_permission.xml
@@ -47,7 +47,7 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Grant Nextcloud News access to your Nextcloud account incrediblyLong_username_with_123456789_number@Nextcloud_dummy.com?" />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btnGrant"
         style="@style/Button.Borderless"
         android:layout_width="wrap_content"
@@ -56,7 +56,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btnDecline"
         style="@style/Button.Borderless"
         android:layout_width="wrap_content"

--- a/src/main/res/layout/choose_template.xml
+++ b/src/main/res/layout/choose_template.xml
@@ -32,7 +32,7 @@
         android:layout_height="0dp"
         android:layout_weight="1"></androidx.recyclerview.widget.RecyclerView>
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/filename"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/src/main/res/layout/contactlist_fragment.xml
+++ b/src/main/res/layout/contactlist_fragment.xml
@@ -49,7 +49,7 @@
                 android:src="@drawable/uploader_list_separator"
                 android:contentDescription="@null"/>
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/contactlist_restore_selected"
                 style="@style/Button.Borderless"
                 android:layout_width="match_parent"

--- a/src/main/res/layout/contacts_backup_fragment.xml
+++ b/src/main/res/layout/contacts_backup_fragment.xml
@@ -19,9 +19,10 @@
   License along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/contacts_linear_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/contacts_linear_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -74,7 +75,8 @@
                 android:layout_margin="@dimen/standard_margin"
                 android:layout_weight="1"
                 android:text="@string/contacts_backup_button"
-                android:theme="@style/Button.Primary"/>
+                android:theme="@style/Button.Primary"
+                app:cornerRadius="@dimen/button_corner_radius" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/contacts_datepicker"
@@ -84,7 +86,8 @@
                 android:layout_weight="1"
                 android:text="@string/contacts_preference_choose_date"
                 android:theme="@style/Button"
-                android:visibility="gone"/>
+                android:visibility="gone"
+                app:cornerRadius="@dimen/button_corner_radius" />
         </LinearLayout>
 
     </LinearLayout>

--- a/src/main/res/layout/contacts_backup_fragment.xml
+++ b/src/main/res/layout/contacts_backup_fragment.xml
@@ -67,7 +67,7 @@
             android:layout_height="match_parent"
             android:orientation="horizontal">
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/contacts_backup_now"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -76,7 +76,7 @@
                 android:text="@string/contacts_backup_button"
                 android:theme="@style/Button.Primary"/>
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/contacts_datepicker"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/src/main/res/layout/edit_box_dialog.xml
+++ b/src/main/res/layout/edit_box_dialog.xml
@@ -24,7 +24,7 @@
     android:orientation="vertical"
     android:padding="@dimen/standard_padding">
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/user_input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/src/main/res/layout/files_folder_picker.xml
+++ b/src/main/res/layout/files_folder_picker.xml
@@ -24,7 +24,7 @@
     <include
         layout="@layout/toolbar_standard" />
 
-    <FrameLayout
+	<FrameLayout
 		android:layout_width="match_parent"
 		android:layout_height="0dp"
         android:layout_weight="1"
@@ -50,7 +50,7 @@
         android:orientation="horizontal"
 		android:padding="@dimen/standard_padding">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/folder_picker_btn_cancel"
             android:theme="@style/Button"
             android:layout_width="wrap_content"
@@ -60,7 +60,7 @@
             android:layout_marginRight="@dimen/standard_half_margin"
             android:layout_marginEnd="@dimen/standard_half_margin"/>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
 		    android:id="@+id/folder_picker_btn_choose"
             android:theme="@style/Button.Primary"
 		    android:layout_width="wrap_content"

--- a/src/main/res/layout/files_folder_picker.xml
+++ b/src/main/res/layout/files_folder_picker.xml
@@ -17,9 +17,10 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <include
         layout="@layout/toolbar_standard" />
@@ -52,13 +53,14 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/folder_picker_btn_cancel"
-            android:theme="@style/Button"
+            android:theme="@style/OutlinedButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/common_cancel"
             android:layout_marginRight="@dimen/standard_half_margin"
-            android:layout_marginEnd="@dimen/standard_half_margin"/>
+            android:layout_marginEnd="@dimen/standard_half_margin"
+            app:cornerRadius="@dimen/button_corner_radius" />
 
         <com.google.android.material.button.MaterialButton
 		    android:id="@+id/folder_picker_btn_choose"
@@ -66,7 +68,8 @@
 		    android:layout_width="wrap_content"
 		    android:layout_height="wrap_content"
 		    android:layout_weight="1"
-		    android:text="@string/folder_picker_choose_button_text" />
+		    android:text="@string/folder_picker_choose_button_text"
+            app:cornerRadius="@dimen/button_corner_radius" />
 
 	</LinearLayout>
 

--- a/src/main/res/layout/first_run_activity.xml
+++ b/src/main/res/layout/first_run_activity.xml
@@ -20,9 +20,10 @@
   along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -63,29 +64,32 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/login"
+                android:theme="@style/Button.Login"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_margin="5dp"
-                android:layout_weight="1"
-                android:maxWidth="500dp"
+                android:maxWidth="400dp"
                 android:minWidth="300dp"
                 android:textStyle="bold"
-                android:text="@string/login"/>
+                android:text="@string/login"
+                android:padding="@dimen/standard_padding"
+                app:cornerRadius="@dimen/button_corner_radius" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/signup"
+                android:theme="@style/Button.Primary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_margin="5dp"
-                android:layout_weight="1"
                 android:maxWidth="500dp"
                 android:minWidth="300dp"
                 android:textStyle="bold"
-                android:text="@string/signup_with_provider"/>
+                android:padding="@dimen/standard_padding"
+                android:text="@string/signup_with_provider"
+                app:cornerRadius="@dimen/button_corner_radius" />
         </LinearLayout>
 
         <TextView

--- a/src/main/res/layout/first_run_activity.xml
+++ b/src/main/res/layout/first_run_activity.xml
@@ -79,7 +79,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/signup"
-                android:theme="@style/Button.Primary"
+                android:theme="@style/OutlineLogindButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"

--- a/src/main/res/layout/generic_explanation.xml
+++ b/src/main/res/layout/generic_explanation.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ownCloud Android client application
 
   Copyright (C) 2015 ownCloud Inc.
@@ -29,10 +30,10 @@
 		android:layout_weight="2"
 	    android:padding="@dimen/alternate_padding_independent"
 	    android:scrollbarAlwaysDrawVerticalTrack="true"
-        android:text="@string/placeholder_sentence"
+		android:text="@string/placeholder_sentence"
 		/>
 
-    <ListView
+	<ListView
 	    android:id="@+id/list"
 	    android:layout_width="match_parent"
 	    android:layout_height="@dimen/zero"
@@ -47,7 +48,7 @@
         android:gravity="center"
         android:orientation="horizontal" >
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/cancel"
             android:theme="@style/Button"
             android:layout_width="wrap_content"
@@ -55,7 +56,7 @@
             android:layout_weight="1"
             android:text="@string/common_cancel" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
 		    android:id="@+id/ok"
             android:theme="@style/Button.Primary"
 		    android:layout_width="wrap_content"
@@ -63,6 +64,6 @@
 		    android:layout_weight="1"
 		    android:text="@string/common_ok" />
 
-    </LinearLayout>
+	</LinearLayout>
 
 </LinearLayout>

--- a/src/main/res/layout/log_send_file.xml
+++ b/src/main/res/layout/log_send_file.xml
@@ -17,10 +17,11 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:weightSum="1" >
+    android:weightSum="1">
 
     <include
         layout="@layout/toolbar_standard" />
@@ -59,12 +60,15 @@
 
         <com.google.android.material.button.MaterialButton
         android:id="@+id/deleteLogHistoryButton"
-        android:theme="@style/Button"
+        android:theme="@style/OutlinedButton"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:layout_weight="1"
-        android:text="@string/prefs_log_delete_history_button" />
+        android:text="@string/prefs_log_delete_history_button"
+        android:layout_marginEnd="@dimen/standard_quarter_margin"
+        android:layout_marginRight="@dimen/standard_quarter_margin"
+        app:cornerRadius="@dimen/button_corner_radius" />
 
         <com.google.android.material.button.MaterialButton
         android:id="@+id/sendLogHistoryButton"
@@ -73,7 +77,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:layout_weight="1"
-        android:text="@string/log_send_history_button" />
+        android:text="@string/log_send_history_button"
+        android:layout_marginStart="@dimen/standard_quarter_margin"
+        android:layout_marginLeft="@dimen/standard_quarter_margin"
+        app:cornerRadius="@dimen/button_corner_radius" />
 
     </LinearLayout>
 

--- a/src/main/res/layout/log_send_file.xml
+++ b/src/main/res/layout/log_send_file.xml
@@ -57,7 +57,7 @@
         android:layout_marginLeft="@dimen/standard_margin"
         android:layout_marginRight="@dimen/standard_margin">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
         android:id="@+id/deleteLogHistoryButton"
         android:theme="@style/Button"
         android:layout_width="fill_parent"
@@ -66,7 +66,7 @@
         android:layout_weight="1"
         android:text="@string/prefs_log_delete_history_button" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
         android:id="@+id/sendLogHistoryButton"
         android:theme="@style/Button.Primary"
         android:layout_width="fill_parent"

--- a/src/main/res/layout/note_dialog.xml
+++ b/src/main/res/layout/note_dialog.xml
@@ -41,7 +41,8 @@
             android:inputType="textCapSentences|textMultiLine|textNoSuggestions"
             android:lines="5"
             android:minLines="3"
-            android:scrollbars="vertical" />
+            android:scrollbars="vertical"
+            android:gravity="top"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/src/main/res/layout/note_dialog.xml
+++ b/src/main/res/layout/note_dialog.xml
@@ -20,21 +20,29 @@
   along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:gravity="clip_horizontal"
-              android:orientation="vertical"
-              android:padding="@dimen/standard_padding">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="clip_horizontal"
+    android:orientation="vertical"
+    android:padding="@dimen/standard_padding">
 
-    <EditText
-        android:id="@+id/user_input"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/user_input_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/hint_note"
-        android:inputType="textCapSentences|textMultiLine|textNoSuggestions"
-        android:minLines="3"
-        android:lines="5"
-        android:scrollbars="vertical"
-        android:importantForAutofill="no"/>
+        style="@style/TextInputLayout"
+        android:hint="@string/hint_note">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/user_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="textCapSentences|textMultiLine|textNoSuggestions"
+            android:lines="5"
+            android:minLines="3"
+            android:scrollbars="vertical" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>

--- a/src/main/res/layout/participate_layout.xml
+++ b/src/main/res/layout/participate_layout.xml
@@ -19,11 +19,12 @@
   License along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <androidx.drawerlayout.widget.DrawerLayout android:id="@+id/drawer_layout"
-                                        xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent"
-                                        android:clickable="true"
-                                        android:fitsSystemWindows="true">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clickable="true"
+    android:fitsSystemWindows="true">
 
     <!-- The main content view -->
     <LinearLayout
@@ -65,7 +66,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/participate_testing_report_text"
-                    android:theme="@style/Button.Primary"/>
+                    android:theme="@style/Button.Primary"
+                    app:cornerRadius="@dimen/button_corner_radius" />
 
                 <TextView
                     android:id="@+id/participate_text"

--- a/src/main/res/layout/participate_layout.xml
+++ b/src/main/res/layout/participate_layout.xml
@@ -60,7 +60,7 @@
                     android:text="@string/participate_testing_bug_text"
                     android:textAppearance="?android:attr/textAppearanceMedium"/>
 
-                <androidx.appcompat.widget.AppCompatButton
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/participate_testing_report"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/src/main/res/layout/passcodelock.xml
+++ b/src/main/res/layout/passcodelock.xml
@@ -18,11 +18,13 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
+
     android:gravity="center_horizontal"
     android:orientation="vertical"
-    android:padding="@dimen/standard_padding" >
+    android:padding="@dimen/standard_padding">
 
     <TextView
         android:id="@+id/header"
@@ -94,6 +96,7 @@
         android:theme="@style/Button.Primary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/common_cancel" />
+        android:text="@string/common_cancel"
+        app:cornerRadius="@dimen/button_corner_radius" />
 
 </LinearLayout>

--- a/src/main/res/layout/passcodelock.xml
+++ b/src/main/res/layout/passcodelock.xml
@@ -51,7 +51,7 @@
         android:layout_height="wrap_content"
         android:gravity="center_horizontal" >
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/txt0"
             android:focusable="true"
             style="@style/PassCodeStyle"
@@ -61,9 +61,9 @@
             android:hint="@string/hidden_character"
             android:textCursorDrawable="@null">
             <requestFocus/>
-        </EditText>
+        </com.google.android.material.textfield.TextInputEditText>
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/txt1"
             style="@style/PassCodeStyle"
             android:cursorVisible="true"
@@ -72,7 +72,7 @@
             android:hint="@string/hidden_character"
             android:textCursorDrawable="@null" />
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/txt2"
             style="@style/PassCodeStyle"
             android:cursorVisible="true"
@@ -81,7 +81,7 @@
             android:hint="@string/hidden_character"
             android:textCursorDrawable="@null" />
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/txt3"
             style="@style/PassCodeStyle"
             android:cursorVisible="true"

--- a/src/main/res/layout/passcodelock.xml
+++ b/src/main/res/layout/passcodelock.xml
@@ -89,7 +89,7 @@
             android:textCursorDrawable="@null" />
     </LinearLayout>
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/cancel"
         android:theme="@style/Button.Primary"
         android:layout_width="wrap_content"

--- a/src/main/res/layout/password_dialog.xml
+++ b/src/main/res/layout/password_dialog.xml
@@ -26,9 +26,10 @@
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:theme="@style/TextInputLayout"
         app:passwordToggleDrawable="@drawable/password_visibility_selector">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/share_password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -37,7 +38,7 @@
             android:inputType="textPassword"
             android:layout_margin="@dimen/standard_margin"
             android:autofillHints="password">
-        </EditText>
+        </com.google.android.material.textfield.TextInputEditText>
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/src/main/res/layout/setup_encryption_dialog.xml
+++ b/src/main/res/layout/setup_encryption_dialog.xml
@@ -41,7 +41,7 @@
         android:textIsSelectable="true"
         android:visibility="gone" />
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/encryption_passwordInput"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/src/main/res/layout/share_file_layout.xml
+++ b/src/main/res/layout/share_file_layout.xml
@@ -122,7 +122,7 @@
                 android:text="@string/share_no_users"
                 android:textSize="@dimen/share_file_layout_text_size"/>
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/addUserButton"
                 style="@style/ownCloud.Button"
                 android:layout_width="match_parent"
@@ -333,7 +333,7 @@
 
                 </RelativeLayout>
 
-                <androidx.appcompat.widget.AppCompatButton
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/shareViaLinkGetLinkButton"
                     style="@style/ownCloud.Button"
                     android:layout_width="match_parent"

--- a/src/main/res/layout/share_file_layout.xml
+++ b/src/main/res/layout/share_file_layout.xml
@@ -15,10 +15,10 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ScrollView
-    android:id="@+id/shareScroll"
+<ScrollView android:id="@+id/shareScroll"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.owncloud.android.ui.fragment.ShareFileFragment">
@@ -130,7 +130,8 @@
                 android:layout_gravity="center_horizontal"
                 android:contentDescription="@string/share_add_user_or_group"
                 android:text="@string/share_add_user_or_group"
-                android:theme="@style/Button.Primary"/>
+                android:theme="@style/Button.Primary"
+                app:cornerRadius="@dimen/button_corner_radius" />
 
         </LinearLayout>
 
@@ -341,7 +342,8 @@
                     android:layout_gravity="center_horizontal"
                     android:contentDescription="@string/share_get_public_link_button"
                     android:text="@string/share_get_public_link_button"
-                    android:theme="@style/Button.Primary"/>
+                    android:theme="@style/Button.Primary"
+                    app:cornerRadius="@dimen/button_corner_radius" />
 
             </LinearLayout>
 

--- a/src/main/res/layout/share_file_layout.xml
+++ b/src/main/res/layout/share_file_layout.xml
@@ -124,7 +124,6 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/addUserButton"
-                style="@style/ownCloud.Button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -336,7 +335,6 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/shareViaLinkGetLinkButton"
-                    style="@style/ownCloud.Button"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"

--- a/src/main/res/layout/sorting_order_fragment.xml
+++ b/src/main/res/layout/sorting_order_fragment.xml
@@ -290,7 +290,7 @@
         android:layout_height="wrap_content"
         android:gravity="end">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/cancel"
             style="@style/Button.Borderless"
             android:layout_width="wrap_content"

--- a/src/main/res/layout/ssl_untrusted_cert_layout.xml
+++ b/src/main/res/layout/ssl_untrusted_cert_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
     ownCloud Android client application
 
     Copyright (C) 2015 ownCloud Inc.
@@ -49,7 +50,7 @@
 		 />
 
 
-    <TextView
+	<TextView
 		android:id="@+id/reason_cert_expired"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
@@ -108,14 +109,14 @@
         android:layout_weight="1"
         >
 
-        <LinearLayout
+		<LinearLayout
 			android:id="@+id/details_view"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:gravity="start"
 			android:orientation="vertical" >
 
-            <TextView
+		    <TextView
 				android:id="@+id/null_cert"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
@@ -136,7 +137,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -144,7 +145,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -153,7 +154,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -161,7 +162,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -170,7 +171,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -178,7 +179,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -187,7 +188,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -195,7 +196,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -212,7 +213,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_C"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -221,7 +222,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -229,7 +230,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -239,7 +240,7 @@
 				/>
 
 
-            <TextView
+				<TextView
         			android:id="@+id/label_issuer"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -248,7 +249,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -256,7 +257,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -265,7 +266,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -273,7 +274,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -282,7 +283,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -290,7 +291,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -299,7 +300,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -307,7 +308,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -324,7 +325,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_C"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -333,7 +334,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -341,7 +342,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -350,7 +351,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
         			android:id="@+id/label_validity"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -359,7 +360,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_validity_from"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -367,7 +368,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_validity_from"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -376,7 +377,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_validity_to"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -384,7 +385,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_validity_to"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -402,7 +403,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
         			android:id="@+id/label_signature_algorithm"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -410,7 +411,7 @@
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
 
-            <TextView
+				<TextView
         			android:id="@+id/value_signature_algorithm"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -437,11 +438,11 @@
 					android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-        </LinearLayout>
+		</LinearLayout>
 
     </ScrollView>
 
-    <TextView
+	<TextView
         android:id="@+id/question"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -457,7 +458,7 @@
         android:layout_height="wrap_content"
         android:gravity="center" >
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/cancel"
 			style="@style/Button.Borderless"
             android:layout_width="@dimen/zero"
@@ -465,7 +466,7 @@
             android:layout_weight="1"
             android:text="@string/common_no" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/details_btn"
 			style="@style/Button.Borderless"
             android:layout_width="@dimen/zero"
@@ -473,7 +474,7 @@
             android:layout_weight="2"
             android:text="@string/ssl_validator_btn_details_see" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/ok"
 			style="@style/Button.Borderless"
             android:layout_width="@dimen/zero"

--- a/src/main/res/layout/ssl_validator_layout.xml
+++ b/src/main/res/layout/ssl_validator_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
     ownCloud Android client application
 
     Copyright (C) 2015 ownCloud Inc.
@@ -92,14 +93,14 @@
         android:layout_width="wrap_content"
         android:layout_height="@dimen/scroll_view_height">
 
-        <LinearLayout
+		<LinearLayout
 			android:id="@+id/details_view"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:gravity="start"
 			android:orientation="vertical" >
 
-            <TextView
+				<TextView
         			android:id="@+id/label_subject"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -108,7 +109,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -116,7 +117,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -125,7 +126,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -133,7 +134,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -142,7 +143,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -150,7 +151,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -159,7 +160,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -167,7 +168,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -184,7 +185,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_C"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -193,7 +194,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_subject_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -201,7 +202,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_subject_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -211,7 +212,7 @@
 				/>
 
 
-            <TextView
+				<TextView
         			android:id="@+id/label_issuer"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -220,7 +221,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -228,7 +229,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_CN"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -237,7 +238,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -245,7 +246,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_O"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -254,7 +255,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -262,7 +263,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_OU"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -271,7 +272,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -279,7 +280,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_ST"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -296,7 +297,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_C"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -305,7 +306,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_issuer_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -313,7 +314,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_issuer_L"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -322,7 +323,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
         			android:id="@+id/label_validity"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -331,7 +332,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_validity_from"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -339,7 +340,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_validity_from"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -348,7 +349,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/label_validity_to"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -356,7 +357,7 @@
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
 
-            <TextView
+				<TextView
 				    android:id="@+id/value_validity_to"
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
@@ -366,7 +367,7 @@
 				/>
 
 
-            <TextView
+				<TextView
         			android:id="@+id/label_signature"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -375,7 +376,7 @@
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
 
-            <TextView
+				<TextView
         			android:id="@+id/label_signature_algorithm"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -383,7 +384,7 @@
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
 
-            <TextView
+								<TextView
         			android:id="@+id/value_signature_algorithm"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -393,7 +394,7 @@
         		/>
 
 
-            <TextView
+				<TextView
         			android:id="@+id/value_signature"
         			android:layout_width="wrap_content"
         			android:layout_height="wrap_content"
@@ -402,11 +403,11 @@
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
 
-        </LinearLayout>
+		</LinearLayout>
 
     </ScrollView>
 
-    <TextView
+	<TextView
         android:id="@+id/question"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -421,7 +422,7 @@
         android:layout_height="wrap_content"
         android:gravity="center" >
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/cancel"
 			style="@style/Button.Borderless"
             android:layout_width="@dimen/zero"
@@ -429,7 +430,7 @@
             android:layout_weight="1"
             android:text="@string/common_no" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/details_btn"
 			style="@style/Button.Borderless"
             android:layout_width="@dimen/zero"
@@ -437,7 +438,7 @@
             android:layout_weight="2"
             android:text="@string/ssl_validator_btn_details_see" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/ok"
 			style="@style/Button.Borderless"
             android:layout_width="@dimen/zero"

--- a/src/main/res/layout/sso_dialog.xml
+++ b/src/main/res/layout/sso_dialog.xml
@@ -18,7 +18,6 @@
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
-    
+    android:layout_height="match_parent">
+
 </RelativeLayout>

--- a/src/main/res/layout/synced_folders_settings_layout.xml
+++ b/src/main/res/layout/synced_folders_settings_layout.xml
@@ -420,7 +420,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/delete"
             style="@style/Button.Borderless.Destructive"
             android:layout_width="wrap_content"
@@ -435,14 +435,14 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true">
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/cancel"
                 style="@style/Button.Borderless"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/common_cancel"/>
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/save"
                 style="@style/Button.Borderless"
                 android:layout_width="wrap_content"

--- a/src/main/res/layout/upload_file_dialog.xml
+++ b/src/main/res/layout/upload_file_dialog.xml
@@ -33,7 +33,7 @@
         android:text="@string/upload_file_dialog_filename"
         tools:text="@string/upload_file_dialog_filename"/>
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/user_input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/src/main/res/layout/upload_files_layout.xml
+++ b/src/main/res/layout/upload_files_layout.xml
@@ -87,7 +87,7 @@
             android:layout_weight="1"
             android:text="@string/common_cancel"
             android:theme="@style/OutlinedButton"
-            app:cornerRadius="120dp" />
+            app:cornerRadius="@dimen/button_corner_radius" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/upload_files_btn_upload"
@@ -96,7 +96,7 @@
             android:layout_weight="1"
             android:text="@string/uploader_btn_upload_text"
             android:theme="@style/Button.Primary"
-            app:cornerRadius="120dp" />
+            app:cornerRadius="@dimen/button_corner_radius" />
 
 	</LinearLayout>
 

--- a/src/main/res/layout/upload_files_layout.xml
+++ b/src/main/res/layout/upload_files_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ownCloud Android client application
 
   Copyright (C) 2015 ownCloud Inc.
@@ -76,7 +77,7 @@
         android:orientation="horizontal"
         android:padding="@dimen/standard_padding">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/upload_files_btn_cancel"
             android:theme="@style/Button"
             android:layout_width="wrap_content"
@@ -86,7 +87,7 @@
             android:layout_marginRight="@dimen/standard_half_margin"
             android:layout_marginEnd="@dimen/standard_half_margin"/>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
 		    android:id="@+id/upload_files_btn_upload"
             android:theme="@style/Button.Primary"
 		    android:layout_width="wrap_content"
@@ -94,6 +95,6 @@
 		    android:layout_weight="1"
 		    android:text="@string/uploader_btn_upload_text" />
 
-    </LinearLayout>
+	</LinearLayout>
 
 </LinearLayout>

--- a/src/main/res/layout/upload_files_layout.xml
+++ b/src/main/res/layout/upload_files_layout.xml
@@ -79,7 +79,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/upload_files_btn_cancel"
-            android:theme="@style/Button"
+            android:theme="@style/OutlinedButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"

--- a/src/main/res/layout/upload_files_layout.xml
+++ b/src/main/res/layout/upload_files_layout.xml
@@ -17,10 +17,11 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/upload_files_layout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <include
         layout="@layout/toolbar_standard" />
@@ -79,21 +80,23 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/upload_files_btn_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/standard_half_margin"
+            android:layout_marginRight="@dimen/standard_half_margin"
+            android:layout_weight="1"
+            android:text="@string/common_cancel"
             android:theme="@style/OutlinedButton"
+            app:cornerRadius="120dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/upload_files_btn_upload"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/common_cancel"
-            android:layout_marginRight="@dimen/standard_half_margin"
-            android:layout_marginEnd="@dimen/standard_half_margin"/>
-
-        <com.google.android.material.button.MaterialButton
-		    android:id="@+id/upload_files_btn_upload"
+            android:text="@string/uploader_btn_upload_text"
             android:theme="@style/Button.Primary"
-		    android:layout_width="wrap_content"
-		    android:layout_height="wrap_content"
-		    android:layout_weight="1"
-		    android:text="@string/uploader_btn_upload_text" />
+            app:cornerRadius="120dp" />
 
 	</LinearLayout>
 

--- a/src/main/res/layout/uploader_layout.xml
+++ b/src/main/res/layout/uploader_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
@@ -61,7 +62,7 @@
         android:orientation="horizontal"
         android:padding="@dimen/standard_padding">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:theme="@style/Button"
             android:id="@+id/uploader_cancel"
             style="@style/ownCloud.Button"
@@ -73,7 +74,7 @@
             android:layout_marginRight="@dimen/standard_half_margin"
             android:layout_marginEnd="@dimen/standard_half_margin"/>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
 		    android:id="@+id/uploader_choose_folder"
 			android:theme="@style/Button.Primary"
 		    android:layout_width="fill_parent"

--- a/src/main/res/layout/uploader_layout.xml
+++ b/src/main/res/layout/uploader_layout.xml
@@ -18,10 +18,11 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/upload_files_layout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <include
         layout="@layout/toolbar_standard" />
@@ -63,16 +64,16 @@
         android:padding="@dimen/standard_padding">
 
         <com.google.android.material.button.MaterialButton
-            android:theme="@style/Button"
+            android:theme="@style/OutlinedButton"
             android:id="@+id/uploader_cancel"
-            style="@style/ownCloud.Button"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:layout_weight="1"
             android:text="@string/common_cancel"
             android:layout_marginRight="@dimen/standard_half_margin"
-            android:layout_marginEnd="@dimen/standard_half_margin"/>
+            android:layout_marginEnd="@dimen/standard_half_margin"
+            app:cornerRadius="@dimen/button_corner_radius" />
 
         <com.google.android.material.button.MaterialButton
 		    android:id="@+id/uploader_choose_folder"
@@ -81,7 +82,8 @@
 		    android:layout_height="wrap_content"
 		    android:layout_gravity="bottom"
 		    android:layout_weight="1"
-		    android:text="@string/uploader_btn_upload_text" />
+		    android:text="@string/uploader_btn_upload_text"
+            app:cornerRadius="@dimen/button_corner_radius" />
 
 	</LinearLayout>
 </LinearLayout>

--- a/src/main/res/layout/whats_new_activity.xml
+++ b/src/main/res/layout/whats_new_activity.xml
@@ -54,7 +54,7 @@
         android:orientation="horizontal"
         android:weightSum="3">
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/skip"
             style="@style/Button.Borderless.Login"
             android:layout_width="0dp"

--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -140,5 +140,6 @@
     <dimen name="bottom_sheet_text_size">16sp</dimen>
     <dimen name="permission_dialog_text_size">18sp</dimen>
     <dimen name="permission_dialog_text_padding">56dp</dimen>
+    <dimen name="button_corner_radius">120dp</dimen>
     <integer name="media_grid_width">4</integer>
 </resources>

--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -140,6 +140,6 @@
     <dimen name="bottom_sheet_text_size">16sp</dimen>
     <dimen name="permission_dialog_text_size">18sp</dimen>
     <dimen name="permission_dialog_text_padding">56dp</dimen>
-    <dimen name="button_corner_radius">120dp</dimen>
+    <dimen name="button_corner_radius">24dp</dimen>
     <integer name="media_grid_width">4</integer>
 </resources>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -132,6 +132,7 @@
 
 	<style name="Button.Login" parent="Button">
 		<item name="colorButtonNormal">@color/white</item>
+        <item name="colorAccent">@color/white</item>
 		<item name="android:textColor">@color/primary_dark</item>
 	</style>
 

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
 -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 	<!-- General ownCloud app style -->
-	<style name="Theme.ownCloud" parent="Theme.AppCompat.Light.DarkActionBar">
+	<style name="Theme.ownCloud" parent="Theme.MaterialComponents.Light.DarkActionBar">
     	<item name="android:actionBarStyle">@style/Theme.ownCloud.Widget.ActionBar</item>
     	<item name="actionBarStyle">@style/Theme.ownCloud.Widget.ActionBar</item>
 		<item name="actionModeBackground">@color/action_mode_background</item>
@@ -34,19 +34,19 @@
         <item name="fontFamily">@font/nunito_regular</item>
 	</style>
 
-	<style name="FallbackThemingTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+	<style name="FallbackThemingTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>
 	</style>
 
-	<style name="FallbackDatePickerDialogTheme" parent="Theme.AppCompat.Light.Dialog">
+	<style name="FallbackDatePickerDialogTheme" parent="Theme.MaterialComponents.Light.Dialog">
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>
 	</style>
 
-	<style name="FallbackTheming.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
+	<style name="FallbackTheming.Dialog" parent="Theme.MaterialComponents.Light.Dialog.Alert">
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>
@@ -56,7 +56,7 @@
 	</style>
 
 	<!-- seperate action bar style for activities without an action bar -->
-	<style name="Theme.ownCloud.Toolbar" parent="Theme.AppCompat.Light.NoActionBar">
+	<style name="Theme.ownCloud.Toolbar" parent="Theme.MaterialComponents.Light.NoActionBar">
 		<item name="windowNoTitle">true</item>
 		<item name="windowActionBar">false</item>
 		<item name="colorPrimary">@color/primary</item>
@@ -82,13 +82,13 @@
 		<item name="android:textColorHint">@color/login_text_hint_color</item>
 	</style>
 
-	<style name="ownCloud.AlertDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
+	<style name="ownCloud.AlertDialog" parent="Theme.MaterialComponents.Light.Dialog.Alert">
 		<item name="colorAccent">@color/color_accent</item>
 		<item name="android:textColorPrimary">@color/primary</item>
 		<item name="searchViewStyle">@style/ownCloud.SearchView</item>
 	</style>
 
-	<style name="ownCloud.Dialog" parent="Theme.AppCompat.Light.Dialog">
+	<style name="ownCloud.Dialog" parent="Theme.MaterialComponents.Light.Dialog">
 		<item name="colorAccent">@color/color_accent</item>
 		<item name="searchViewStyle">@style/ownCloud.SearchView</item>
 	</style>
@@ -110,11 +110,11 @@
 		<!--<item name="suggestionRowLayout">...</item>-->
 	</style>
 
-	<style name="ownCloud.Button" parent="Widget.AppCompat.Button">
+	<style name="ownCloud.Button" parent="Widget.MaterialComponents.Button">
 		<item name="colorButtonNormal">@color/primary</item>
 	</style>
 
-	<style name="Button" parent="Base.Widget.AppCompat.Button">
+	<style name="Button" parent="Widget.MaterialComponents.Button">
 		<item name="colorButtonNormal">@color/secondary_button_background_color</item>
 		<item name="android:textColor">@color/secondary_button_text_color</item>
 	</style>
@@ -130,15 +130,15 @@
 		<item name="android:textColor">@color/primary_dark</item>
 	</style>
 
-	<style name="Button.Borderless" parent="Base.Widget.AppCompat.Button.Borderless">
+	<style name="Button.Borderless" parent="Widget.MaterialComponents.Button.TextButton">
 		<item name="android:textColor">@drawable/borderless_btn</item>
 	</style>
 
-	<style name="Button.Borderless.Destructive" parent="Base.Widget.AppCompat.Button.Borderless">
+	<style name="Button.Borderless.Destructive" parent="Widget.MaterialComponents.Button.TextButton">
 		<item name="android:textColor">@color/highlight_textColor_Warning</item>
 	</style>
 
-	<style name="Button.Borderless.Login" parent="Base.Widget.AppCompat.Button.Borderless">
+	<style name="Button.Borderless.Login" parent="Widget.MaterialComponents.Button.TextButton">
 		<item name="android:textColor">@color/white</item>
 	</style>
 
@@ -153,7 +153,7 @@
 	</style>
 
 	<!-- ACTION BAR STYLES -->
-	<style name="Theme.ownCloud.Overlay.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
+	<style name="Theme.ownCloud.Overlay.ActionBar" parent="@style/Widget.MaterialComponents.Toolbar">
 		<item name="android:background">@color/color_transparent</item>
 		<item name="android:windowActionBarOverlay">true</item>
 		<!-- Support library compatibility -->
@@ -173,14 +173,14 @@
 		<item name="android:indeterminateDrawable">@drawable/actionbar_progress_indeterminate_horizontal</item>
 	</style>
 
-	<style name="Theme.ownCloud.Fullscreen" parent="@style/Theme.AppCompat">
+	<style name="Theme.ownCloud.Fullscreen" parent="@style/Theme.MaterialComponents">
         <item name="android:windowFullscreen">true</item>
 		<item name="colorAccent">@color/color_accent</item>
     </style>
 
 
-    <style name="Theme.ownCloud.Widget.ActionBar"
-		parent="@style/Widget.AppCompat.Light.ActionBar.Solid.Inverse">
+	<style name="Theme.ownCloud.Widget.ActionBar"
+		parent="@style/Theme.MaterialComponents.Light.DarkActionBar">
 		<item name="android:background">@color/primary</item>
 		<item name="background">@color/primary</item>
     	<item name="android:textColor">#ffffff</item>
@@ -191,7 +191,7 @@
 	</style>
 
 	<!-- Dialogs -->
-	<style name="Theme.ownCloud.Dialog" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
+	<style name="Theme.ownCloud.Dialog" parent="@style/Theme.MaterialComponents.Light.Dialog.Alert">
 		<item name="windowNoTitle">false</item>
 		<item name="colorAccent">@color/color_accent</item>
 		<item name="buttonBarButtonStyle">@style/Theme.ownCloud.Dialog.ButtonBar.Button</item>
@@ -203,7 +203,7 @@
 		<item name="colorAccent">@color/color_accent</item>
 	</style>
 
-	<style name="Theme.ownCloud.Dialog.NoButtonBarStyle" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
+	<style name="Theme.ownCloud.Dialog.NoButtonBarStyle" parent="@style/Theme.MaterialComponents.Light.Dialog.Alert">
 		<item name="windowNoTitle">false</item>
 		<item name="colorAccent">@color/color_accent</item>
 	</style>
@@ -226,7 +226,7 @@
 		<item name="android:minHeight">@null</item>
 	</style>
 
-	<style name="Theme.ownCloud.Dialog.ButtonBar.Button" parent="@style/Widget.AppCompat.Button.Borderless.Colored">
+	<style name="Theme.ownCloud.Dialog.ButtonBar.Button" parent="@style/Widget.MaterialComponents.Button.TextButton">
 		<!-- Setting the weight as follows should result in equally wide buttons filling the alert dialog width,
             but instead they span further out of the dialog, breaking in multiple lines though -->
 		<item name="android:layout_width">0dp</item>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -265,10 +265,8 @@
 	<style name="NextcloudTextAppearanceMedium" parent="@style/TextAppearance.AppCompat.Medium">
 	</style>
 
-	<style name="EditText" parent="Theme.AppCompat.Light">
-		<item name="colorControlActivated">@color/login_text_color</item>
-		<item name="colorControlNormal">@color/login_text_color</item>
-		<item name="android:textColorHint">@color/login_text_color</item>
+	<style name="TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
 	</style>
 
 	<style name="AppTabTextAppearance" parent="@style/TextAppearance.Design.Tab">

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -110,11 +110,11 @@
 		<!--<item name="suggestionRowLayout">...</item>-->
 	</style>
 
-	<style name="ownCloud.Button" parent="Widget.MaterialComponents.Button">
+	<style name="ownCloud.Button" parent="Widget.MaterialComponents.Button.UnelevatedButton">
 		<item name="colorButtonNormal">@color/primary</item>
 	</style>
 
-	<style name="Button" parent="Widget.MaterialComponents.Button">
+	<style name="Button" parent="Widget.MaterialComponents.Button.UnelevatedButton">
 		<item name="colorButtonNormal">@color/secondary_button_background_color</item>
 		<item name="android:textColor">@color/secondary_button_text_color</item>
 	</style>
@@ -171,7 +171,6 @@
 		<item name="android:windowBackground">@drawable/launch_screen</item>
 	</style>
 
-
 	<!-- Progress bar -->
 	<style name="Widget.ownCloud.TopProgressBar" parent="@style/Widget.AppCompat.ProgressBar.Horizontal">
 		<item name="android:progressDrawable">@drawable/actionbar_progress_horizontal</item>
@@ -182,7 +181,6 @@
         <item name="android:windowFullscreen">true</item>
 		<item name="colorAccent">@color/color_accent</item>
     </style>
-
 
 	<style name="Theme.ownCloud.Widget.ActionBar"
 		parent="@style/Theme.MaterialComponents.Light.DarkActionBar.Bridge">
@@ -251,7 +249,6 @@
 		<item name="android:maxLength">1</item>
 		<item name="android:password">true</item>
 		<item name="android:maxLines">1</item>
-
     </style>
 
     <style name="Theme.ownCloud.NoActionBar">

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
 -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 	<!-- General ownCloud app style -->
-	<style name="Theme.ownCloud" parent="Theme.MaterialComponents.Light.DarkActionBar">
+	<style name="Theme.ownCloud" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
     	<item name="android:actionBarStyle">@style/Theme.ownCloud.Widget.ActionBar</item>
     	<item name="actionBarStyle">@style/Theme.ownCloud.Widget.ActionBar</item>
 		<item name="actionModeBackground">@color/action_mode_background</item>
@@ -34,7 +34,7 @@
         <item name="fontFamily">@font/nunito_regular</item>
 	</style>
 
-	<style name="FallbackThemingTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
+	<style name="FallbackThemingTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>
@@ -56,7 +56,7 @@
 	</style>
 
 	<!-- seperate action bar style for activities without an action bar -->
-	<style name="Theme.ownCloud.Toolbar" parent="Theme.MaterialComponents.Light.NoActionBar">
+	<style name="Theme.ownCloud.Toolbar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
 		<item name="windowNoTitle">true</item>
 		<item name="windowActionBar">false</item>
 		<item name="colorPrimary">@color/primary</item>
@@ -119,6 +119,11 @@
 		<item name="android:textColor">@color/secondary_button_text_color</item>
 	</style>
 
+    <style name="OutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="colorAccent">@color/transparent</item>
+        <item name="android:textColor">@color/primary_dark</item>
+    </style>
+
 	<style name="Button.Primary" parent="Button">
 		<item name="colorButtonNormal">@color/primary_button_background_color</item>
 		<item name="android:textColor">@color/primary_button_text_color</item>
@@ -180,7 +185,7 @@
 
 
 	<style name="Theme.ownCloud.Widget.ActionBar"
-		parent="@style/Theme.MaterialComponents.Light.DarkActionBar">
+		parent="@style/Theme.MaterialComponents.Light.DarkActionBar.Bridge">
 		<item name="android:background">@color/primary</item>
 		<item name="background">@color/primary</item>
     	<item name="android:textColor">#ffffff</item>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -134,6 +134,14 @@
         <item name="fontFamily">@font/nunito_bold</item>
     </style>
 
+    <style name="OutlineLogindButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="colorAccent">@color/transparent</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="fontFamily">@font/nunito_bold</item>
+        <item name="strokeColor">@color/white</item>
+    </style>
+
 	<style name="Button.Primary" parent="Button">
 		<item name="colorButtonNormal">@color/primary_button_background_color</item>
 		<item name="android:textColor">@color/primary_button_text_color</item>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -38,12 +38,14 @@
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>
+        <item name="android:textAllCaps">false</item>
 	</style>
 
 	<style name="FallbackDatePickerDialogTheme" parent="Theme.MaterialComponents.Light.Dialog">
 		<item name="colorPrimary">#424242</item>
 		<item name="colorPrimaryDark">#212121</item>
 		<item name="colorAccent">#757575</item>
+        <item name="android:textAllCaps">false</item>
 	</style>
 
 	<style name="FallbackTheming.Dialog" parent="Theme.MaterialComponents.Light.Dialog.Alert">
@@ -86,12 +88,20 @@
 		<item name="colorAccent">@color/color_accent</item>
 		<item name="android:textColorPrimary">@color/primary</item>
 		<item name="searchViewStyle">@style/ownCloud.SearchView</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:buttonStyle">@style/nextcloudButtonStyle</item>
 	</style>
 
 	<style name="ownCloud.Dialog" parent="Theme.MaterialComponents.Light.Dialog">
 		<item name="colorAccent">@color/color_accent</item>
 		<item name="searchViewStyle">@style/ownCloud.SearchView</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:buttonStyle">@style/nextcloudButtonStyle</item>
 	</style>
+
+    <style name="nextcloudButtonStyle" parent="Widget.MaterialComponents.Button">
+        <item name="fontFamily">@font/nunito_bold</item>
+    </style>
 
 	<style name="ProgressDialogTheme" parent="ownCloud.Dialog">
 		<item name="colorAccent">@color/color_accent</item>
@@ -110,24 +120,23 @@
 		<!--<item name="suggestionRowLayout">...</item>-->
 	</style>
 
-	<style name="ownCloud.Button" parent="Widget.MaterialComponents.Button.UnelevatedButton">
-		<item name="colorButtonNormal">@color/primary</item>
-	</style>
-
 	<style name="Button" parent="Widget.MaterialComponents.Button.UnelevatedButton">
 		<item name="colorButtonNormal">@color/secondary_button_background_color</item>
 		<item name="android:textColor">@color/secondary_button_text_color</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="fontFamily">@font/nunito_bold</item>
 	</style>
 
     <style name="OutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="colorAccent">@color/transparent</item>
         <item name="android:textColor">@color/primary_dark</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="fontFamily">@font/nunito_bold</item>
     </style>
 
 	<style name="Button.Primary" parent="Button">
 		<item name="colorButtonNormal">@color/primary_button_background_color</item>
 		<item name="android:textColor">@color/primary_button_text_color</item>
-        <item name="fontFamily">@font/nunito_bold</item>
 	</style>
 
 	<style name="Button.Login" parent="Button">
@@ -138,14 +147,20 @@
 
 	<style name="Button.Borderless" parent="Widget.MaterialComponents.Button.TextButton">
 		<item name="android:textColor">@drawable/borderless_btn</item>
+        <item name="fontFamily">@font/nunito_bold</item>
+        <item name="android:textAllCaps">false</item>
 	</style>
 
 	<style name="Button.Borderless.Destructive" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="fontFamily">@font/nunito_bold</item>
 		<item name="android:textColor">@color/highlight_textColor_Warning</item>
+        <item name="android:textAllCaps">false</item>
 	</style>
 
 	<style name="Button.Borderless.Login" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="fontFamily">@font/nunito_bold</item>
 		<item name="android:textColor">@color/white</item>
+        <item name="android:textAllCaps">false</item>
 	</style>
 
 	<!-- separat translucent action bar style -->
@@ -237,6 +252,7 @@
 		<item name="android:layout_weight">1</item>
 		<!-- setting a fixed width as follows results in narrow buttons with line breaks, but of course this is not a solution -->
 		<!-- <item name="android:width">100dp</item> -->
+        <item name="android:textAllCaps">false</item>
 	</style>
 
     <style name="PassCodeStyle">


### PR DESCRIPTION
Move to new Android X implementation and thus upgrade to latest material design theming.

**DONE**
* [x] Use sentence case for button labels
* [x] Use primary color for status bar too (instead of primary dark color), like refresh Google apps do too
* [x] replace accent color with primary color
* [x] use new outlined style for secondary buttons and for textfields, use pill style buttons. 

**Screenshot on Android 9**
![device-2018-12-28-152236](https://user-images.githubusercontent.com/1315170/50518157-88619b80-0ab4-11e9-808f-8b9a2617b31a.png)

![device-2018-12-28-152357](https://user-images.githubusercontent.com/1315170/50518175-9c0d0200-0ab4-11e9-818c-eb99e758c097.png)
