### PR TITLE
Enable Kotlin support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 import com.github.spotbugs.SpotBugsTask
 
 buildscript {
+    ext.kotlin_version = '1.3.31'
     repositories {
         google()
         jcenter()
@@ -24,10 +25,13 @@ buildscript {
             exclude group: 'org.codehaus.groovy', module: 'groovy-all'
         }
         classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.6'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'checkstyle'
 apply plugin: 'pmd'
 apply plugin: 'findbugs'
@@ -320,6 +324,7 @@ dependencies {
     // fix conflict in dependencies; see http://g.co/androidstudio/app-test-app-conflict for details
     //androidTestImplementation "com.android.support:support-annotations:${supportLibraryVersion}"
     androidTestImplementation 'tools.fastlane:screengrab:1.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
 //    jacocoAnt "org.jacoco:org.jacoco.ant:${jacocoVersion}"
 //    jacocoAgent "org.jacoco:org.jacoco.agent:${jacocoVersion}"


### PR DESCRIPTION
Enabling Kotlin support would allow us to start deprecating Lombok and start using Kotlin in unit tests.

It is worth mentioning that Kotlin data classes provide compile-time generated `hashCode()` and `equals()`.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
