### PR TITLE
Upload: only allow upload behaviour if writable folders

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -216,6 +216,8 @@ public class UploadFilesActivity extends FileActivity implements
             mCurrentDialog = null;
         }
 
+        checkWritableFolder(mCurrentDir);
+
         Log_OC.d(TAG, "onCreate() end");
     }
 
@@ -351,6 +353,7 @@ public class UploadFilesActivity extends FileActivity implements
             popDirname();
             mFileListFragment.onNavigateUp();
             mCurrentDir = mFileListFragment.getCurrentDirectory();
+            checkWritableFolder(mCurrentDir);
 
             if (mCurrentDir.getParentFile() == null) {
                 ActionBar actionBar = getSupportActionBar();
@@ -393,6 +396,7 @@ public class UploadFilesActivity extends FileActivity implements
         }
         mDirectories.insert(directory.getName(), 0);
         mCurrentDir = directory;
+        checkWritableFolder(mCurrentDir);
     }
 
     /**
@@ -458,6 +462,25 @@ public class UploadFilesActivity extends FileActivity implements
         pushDirname(directory);
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
+    }
+
+    private void checkWritableFolder(File folder) {
+        boolean canWriteIntoFolder = folder.canWrite();
+        mBehaviourSpinner.setEnabled(canWriteIntoFolder);
+
+        TextView textView = findViewById(R.id.upload_files_upload_files_behaviour_text);
+
+        if (canWriteIntoFolder) {
+            textView.setText(getString(R.string.uploader_upload_files_behaviour));
+            int localBehaviour = PreferenceManager.getUploaderBehaviour(this);
+            mBehaviourSpinner.setSelection(localBehaviour);
+        } else {
+            mBehaviourSpinner.setSelection(1);
+            textView.setText(new StringBuilder().append(getString(R.string.uploader_upload_files_behaviour))
+                                 .append(" ")
+                                 .append(getString(R.string.uploader_upload_files_behaviour_not_writable))
+                                 .toString());
+        }
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -64,8 +64,12 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
     public static final String SYNCED_FOLDER_PARCELABLE = "SyncedFolderParcelable";
     public static final int REQUEST_CODE__SELECT_REMOTE_FOLDER = 0;
     public static final int REQUEST_CODE__SELECT_LOCAL_FOLDER = 1;
+
     private final static String TAG = SyncedFolderPreferencesDialogFragment.class.getSimpleName();
     private static final String BEHAVIOUR_DIALOG_STATE = "BEHAVIOUR_DIALOG_STATE";
+    private final static float alphaEnabled = 1.0f;
+    private final static float alphaDisabled = 0.7f;
+
     protected View mView;
     private CharSequence[] mUploadBehaviorItemStrings;
     private SwitchCompat mEnabledSwitch;
@@ -120,7 +124,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         Log_OC.d(TAG, "onCreateView, savedInstanceState is " + savedInstanceState);
 
         mView = inflater.inflate(R.layout.synced_folders_settings_layout, container, false);
@@ -277,14 +281,32 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         } else {
             mView.findViewById(R.id.save).setEnabled(false);
         }
+
+        checkWritableFolder();
+    }
+
+    private void checkWritableFolder() {
+        if (mSyncedFolder.getLocalPath() != null && new File(mSyncedFolder.getLocalPath()).canWrite()) {
+            mView.findViewById(R.id.setting_instant_behaviour_container).setEnabled(true);
+            mView.findViewById(R.id.setting_instant_behaviour_container).setAlpha(alphaEnabled);
+            mUploadBehaviorSummary.setText(mUploadBehaviorItemStrings[mSyncedFolder.getUploadActionInteger()]);
+        } else {
+            mView.findViewById(R.id.setting_instant_behaviour_container).setEnabled(false);
+            mView.findViewById(R.id.setting_instant_behaviour_container).setAlpha(alphaDisabled);
+
+            mSyncedFolder.setUploadAction(
+                getResources().getTextArray(R.array.pref_behaviour_entryValues)[0].toString());
+
+            mUploadBehaviorSummary.setText(R.string.auto_upload_file_behaviour_kept_in_folder);
+        }
     }
 
     private void setupViews(View view, boolean enable) {
         float alpha;
         if (enable) {
-            alpha = 1.0f;
+            alpha = alphaEnabled;
         } else {
-            alpha = 0.7f;
+            alpha = alphaDisabled;
         }
         view.findViewById(R.id.setting_instant_upload_on_wifi_container).setEnabled(enable);
         view.findViewById(R.id.setting_instant_upload_on_wifi_container).setAlpha(alpha);
@@ -303,8 +325,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         view.findViewById(R.id.local_folder_container).setEnabled(enable);
         view.findViewById(R.id.local_folder_container).setAlpha(alpha);
 
-        view.findViewById(R.id.setting_instant_behaviour_container).setEnabled(enable);
-        view.findViewById(R.id.setting_instant_behaviour_container).setAlpha(alpha);
+        checkWritableFolder();
     }
 
     /**
@@ -443,7 +464,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putBoolean(BEHAVIOUR_DIALOG_STATE, behaviourDialogShown);
 
         super.onSaveInstanceState(outState);

--- a/src/main/res/layout/upload_files_layout.xml
+++ b/src/main/res/layout/upload_files_layout.xml
@@ -60,6 +60,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/uploader_upload_files_behaviour"
+            android:id="@+id/upload_files_upload_files_behaviour_text"
             android:textColor="@color/black"
             android:textStyle="bold"
             android:paddingBottom="@dimen/standard_half_padding"/>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -845,4 +845,6 @@
     <string name="battery_optimization_close">Close</string>
     <string name="battery_optimization_no_setting">Unable to start battery settings directly. Please adjust manually in settings.</string>
     <string name="file_details_no_content">Failed to load details</string>
+    <string name="uploader_upload_files_behaviour_not_writable">not writable, thus only copy possible</string>
+    <string name="auto_upload_file_behaviour_kept_in_folder">kept in original folder, as it is readonly</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -845,6 +845,6 @@
     <string name="battery_optimization_close">Close</string>
     <string name="battery_optimization_no_setting">Unable to start battery settings directly. Please adjust manually in settings.</string>
     <string name="file_details_no_content">Failed to load details</string>
-    <string name="uploader_upload_files_behaviour_not_writable">not writable, thus only copy possible</string>
+    <string name="uploader_upload_files_behaviour_not_writable">source folder is read-only; file will only be uploaded</string>
     <string name="auto_upload_file_behaviour_kept_in_folder">kept in original folder, as it is readonly</string>
 </resources>


### PR DESCRIPTION
Only allow upload behaviour if writable folders, otherwise they cannot be move/deleted.

Left: sdcard is writable, thus upload behaviour is enabled (and choosable), right / is read-only.
![2019-01-15-072620](https://user-images.githubusercontent.com/5836855/51162819-db4e9780-1897-11e9-877e-2558a7c2f4d1.png) ![2019-01-15-072559](https://user-images.githubusercontent.com/5836855/51162820-db4e9780-1897-11e9-9760-7746195c9080.png)

Same works for manual uploads.

![2019-01-15-073433](https://user-images.githubusercontent.com/5836855/51162879-0e912680-1898-11e9-916a-3add8167ade6.png) ![2019-01-15-073446](https://user-images.githubusercontent.com/5836855/51162880-0e912680-1898-11e9-8ce5-32eddee37e8f.png)

@AndyScherzinger what do we want to do with existing synced folders?
Having some kind of migration step would require to show it somehow to the user…

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>