### PR TITLE
PullApprove: Only one review

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -27,14 +27,14 @@ group_defaults:
 
 groups:
   code-review:
-    required: 2
+    required: 1
     reject_value: -99
     users:
       - AndyScherzinger
       - tobiasKaminsky
       - mario
       - przybylski
-      - ardevd 
+      - ardevd
 
   design-review:
     conditions:
@@ -45,5 +45,5 @@ groups:
     required: 1
     reject_value: -99
     users:
-      - jancborchardt 
+      - jancborchardt
       - eppfel


### PR DESCRIPTION
Although we disussed to have two reviews, this seems not to scale (for now).
So I revert this to at least one review. Otherwise we would have to use admin rights to merge a PR all the time.
This does not mean that we should not try to have 2 reviews, if possible.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>