### PR TITLE
Receive files activity: reflect write status

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -33,6 +33,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Resources.NotFoundException;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -783,6 +784,15 @@ public class ReceiveExternalFilesActivity extends FileActivity
             btnChooseFolder.getBackground().setColorFilter(ThemeUtils.primaryColor(getAccount(), true, this),
                         PorterDuff.Mode.SRC_ATOP);
             btnChooseFolder.setTextColor(ThemeUtils.fontColor(this));
+
+            if (mFile.canWrite()) {
+                btnChooseFolder.setEnabled(true);
+                ThemeUtils.tintDrawable(btnChooseFolder.getBackground(),
+                                        ThemeUtils.primaryColor(getAccount(), true, this));
+            } else {
+                btnChooseFolder.setEnabled(false);
+                ThemeUtils.tintDrawable(btnChooseFolder.getBackground(), Color.GRAY);
+            }
 
             if (getSupportActionBar() != null) {
                 getSupportActionBar().setBackgroundDrawable(new ColorDrawable(


### PR DESCRIPTION
Left: no write permission
Right: write permission
![2019-01-18-065116](https://user-images.githubusercontent.com/5836855/51368021-b0f61780-1aed-11e9-9ff2-7f0c7520308f.png) ![2019-01-18-065120](https://user-images.githubusercontent.com/5836855/51368022-b18eae00-1aed-11e9-9324-d90a27bd3c63.png)

To test:
- share a file to NC
- have a shared folder which is read only

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>