### PR TITLE
authentication: do not set unlock timestamp when prompting for passcode.

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -44,6 +44,8 @@ public final class PassCodeManager {
 
     public static final int PASSCODE_ACTIVITY = 9999;
 
+    private boolean LOCK_PROMPTED = false;
+
     static {
         exemptOfPasscodeActivities = new HashSet<>();
         exemptOfPasscodeActivities.add(PassCodeActivity.class);
@@ -84,6 +86,7 @@ public final class PassCodeManager {
             i.setAction(PassCodeActivity.ACTION_CHECK);
             i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             activity.startActivityForResult(i, PASSCODE_ACTIVITY);
+            LOCK_PROMPTED = true;
         }
 
         if (!exemptOfPasscodeActivities.contains(activity.getClass()) &&
@@ -100,7 +103,12 @@ public final class PassCodeManager {
         if (visibleActivitiesCounter > 0) {
             visibleActivitiesCounter--;
         }
-        setUnlockTimestamp(activity);
+        // Only set unlock timestamp if activity is not passcode related
+        if (!exemptOfPasscodeActivities.contains(activity.getClass()) && !LOCK_PROMPTED) {
+            setUnlockTimestamp(activity);
+        } else {
+            LOCK_PROMPTED = false;
+        }
         PowerManager powerMgr = (PowerManager) activity.getSystemService(Context.POWER_SERVICE);
         if ((isPassCodeEnabled() || deviceCredentialsAreEnabled(activity)) && powerMgr != null
                 && !powerMgr.isScreenOn()) {


### PR DESCRIPTION
Currently, every time an activity is stopped the `PassCodeManager` registers the current time and stores it as the last unlock time. This should not happen when the pass code activity is being stopped. To make matters worse, when the passcode activity is started whatever other activity was initially being started is then stopped which also registeres the last unlock time. By killing the app and restarting it before the 5 second timeout expires the lock will be bypassed entirely.

The only reason the lock works at all when not killing the app is simply because the PassCode activity is on top of the activity stack so the user is presented with it when resuming the app.

To combat the issue this commit introduces two changes.

1. Do not register unlock timestamp when the PassCodeActivity is stopped.
2. When the PassCodeActivity is started, set a `LOCK_PROMPTED` to `true`. When the PassCodeActivity is stopped we set the `LOCK_PROMPTED` to `false`.

Only when `LOCK_PROMPTED` is false and an activity other than the `PassCodeActivity` is stopped will we register the unlock time.

This fixes #3757

Signed-off-by: ardevd <edvard.holst@gmail.com>