### PR TITLE
Use own fork with backported android 9 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ dependencies {
     implementation 'com.github.albfernandez:juniversalchardet:2.0.0' // need this version for Android <7
     implementation 'com.google.code.findbugs:annotations:2.0.1'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'com.github.evernote:android-job:v1.2.5'
+    implementation 'com.github.tobiaskaminsky:android-job:v1.2.6.1' // 'com.github.evernote:android-job:v1.2.5'
     implementation 'com.jakewharton:butterknife:9.0.0-rc2'
     annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-rc2'
     implementation 'org.greenrobot:eventbus:3.1.1'


### PR DESCRIPTION
This should fix #3317, I forked v1.2.6 and applied the fix manually.

I tested it on 
- android 9 emulator with google api
	- generic version
	- gplay version
- android 9 emulator without google api
	- generic version
	- gplay version

Once 1.3.0 is out we can bump.
We have to occasionally check this as DependAbot will not notice it.
 
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>