### PR TITLE
files: avoid possible dereference of null pointer.

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
@@ -2023,6 +2024,7 @@ public class FileDataStorageManager {
         return c;
     }
 
+    @NonNull
     public OCCapability getCapability(String accountName) {
         OCCapability capability;
         Cursor c = getCapabilityCursorForAccount(accountName);

--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -165,7 +165,7 @@ public class FileMenuFilter {
     private void filter(List<Integer> toShow, List<Integer> toHide, boolean inSingleFileFragment) {
         boolean synchronizing = anyFileSynchronizing();
         OCCapability capability = mComponentsGetter.getStorageManager().getCapability(mAccount.name);
-        boolean endToEndEncryptionEnabled = capability != null && capability.getEndToEndEncryption().isTrue();
+        boolean endToEndEncryptionEnabled = capability.getEndToEndEncryption().isTrue();
 
         filterDownload(toShow, toHide, synchronizing);
         filterRename(toShow, toHide, synchronizing);
@@ -184,9 +184,7 @@ public class FileMenuFilter {
         filterUnsetEncrypted(toShow, toHide, endToEndEncryptionEnabled);
         filterSetPictureAs(toShow, toHide);
         filterStream(toShow, toHide);
-        if (endToEndEncryptionEnabled) {
-            filterOpenAsRichDocument(toShow, toHide, capability);
-        }
+        filterOpenAsRichDocument(toShow, toHide, capability);
     }
 
     private void filterShareFile(List<Integer> toShow, List<Integer> toHide, OCCapability capability) {

--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -184,7 +184,9 @@ public class FileMenuFilter {
         filterUnsetEncrypted(toShow, toHide, endToEndEncryptionEnabled);
         filterSetPictureAs(toShow, toHide);
         filterStream(toShow, toHide);
-        filterOpenAsRichDocument(toShow, toHide, capability);
+        if (endToEndEncryptionEnabled) {
+            filterOpenAsRichDocument(toShow, toHide, capability);
+        }
     }
 
     private void filterShareFile(List<Integer> toShow, List<Integer> toHide, OCCapability capability) {


### PR DESCRIPTION
~~itseems the `capability` object can be null. In which case it is probably a bad idea to pass a null object into `getRichDocumentsDirectEditing()`.~~

This might not be necessary but it looks very strange to me when you define a variable `endToEndEncryptionEnabled` based on whether the `capability` object is `null` first and then pass that same object to the `filterOpenAsRichDocument()` method later on. That function seemingly assumes the `capability` argument is not null too so something should be done here.

`capability` object cannot be null. Updated associated method with `@NonNull` annotation and removed unnecessary NPE check.

