### PR TITLE
Refactor legacy instant upload prefs removal

### DIFF
--- a/src/generic/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/generic/java/com/owncloud/android/utils/PushUtils.java
@@ -24,7 +24,7 @@ import android.content.Context;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.SignatureVerification;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 
 import java.security.Key;
 

--- a/src/gplay/java/com/owncloud/android/services/firebase/NCFirebaseInstanceIDService.java
+++ b/src/gplay/java/com/owncloud/android/services/firebase/NCFirebaseInstanceIDService.java
@@ -23,9 +23,9 @@ import android.text.TextUtils;
 
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.FirebaseInstanceIdService;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
-import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.utils.PushUtils;
 
 public class NCFirebaseInstanceIDService extends FirebaseInstanceIdService {

--- a/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -29,13 +29,13 @@ import android.util.Base64;
 import android.util.Log;
 
 import com.google.gson.Gson;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.PushConfigurationState;
 import com.owncloud.android.datamodel.SignatureVerification;
-import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;

--- a/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -1,0 +1,28 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Chris Narkiewicz
+ * Copyright (C) 2019 Chris Narkiewicz, EZ Aquarii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.client.preferences;
+
+public interface AppPreferences {
+    boolean instantPictureUploadEnabled();
+    boolean instantVideoUploadEnabled();
+
+    void removeLegacyPreferences();
+}

--- a/src/main/java/com/nextcloud/client/preferences/PreferenceManager.java
+++ b/src/main/java/com/nextcloud/client/preferences/PreferenceManager.java
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.owncloud.android.db;
+package com.nextcloud.client.preferences;
 
 import android.accounts.Account;
 import android.content.Context;
@@ -36,7 +36,7 @@ import static com.owncloud.android.ui.fragment.OCFileListFragment.FOLDER_LAYOUT_
 /**
  * Helper to simplify reading of Preferences all around the app
  */
-public final class PreferenceManager {
+public final class PreferenceManager implements AppPreferences {
     /**
      * Constant to access value of last path selected by the user to upload a file shared from other app.
      * Value handled by the app without direct access in the UI.
@@ -69,7 +69,15 @@ public final class PreferenceManager {
     public static final String PREF__LOCK_TIMESTAMP = "lock_timestamp";
     private static final String PREF__SHOW_MEDIA_SCAN_NOTIFICATIONS = "show_media_scan_notifications";
 
-    private PreferenceManager() {
+    private final SharedPreferences preferences;
+
+    public static AppPreferences fromContext(Context context) {
+        SharedPreferences prefs = getDefaultSharedPreferences(context.getApplicationContext());
+        return new PreferenceManager(prefs);
+    }
+
+    PreferenceManager(SharedPreferences preferences) {
+        this.preferences = preferences;
     }
 
     public static void setKeysReInit(Context context) {
@@ -88,12 +96,14 @@ public final class PreferenceManager {
         return getDefaultSharedPreferences(context).getString(PREF__PUSH_TOKEN, "");
     }
 
-    public static boolean instantPictureUploadEnabled(Context context) {
-        return getDefaultSharedPreferences(context).getBoolean(PREF__INSTANT_UPLOADING, false);
+    @Override
+    public boolean instantPictureUploadEnabled() {
+        return preferences.getBoolean(PREF__INSTANT_UPLOADING, false);
     }
 
-    public static boolean instantVideoUploadEnabled(Context context) {
-        return getDefaultSharedPreferences(context).getBoolean(PREF__INSTANT_VIDEO_UPLOADING, false);
+    @Override
+    public boolean instantVideoUploadEnabled() {
+        return preferences.getBoolean(PREF__INSTANT_VIDEO_UPLOADING, false);
     }
 
     public static boolean instantPictureUploadPathUseSubfolders(Context context) {
@@ -592,5 +602,23 @@ public final class PreferenceManager {
 
     public static SharedPreferences getDefaultSharedPreferences(Context context) {
         return android.preference.PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+    }
+
+    @Override
+    public void removeLegacyPreferences() {
+        preferences.edit()
+                .remove("instant_uploading")
+                .remove("instant_video_uploading")
+                .remove("instant_upload_path")
+                .remove("instant_upload_path_use_subfolders")
+                .remove("instant_upload_on_wifi")
+                .remove("instant_upload_on_charging")
+                .remove("instant_video_upload_path")
+                .remove("instant_video_upload_path_use_subfolders")
+                .remove("instant_video_upload_on_wifi")
+                .remove("instant_video_uploading")
+                .remove("instant_video_upload_on_charging")
+                .remove("prefs_instant_behaviour")
+                .apply();
     }
 }

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -51,7 +51,8 @@ import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.datastorage.DataStorageProvider;
 import com.owncloud.android.datastorage.StoragePoint;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.jobs.MediaFoldersDetectionJob;
 import com.owncloud.android.jobs.NCJobCreator;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
@@ -113,6 +114,7 @@ public class MainApp extends MultiDexApplication {
     private static boolean mOnlyOnDevice;
 
     private SharedPreferences appPrefs;
+
     @SuppressWarnings("unused")
     private boolean mBound;
 
@@ -507,23 +509,9 @@ public class MainApp extends MultiDexApplication {
 
     private static void updateToAutoUpload() {
             Context context = getAppContext();
-            if (PreferenceManager.instantPictureUploadEnabled(context) ||
-                    PreferenceManager.instantVideoUploadEnabled(context)){
-
-                // remove legacy shared preferences
-                SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
-                editor.remove("instant_uploading")
-                        .remove("instant_video_uploading")
-                        .remove("instant_upload_path")
-                        .remove("instant_upload_path_use_subfolders")
-                        .remove("instant_upload_on_wifi")
-                        .remove("instant_upload_on_charging")
-                        .remove("instant_video_upload_path")
-                        .remove("instant_video_upload_path_use_subfolders")
-                        .remove("instant_video_upload_on_wifi")
-                        .remove("instant_video_uploading")
-                        .remove("instant_video_upload_on_charging")
-                        .remove("prefs_instant_behaviour").apply();
+            AppPreferences preferences = PreferenceManager.fromContext(context);
+            if (preferences.instantPictureUploadEnabled() || preferences.instantVideoUploadEnabled()){
+                preferences.removeLegacyPreferences();
 
                 // show info pop-up
                 try {

--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -28,7 +28,7 @@ import android.view.Window;
 import android.view.WindowManager;
 
 import com.owncloud.android.MainApp;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.ui.activity.PassCodeActivity;
 import com.owncloud.android.ui.activity.Preferences;
 import com.owncloud.android.ui.activity.RequestCredentialsActivity;

--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -27,7 +27,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.db.ProviderMeta;
 import com.owncloud.android.lib.common.utils.Log_OC;
 

--- a/src/main/java/com/owncloud/android/jobs/MediaFoldersDetectionJob.java
+++ b/src/main/java/com/owncloud/android/jobs/MediaFoldersDetectionJob.java
@@ -43,7 +43,7 @@ import com.owncloud.android.datamodel.MediaFolder;
 import com.owncloud.android.datamodel.MediaFoldersModel;
 import com.owncloud.android.datamodel.MediaProvider;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.activity.ManageAccountsActivity;
 import com.owncloud.android.ui.activity.SyncedFoldersActivity;

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -62,7 +62,7 @@ import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.ExternalLinksProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.lib.common.ExternalLink;
 import com.owncloud.android.lib.common.ExternalLinkType;
 import com.owncloud.android.lib.common.OwnCloudAccount;

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -37,7 +37,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
-import android.content.SharedPreferences;
 import android.content.SyncRequest;
 import android.content.pm.PackageManager;
 import android.content.res.Resources.NotFoundException;
@@ -63,7 +62,8 @@ import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.files.services.FileDownloader;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
 import com.owncloud.android.files.services.FileUploader;
@@ -206,6 +206,7 @@ public class FileDisplayActivity extends HookActivity
     private boolean searchOpen;
 
     private SearchView searchView;
+    private AppPreferences preferences;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -214,6 +215,8 @@ public class FileDisplayActivity extends HookActivity
         setTheme(R.style.Theme_ownCloud_Toolbar_Drawer);
         super.onCreate(savedInstanceState); // this calls onAccountChanged() when ownCloud Account
         // is valid
+
+        preferences = PreferenceManager.fromContext(this);
 
         /// Load of saved instance state
         if (savedInstanceState != null) {
@@ -316,24 +319,8 @@ public class FileDisplayActivity extends HookActivity
      */
     private void upgradeNotificationForInstantUpload() {
         // check for Android 6+ if legacy instant upload is activated --> disable + show info
-        if (PreferenceManager.instantPictureUploadEnabled(this) ||
-                PreferenceManager.instantVideoUploadEnabled(this)) {
-
-            // remove legacy shared preferences
-            SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
-            editor.remove("instant_uploading")
-                    .remove("instant_video_uploading")
-                    .remove("instant_upload_path")
-                    .remove("instant_upload_path_use_subfolders")
-                    .remove("instant_upload_on_wifi")
-                    .remove("instant_upload_on_charging")
-                    .remove("instant_video_upload_path")
-                    .remove("instant_video_upload_path_use_subfolders")
-                    .remove("instant_video_upload_on_wifi")
-                    .remove("instant_video_uploading")
-                    .remove("instant_video_upload_on_charging")
-                    .remove("prefs_instant_behaviour").apply();
-
+        if (preferences.instantPictureUploadEnabled() || preferences.instantVideoUploadEnabled()) {
+            preferences.removeLegacyPreferences();
             // show info pop-up
             new AlertDialog.Builder(this, R.style.Theme_ownCloud_Dialog)
                     .setTitle(R.string.drawer_synced_folders)

--- a/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
@@ -40,7 +40,7 @@ import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.authentication.AuthenticatorActivity;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.features.FeatureItem;
 import com.owncloud.android.ui.adapter.FeaturesViewAdapter;
 import com.owncloud.android.ui.whatsnew.ProgressIndicator;

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -64,7 +64,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import static com.owncloud.android.db.PreferenceManager.getSortOrderByFolder;
+import static com.nextcloud.client.preferences.PreferenceManager.getSortOrderByFolder;
 
 public class FolderPickerActivity extends FileActivity implements FileFragment.ContainerActivity,
     OnClickListener, OnEnforceableRefreshListener {

--- a/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -506,7 +506,7 @@ public class Preferences extends PreferenceActivity
         boolean fDeviceCredentialsEnabled = getResources().getBoolean(R.bool.device_credentials_enabled);
         boolean fShowHiddenFilesEnabled = getResources().getBoolean(R.bool.show_hidden_files_enabled);
         boolean fSyncedFolderLightEnabled = getResources().getBoolean(R.bool.syncedFolder_light);
-        boolean fShowMediaScanNotifications = com.owncloud.android.db.PreferenceManager
+        boolean fShowMediaScanNotifications = com.nextcloud.client.preferences.PreferenceManager
             .isShowMediaScanNotifications(this);
 
         setupLockPreference(preferenceCategoryDetails, fPassCodeEnabled, fDeviceCredentialsEnabled);

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -63,7 +63,7 @@ import android.widget.TextView;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -43,7 +43,7 @@ import android.widget.TextView;
 
 import com.google.android.material.button.MaterialButton;
 import com.owncloud.android.R;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.adapter.StoragePathAdapter;

--- a/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
@@ -34,7 +34,7 @@ import android.widget.TextView;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.features.FeatureItem;
 import com.owncloud.android.ui.adapter.FeaturesViewAdapter;
 import com.owncloud.android.ui.adapter.FeaturesWebViewAdapter;

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -33,7 +33,7 @@ import android.widget.TextView;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.interfaces.LocalFileListFragmentInterface;
 import com.owncloud.android.utils.DisplayUtils;

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -48,7 +48,6 @@ package com.owncloud.android.ui.adapter;
     import com.owncloud.android.datamodel.OCFile;
     import com.owncloud.android.datamodel.ThumbnailsCacheManager;
     import com.owncloud.android.datamodel.VirtualFolderType;
-    import com.owncloud.android.db.PreferenceManager;
     import com.owncloud.android.db.ProviderMeta;
     import com.owncloud.android.files.services.FileDownloader;
     import com.owncloud.android.files.services.FileUploader;
@@ -71,6 +70,8 @@ package com.owncloud.android.ui.adapter;
     import com.owncloud.android.utils.FileStorageUtils;
     import com.owncloud.android.utils.MimeTypeUtil;
     import com.owncloud.android.utils.ThemeUtils;
+
+    import com.nextcloud.client.preferences.PreferenceManager;
 
     import java.io.File;
     import java.util.ArrayList;

--- a/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
@@ -35,7 +35,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.trashbin.model.TrashbinFile;
 import com.owncloud.android.ui.interfaces.TrashbinActivityInterface;

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -54,7 +54,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.SearchRemoteOperation;
 import com.owncloud.android.ui.EmptyRecyclerView;

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -45,7 +45,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -56,7 +56,7 @@ import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -28,7 +28,7 @@ import android.view.ViewGroup;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.utils.FileSortOrder;
 import com.owncloud.android.utils.FileStorageUtils;

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -31,7 +31,7 @@ import android.widget.TextView;
 
 import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.lib.resources.trashbin.model.TrashbinFile;
 import com.owncloud.android.ui.EmptyRecyclerView;
 import com.owncloud.android.ui.activity.FileActivity;

--- a/src/test/java/com/nextcloud/client/preferences/TestPreferenceManager.java
+++ b/src/test/java/com/nextcloud/client/preferences/TestPreferenceManager.java
@@ -1,0 +1,48 @@
+package com.nextcloud.client.preferences;
+
+import android.content.SharedPreferences;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+public class TestPreferenceManager {
+
+    @Mock
+    private SharedPreferences sharedPreferences;
+
+    @Mock
+    private SharedPreferences.Editor editor;
+
+    private PreferenceManager appPreferences;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(editor.remove(anyString())).thenReturn(editor);
+        when(sharedPreferences.edit()).thenReturn(editor);
+        appPreferences = new PreferenceManager(sharedPreferences);
+    }
+
+    @Test
+    public void removeLegacyPreferences() {
+        appPreferences.removeLegacyPreferences();
+        InOrder inOrder = inOrder(editor);
+        inOrder.verify(editor).remove("instant_uploading");
+        inOrder.verify(editor).remove("instant_video_uploading");
+        inOrder.verify(editor).remove("instant_upload_path");
+        inOrder.verify(editor).remove("instant_upload_path_use_subfolders");
+        inOrder.verify(editor).remove("instant_upload_on_wifi");
+        inOrder.verify(editor).remove("instant_upload_on_charging");
+        inOrder.verify(editor).remove("instant_video_upload_path");
+        inOrder.verify(editor).remove("instant_video_upload_path_use_subfolders");
+        inOrder.verify(editor).remove("instant_video_upload_on_wifi");
+        inOrder.verify(editor).remove("instant_video_uploading");
+        inOrder.verify(editor).remove("instant_video_upload_on_charging");
+        inOrder.verify(editor).remove("prefs_instant_behaviour");
+        inOrder.verify(editor).apply();
+    }
+}

--- a/src/versionDev/java/com/owncloud/android/utils/PushUtils.java
+++ b/src/versionDev/java/com/owncloud/android/utils/PushUtils.java
@@ -24,7 +24,7 @@ import android.content.Context;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.SignatureVerification;
-import com.owncloud.android.db.PreferenceManager;
+import com.nextcloud.client.preferences.PreferenceManager;
 
 import java.security.Key;
 


### PR DESCRIPTION
- Refactored legacy instant upload preferences to instance methods
- Duplicate legacy preferences removal logic moved to `PreferenceManager`

This is purposefully small change to open discussion about next move. Impact around legacy code should have minimal influence on currently deployed clients.