### PR TITLE
Sets the cursor colour on the passcode screen to grey.

### DIFF
--- a/src/main/res/layout/passcodelock.xml
+++ b/src/main/res/layout/passcodelock.xml
@@ -56,7 +56,8 @@
             android:cursorVisible="true"
             android:imeOptions="flagNoExtractUi"
             android:importantForAutofill="no"
-            android:hint="@string/hidden_character">
+            android:hint="@string/hidden_character"
+            android:textCursorDrawable="@null">
             <requestFocus/>
         </EditText>
 
@@ -66,7 +67,8 @@
             android:cursorVisible="true"
             android:imeOptions="flagNoExtractUi"
             android:importantForAutofill="no"
-            android:hint="@string/hidden_character"/>
+            android:hint="@string/hidden_character"
+            android:textCursorDrawable="@null" />
 
         <EditText
             android:id="@+id/txt2"
@@ -74,7 +76,8 @@
             android:cursorVisible="true"
             android:imeOptions="flagNoExtractUi"
             android:importantForAutofill="no"
-            android:hint="@string/hidden_character"/>
+            android:hint="@string/hidden_character"
+            android:textCursorDrawable="@null" />
 
         <EditText
             android:id="@+id/txt3"
@@ -82,7 +85,8 @@
             android:cursorVisible="true"
             android:imeOptions="flagNoExtractUi"
             android:importantForAutofill="no"
-            android:hint="@string/hidden_character"/>
+            android:hint="@string/hidden_character"
+            android:textCursorDrawable="@null" />
     </LinearLayout>
 
     <android.support.v7.widget.AppCompatButton


### PR DESCRIPTION
Before this change, if the user has a custom colour set on their
nextcloud server, the cursor would be blue regardless of the custom
theme colour.

Before the change:
![screenshot_20181201_123203](https://user-images.githubusercontent.com/1926270/49328261-4e5cb280-f565-11e8-8f8a-7a07e0827ae6.png)

After:
![screenshot_20181201_123241](https://user-images.githubusercontent.com/1926270/49328263-5288d000-f565-11e8-9d74-acc0c8d5ac0b.png)

