### PR TITLE
Match branch name

### DIFF
--- a/scripts/analysis/getBranchName.sh
+++ b/scripts/analysis/getBranchName.sh
@@ -5,5 +5,5 @@
 if [ -z $3 ] ; then
     echo "master";
 else
-    curl 2>/dev/null -u $1:$2 https://api.github.com/repos/nextcloud/android/pulls/$3 | grep \"ref\": | grep -v stable-3.4.x | cut -d"\"" -f4
+    curl 2>/dev/null -u $1:$2 https://api.github.com/repos/nextcloud/android/pulls/$3 | grep \"ref\": | grep -v '"stable-3.4.x"' | cut -d"\"" -f4
 fi


### PR DESCRIPTION
Otherwise drone is not working on branches created by backport bot, as it contains base branch and thus grep is too greedy.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>