### PR TITLE
use 90 as first stable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 def versionMajor = 3
 def versionMinor = 4
 def versionPatch = 0
-def versionBuild = 0 // 0-50=Alpha / 51-98=RC / 99=stable
+def versionBuild = 0 // 0-50=Alpha / 51-98=RC / 90-99=stable
 
 def taskRequest = getGradle().getStartParameter().getTaskRequests().toString()
 if (taskRequest.contains("Gplay") || taskRequest.contains("findbugs") || taskRequest.contains("lint")) {
@@ -93,7 +93,7 @@ android {
 
         versionCode versionMajor * 10000000 + versionMinor * 10000 + versionPatch * 100 + versionBuild
 
-        if (versionBuild > 98) {
+        if (versionBuild > 89) {
             versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         } else if (versionBuild > 50) {
             versionName "${versionMajor}.${versionMinor}.${versionPatch} RC" + (versionBuild - 50)


### PR DESCRIPTION
With next stable release, build version should be starting with 90 for stable.
This is not needed in a normal release cycle, but could be needed for an emergency release, like when a changelog is missing, or if a branded version needs to be rebuild and thus needs to have a new version code.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>