### PR TITLE
fix crash on evernote

### DIFF
--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -84,12 +84,7 @@
         <service
             android:name="com.evernote.android.job.gcm.PlatformGcmService"
             android:enabled="true"
-            android:exported="true"
-            android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE"
-            tools:replace="android:enabled">
-            <intent-filter>
-                <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY"/>
-            </intent-filter>
+            tools:node="remove">
         </service>
 
     </application>


### PR DESCRIPTION
We have lots of suspicious crashes on upgrade.
I think they were introduced by https://github.com/nextcloud/android/pull/2650, where I added this https://github.com/evernote/android-job/issues/415#issuecomment-380017997, but after that they added/updated readme and suggest:
https://github.com/evernote/android-job/wiki/FAQ#how-can-i-remove-the-gcm-dependency-from-my-app

Note that our app is only crashing once after update and then works as intended.
I could reproduce it via:
- install genericDebug
- install gplayDebug (current master) --> crash

- remove  app
- install genericDebug
- install gplayDebug from this PR --> no crash

```
java.lang.RuntimeException: Unable to instantiate service com.evernote.android.job.gcm.PlatformGcmService: java.lang.ClassNotFoundException: Didn't find class "com.evernote.android.job.gcm.PlatformGcmService" on path: DexPathList[[zip file "/system/framework/org.apache.http.legacy.boot.jar", zip file "/data/app/com.nextcloud.client-PYR9bPIG1Ozwme9wMAYPuw==/base.apk"],nativeLibraryDirectories=[/data/app/com.nextcloud.client-PYR9bPIG1Ozwme9wMAYPuw==/lib/x86, /data/app/com.nextcloud.client-PYR9bPIG1Ozwme9wMAYPuw==/base.apk!/lib/x86, /system/lib]]
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:3519)
        at android.app.ActivityThread.access$1300(ActivityThread.java:199)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1666)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
     Caused by: java.lang.ClassNotFoundException: Didn't find class "com.evernote.android.job.gcm.PlatformGcmService" on path: DexPathList[[zip file "/system/framework/org.apache.http.legacy.boot.jar", zip file "/data/app/com.nextcloud.client-PYR9bPIG1Ozwme9wMAYPuw==/base.apk"],nativeLibraryDirectories=[/data/app/com.nextcloud.client-PYR9bPIG1Ozwme9wMAYPuw==/lib/x86, /data/app/com.nextcloud.client-PYR9bPIG1Ozwme9wMAYPuw==/base.apk!/lib/x86, /system/lib]]
        at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:134)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
        at android.app.AppComponentFactory.instantiateService(AppComponentFactory.java:103)
        at androidx.core.app.CoreComponentFactory.instantiateService(CoreComponentFactory.java:68)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:3514)
        at android.app.ActivityThread.access$1300(ActivityThread.java:199) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1666) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:193) 
        at android.app.ActivityThread.main(ActivityThread.java:6669) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858) 
    	Suppressed: java.lang.NoClassDefFoundError: Failed resolution of: Lcom/google/android/gms/gcm/GcmTaskService;
        at java.lang.VMClassLoader.findLoadedClass(Native Method)
        at java.lang.ClassLoader.findLoadedClass(ClassLoader.java:738)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:363)
        		... 12 more
```

I would love to give this a try on RC3, @AndyScherzinger?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>