### PR TITLE
Do not open ics within our app

### DIFF
--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -477,6 +477,7 @@ public class PreviewTextFragment extends FileFragment implements SearchView.OnQu
         final List<String> unsupportedTypes = new LinkedList<>();
         unsupportedTypes.add("text/richtext");
         unsupportedTypes.add("text/rtf");
+        unsupportedTypes.add("text/calendar");
         unsupportedTypes.add("text/vnd.abc");
         unsupportedTypes.add("text/vnd.fmi.flexstor");
         unsupportedTypes.add("text/vnd.rn-realtext");


### PR DESCRIPTION
Fix #3417 
ICS are calendar files, and while they are technically text files, it does not make sense to open them internally, as there is a calendar app which handles it way better.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>