### PR TITLE
Check external link only in default switch

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -495,14 +495,14 @@ public abstract class DrawerActivity extends ToolbarActivity implements DisplayU
                 accountClicked(menuItem.getTitle().toString());
                 break;
             default:
+                if (menuItem.getItemId() >= MENU_ITEM_EXTERNAL_LINK &&
+                    menuItem.getItemId() <= MENU_ITEM_EXTERNAL_LINK + 100) {
+                    // external link clicked
+                    externalLinkClicked(menuItem);
+                } else {
+                    Log_OC.i(TAG, "Unknown drawer menu item clicked: " + menuItem.getTitle());
+                }
                 break;
-        }
-
-        if (menuItem.getItemId() >= MENU_ITEM_EXTERNAL_LINK && menuItem.getItemId() <= MENU_ITEM_EXTERNAL_LINK + 100) {
-            // external link clicked
-            externalLinkClicked(menuItem);
-        } else {
-            Log_OC.i(TAG, "Unknown drawer menu item clicked: " + menuItem.getTitle());
         }
     }
 


### PR DESCRIPTION
Fix #2947 

- external link check should only be done when no other switch case applies
- log info should only be shown if external link cannot be used

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>