### PR TITLE
enhance DocumentsProvider

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -62,6 +62,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.provider.DocumentsContract;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -1767,6 +1768,13 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
             setAccountAuthenticatorResult(intent.getExtras());
             setResult(RESULT_OK, intent);
+
+            // notify Document Provider
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                String authority = getResources().getString(R.string.document_provider_authority);
+                Uri rootsUri = DocumentsContract.buildRootsUri(authority);
+                getContentResolver().notifyChange(rootsUri, null);
+            }
 
             return true;
         }

--- a/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
+++ b/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
@@ -30,6 +30,9 @@ import android.accounts.AccountManagerCallback;
 import android.accounts.AccountManagerFuture;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.DocumentsContract;
 import android.text.TextUtils;
 
 import com.evernote.android.job.Job;
@@ -140,6 +143,13 @@ public class AccountRemovalJob extends Job implements AccountManagerCallback<Boo
             if (remoteWipe && client != null) {
                 String authToken = client.getCredentials().getAuthToken();
                 new RemoteWipeSuccessRemoteOperation(authToken).execute(client);
+            }
+
+            // notify Document Provider
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                String authority = context.getResources().getString(R.string.document_provider_authority);
+                Uri rootsUri = DocumentsContract.buildRootsUri(authority);
+                context.getContentResolver().notifyChange(rootsUri, null);
             }
 
             return Result.SUCCESS;

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -125,6 +125,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return new FileCursor();
         }
 
+        initiateStorageMap();
+
         final RootCursor result = new RootCursor(projection);
         for(int i = 0; i < rootIdToStorageManager.size(); i++) {
             result.addRoot(new Document(rootIdToStorageManager.valueAt(i), ROOT_PATH), getContext());
@@ -291,7 +293,6 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public boolean onCreate() {
         accountManager = UserAccountManagerImpl.fromContext(getContext());
-        initiateStorageMap();
         return true;
     }
 

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -111,6 +111,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     UserAccountManager accountManager;
 
     private static final String DOCUMENTID_SEPARATOR = "/";
+    private static final int DOCUMENTID_PARTS = 2;
     private final SparseArray<FileDataStorageManager> rootIdToStorageManager = new SparseArray<>();
 
     private final Executor executor = Executors.newCachedThreadPool();
@@ -705,8 +706,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     private Document toDocument(String documentId) {
-        String[] separated = documentId.split(DOCUMENTID_SEPARATOR, 2);
-        if (separated.length != 2) {
+        String[] separated = documentId.split(DOCUMENTID_SEPARATOR, DOCUMENTID_PARTS);
+        if (separated.length != DOCUMENTID_PARTS) {
             return null;
         }
 

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -146,12 +146,12 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         throws FileNotFoundException {
         Log.d(TAG, "queryChildDocuments(), id=" + parentDocumentId);
 
-        Document parentFolder = toDocument(parentDocumentId);
-
         Context context = getContext();
         if (context == null) {
             throw new FileNotFoundException("Context may not be null");
         }
+
+        Document parentFolder = toDocument(parentDocumentId);
 
         FileDataStorageManager storageManager = parentFolder.getStorageManager();
 
@@ -327,12 +327,12 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public String renameDocument(String documentId, String displayName) throws FileNotFoundException {
         Log.d(TAG, "renameDocument(), id=" + documentId);
 
-        Document document = toDocument(documentId);
-
         Context context = getContext();
         if (context == null) {
             throw new FileNotFoundException("Context may not be null!");
         }
+
+        Document document = toDocument(documentId);
 
         RemoteOperationResult result = new RenameFileOperation(document.getRemotePath(), displayName)
             .execute(document.getClient(), document.getStorageManager());
@@ -351,15 +351,15 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public String copyDocument(String sourceDocumentId, String targetParentDocumentId) throws FileNotFoundException {
         Log.d(TAG, "copyDocument(), id=" + sourceDocumentId);
 
-        Document document = toDocument(sourceDocumentId);
-        Document targetFolder = toDocument(targetParentDocumentId);
-
         Context context = getContext();
         if (context == null) {
             throw new FileNotFoundException("Context may not be null!");
         }
 
+        Document document = toDocument(sourceDocumentId);
+
         FileDataStorageManager storageManager = document.getStorageManager();
+        Document targetFolder = toDocument(targetParentDocumentId);
 
         RemoteOperationResult result = new CopyFileOperation(document.getRemotePath(), targetFolder.getRemotePath())
             .execute(document.getClient(), storageManager);
@@ -398,14 +398,13 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         throws FileNotFoundException {
         Log.d(TAG, "moveDocument(), id=" + sourceDocumentId);
 
-        Document document = toDocument(sourceDocumentId);
-        Document sourceFolder = toDocument(sourceParentDocumentId);
-        Document targetFolder = toDocument(targetParentDocumentId);
-
         Context context = getContext();
         if (context == null) {
             throw new FileNotFoundException("Context may not be null!");
         }
+
+        Document document = toDocument(sourceDocumentId);
+        Document targetFolder = toDocument(targetParentDocumentId);
 
         RemoteOperationResult result = new MoveFileOperation(document.getRemotePath(), targetFolder.getRemotePath())
             .execute(document.getClient(), document.getStorageManager());
@@ -414,6 +413,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Failed to move document with documentId " + sourceDocumentId
                                                 + " to " + targetParentDocumentId);
         }
+
+        Document sourceFolder = toDocument(sourceParentDocumentId);
 
         getContext().getContentResolver().notifyChange(toNotifyUri(sourceFolder), null, false);
         getContext().getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
@@ -494,7 +495,6 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         Account account = targetFolder.getAccount();
-        OwnCloudClient client = targetFolder.getClient();
 
         // create dummy file
         File tempDir = new File(FileStorageUtils.getTemporalPath(account.name));
@@ -520,6 +520,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         String newFilePath = targetFolder.getRemotePath() + displayName;
 
         // perform the upload, no need for chunked operation as we have a empty file
+        OwnCloudClient client = targetFolder.getClient();
         RemoteOperationResult result = new UploadFileRemoteOperation(emptyFile.getAbsolutePath(),
                                                                      newFilePath,
                                                                      null,
@@ -561,16 +562,14 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public void deleteDocument(String documentId) throws FileNotFoundException {
         Log.d(TAG, "deleteDocument(), id=" + documentId);
 
-        Document document = toDocument(documentId);
-
         Context context = getContext();
         if (context == null) {
             throw new FileNotFoundException("Context may not be null!");
         }
 
-        recursiveRevokePermission(document);
+        Document document = toDocument(documentId);
 
-        Document parentFolder = document.getParent();
+        recursiveRevokePermission(document);
 
         RemoteOperationResult result = new RemoveFileOperation(document.getRemotePath(), false,
                                                                document.getAccount(), true, context)
@@ -580,6 +579,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Failed to delete document with documentId " + documentId);
         }
 
+        Document parentFolder = document.getParent();
         context.getContentResolver().notifyChange(toNotifyUri(parentFolder), null, false);
     }
 

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -179,7 +179,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         boolean isLoading = false;
         if (parentFolder.isExpired()) {
-            final LoadChildrenTask task = new LoadChildrenTask(parentFolder, getContext(), loadChildrenCallback);
+            final LoadChildrenTask task = new LoadChildrenTask(parentFolder, loadChildrenCallback);
             task.executeOnExecutor(executor);
             resultCursor.setLoadingTask(task);
             isLoading = true;
@@ -735,12 +735,10 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     static class LoadChildrenTask extends AsyncTask<Void, Void, RemoteOperationResult> {
 
         private final Document document;
-        private final Context context;
         private final OnTaskFinishedCallback<Document> callback;
 
-        LoadChildrenTask(Document document, Context context, OnTaskFinishedCallback<Document> callback) {
+        LoadChildrenTask(Document document, OnTaskFinishedCallback<Document> callback) {
             this.document = document;
-            this.context = context;
             this.callback = callback;
         }
 
@@ -749,7 +747,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             Log.d(TAG, "run RefreshDocumentTask(), id=" + document.getDocumentId());
             return new RefreshFolderOperation(document.getFile(), System.currentTimeMillis(), false,
                                               false, true, document.getStorageManager(), document.getAccount(),
-                                              context).execute(document.getClient());
+                                              MainApp.getAppContext()).execute(document.getClient());
         }
 
         @Override
@@ -768,9 +766,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     public class Document {
         private final FileDataStorageManager storageManager;
-        private final Long fileId;
+        private final long fileId;
 
-        Document(FileDataStorageManager storageManager, Long fileId) {
+        Document(FileDataStorageManager storageManager, long fileId) {
             this.storageManager = storageManager;
             this.fileId = fileId;
         }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -34,17 +34,18 @@ import android.content.res.AssetFileDescriptor;
 import android.database.Cursor;
 import android.graphics.Point;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.ParcelFileDescriptor;
+import android.provider.DocumentsContract;
 import android.provider.DocumentsProvider;
 import android.util.Log;
 import android.widget.Toast;
 
-import com.evernote.android.job.JobRequest;
-import com.evernote.android.job.util.Device;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.account.UserAccountManagerImpl;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -80,10 +81,20 @@ import org.nextcloud.providers.cursors.RootCursor;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import dagger.android.AndroidInjection;
 
 import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
 import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
@@ -91,16 +102,24 @@ import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
 @TargetApi(Build.VERSION_CODES.KITKAT)
 public class DocumentsStorageProvider extends DocumentsProvider {
 
-    private static final String TAG = "DocumentsStorageProvider";
+    private static final String TAG = DocumentsStorageProvider.class.getSimpleName();
 
-    private FileDataStorageManager currentStorageManager;
-    private Map<Long, FileDataStorageManager> rootIdToStorageManager;
-    private OwnCloudClient client;
+    private static final long CACHE_EXPIRATION = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
 
     UserAccountManager accountManager;
 
+    private static final String ROOT_SEPARATOR = "/";
+    private final Map<Integer, FileDataStorageManager> rootIdToStorageManager = new HashMap<>();
+
+    private final Executor executor = Executors.newCachedThreadPool();
+
+    private final OnTaskFinishedCallback<Document> loadChildrenCallback =
+        (status, document, exception) -> getContext().getContentResolver().notifyChange(toNotifyUri(document), null, false);
+
     @Override
-    public Cursor queryRoots(String[] projection) throws FileNotFoundException {
+    public Cursor queryRoots(String[] projection) {
+        Log.d(TAG, "queryRoots()");
+
         Context context = MainApp.getAppContext();
         AppPreferences preferences = AppPreferencesImpl.fromContext(context);
         if (SettingsActivity.LOCK_PASSCODE.equals(preferences.getLockPreference()) ||
@@ -108,12 +127,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return new FileCursor();
         }
 
-        initiateStorageMap();
-
         final RootCursor result = new RootCursor(projection);
-
-        for (Account account : accountManager.getAccounts()) {
-            result.addRoot(account, getContext());
+        for (Map.Entry<Integer, FileDataStorageManager> entry : rootIdToStorageManager.entrySet()) {
+            result.addRoot(new Document(entry.getValue(), "/"), getContext());
         }
 
         return result;
@@ -121,28 +137,16 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     @Override
     public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
-        final long docId = Long.parseLong(documentId);
-        updateCurrentStorageManagerIfNeeded(docId);
+        Log.d(TAG, "queryDocument(), id=" + documentId);
 
-        if (currentStorageManager == null) {
+        Document document = toDocument(documentId);
 
-            for (Map.Entry<Long, FileDataStorageManager> entry : rootIdToStorageManager.entrySet()) {
-                if (entry.getValue().getFileById(docId) != null) {
-                    currentStorageManager = entry.getValue();
-                    break;
-                }
-            }
-        }
-
-        if (currentStorageManager == null) {
-            throw new FileNotFoundException("File with id " + documentId + " not found");
+        if (document == null) {
+            throw new FileNotFoundException("File " + documentId + " not found!");
         }
 
         final FileCursor result = new FileCursor(projection);
-        OCFile file = currentStorageManager.getFileById(docId);
-        if (file != null) {
-            result.addFile(file);
-        }
+        result.addFile(document);
 
         return result;
     }
@@ -151,34 +155,38 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder)
         throws FileNotFoundException {
+        Log.d(TAG, "queryChildDocuments(), id=" + parentDocumentId);
 
-        final long folderId = Long.parseLong(parentDocumentId);
-        updateCurrentStorageManagerIfNeeded(folderId);
+        Document parentFolder = toDocument(parentDocumentId);
+        if (parentFolder == null) {
+            throw new FileNotFoundException("File " + parentDocumentId + " not found!");
+        }
 
         Context context = getContext();
-
         if (context == null) {
             throw new FileNotFoundException("Context may not be null");
         }
 
-        Account account = currentStorageManager.getAccount();
-        final OCFile browsedDir = currentStorageManager.getFileById(folderId);
-        if (Device.getNetworkType(context).equals(JobRequest.NetworkType.UNMETERED)) {
-            RemoteOperationResult result = new RefreshFolderOperation(browsedDir, System.currentTimeMillis(), false,
-                                                                      false, true, currentStorageManager, account,
-                                                                      getContext()).execute(client);
-
-            if (!result.isSuccess()) {
-                throw new FileNotFoundException("Failed to update document " + parentDocumentId);
-            }
-        }
+        FileDataStorageManager storageManager = parentFolder.getStorageManager();
 
         final FileCursor resultCursor = new FileCursor(projection);
 
-        for (OCFile file : currentStorageManager.getFolderContent(browsedDir, false)) {
-            resultCursor.addFile(file);
+        for (OCFile file : storageManager.getFolderContent(parentFolder.getFile(), false)) {
+            resultCursor.addFile(new Document(storageManager, file));
         }
 
+        boolean isLoading = false;
+        if (parentFolder.isExpired()) {
+            final LoadChildrenTask task = new LoadChildrenTask(parentFolder, getContext(), loadChildrenCallback);
+            task.executeOnExecutor(executor);
+            resultCursor.setLoadingTask(task);
+            isLoading = true;
+        }
+
+        final Bundle extra = new Bundle();
+        extra.putBoolean(DocumentsContract.EXTRA_LOADING, isLoading);
+        resultCursor.setExtras(extra);
+        resultCursor.setNotificationUri(getContext().getContentResolver(), toNotifyUri(parentFolder));
         return resultCursor;
     }
 
@@ -186,12 +194,10 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public ParcelFileDescriptor openDocument(String documentId, String mode, CancellationSignal cancellationSignal)
             throws FileNotFoundException {
-        final long docId = Long.parseLong(documentId);
-        updateCurrentStorageManagerIfNeeded(docId);
+        Log.d(TAG, "openDocument(), id=" + documentId);
 
-        OCFile ocFile = currentStorageManager.getFileById(docId);
-
-        if (ocFile == null) {
+        Document document = toDocument(documentId);
+        if (document == null) {
             throw new FileNotFoundException("File not found: " + documentId);
         }
 
@@ -201,7 +207,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Context may not be null!");
         }
 
-        Account account = currentStorageManager.getAccount();
+        OCFile ocFile = document.getFile();
+        Account account = document.getAccount();
+
         if (!ocFile.isDown()) {
             Intent i = new Intent(getContext(), FileDownloader.class);
             i.putExtra(FileDownloader.EXTRA_ACCOUNT, account);
@@ -216,7 +224,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                 if (!waitOrGetCancelled(cancellationSignal)) {
                     throw new FileNotFoundException("File with id " + documentId + " not found!");
                 }
-                ocFile = currentStorageManager.getFileById(docId);
+                ocFile = document.getFile();
 
                 if (ocFile == null) {
                     throw new FileNotFoundException("File with id " + documentId + " not found!");
@@ -226,11 +234,11 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             OCFile finalFile = ocFile;
             Thread syncThread = new Thread(() -> {
                 try {
-                    FileDataStorageManager storageManager =
+                    FileDataStorageManager sm =
                             new FileDataStorageManager(account, context.getContentResolver());
                     SynchronizeFileOperation sfo =
                             new SynchronizeFileOperation(finalFile, null, account, true, context);
-                    RemoteOperationResult result = sfo.execute(storageManager, context);
+                    RemoteOperationResult result = sfo.execute(sm, context);
                     if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {
                         // ISSUE 5: if the user is not running the app (this is a service!),
                         // this can be very intrusive; a notification should be preferred
@@ -271,7 +279,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                 return ParcelFileDescriptor.open(file, accessMode, handler, l -> {
                     RemoteOperationResult result = new SynchronizeFileOperation(newFile, oldFile, account, true,
                                                                                 context)
-                        .execute(client, currentStorageManager);
+                        .execute(document.getClient(), document.getStorageManager());
 
                     boolean success = result.isSuccess();
 
@@ -297,6 +305,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public boolean onCreate() {
         accountManager = UserAccountManagerImpl.fromContext(getContext());
+        initiateStorageMap();
         return true;
     }
 
@@ -305,13 +314,11 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                                                      Point sizeHint,
                                                      CancellationSignal signal)
             throws FileNotFoundException {
-        long docId = Long.parseLong(documentId);
-        updateCurrentStorageManagerIfNeeded(docId);
+        Log.d(TAG, "openDocumentThumbnail(), id=" + documentId);
 
-        OCFile file = currentStorageManager.getFileById(docId);
-
-        if (file == null) {
-            throw new FileNotFoundException("File with id " + documentId + " not found!");
+        Document document = toDocument(documentId);
+        if (document == null) {
+            throw new FileNotFoundException("File " + documentId + " not found!");
         }
 
         Context context = getContext();
@@ -321,125 +328,152 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         boolean exists = ThumbnailsCacheManager.containsBitmap(ThumbnailsCacheManager.PREFIX_THUMBNAIL
-                                                                   + file.getRemoteId());
+                                                                   + document.getFile().getRemoteId());
 
         if (!exists) {
-            ThumbnailsCacheManager.generateThumbnailFromOCFile(file);
+            ThumbnailsCacheManager.generateThumbnailFromOCFile(document.getFile());
         }
 
         Uri uri = Uri.parse(UriUtils.URI_CONTENT_SCHEME + context.getResources().getString(
-            R.string.image_cache_provider_authority) + file.getRemotePath());
+            R.string.image_cache_provider_authority) + document.getFile().getRemotePath());
+        Log.d(TAG, "open thumbnail, uri=" + uri);
         return context.getContentResolver().openAssetFileDescriptor(uri, "r");
     }
 
     @Override
     public String renameDocument(String documentId, String displayName) throws FileNotFoundException {
-        long docId = Long.parseLong(documentId);
-        updateCurrentStorageManagerIfNeeded(docId);
+        Log.d(TAG, "renameDocument(), id=" + documentId);
 
-        OCFile file = currentStorageManager.getFileById(docId);
-
-        if (file == null) {
+        Document document = toDocument(documentId);
+        if (document == null) {
             throw new FileNotFoundException("File " + documentId + " not found!");
         }
 
-        RemoteOperationResult result = new RenameFileOperation(file.getRemotePath(), displayName)
-            .execute(client, currentStorageManager);
+        Context context = getContext();
+
+        if (context == null) {
+            throw new FileNotFoundException("Context may not be null!");
+        }
+
+        RemoteOperationResult result = new RenameFileOperation(document.getFile().getRemotePath(), displayName)
+            .execute(document.getClient(), document.getStorageManager());
 
         if (!result.isSuccess()) {
             throw new FileNotFoundException("Failed to rename document with documentId " + documentId + ": " +
                                                 result.getException());
         }
 
+        context.getContentResolver().notifyChange(toNotifyUri(document.getParent()), null, false);
+
         return null;
     }
 
     @Override
     public String copyDocument(String sourceDocumentId, String targetParentDocumentId) throws FileNotFoundException {
-        long sourceId = Long.parseLong(sourceDocumentId);
+        Log.d(TAG, "copyDocument(), id=" + sourceDocumentId);
 
-        updateCurrentStorageManagerIfNeeded(sourceId);
-
-        OCFile file = currentStorageManager.getFileById(sourceId);
-        if (file == null) {
+        Document document = toDocument(sourceDocumentId);
+        if (document == null) {
             throw new FileNotFoundException("File " + sourceDocumentId + " not found!");
         }
 
-        long targetId = Long.parseLong(targetParentDocumentId);
-        OCFile targetFolder = currentStorageManager.getFileById(targetId);
+        Document targetFolder = toDocument(targetParentDocumentId);
         if (targetFolder == null) {
             throw new FileNotFoundException("File " + targetParentDocumentId + " not found!");
         }
 
-        RemoteOperationResult result = new CopyFileOperation(file.getRemotePath(), targetFolder.getRemotePath())
-            .execute(client, currentStorageManager);
+        Context context = getContext();
+
+        if (context == null) {
+            throw new FileNotFoundException("Context may not be null!");
+        }
+
+        FileDataStorageManager storageManager = document.getStorageManager();
+
+        RemoteOperationResult result = new CopyFileOperation(document.getFile().getRemotePath(), targetFolder.getFile().getRemotePath())
+            .execute(document.getClient(), storageManager);
 
         if (!result.isSuccess()) {
             throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
                                                 + " to " + targetParentDocumentId);
         }
 
-        Account account = currentStorageManager.getAccount();
+        Account account = document.getAccount();
 
-        RemoteOperationResult updateParent = new RefreshFolderOperation(targetFolder, System.currentTimeMillis(),
-                                                                        false, false, true, currentStorageManager,
-                                                                        account, getContext()).execute(client);
+        RemoteOperationResult updateParent = new RefreshFolderOperation(targetFolder.getFile(), System.currentTimeMillis(),
+                                                                        false, false, true, storageManager,
+                                                                        account, context).execute(targetFolder.getClient());
 
         if (!updateParent.isSuccess()) {
             throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
                                                 + " to " + targetParentDocumentId);
         }
 
-        String newPath = targetFolder.getRemotePath() + file.getFileName();
+        String newPath = targetFolder.getFile().getRemotePath() + document.getFile().getFileName();
 
-        if (file.isFolder()) {
-            newPath = newPath + PATH_SEPARATOR;
+        if (document.getFile().isFolder()) {
+            newPath = newPath + "/";
         }
-        OCFile newFile = currentStorageManager.getFileByPath(newPath);
+        Document newFile = new Document(storageManager, newPath);
 
-        return String.valueOf(newFile.getFileId());
+        context.getContentResolver().notifyChange(toNotifyUri(newFile.getParent()), null, false);
+
+        return newFile.getDocumentId();
     }
 
     @Override
     public String moveDocument(String sourceDocumentId, String sourceParentDocumentId, String targetParentDocumentId)
         throws FileNotFoundException {
-        long sourceId = Long.parseLong(sourceDocumentId);
+        Log.d(TAG, "moveDocument(), id=" + sourceDocumentId);
 
-        updateCurrentStorageManagerIfNeeded(sourceId);
-
-        OCFile file = currentStorageManager.getFileById(sourceId);
-
-        if (file == null) {
+        Document document = toDocument(sourceDocumentId);
+        if (document == null) {
             throw new FileNotFoundException("File " + sourceDocumentId + " not found!");
         }
 
-        long targetId = Long.parseLong(targetParentDocumentId);
-        OCFile targetFolder = currentStorageManager.getFileById(targetId);
+        Document sourceFolder = toDocument(sourceParentDocumentId);
+        if (sourceFolder == null) {
+            throw new FileNotFoundException("File " + sourceParentDocumentId + " not found!");
+        }
 
+        Document targetFolder = toDocument(targetParentDocumentId);
         if (targetFolder == null) {
             throw new FileNotFoundException("File " + targetParentDocumentId + " not found!");
         }
 
-        RemoteOperationResult result = new MoveFileOperation(file.getRemotePath(), targetFolder.getRemotePath())
-            .execute(client, currentStorageManager);
+        Context context = getContext();
+
+        if (context == null) {
+            throw new FileNotFoundException("Context may not be null!");
+        }
+
+        RemoteOperationResult result = new MoveFileOperation(document.getFile().getRemotePath(), targetFolder.getFile().getRemotePath())
+            .execute(document.getClient(), document.getStorageManager());
 
         if (!result.isSuccess()) {
             throw new FileNotFoundException("Failed to move document with documentId " + sourceDocumentId
                                                 + " to " + targetParentDocumentId);
         }
 
-        return String.valueOf(file.getFileId());
+        getContext().getContentResolver().notifyChange(toNotifyUri(sourceFolder), null, false);
+        getContext().getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+
+        return sourceDocumentId;
     }
 
     @Override
     public Cursor querySearchDocuments(String rootId, String query, String[] projection) {
-        updateCurrentStorageManagerIfNeeded(rootId);
+        Log.d(TAG, "querySearchDocuments(), rootId=" + rootId);
 
-        OCFile root = currentStorageManager.getFileByPath(ROOT_PATH);
         FileCursor result = new FileCursor(projection);
 
-        for (OCFile f : findFiles(root, query)) {
-            result.addFile(f);
+        FileDataStorageManager storageManager = getStorageManager(rootId);
+        if (storageManager == null) {
+            return result;
+        }
+
+        for (Document d : findFiles(new Document(storageManager, "/"), query)) {
+            result.addFile(d);
         }
 
         return result;
@@ -447,49 +481,66 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     @Override
     public String createDocument(String documentId, String mimeType, String displayName) throws FileNotFoundException {
-        long docId = Long.parseLong(documentId);
-        updateCurrentStorageManagerIfNeeded(docId);
+        Log.d(TAG, "createDocument(), id=" + documentId);
 
-        OCFile parent = currentStorageManager.getFileById(docId);
-
-        if (parent == null) {
+        Document folderDocument = toDocument(documentId);
+        if (folderDocument == null) {
             throw new FileNotFoundException("Parent file not found");
         }
 
-        if ("vnd.android.document/directory".equalsIgnoreCase(mimeType)) {
-            return createFolder(parent, displayName, documentId);
+        if (DocumentsContract.Document.MIME_TYPE_DIR.equalsIgnoreCase(mimeType)) {
+            return createFolder(folderDocument, displayName);
         } else {
-            return createFile(parent, displayName, documentId);
+            return createFile(folderDocument, displayName);
         }
     }
 
-    private String createFolder(OCFile parent, String displayName, String documentId) throws FileNotFoundException {
+    private String createFolder(Document targetFolder, String displayName) throws FileNotFoundException {
 
-        CreateFolderOperation createFolderOperation = new CreateFolderOperation(parent.getRemotePath() + displayName
-                                                                                    + PATH_SEPARATOR, true);
-        RemoteOperationResult result = createFolderOperation.execute(client, currentStorageManager);
-
-
-        if (!result.isSuccess()) {
-            throw new FileNotFoundException("Failed to create document with name " +
-                                                displayName + " and documentId " + documentId);
-        }
-
-
-        String newDirPath = parent.getRemotePath() + displayName + PATH_SEPARATOR;
-        OCFile newFolder = currentStorageManager.getFileByPath(newDirPath);
-
-        return String.valueOf(newFolder.getFileId());
-    }
-
-    private String createFile(OCFile parent, String displayName, String documentId) throws FileNotFoundException {
         Context context = getContext();
 
         if (context == null) {
             throw new FileNotFoundException("Context may not be null!");
         }
 
-        Account account = currentStorageManager.getAccount();
+        FileDataStorageManager storageManager = targetFolder.getStorageManager();
+
+        CreateFolderOperation createFolderOperation = new CreateFolderOperation(targetFolder.getFile().getRemotePath() + displayName
+                                                                                    + "/", true);
+        RemoteOperationResult result = createFolderOperation.execute(targetFolder.getClient(), storageManager);
+
+
+        if (!result.isSuccess()) {
+            throw new FileNotFoundException("Failed to create document with name " +
+                                                displayName + " and documentId " + targetFolder.getDocumentId());
+        }
+
+
+        Account account = targetFolder.getAccount();
+        OwnCloudClient client = targetFolder.getClient();
+        RemoteOperationResult updateParent = new RefreshFolderOperation(targetFolder.getFile(), System.currentTimeMillis(),
+                                                                        false, false, true, storageManager,
+                                                                        account, context).execute(client);
+
+        if (!updateParent.isSuccess()) {
+            throw new FileNotFoundException("Failed to create document with documentId " + targetFolder.getDocumentId());
+        }
+
+        String newDirPath = targetFolder.getFile().getRemotePath() + displayName + "/";
+        Document newFolder = new Document(storageManager, newDirPath);
+
+        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+
+        return newFolder.getDocumentId();
+    }
+
+    private String createFile(Document targetFolder, String displayName) throws FileNotFoundException {
+        Context context = getContext();
+        if (context == null) {
+            throw new FileNotFoundException("Context may not be null!");
+        }
+
+        Account account = targetFolder.getAccount();
 
         // create dummy file
         File tempDir = new File(FileStorageUtils.getTemporalPath(account.name));
@@ -503,8 +554,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         FileUploader.UploadRequester requester = new FileUploader.UploadRequester();
-        requester.uploadNewFile(getContext(), account, new String[]{emptyFile.getAbsolutePath()},
-                                new String[]{parent.getRemotePath() + displayName}, null,
+        requester.uploadNewFile(context, account, new String[]{emptyFile.getAbsolutePath()},
+                                new String[]{targetFolder.getFile().getRemotePath() + displayName}, null,
                                 FileUploader.LOCAL_BEHAVIOUR_MOVE, true, UploadFileOperation.CREATED_BY_USER, false,
                                 false);
 
@@ -514,18 +565,23 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             Log_OC.e(TAG, "Thread interruption error");
         }
 
-        RemoteOperationResult updateParent = new RefreshFolderOperation(parent, System.currentTimeMillis(),
-                                                                        false, false, true, currentStorageManager,
-                                                                        account, getContext()).execute(client);
+        OwnCloudClient client = targetFolder.getClient();
+        FileDataStorageManager storageManager = targetFolder.getStorageManager();
+
+        RemoteOperationResult updateParent = new RefreshFolderOperation(targetFolder.getFile(), System.currentTimeMillis(),
+                                                                        false, false, true, storageManager,
+                                                                        account, context).execute(client);
 
         if (!updateParent.isSuccess()) {
-            throw new FileNotFoundException("Failed to create document with documentId " + documentId);
+            throw new FileNotFoundException("Failed to create document with documentId " + targetFolder.getDocumentId());
         }
 
-        String newFilePath = parent.getRemotePath() + displayName;
-        OCFile newFile = currentStorageManager.getFileByPath(newFilePath);
+        String newFilePath = targetFolder.getFile().getRemotePath() + displayName;
+        Document newFile = new Document(storageManager, newFilePath);
 
-        return String.valueOf(newFile.getFileId());
+        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+
+        return newFile.getDocumentId();
     }
 
     @Override
@@ -535,76 +591,86 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     @Override
     public void deleteDocument(String documentId) throws FileNotFoundException {
-        long docId = Long.parseLong(documentId);
-        updateCurrentStorageManagerIfNeeded(docId);
+        Log.d(TAG, "deleteDocument(), id=" + documentId);
 
-        OCFile file = currentStorageManager.getFileById(docId);
-
-        if (file == null) {
+        Document document = toDocument(documentId);
+        if (document == null) {
             throw new FileNotFoundException("File " + documentId + " not found!");
         }
-        Account account = currentStorageManager.getAccount();
-
-        RemoveFileOperation removeFileOperation = new RemoveFileOperation(file.getRemotePath(), false, account, true,
-                                                                          getContext());
-
-        RemoteOperationResult result = removeFileOperation.execute(client, currentStorageManager);
-
-        if (!result.isSuccess()) {
-            throw new FileNotFoundException("Failed to delete document with documentId " + documentId);
-        }
-    }
-
-    @SuppressLint("LongLogTag")
-    private void updateCurrentStorageManagerIfNeeded(long docId) {
-        if (rootIdToStorageManager == null) {
-            try {
-                queryRoots(FileCursor.DEFAULT_DOCUMENT_PROJECTION);
-            } catch (FileNotFoundException e) {
-                Log.e(TAG, "Failed to query roots");
-            }
-        }
-
-        if (currentStorageManager == null ||
-            rootIdToStorageManager.containsKey(docId) && currentStorageManager != rootIdToStorageManager.get(docId)) {
-            currentStorageManager = rootIdToStorageManager.get(docId);
-        }
-
-        try {
-            Account account = currentStorageManager.getAccount();
-            OwnCloudAccount ocAccount = new OwnCloudAccount(account, MainApp.getAppContext());
-            client = OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount, getContext());
-        } catch (OperationCanceledException | IOException | AuthenticatorException |
-            com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
-            Log_OC.e(TAG, "Failed to set client", e);
-        }
-    }
-
-    private void updateCurrentStorageManagerIfNeeded(String rootId) {
-        for (FileDataStorageManager data : rootIdToStorageManager.values()) {
-            if (data.getAccount().name.equals(rootId)) {
-                currentStorageManager = data;
-            }
-        }
-    }
-
-    @SuppressLint("UseSparseArrays")
-    private void initiateStorageMap() throws FileNotFoundException {
 
         Context context = getContext();
-
-        final Account[] allAccounts = accountManager.getAccounts();
-        rootIdToStorageManager = new HashMap<>(allAccounts.length);
-
         if (context == null) {
             throw new FileNotFoundException("Context may not be null!");
         }
 
-        final ContentResolver contentResolver = context.getContentResolver();
-        for (Account account : allAccounts) {
+        recursiveRevokePermission(document);
+
+        Document parentFolder = document.getParent();
+
+        RemoveFileOperation removeFileOperation = new RemoveFileOperation(document.getFile().getRemotePath(), false, document.getAccount(), true,
+                                                                          context);
+
+        RemoteOperationResult result = removeFileOperation.execute(document.getClient(), document.getStorageManager());
+
+        if (!result.isSuccess()) {
+            throw new FileNotFoundException("Failed to delete document with documentId " + documentId);
+        }
+
+        context.getContentResolver().notifyChange(toNotifyUri(parentFolder), null, false);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void recursiveRevokePermission(Document document) {
+        FileDataStorageManager storageManager = document.getStorageManager();
+        OCFile file = document.getFile();
+        if (file.isFolder()) {
+            for (OCFile child : storageManager.getFolderContent(file, false)) {
+                recursiveRevokePermission(new Document(storageManager, child));
+            }
+        }
+
+        revokeDocumentPermission(document.getDocumentId());
+    }
+
+    @Override
+    public void removeDocument(String documentId, String parentDocumentId) throws FileNotFoundException {
+        Log.d(TAG, "removeDocument(), id=" + documentId);
+        deleteDocument(documentId);
+    }
+
+    @Override
+    public boolean isChildDocument(String parentDocumentId, String documentId) {
+        Log.d(TAG, "isChildDocument(), parent=" + parentDocumentId + ", id=" + documentId);
+        Document document = toDocument(documentId);
+        Document folderDocument = toDocument(parentDocumentId);
+
+        if (null == document || null == folderDocument) {
+            return false;
+        }
+
+        return document.getFile().getParentId() == folderDocument.getFile().getFileId();
+    }
+
+    private FileDataStorageManager getStorageManager(String rootId) {
+        for (FileDataStorageManager data : rootIdToStorageManager.values()) {
+            if (data.getAccount().name.equals(rootId)) {
+                return data;
+            }
+        }
+
+        return null;
+    }
+
+    @SuppressLint("UseSparseArrays")
+    private void initiateStorageMap() {
+
+        rootIdToStorageManager.clear();
+
+        ContentResolver contentResolver = getContext().getContentResolver();
+
+        for (Account account : accountManager.getAccounts()) {
             final FileDataStorageManager storageManager = new FileDataStorageManager(account, contentResolver);
-            final OCFile rootDir = storageManager.getFileByPath(ROOT_PATH);
-            rootIdToStorageManager.put(rootDir.getFileId(), storageManager);
+            rootIdToStorageManager.put(account.hashCode(), storageManager);
         }
     }
 
@@ -618,15 +684,143 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         return !(cancellationSignal != null && cancellationSignal.isCanceled());
     }
 
-    List<OCFile> findFiles(OCFile root, String query) {
-        List<OCFile> result = new ArrayList<>();
-        for (OCFile f : currentStorageManager.getFolderContent(root, false)) {
+    private List<Document> findFiles(Document root, String query) {
+        FileDataStorageManager storageManager = root.getStorageManager();
+        List<Document> result = new ArrayList<>();
+        for (OCFile f : storageManager.getFolderContent(root.getFile(), false)) {
             if (f.isFolder()) {
-                result.addAll(findFiles(f, query));
+                result.addAll(findFiles(new Document(storageManager, f), query));
             } else if (f.getFileName().contains(query)) {
-                result.add(f);
+                result.add(new Document(storageManager, f));
             }
         }
         return result;
+    }
+
+    private Uri toNotifyUri(Document document) {
+        return DocumentsContract.buildDocumentUri(
+            getContext().getString(R.string.document_provider_authority),
+            document.getDocumentId());
+    }
+
+    private Document toDocument(String documentId) {
+        String[] separated = documentId.split(ROOT_SEPARATOR);
+        if (separated.length != 2) {
+            return null;
+        }
+
+        FileDataStorageManager storageManager = rootIdToStorageManager.get(Integer.parseInt(separated[0]));
+        if (storageManager == null) {
+            return null;
+        }
+
+        return new Document(storageManager, Long.parseLong(separated[1]));
+    }
+
+    public interface OnTaskFinishedCallback<T> {
+
+        int SUCCEEDED = 0;
+        int FAILED = 1;
+        int CANCELLED = 2;
+
+        @IntDef({ SUCCEEDED, FAILED, CANCELLED })
+        @Retention(RetentionPolicy.SOURCE)
+        @interface Status {}
+
+        void onTaskFinished(@Status int status, @Nullable T item, @Nullable Exception exception);
+    }
+
+    static class LoadChildrenTask extends AsyncTask<Void, Void, RemoteOperationResult> {
+
+        private final Document document;
+        private final Context context;
+        private final OnTaskFinishedCallback<Document> callback;
+
+        LoadChildrenTask(Document document, Context context, OnTaskFinishedCallback<Document> callback) {
+            this.document = document;
+            this.context = context;
+            this.callback = callback;
+        }
+
+        @Override
+        public final RemoteOperationResult doInBackground(Void... params) {
+            Log.d(TAG, "run RefreshDocumentTask(), id=" + document.getDocumentId());
+            return new RefreshFolderOperation(document.getFile(), System.currentTimeMillis(), false,
+                                              false, true, document.getStorageManager(), document.getAccount(),
+                                              context).execute(document.getClient());
+        }
+
+        @Override
+        public final void onPostExecute(RemoteOperationResult result) {
+            if (callback != null) {
+                if (result.isSuccess()) {
+                    callback.onTaskFinished(OnTaskFinishedCallback.SUCCEEDED, document, null);
+                } else if (result.isCancelled()) {
+                    callback.onTaskFinished(OnTaskFinishedCallback.CANCELLED, document, null);
+                } else {
+                    callback.onTaskFinished(OnTaskFinishedCallback.FAILED, document, result.getException());
+                }
+            }
+        }
+    }
+
+    public class Document {
+        private final FileDataStorageManager storageManager;
+        private final Long fileId;
+
+        Document(FileDataStorageManager storageManager, Long fileId) {
+            this.storageManager = storageManager;
+            this.fileId = fileId;
+        }
+
+        Document(FileDataStorageManager storageManager, OCFile file) {
+            this.storageManager = storageManager;
+            this.fileId = file.getFileId();
+        }
+
+        Document(FileDataStorageManager storageManager, String filePath) {
+            this.storageManager = storageManager;
+            this.fileId = storageManager.getFileByPath(filePath).getFileId();
+        }
+
+        public String getDocumentId() {
+            for (Map.Entry<Integer, FileDataStorageManager> entry : rootIdToStorageManager.entrySet()) {
+                if (Objects.equals(storageManager, entry.getValue())) {
+                    return entry.getKey() + ROOT_SEPARATOR + fileId;
+                }
+            }
+            return null;
+        }
+
+        FileDataStorageManager getStorageManager() {
+            return storageManager;
+        }
+
+        public Account getAccount() {
+            return getStorageManager().getAccount();
+        }
+
+        public OCFile getFile() {
+            return getStorageManager().getFileById(fileId);
+        }
+
+        OwnCloudClient getClient() {
+            try {
+                OwnCloudAccount ocAccount = new OwnCloudAccount(getAccount(), MainApp.getAppContext());
+                return OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount, getContext());
+            } catch (OperationCanceledException | IOException | AuthenticatorException |
+                com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
+                Log_OC.e(TAG, "Failed to set client", e);
+            }
+            return null;
+        }
+
+        boolean isExpired() {
+            return getFile().getLastSyncDateForData() + CACHE_EXPIRATION < System.currentTimeMillis();
+        }
+
+        Document getParent() {
+            return new Document(getStorageManager(), getFile().getParentId());
+        }
     }
 }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -705,7 +705,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     private Document toDocument(String documentId) {
-        String[] separated = documentId.split(DOCUMENTID_SEPARATOR);
+        String[] separated = documentId.split(DOCUMENTID_SEPARATOR, 2);
         if (separated.length != 2) {
             return null;
         }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -91,9 +91,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Inject;
-
-import dagger.android.AndroidInjection;
+import androidx.annotation.IntDef;
+import androidx.annotation.Nullable;
 
 import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
 import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
@@ -104,9 +103,6 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     private static final String TAG = DocumentsStorageProvider.class.getSimpleName();
 
     private static final long CACHE_EXPIRATION = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
-
-    private static final String ROOT_PATH = "/";
-    public static final String PATH_SEPARATOR = "/";
 
     UserAccountManager accountManager;
 
@@ -632,12 +628,6 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         revokeDocumentPermission(document.getDocumentId());
-    }
-
-    @Override
-    public void removeDocument(String documentId, String parentDocumentId) throws FileNotFoundException {
-        Log.d(TAG, "removeDocument(), id=" + documentId);
-        deleteDocument(documentId);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -387,7 +387,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
         Document newFile = new Document(storageManager, newPath);
 
-        context.getContentResolver().notifyChange(toNotifyUri(newFile.getParent()), null, false);
+        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
 
         return newFile.getDocumentId();
     }
@@ -746,27 +746,27 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     public class Document {
         private final FileDataStorageManager storageManager;
-        private final long fileId;
+        private final OCFile file;
 
         Document(FileDataStorageManager storageManager, long fileId) {
             this.storageManager = storageManager;
-            this.fileId = fileId;
+            this.file = storageManager.getFileById(fileId);
         }
 
         Document(FileDataStorageManager storageManager, OCFile file) {
             this.storageManager = storageManager;
-            this.fileId = file.getFileId();
+            this.file = file;
         }
 
         Document(FileDataStorageManager storageManager, String filePath) {
             this.storageManager = storageManager;
-            this.fileId = storageManager.getFileByPath(filePath).getFileId();
+            this.file = storageManager.getFileByPath(filePath);
         }
 
         public String getDocumentId() {
             for(int i = 0; i < rootIdToStorageManager.size(); i++) {
                 if (Objects.equals(storageManager, rootIdToStorageManager.valueAt(i))) {
-                    return rootIdToStorageManager.keyAt(i) + DOCUMENTID_SEPARATOR + fileId;
+                    return rootIdToStorageManager.keyAt(i) + DOCUMENTID_SEPARATOR + file.getFileId();
                 }
             }
             return null;
@@ -781,7 +781,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         public OCFile getFile() {
-            return getStorageManager().getFileById(fileId);
+            return file;
         }
 
         public String getRemotePath() {
@@ -804,7 +804,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         Document getParent() {
-            long parentId = getFile().getParentId();
+            long parentId = file.getParentId();
             if (parentId <= 0) {
                 return null;
             }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -118,14 +118,16 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public Cursor queryRoots(String[] projection) {
 
+        // always recreate storage manager collection, as it will change after account creation/removal
+        // and we need to serve document(tree)s with persist permissions
+        initiateStorageMap();
+
         Context context = MainApp.getAppContext();
         AppPreferences preferences = AppPreferencesImpl.fromContext(context);
         if (SettingsActivity.LOCK_PASSCODE.equals(preferences.getLockPreference()) ||
             SettingsActivity.LOCK_DEVICE_CREDENTIALS.equals(preferences.getLockPreference())) {
             return new FileCursor();
         }
-
-        initiateStorageMap();
 
         final RootCursor result = new RootCursor(projection);
         for(int i = 0; i < rootIdToStorageManager.size(); i++) {
@@ -293,6 +295,11 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public boolean onCreate() {
         accountManager = UserAccountManagerImpl.fromContext(getContext());
+
+        // initiate storage manager collection, because we need to serve document(tree)s
+        // with persist permissions
+        initiateStorageMap();
+
         return true;
     }
 

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -616,14 +616,16 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         Log.d(TAG, "isChildDocument(), parent=" + parentDocumentId + ", id=" + documentId);
 
         try {
-            Document document = toDocument(documentId);
-            Document folderDocument = toDocument(parentDocumentId);
+            Document currentDocument = toDocument(documentId);
+            Document parentDocument = toDocument(parentDocumentId);
 
-            if (null == document || null == folderDocument) {
-                return false;
+            while (!ROOT_PATH.equals(currentDocument.getRemotePath())) {
+                currentDocument = currentDocument.getParent();
+                if (parentDocument.getFile().equals(currentDocument.getFile())) {
+                    return true;
+                }
             }
 
-            return document.getFile().getParentId() == folderDocument.getFile().getFileId();
         } catch (FileNotFoundException e) {
             Log.e(TAG, "failed to check for child document", e);
         }
@@ -802,7 +804,12 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         Document getParent() {
-            return new Document(getStorageManager(), getFile().getParentId());
+            long parentId = getFile().getParentId();
+            if (parentId <= 0) {
+                return null;
+            }
+
+            return new Document(getStorageManager(), parentId);
         }
     }
 }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -524,7 +524,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                                                                      newFilePath,
                                                                      null,
                                                                      "",
-                                                                     String.valueOf(System.currentTimeMillis()))
+                                                                     String.valueOf(System.currentTimeMillis() / 1000))
             .execute(client);
 
         if (!result.isSuccess()) {

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -395,7 +395,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
         Document newFile = new Document(storageManager, newPath);
 
-        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+        context.getContentResolver().notifyChange(toNotifyUri(newFile.getParent()), null, false);
 
         return newFile.getDocumentId();
     }
@@ -754,27 +754,27 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     public class Document {
         private final FileDataStorageManager storageManager;
-        private final OCFile file;
+        private final long fileId;
 
         Document(FileDataStorageManager storageManager, long fileId) {
             this.storageManager = storageManager;
-            this.file = storageManager.getFileById(fileId);
+            this.fileId = fileId;
         }
 
         Document(FileDataStorageManager storageManager, OCFile file) {
             this.storageManager = storageManager;
-            this.file = file;
+            this.fileId = file.getFileId();
         }
 
         Document(FileDataStorageManager storageManager, String filePath) {
             this.storageManager = storageManager;
-            this.file = storageManager.getFileByPath(filePath);
+            this.fileId = storageManager.getFileByPath(filePath).getFileId();
         }
 
         public String getDocumentId() {
             for(int i = 0; i < rootIdToStorageManager.size(); i++) {
                 if (Objects.equals(storageManager, rootIdToStorageManager.valueAt(i))) {
-                    return rootIdToStorageManager.keyAt(i) + DOCUMENTID_SEPARATOR + file.getFileId();
+                    return rootIdToStorageManager.keyAt(i) + DOCUMENTID_SEPARATOR + fileId;
                 }
             }
             return null;
@@ -789,7 +789,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         public OCFile getFile() {
-            return file;
+            return getStorageManager().getFileById(fileId);
         }
 
         public String getRemotePath() {
@@ -812,7 +812,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         Document getParent() {
-            long parentId = file.getParentId();
+            long parentId = getFile().getParentId();
             if (parentId <= 0) {
                 return null;
             }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -44,6 +44,7 @@ import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.DocumentsProvider;
 import android.util.Log;
+import android.util.SparseArray;
 import android.widget.Toast;
 
 import com.nextcloud.client.account.UserAccountManager;
@@ -84,9 +85,7 @@ import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -106,10 +105,13 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     private static final long CACHE_EXPIRATION = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
 
+    private static final String ROOT_PATH = "/";
+    public static final String PATH_SEPARATOR = "/";
+
     UserAccountManager accountManager;
 
-    private static final String ROOT_SEPARATOR = "/";
-    private final Map<Integer, FileDataStorageManager> rootIdToStorageManager = new HashMap<>();
+    private static final String DOCUMENTID_SEPARATOR = "/";
+    private final SparseArray<FileDataStorageManager> rootIdToStorageManager = new SparseArray<>();
 
     private final Executor executor = Executors.newCachedThreadPool();
 
@@ -118,7 +120,6 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     @Override
     public Cursor queryRoots(String[] projection) {
-        Log.d(TAG, "queryRoots()");
 
         Context context = MainApp.getAppContext();
         AppPreferences preferences = AppPreferencesImpl.fromContext(context);
@@ -128,8 +129,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         final RootCursor result = new RootCursor(projection);
-        for (Map.Entry<Integer, FileDataStorageManager> entry : rootIdToStorageManager.entrySet()) {
-            result.addRoot(new Document(entry.getValue(), "/"), getContext());
+        for(int i = 0; i < rootIdToStorageManager.size(); i++) {
+            result.addRoot(new Document(rootIdToStorageManager.valueAt(i), ROOT_PATH), getContext());
         }
 
         return result;
@@ -234,11 +235,10 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             OCFile finalFile = ocFile;
             Thread syncThread = new Thread(() -> {
                 try {
-                    FileDataStorageManager sm =
-                            new FileDataStorageManager(account, context.getContentResolver());
-                    SynchronizeFileOperation sfo =
-                            new SynchronizeFileOperation(finalFile, null, account, true, context);
-                    RemoteOperationResult result = sfo.execute(sm, context);
+                    FileDataStorageManager storageManager = new FileDataStorageManager(account, context.getContentResolver());
+                    RemoteOperationResult result = new SynchronizeFileOperation(finalFile, null, account,
+                                                                                true, context)
+                        .execute(storageManager, context);
                     if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {
                         // ISSUE 5: if the user is not running the app (this is a service!),
                         // this can be very intrusive; a notification should be preferred
@@ -335,7 +335,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         Uri uri = Uri.parse(UriUtils.URI_CONTENT_SCHEME + context.getResources().getString(
-            R.string.image_cache_provider_authority) + document.getFile().getRemotePath());
+            R.string.image_cache_provider_authority) + document.getRemotePath());
         Log.d(TAG, "open thumbnail, uri=" + uri);
         return context.getContentResolver().openAssetFileDescriptor(uri, "r");
     }
@@ -355,7 +355,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Context may not be null!");
         }
 
-        RemoteOperationResult result = new RenameFileOperation(document.getFile().getRemotePath(), displayName)
+        RemoteOperationResult result = new RenameFileOperation(document.getRemotePath(), displayName)
             .execute(document.getClient(), document.getStorageManager());
 
         if (!result.isSuccess()) {
@@ -390,7 +390,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         FileDataStorageManager storageManager = document.getStorageManager();
 
-        RemoteOperationResult result = new CopyFileOperation(document.getFile().getRemotePath(), targetFolder.getFile().getRemotePath())
+        RemoteOperationResult result = new CopyFileOperation(document.getRemotePath(), targetFolder.getRemotePath())
             .execute(document.getClient(), storageManager);
 
         if (!result.isSuccess()) {
@@ -402,17 +402,18 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         RemoteOperationResult updateParent = new RefreshFolderOperation(targetFolder.getFile(), System.currentTimeMillis(),
                                                                         false, false, true, storageManager,
-                                                                        account, context).execute(targetFolder.getClient());
+                                                                        account, context)
+            .execute(targetFolder.getClient());
 
         if (!updateParent.isSuccess()) {
             throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
                                                 + " to " + targetParentDocumentId);
         }
 
-        String newPath = targetFolder.getFile().getRemotePath() + document.getFile().getFileName();
+        String newPath = targetFolder.getRemotePath() + document.getFile().getFileName();
 
         if (document.getFile().isFolder()) {
-            newPath = newPath + "/";
+            newPath = newPath + PATH_SEPARATOR;
         }
         Document newFile = new Document(storageManager, newPath);
 
@@ -447,7 +448,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Context may not be null!");
         }
 
-        RemoteOperationResult result = new MoveFileOperation(document.getFile().getRemotePath(), targetFolder.getFile().getRemotePath())
+        RemoteOperationResult result = new MoveFileOperation(document.getRemotePath(), targetFolder.getRemotePath())
             .execute(document.getClient(), document.getStorageManager());
 
         if (!result.isSuccess()) {
@@ -472,7 +473,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return result;
         }
 
-        for (Document d : findFiles(new Document(storageManager, "/"), query)) {
+        for (Document d : findFiles(new Document(storageManager, ROOT_PATH), query)) {
             result.addFile(d);
         }
 
@@ -505,9 +506,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         FileDataStorageManager storageManager = targetFolder.getStorageManager();
 
-        CreateFolderOperation createFolderOperation = new CreateFolderOperation(targetFolder.getFile().getRemotePath() + displayName
-                                                                                    + "/", true);
-        RemoteOperationResult result = createFolderOperation.execute(targetFolder.getClient(), storageManager);
+        RemoteOperationResult result = new CreateFolderOperation(targetFolder.getRemotePath() + displayName
+                                                                     + PATH_SEPARATOR, true)
+            .execute(targetFolder.getClient(), storageManager);
 
 
         if (!result.isSuccess()) {
@@ -520,13 +521,14 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         OwnCloudClient client = targetFolder.getClient();
         RemoteOperationResult updateParent = new RefreshFolderOperation(targetFolder.getFile(), System.currentTimeMillis(),
                                                                         false, false, true, storageManager,
-                                                                        account, context).execute(client);
+                                                                        account, context)
+            .execute(client);
 
         if (!updateParent.isSuccess()) {
             throw new FileNotFoundException("Failed to create document with documentId " + targetFolder.getDocumentId());
         }
 
-        String newDirPath = targetFolder.getFile().getRemotePath() + displayName + "/";
+        String newDirPath = targetFolder.getRemotePath() + displayName + PATH_SEPARATOR;
         Document newFolder = new Document(storageManager, newDirPath);
 
         context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
@@ -555,7 +557,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         FileUploader.UploadRequester requester = new FileUploader.UploadRequester();
         requester.uploadNewFile(context, account, new String[]{emptyFile.getAbsolutePath()},
-                                new String[]{targetFolder.getFile().getRemotePath() + displayName}, null,
+                                new String[]{targetFolder.getRemotePath() + displayName}, null,
                                 FileUploader.LOCAL_BEHAVIOUR_MOVE, true, UploadFileOperation.CREATED_BY_USER, false,
                                 false);
 
@@ -576,7 +578,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Failed to create document with documentId " + targetFolder.getDocumentId());
         }
 
-        String newFilePath = targetFolder.getFile().getRemotePath() + displayName;
+        String newFilePath = targetFolder.getRemotePath() + displayName;
         Document newFile = new Document(storageManager, newFilePath);
 
         context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
@@ -607,10 +609,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         Document parentFolder = document.getParent();
 
-        RemoveFileOperation removeFileOperation = new RemoveFileOperation(document.getFile().getRemotePath(), false, document.getAccount(), true,
-                                                                          context);
-
-        RemoteOperationResult result = removeFileOperation.execute(document.getClient(), document.getStorageManager());
+        RemoteOperationResult result = new RemoveFileOperation(document.getRemotePath(), false,
+                                                               document.getAccount(), true, context)
+            .execute(document.getClient(), document.getStorageManager());
 
         if (!result.isSuccess()) {
             throw new FileNotFoundException("Failed to delete document with documentId " + documentId);
@@ -652,16 +653,16 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     private FileDataStorageManager getStorageManager(String rootId) {
-        for (FileDataStorageManager data : rootIdToStorageManager.values()) {
-            if (data.getAccount().name.equals(rootId)) {
-                return data;
+        for(int i = 0; i < rootIdToStorageManager.size(); i++) {
+            FileDataStorageManager storageManager = rootIdToStorageManager.valueAt(i);
+            if (storageManager.getAccount().name.equals(rootId)) {
+                return storageManager;
             }
         }
 
         return null;
     }
 
-    @SuppressLint("UseSparseArrays")
     private void initiateStorageMap() {
 
         rootIdToStorageManager.clear();
@@ -704,7 +705,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     private Document toDocument(String documentId) {
-        String[] separated = documentId.split(ROOT_SEPARATOR);
+        String[] separated = documentId.split(DOCUMENTID_SEPARATOR);
         if (separated.length != 2) {
             return null;
         }
@@ -784,9 +785,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         }
 
         public String getDocumentId() {
-            for (Map.Entry<Integer, FileDataStorageManager> entry : rootIdToStorageManager.entrySet()) {
-                if (Objects.equals(storageManager, entry.getValue())) {
-                    return entry.getKey() + ROOT_SEPARATOR + fileId;
+            for(int i = 0; i < rootIdToStorageManager.size(); i++) {
+                if (Objects.equals(storageManager, rootIdToStorageManager.valueAt(i))) {
+                    return rootIdToStorageManager.keyAt(i) + DOCUMENTID_SEPARATOR + fileId;
                 }
             }
             return null;
@@ -802,6 +803,10 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         public OCFile getFile() {
             return getStorageManager().getFileById(fileId);
+        }
+
+        public String getRemotePath() {
+            return getFile().getRemotePath();
         }
 
         OwnCloudClient getClient() {

--- a/src/main/java/org/nextcloud/providers/cursors/FileCursor.java
+++ b/src/main/java/org/nextcloud/providers/cursors/FileCursor.java
@@ -22,10 +22,13 @@ package org.nextcloud.providers.cursors;
 
 import android.annotation.TargetApi;
 import android.database.MatrixCursor;
+import android.os.AsyncTask;
 import android.os.Build;
+import android.os.Bundle;
 import android.provider.DocumentsContract.Document;
 
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.providers.DocumentsStorageProvider;
 import com.owncloud.android.utils.MimeTypeUtil;
 
 @TargetApi(Build.VERSION_CODES.KITKAT)
@@ -37,14 +40,41 @@ public class FileCursor extends MatrixCursor {
             Document.COLUMN_FLAGS, Document.COLUMN_LAST_MODIFIED
     };
 
+    private Bundle extra;
+    private AsyncTask<?, ?, ?> loadingTask;
+
     public FileCursor(String... projection) {
         super(projection != null ? projection : DEFAULT_DOCUMENT_PROJECTION);
     }
 
-    public void addFile(OCFile file) {
-        if (file == null) {
+    public void setLoadingTask(AsyncTask<?, ?, ?> task) {
+        this.loadingTask = task;
+    }
+
+    @Override
+    public void setExtras(Bundle extras) {
+        this.extra = extras;
+    }
+
+    @Override
+    public Bundle getExtras() {
+        return extra;
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        if (loadingTask != null && loadingTask.getStatus() != AsyncTask.Status.FINISHED) {
+            loadingTask.cancel(false);
+        }
+    }
+
+    public void addFile(DocumentsStorageProvider.Document document) {
+        if (document == null) {
             return;
         }
+
+        OCFile file = document.getFile();
 
         final int iconRes = MimeTypeUtil.getFileTypeIconId(file.getMimeType(), file.getFileName());
         final String mimeType = file.isFolder() ? Document.MIME_TYPE_DIR : file.getMimeType();
@@ -64,7 +94,7 @@ public class FileCursor extends MatrixCursor {
             flags = Document.FLAG_SUPPORTS_RENAME | flags;
         }
 
-        newRow().add(Document.COLUMN_DOCUMENT_ID, Long.toString(file.getFileId()))
+        newRow().add(Document.COLUMN_DOCUMENT_ID, document.getDocumentId())
                 .add(Document.COLUMN_DISPLAY_NAME, file.getFileName())
                 .add(Document.COLUMN_LAST_MODIFIED, file.getModificationTimestamp())
                 .add(Document.COLUMN_SIZE, file.getFileLength())

--- a/src/main/java/org/nextcloud/providers/cursors/RootCursor.java
+++ b/src/main/java/org/nextcloud/providers/cursors/RootCursor.java
@@ -30,6 +30,7 @@ import android.provider.DocumentsContract.Root;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.providers.DocumentsStorageProvider;
 
 import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
 
@@ -47,16 +48,14 @@ public class RootCursor extends MatrixCursor {
         super(projection != null ? projection : DEFAULT_ROOT_PROJECTION);
     }
 
-    public void addRoot(Account account, Context context) {
-        final FileDataStorageManager manager = new FileDataStorageManager(account, context.getContentResolver());
-        final OCFile mainDir = manager.getFileByPath(ROOT_PATH);
-
+    public void addRoot(DocumentsStorageProvider.Document document, Context context) {
+        Account account = document.getAccount();
         newRow().add(Root.COLUMN_ROOT_ID, account.name)
-            .add(Root.COLUMN_DOCUMENT_ID, mainDir.getFileId())
+            .add(Root.COLUMN_DOCUMENT_ID, document.getDocumentId())
             .add(Root.COLUMN_SUMMARY, account.name)
             .add(Root.COLUMN_TITLE, context.getString(R.string.app_name))
             .add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
-            .add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_RECENTS |
-                Root.FLAG_SUPPORTS_SEARCH);
+            .add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_IS_CHILD |
+                Root.FLAG_SUPPORTS_RECENTS | Root.FLAG_SUPPORTS_SEARCH);
     }
 }

--- a/src/main/java/org/nextcloud/providers/cursors/RootCursor.java
+++ b/src/main/java/org/nextcloud/providers/cursors/RootCursor.java
@@ -25,6 +25,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.database.MatrixCursor;
 import android.os.Build;
+import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Root;
 
 import com.owncloud.android.R;
@@ -50,12 +51,17 @@ public class RootCursor extends MatrixCursor {
 
     public void addRoot(DocumentsStorageProvider.Document document, Context context) {
         Account account = document.getAccount();
+
+        int rootFlags = Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_RECENTS | Root.FLAG_SUPPORTS_SEARCH;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            rootFlags = rootFlags | Root.FLAG_SUPPORTS_IS_CHILD;
+        }
+
         newRow().add(Root.COLUMN_ROOT_ID, account.name)
             .add(Root.COLUMN_DOCUMENT_ID, document.getDocumentId())
             .add(Root.COLUMN_SUMMARY, account.name)
             .add(Root.COLUMN_TITLE, context.getString(R.string.app_name))
             .add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
-            .add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_IS_CHILD |
-                Root.FLAG_SUPPORTS_RECENTS | Root.FLAG_SUPPORTS_SEARCH);
+            .add(Root.COLUMN_FLAGS, rootFlags);
     }
 }

--- a/src/main/java/org/nextcloud/providers/cursors/RootCursor.java
+++ b/src/main/java/org/nextcloud/providers/cursors/RootCursor.java
@@ -25,15 +25,10 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.database.MatrixCursor;
 import android.os.Build;
-import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Root;
 
 import com.owncloud.android.R;
-import com.owncloud.android.datamodel.FileDataStorageManager;
-import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.providers.DocumentsStorageProvider;
-
-import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
 
 
 @TargetApi(Build.VERSION_CODES.KITKAT)


### PR DESCRIPTION
This commit enhances DocumentProvider implementation in several ways:
- Get rid of 'currentStorageManager' and 'client' member variable. They are assigned (and only there) if one browsed over the document root of an account. But there are problems with this implementation. If a client request a child document information via content uri after some time again, these variables may be set to a different account.
- Delayed update of folder contents (faster). Instead of sending a network request and waiting for response before displaying folder contents, provide the least recent offline version. If the information is outdatet a update is queued and the UI is updated after response.
- Update folder contents in UI after create/rename/copy/move operations (which are currently not)
- Implement 'isChildDocument()' and expose it to support 'ACTION_OPEN_DOCUMENT_TREE' intent
- Implement 'removeDocument()' in addition to 'deleteDocument()' to support delete operations on Android >= 7.0