### PR TITLE
activity: finish the activity when pressing back from the root folder.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -379,7 +379,7 @@ public class UploadFilesActivity extends FileActivity implements
 
             File parentFolder = mCurrentDir.getParentFile();
             if (!parentFolder.canRead()) {
-                showLocalStoragePathPickerDialog();
+                finish();
                 return;
             }
 


### PR DESCRIPTION
When browsing for files to upload a storage location selection prompt is shown when hitting the back toolbar button when in the root directory. It probably makes more sense to finish the activity.

Fixes #3811