### PR TITLE
Only use ifPreviewIsAvailable for thumbnail generation

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -38,7 +38,12 @@ import android.widget.Filter;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-
+import androidx.annotation.NonNull;
+import androidx.core.graphics.drawable.RoundedBitmapDrawable;
+import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
+import androidx.recyclerview.widget.RecyclerView;
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.BitmapImageViewTarget;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -71,8 +76,6 @@ import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.ThemeUtils;
 
-import com.nextcloud.client.preferences.PreferenceManager;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -80,13 +83,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.Vector;
-
-import androidx.annotation.NonNull;
-import androidx.core.graphics.drawable.RoundedBitmapDrawable;
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
-import androidx.recyclerview.widget.RecyclerView;
-import butterknife.BindView;
-import butterknife.ButterKnife;
 
 /**
  * This Adapter populates a RecyclerView with all files and folders in a Nextcloud instance.
@@ -465,8 +461,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                             file.isSharedWithSharee(), file.isSharedViaLink(), file.isEncrypted(), file.getMountType(),
                     mContext));
         } else {
-            if ((MimeTypeUtil.isImage(file) || MimeTypeUtil.isVideo(file)) && file.getRemoteId() != null &&
-                file.isPreviewAvailable()) {
+            if (file.getRemoteId() != null && file.isPreviewAvailable()) {
                 // Thumbnail in cache?
                 Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
                         ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.getRemoteId()


### PR DESCRIPTION
Fix: https://github.com/nextcloud/android/issues/3649

We now rely on isPreviewAvailable for generating thumbnails.
This is included since NC10.
If webdav is returning 404 for this property, we assume "true" as fallback.
So worst case is a slightly increased thumbnail generation try for such old server.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>