### PR TITLE
Documents Provider: allow editing of files, saves back to server

### DIFF
--- a/src/main/java/org/nextcloud/providers/cursors/FileCursor.java
+++ b/src/main/java/org/nextcloud/providers/cursors/FileCursor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *   nextCloud Android client application
  *
  *   @author Bartosz Przybylski
@@ -49,7 +49,7 @@ public class FileCursor extends MatrixCursor {
         final int iconRes = MimeTypeUtil.getFileTypeIconId(file.getMimeType(), file.getFileName());
         final String mimeType = file.isFolder() ? Document.MIME_TYPE_DIR : file.getMimeType();
         final String imagePath = MimeTypeUtil.isImage(file) && file.isDown() ? file.getStoragePath() : null;
-        int flags = imagePath != null ? Document.FLAG_SUPPORTS_THUMBNAIL : 0;
+        int flags = Document.FLAG_SUPPORTS_WRITE | (imagePath != null ? Document.FLAG_SUPPORTS_THUMBNAIL : 0);
 
         if (file.isFolder()) {
             flags = flags | Document.FLAG_DIR_SUPPORTS_CREATE;


### PR DESCRIPTION
Once base is merged, we can set this to master so we get proper codacy/etc.

To test 1:
- install text editor, I tested with: https://play.google.com/store/apps/details?id=com.byteexperts.texteditor
- open text editor and select file 
- edit text file & save
- see that file gets immediately uploaded to server
- verify on server

Test 2:
- open files/documents app
- select text file
- open with text editor
- edit text & save

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>