### PR TITLE
UI improvement on first run

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
@@ -35,19 +35,17 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-
+import androidx.viewpager.widget.ViewPager;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.authentication.AuthenticatorActivity;
-import com.nextcloud.client.preferences.PreferenceManager;
 import com.owncloud.android.features.FeatureItem;
 import com.owncloud.android.ui.adapter.FeaturesViewAdapter;
 import com.owncloud.android.ui.whatsnew.ProgressIndicator;
 import com.owncloud.android.utils.DisplayUtils;
-
-import androidx.viewpager.widget.ViewPager;
 
 /**
  * Activity displaying general feature after a fresh install.
@@ -73,7 +71,7 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
 
         Button loginButton = findViewById(R.id.login);
         loginButton.setBackgroundColor(Color.WHITE);
-        loginButton.setTextColor(Color.BLACK);
+        loginButton.setTextColor(getResources().getColor(R.color.primary));
 
         loginButton.setOnClickListener(v -> {
             if (getIntent().getBooleanExtra(EXTRA_ALLOW_CLOSE, false)) {

--- a/src/main/res/layout/first_run_activity.xml
+++ b/src/main/res/layout/first_run_activity.xml
@@ -28,9 +28,10 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/standard_margin"
         android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:layout_marginBottom="@dimen/standard_margin"
+        android:layout_marginTop="@dimen/standard_margin">
 
         <androidx.viewpager.widget.ViewPager
             android:id="@+id/contentPanel"


### PR DESCRIPTION
use primary color on primary button
swipe container without margin

As discussed with @jancborchardt during Contributor Week.

Before:
![image](https://user-images.githubusercontent.com/5836855/54807234-e3063000-4c7c-11e9-89d5-d38943d6a96a.png)


After:
![image](https://user-images.githubusercontent.com/5836855/54807308-22cd1780-4c7d-11e9-937d-95f713254875.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>