### PR TITLE
further hardening of SSO

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/Constants.java
+++ b/src/main/java/com/nextcloud/android/sso/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
     public static final String NEXTCLOUD_SSO_EXCEPTION = "NextcloudSsoException";
     public static final String NEXTCLOUD_SSO = "NextcloudSSO";
     public static final String NEXTCLOUD_FILES_ACCOUNT = "NextcloudFilesAccount";
+    public static final String DELIMITER = "_";
 
 
     // Custom Exceptions

--- a/src/main/java/com/nextcloud/android/sso/InputStreamBinder.java
+++ b/src/main/java/com/nextcloud/android/sso/InputStreamBinder.java
@@ -31,7 +31,6 @@ import android.os.Binder;
 import android.os.ParcelFileDescriptor;
 import android.text.TextUtils;
 import android.util.Log;
-
 import com.nextcloud.android.sso.aidl.IInputStreamService;
 import com.nextcloud.android.sso.aidl.NextcloudRequest;
 import com.nextcloud.android.sso.aidl.ParcelFileDescriptorUtil;
@@ -42,7 +41,6 @@ import com.owncloud.android.lib.common.OwnCloudClientManager;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.EncryptionUtils;
-
 import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpMethodBase;
 import org.apache.commons.httpclient.HttpState;
@@ -71,6 +69,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+import static com.nextcloud.android.sso.Constants.DELIMITER;
 import static com.nextcloud.android.sso.Constants.EXCEPTION_ACCOUNT_NOT_FOUND;
 import static com.nextcloud.android.sso.Constants.EXCEPTION_HTTP_REQUEST_FAILED;
 import static com.nextcloud.android.sso.Constants.EXCEPTION_INVALID_REQUEST_URL;
@@ -310,7 +309,7 @@ public class InputStreamBinder extends IInputStreamService.Stub {
 
         SharedPreferences sharedPreferences = context.getSharedPreferences(SSO_SHARED_PREFERENCE,
                 Context.MODE_PRIVATE);
-        String hash = sharedPreferences.getString(callingPackageName, "");
+        String hash = sharedPreferences.getString(callingPackageName + DELIMITER + request.getAccountName(), "");
         return validateToken(hash, request.getToken());
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
@@ -42,7 +42,10 @@ import android.util.Log;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
-
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import butterknife.Unbinder;
 import com.nextcloud.android.sso.Constants;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -54,17 +57,14 @@ import com.owncloud.android.utils.ThemeUtils;
 
 import java.util.UUID;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-import butterknife.Unbinder;
-
+import static com.nextcloud.android.sso.Constants.DELIMITER;
 import static com.nextcloud.android.sso.Constants.EXCEPTION_ACCOUNT_ACCESS_DECLINED;
 import static com.nextcloud.android.sso.Constants.EXCEPTION_ACCOUNT_NOT_FOUND;
 import static com.nextcloud.android.sso.Constants.NEXTCLOUD_FILES_ACCOUNT;
 import static com.nextcloud.android.sso.Constants.NEXTCLOUD_SSO;
 import static com.nextcloud.android.sso.Constants.NEXTCLOUD_SSO_EXCEPTION;
 import static com.nextcloud.android.sso.Constants.SSO_SHARED_PREFERENCE;
+
 
 /**
  * Activity for granting access rights to a Nextcloud account, used for SSO.
@@ -180,7 +180,7 @@ public class SsoGrantPermissionActivity extends BaseActivity {
         String hashedTokenWithSalt = EncryptionUtils.generateSHA512(token);
 
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(packageName, hashedTokenWithSalt);
+        editor.putString(packageName + DELIMITER + account.name, hashedTokenWithSalt);
         editor.apply();
 
         String serverUrl;


### PR DESCRIPTION
- include account name to check 
- fix https://github.com/nextcloud/Android-SingleSignOn/pull/47#issuecomment-473828198

@David-Development this requires every user to re-authenticate.
But with the upcoming PR (mentioned in the same comment above) this should be no problem, or do you think this might confuse/fear user?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>