### PR TITLE
use authenticated glide loader for svg

### DIFF
--- a/src/main/java/com/nextcloud/client/di/ComponentsModule.java
+++ b/src/main/java/com/nextcloud/client/di/ComponentsModule.java
@@ -20,6 +20,7 @@
 
 package com.nextcloud.client.di;
 
+import com.nextcloud.client.whatsnew.WhatsNewActivity;
 import com.owncloud.android.authentication.AuthenticatorActivity;
 import com.owncloud.android.authentication.DeepLinkLoginActivity;
 import com.owncloud.android.files.BootupBroadcastReceiver;
@@ -56,7 +57,6 @@ import com.owncloud.android.ui.activity.UploadFilesActivity;
 import com.owncloud.android.ui.activity.UploadListActivity;
 import com.owncloud.android.ui.activity.UploadPathActivity;
 import com.owncloud.android.ui.activity.UserInfoActivity;
-import com.nextcloud.client.whatsnew.WhatsNewActivity;
 import com.owncloud.android.ui.dialog.ChooseTemplateDialogFragment;
 import com.owncloud.android.ui.errorhandling.ErrorShowActivity;
 import com.owncloud.android.ui.fragment.ExtendedListFragment;
@@ -64,6 +64,7 @@ import com.owncloud.android.ui.fragment.FileDetailActivitiesFragment;
 import com.owncloud.android.ui.fragment.FileDetailFragment;
 import com.owncloud.android.ui.fragment.LocalFileListFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
+import com.owncloud.android.ui.fragment.contactsbackup.ContactListFragment;
 import com.owncloud.android.ui.preview.PreviewImageActivity;
 import com.owncloud.android.ui.preview.PreviewVideoActivity;
 import com.owncloud.android.ui.trashbin.TrashbinActivity;
@@ -120,6 +121,9 @@ abstract class ComponentsModule {
     @ContributesAndroidInjector abstract OCFileListFragment ocFileListFragment();
     @ContributesAndroidInjector abstract FileDetailActivitiesFragment fileDetailActivitiesFragment();
     @ContributesAndroidInjector abstract ChooseTemplateDialogFragment chooseTemplateDialogFragment();
+
+    @ContributesAndroidInjector
+    abstract ContactListFragment chooseContactListFragment();
 
     @ContributesAndroidInjector abstract FileUploader fileUploader();
 

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -924,7 +924,13 @@ public abstract class DrawerActivity extends ToolbarActivity
                         }
                     };
 
-                    DisplayUtils.downloadIcon(this, firstQuota.iconUrl, target, R.drawable.ic_link, size, size);
+                    DisplayUtils.downloadIcon(getUserAccountManager(),
+                                              this,
+                                              firstQuota.iconUrl,
+                                              target,
+                                              R.drawable.ic_link,
+                                              size,
+                                              size);
 
                 } else {
                     mQuotaTextLink.setVisibility(View.GONE);
@@ -1051,7 +1057,13 @@ public abstract class DrawerActivity extends ToolbarActivity
                     }
                 };
 
-                DisplayUtils.downloadIcon(this, link.iconUrl, target, R.drawable.ic_link, size, size);
+                DisplayUtils.downloadIcon(getUserAccountManager(),
+                                          this,
+                                          link.iconUrl,
+                                          target,
+                                          R.drawable.ic_link,
+                                          size,
+                                          size);
             }
 
             setDrawerMenuItemChecked(mCheckedMenuItem);

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -57,6 +57,7 @@ import com.bumptech.glide.request.target.Target;
 import com.caverock.androidsvg.SVG;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.client.account.CurrentAccountProvider;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -71,6 +72,7 @@ import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.events.MenuItemClickEvent;
 import com.owncloud.android.ui.events.SearchEvent;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
+import com.owncloud.android.utils.glide.CustomGlideUriLoader;
 import com.owncloud.android.utils.svg.SvgDecoder;
 import com.owncloud.android.utils.svg.SvgDrawableTranscoder;
 
@@ -497,11 +499,16 @@ public final class DisplayUtils {
         }
     }
 
-    public static void downloadIcon(Context context, String iconUrl, SimpleTarget imageView, int placeholder,
-                                    int width, int height) {
+    public static void downloadIcon(CurrentAccountProvider currentAccountProvider,
+                                    Context context,
+                                    String iconUrl,
+                                    SimpleTarget imageView,
+                                    int placeholder,
+                                    int width,
+                                    int height) {
         try {
             if (iconUrl.endsWith(".svg")) {
-                downloadSVGIcon(context, iconUrl, imageView, placeholder, width, height);
+                downloadSVGIcon(currentAccountProvider, context, iconUrl, imageView, placeholder, width, height);
             } else {
                 downloadPNGIcon(context, iconUrl, imageView, placeholder);
             }
@@ -521,10 +528,15 @@ public final class DisplayUtils {
                 .into(imageView);
     }
 
-    private static void downloadSVGIcon(Context context, String iconUrl, SimpleTarget imageView, int placeholder,
-                                        int width, int height) {
+    private static void downloadSVGIcon(CurrentAccountProvider currentAccountProvider,
+                                        Context context,
+                                        String iconUrl,
+                                        SimpleTarget imageView,
+                                        int placeholder,
+                                        int width,
+                                        int height) {
         GenericRequestBuilder<Uri, InputStream, SVG, PictureDrawable> requestBuilder = Glide.with(context)
-                .using(Glide.buildStreamModelLoader(Uri.class, context), InputStream.class)
+            .using(new CustomGlideUriLoader(currentAccountProvider), InputStream.class)
                 .from(Uri.class)
                 .as(SVG.class)
                 .transcode(new SvgDrawableTranscoder(), PictureDrawable.class)

--- a/src/main/java/com/owncloud/android/utils/glide/CustomGlideUriLoader.java
+++ b/src/main/java/com/owncloud/android/utils/glide/CustomGlideUriLoader.java
@@ -1,0 +1,46 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2019 Tobias Kaminsky
+ * Copyright (C) 2019 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.utils.glide;
+
+import android.net.Uri;
+
+import com.bumptech.glide.load.data.DataFetcher;
+import com.bumptech.glide.load.model.stream.StreamModelLoader;
+import com.nextcloud.client.account.CurrentAccountProvider;
+
+import java.io.InputStream;
+
+/**
+ * Custom Model for authenticated fetching from Uri
+ */
+public class CustomGlideUriLoader implements StreamModelLoader<Uri> {
+
+    private final CurrentAccountProvider currentAccount;
+
+    public CustomGlideUriLoader(CurrentAccountProvider currentAccount) {
+        this.currentAccount = currentAccount;
+    }
+
+    @Override
+    public DataFetcher<InputStream> getResourceFetcher(Uri url, int width, int height) {
+        return new HttpStreamFetcher(currentAccount, url.toString());
+    }
+}


### PR DESCRIPTION
- have external app installed
- previously: links in drawer had default icon
- now: they do get the real icon

This was due to a change that requires that icons can only be fetched if authenticated

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>