### PR TITLE
disable lint warning on not secure RNG on < 4.3

### DIFF
--- a/src/main/java/com/owncloud/android/utils/DataHolderUtil.java
+++ b/src/main/java/com/owncloud/android/utils/DataHolderUtil.java
@@ -19,6 +19,8 @@
  */
 package com.owncloud.android.utils;
 
+import android.annotation.SuppressLint;
+
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.security.SecureRandom;
@@ -34,6 +36,7 @@ public class DataHolderUtil {
 
     private static DataHolderUtil instance;
 
+    @SuppressLint("TrulyRandom")
     private SecureRandom random = new SecureRandom();
 
     public static synchronized DataHolderUtil getInstance() {


### PR DESCRIPTION
> Key generation, signing, encryption, and random number generation may not receive cryptographically strong values due to improper initialization of the underlying PRNG on Android 4.3 and below.

The RNG in question is used to generate a random number for inter-app communication and thus it is not needed to that strong, but only needs to be random.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>