### PR TITLE
Fix #3111 - Remove upload success notification

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1207,16 +1207,16 @@ public class FileUploader extends Service
 
         mNotificationManager.cancel(R.string.uploader_upload_in_progress_ticker);
 
-        // Show the result: success or fail notification
+        // Only notify if the upload fails
         if (!uploadResult.isCancelled() &&
+            !uploadResult.isSuccess() &&
             !ResultCode.LOCAL_FILE_NOT_FOUND.equals(uploadResult.getCode()) &&
             !uploadResult.getCode().equals(ResultCode.DELAYED_FOR_WIFI) &&
             !uploadResult.getCode().equals(ResultCode.DELAYED_FOR_CHARGING) &&
             !uploadResult.getCode().equals(ResultCode.DELAYED_IN_POWER_SAVE_MODE) &&
             !uploadResult.getCode().equals(ResultCode.LOCK_FAILED)    ) {
 
-            int tickerId = uploadResult.isSuccess() ? R.string.uploader_upload_succeeded_ticker :
-                    R.string.uploader_upload_failed_ticker;
+            int tickerId = R.string.uploader_upload_failed_ticker;
 
             String content;
 
@@ -1255,10 +1255,6 @@ public class FileUploader extends Service
                 ));
 
             } else {
-                mNotificationBuilder.setContentText(content);
-            }
-
-            if (!uploadResult.isSuccess() && !needsToUpdateCredentials ) {
                 //in case of failure, do not show details file view (because there is no file!)
                 Intent showUploadListIntent = new Intent(this, UploadListActivity.class);
                 showUploadListIntent.putExtra(FileActivity.EXTRA_FILE, upload.getFile());
@@ -1270,15 +1266,6 @@ public class FileUploader extends Service
 
             mNotificationBuilder.setContentText(content);
             mNotificationManager.notify(tickerId, mNotificationBuilder.build());
-
-            if (uploadResult.isSuccess()) {
-                mPendingUploads.remove(upload.getAccount().name, upload.getFile().getRemotePath());
-                // remove success notification, with a delay of 2 seconds
-                NotificationUtils.cancelWithDelay(
-                        mNotificationManager,
-                        R.string.uploader_upload_succeeded_ticker,
-                        2000);
-            }
         }
     }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -145,7 +145,6 @@
     <string name="uploader_info_dirname">Folder name</string>
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>
-    <string name="uploader_upload_succeeded_ticker">Uploaded</string>
     <string name="uploader_upload_succeeded_content_single">%1$s uploaded</string>
     <string name="uploader_upload_failed_ticker">Upload failed</string>
     <string name="uploader_upload_failed_content_single">Could not upload %1$s</string>


### PR DESCRIPTION
Fix #3111 

As per the final decision in issue #3111 to remove notification for successful uploads. Kindly review and let me know if any changes are required. 