### PR TITLE
Check for 500 char limit

### DIFF
--- a/scripts/analysis/analysis-wrapper.sh
+++ b/scripts/analysis/analysis-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #1: GIT_USERNAME
 #2: GIT_TOKEN
@@ -110,7 +110,18 @@ else
         findbugsMessage="<h1>Findbugs increased!</h1>"
     fi
 
-    curl -u $1:$2 -X POST https://api.github.com/repos/nextcloud/android/issues/$7/comments -d "{ \"body\" : \"$lintResult $findbugsResultNew $findbugsResultOld $checkLibraryMessage $lintMessage $findbugsMessage \" }"
+    # check gplay limitation: all changelog files must only have 500 chars
+    gplayLimitation=$(scripts/checkGplayLimitation.sh)
+
+    if [ ! -z "$gplayLimitation" ]; then
+        gplayLimitation="<h1>Following files are beyond 500 char limit:</h1><br><br>"$gplayLimitation
+    fi
+
+    curl -u $1:$2 -X POST https://api.github.com/repos/nextcloud/android/issues/$7/comments -d "{ \"body\" : \"$lintResult $findbugsResultNew $findbugsResultOld $checkLibraryMessage $lintMessage $findbugsMessage $gplayLimitation \" }"
+
+    if [ ! -z "$gplayLimitation" ]; then
+        exit 1
+    fi
 
     if [ $checkLibrary -eq 1 ]; then
         exit 1

--- a/scripts/checkGplayLimitation.sh
+++ b/scripts/checkGplayLimitation.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+result=""
+
+for log in fastlane/metadata/android/*/changelogs/*
+    do
+    if [[ -e $log && $(wc -m $log | cut -d" " -f1) -gt 500 ]]
+        then
+        result=$log"<br>"$result
+    fi
+done
+
+echo -e "$result";


### PR DESCRIPTION
Gplay has limit of 500 char for each changelog.
While we use this only in stable-x.y branch, this should be in master for next stable-3.6 branch.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>