### PR TITLE
Missing Injectable lead to half-stored account

### DIFF
--- a/src/gplay/java/com/nextcloud/client/di/VariantComponentsModule.java
+++ b/src/gplay/java/com/nextcloud/client/di/VariantComponentsModule.java
@@ -19,6 +19,7 @@
  */
 package com.nextcloud.client.di;
 
+import com.owncloud.android.authentication.ModifiedAuthenticatorActivity;
 import com.owncloud.android.services.firebase.NCFirebaseInstanceIDService;
 
 import dagger.Module;
@@ -27,4 +28,5 @@ import dagger.android.ContributesAndroidInjector;
 @Module
 abstract class VariantComponentsModule {
     @ContributesAndroidInjector abstract NCFirebaseInstanceIDService ncFirebaseInstanceIDService();
+    @ContributesAndroidInjector abstract ModifiedAuthenticatorActivity modifiedAuthenticatorActivity();
 }

--- a/src/gplay/java/com/owncloud/android/authentication/ModifiedAuthenticatorActivity.java
+++ b/src/gplay/java/com/owncloud/android/authentication/ModifiedAuthenticatorActivity.java
@@ -2,6 +2,7 @@ package com.owncloud.android.authentication;
 
 import android.os.Bundle;
 
+import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.utils.GooglePlayUtils;
 
 /**
@@ -24,7 +25,7 @@ import com.owncloud.android.utils.GooglePlayUtils;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class ModifiedAuthenticatorActivity extends AuthenticatorActivity {
+public class ModifiedAuthenticatorActivity extends AuthenticatorActivity implements Injectable {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -88,6 +88,7 @@ import com.blikoon.qrcodescanner.QrCodeActivity;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputLayout;
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.OwnCloudAccount;
@@ -147,7 +148,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class AuthenticatorActivity extends AccountAuthenticatorActivity
     implements OnRemoteOperationListener, OnFocusChangeListener, OnEditorActionListener, OnSslUntrustedCertListener,
-        AuthenticatorAsyncTask.OnAuthenticatorTaskListener {
+    AuthenticatorAsyncTask.OnAuthenticatorTaskListener, Injectable {
 
     private static final String TAG = AuthenticatorActivity.class.getSimpleName();
 


### PR DESCRIPTION
Otherwise this 
https://github.com/nextcloud/android/blob/33d8b667ad9f85fe0d7438f2d845688967cd119a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java#L1669

lead to a NPE.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>