### PR TITLE
Base for updated documents provider

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -178,7 +178,40 @@
             android:enabled="true"
             android:exported="true"
             android:label="@string/sync_string_files"
-            android:syncable="true" />
+            android:syncable="true">
+            <path-permission
+                android:pathPrefix="/shares"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/capabilities"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/uploads"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/synced_folders"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/external_links"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/arbitrary_data"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/virtual"
+                android:readPermission="false"
+                android:writePermission="false" />
+            <path-permission
+                android:pathPrefix="/filesystem"
+                android:readPermission="false"
+                android:writePermission="false" />
+        </provider>
 
         <provider
             android:name=".providers.UsersAndGroupsSearchProvider"

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -76,9 +76,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         SharedPreferences appPrefs = PreferenceManager.getDefaultSharedPreferences(MainApp.getAppContext());
         if (appPrefs.getString(Preferences.PREFERENCE_LOCK, "").equals(Preferences.LOCK_PASSCODE) ||
                 appPrefs.getString(Preferences.PREFERENCE_LOCK, "").equals(Preferences.LOCK_DEVICE_CREDENTIALS)) {
-            return new FileCursor(new String[]{});
+            return new FileCursor();
         }
-        
+
         initiateStorageMap();
 
         final RootCursor result = new RootCursor(projection);
@@ -91,7 +91,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     @Override
-    public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
+    public Cursor queryDocument(String documentId, String[] projection) {
         final long docId = Long.parseLong(documentId);
         updateCurrentStorageManagerIfNeeded(docId);
 
@@ -114,8 +114,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     @Override
-    public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder)
-            throws FileNotFoundException {
+    public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) {
 
         final long folderId = Long.parseLong(parentDocumentId);
         updateCurrentStorageManagerIfNeeded(folderId);
@@ -230,7 +229,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     @Override
-    public Cursor querySearchDocuments(String rootId, String query, String[] projection) throws FileNotFoundException {
+    public Cursor querySearchDocuments(String rootId, String query, String[] projection) {
         updateCurrentStorageManagerIfNeeded(rootId);
 
         OCFile root = mCurrentStorageManager.getFileByPath("/");

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -96,7 +96,7 @@ public class FileContentProvider extends ContentProvider {
 
     @Override
     public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
-        if (isCallerNotAllowed()) {
+        if (isCallerNotAllowed(uri)) {
             return -1;
         }
 
@@ -114,7 +114,7 @@ public class FileContentProvider extends ContentProvider {
     }
 
     private int delete(SQLiteDatabase db, Uri uri, String where, String... whereArgs) {
-        if (isCallerNotAllowed()) {
+        if (isCallerNotAllowed(uri)) {
             return -1;
         }
 
@@ -248,7 +248,7 @@ public class FileContentProvider extends ContentProvider {
 
     @Override
     public Uri insert(@NonNull Uri uri, ContentValues values) {
-        if (isCallerNotAllowed()) {
+        if (isCallerNotAllowed(uri)) {
             return null;
         }
 
@@ -476,7 +476,7 @@ public class FileContentProvider extends ContentProvider {
                 break;
 
             default:
-                if (isCallerNotAllowed()) {
+                if (isCallerNotAllowed(uri)) {
                     return null;
                 }
         }
@@ -643,7 +643,7 @@ public class FileContentProvider extends ContentProvider {
     @Override
     public int update(@NonNull Uri uri, ContentValues values, String selection, String[] selectionArgs) {
 
-        if (isCallerNotAllowed()) {
+        if (isCallerNotAllowed(uri)) {
             return -1;
         }
 
@@ -1023,9 +1023,25 @@ public class FileContentProvider extends ContentProvider {
         }
     }
 
-    private boolean isCallerNotAllowed() {
-        String callingPackage = mContext.getPackageManager().getNameForUid(Binder.getCallingUid());
-        return callingPackage == null || !callingPackage.equals(mContext.getPackageName());
+    private boolean isCallerNotAllowed(Uri uri) {
+        switch (mUriMatcher.match(uri)) {
+            case SHARES:
+            case CAPABILITIES:
+            case UPLOADS:
+            case SYNCED_FOLDERS:
+            case EXTERNAL_LINKS:
+            case ARBITRARY_DATA:
+            case VIRTUAL:
+            case FILESYSTEM:
+                String callingPackage = mContext.getPackageManager().getNameForUid(Binder.getCallingUid());
+                return callingPackage == null || !callingPackage.equals(mContext.getPackageName());
+
+            case ROOT_DIRECTORY:
+            case SINGLE_FILE:
+            case DIRECTORY:
+            default:
+                return false;
+        }
     }
 
     class DataBaseHelper extends SQLiteOpenHelper {


### PR DESCRIPTION
This prevents access to file content provider via AndroidManifest.
But it allows access to /file /dir as this is needed if we want to let the system create folders / change files via our provider.

This is the base for further CRUD operations on provider.
For easier review I will split them all up.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>