### PR TITLE
NPE check on note

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -283,7 +283,7 @@ public class FileDetailSharingFragment extends Fragment implements UserListAdapt
 
             String note = file.getNote();
 
-            if (!note.isEmpty()) {
+            if (!TextUtils.isEmpty(note)) {
                 sharedWithYouNote.setText(file.getNote());
                 sharedWithYouNote.setVisibility(View.VISIBLE);
             } else {


### PR DESCRIPTION
Resolves: #3808

It should never be null due to our fetch, which fails back to "" (empty string), but there are few crash reports on google…

I assume that this is due to to upgrade:
- app is upgraded 
- directly show details of a file
--> thus no note property was set/fetched and thus it is null

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>