### PR TITLE
ignore warning about reading file

### DIFF
--- a/findbugs-filter.xml
+++ b/findbugs-filter.xml
@@ -8,4 +8,5 @@
     <Match>
         <Class name="~.*\.R\$.*"/>
     </Match>
+    <Bug pattern="PATH_TRAVERSAL_IN" />
 </FindBugsFilter>


### PR DESCRIPTION
https://find-sec-bugs.github.io/bugs.htm#PATH_TRAVERSAL_IN

we have this warning in nearly every case, e.g:
https://github.com/nextcloud/android/blob/59cf6b9ba4965f38f2749f0624013daf0b83c946/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java#L534-L536

This is not a user input field, but OCFile, which cannot changed by the user.

So let us disable this.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>