### PR TITLE
Add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 28
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+    - 1. developing
+    - 2. to review
+    - 3. to release
+    - approved
+    - enhancement
+    - overview
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    This request did not receive an update in the last 4 weeks.
+    Please take a look again and update the issue with new details,
+    otherwise the issue will be automatically closed in 2 weeks. Thank you!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This will only affect bug/none labelled issues.
As we have too many non-reproducible bugs open, every bug that is not approved and has no reply within 28 days will get notified, and after 14 days closed.

I try to reproduce every new bug, but as there is such a lot, I am sometimes failing to do so. 
If a bug is closed, it still can get re-opened.

Let us see, how this works out…

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>