### PR TITLE
AuthenticatorActivity: show dialog only if not suspended

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1305,9 +1305,11 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         }
 
         /// be gentle with the user
-        IndeterminateProgressDialog dialog =
-                IndeterminateProgressDialog.newInstance(R.string.auth_trying_to_login, true);
-        dialog.show(getSupportFragmentManager(), WAIT_DIALOG_TAG);
+        IndeterminateProgressDialog dialog = IndeterminateProgressDialog.newInstance(R.string.auth_trying_to_login,
+                                                                                     true);
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.add(dialog, WAIT_DIALOG_TAG);
+        ft.commitAllowingStateLoss();
 
         /// validate credentials accessing the root folder
         OwnCloudCredentials credentials = OwnCloudCredentialsFactory.newBasicCredentials(username, password);


### PR DESCRIPTION
Fix #3561

This is trying to fix it. Basically you are not allowed to show a dialog after suspending an activity, as on resume Android cannot restore this dialog and as this is bad UX, they chose to refuse it.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>