### PR TITLE
Added private constructors to hide implicit public ones.

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/Constants.java
+++ b/src/main/java/com/nextcloud/android/sso/Constants.java
@@ -2,6 +2,10 @@ package com.nextcloud.android.sso;
 
 public class Constants {
 
+    private Constants() {
+        // No instance
+    }
+
     // Authenticator related constants
     public static final String SSO_USERNAME = "username";
     public static final String SSO_TOKEN = "token";

--- a/src/main/java/com/owncloud/android/authentication/OAuth2Constants.java
+++ b/src/main/java/com/owncloud/android/authentication/OAuth2Constants.java
@@ -27,6 +27,10 @@ package com.owncloud.android.authentication;
  */
 
 public class OAuth2Constants {
+
+    private OAuth2Constants() {
+        // No instance
+    }
     
     /// Parameters to send to the Authorization Endpoint
     public static final String KEY_RESPONSE_TYPE = "response_type";

--- a/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -35,9 +35,15 @@ public class ProviderMeta {
     public static final int DB_VERSION = 44;
 
     private ProviderMeta() {
+        // No instance
     }
 
     static public class ProviderTableMeta implements BaseColumns {
+
+        private ProviderTableMeta() {
+            // No instance
+        }
+
         public static final String FILE_TABLE_NAME = "filelist";
         public static final String OCSHARES_TABLE_NAME = "ocshares";
         public static final String CAPABILITIES_TABLE_NAME = "capabilities";

--- a/src/main/java/com/owncloud/android/utils/MimeType.java
+++ b/src/main/java/com/owncloud/android/utils/MimeType.java
@@ -21,6 +21,11 @@ package com.owncloud.android.utils;
  * Class containing the mime types.
  */
 public class MimeType {
+
+    private MimeType() {
+        // No instance
+    }
+    
     public static final String DIRECTORY = "DIR";
     public static final String JPEG = "image/jpeg";
     public static final String TIFF = "image/tiff";


### PR DESCRIPTION
Utility classes, which are collections of static members, are not meant to be instantiated.

Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.