### PR TITLE
[DO NOT MERGE] ACRA crash reporting prototype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,6 +341,10 @@ dependencies {
 //    androidJacocoAnt "org.jacoco:org.jacoco.core:${jacocoVersion}"
 //    androidJacocoAnt "org.jacoco:org.jacoco.report:${jacocoVersion}"
 //    androidJacocoAnt "org.jacoco:org.jacoco.agent:${jacocoVersion}"
+
+    // ACRA crash reporter
+    implementation "ch.acra:acra-mail:5.3.0"
+    implementation "ch.acra:acra-dialog:5.3.0"
 }
 
 configurations.all {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -375,6 +375,14 @@
             android:name=".ui.activity.SsoGrantPermissionActivity"
             android:exported="true"
             android:theme="@style/Theme.ownCloud.Dialog.NoTitle" />
+
+        <activity
+            android:theme="@android:style/Theme.DeviceDefault.Light.Dialog.NoActionBar"
+            android:name="com.nextcloud.client.diagnostics.CrashAcraDialog"
+            android:process=":acra"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"
+            android:launchMode="singleInstance"/>
     </application>
 
 </manifest>

--- a/src/main/java/com/nextcloud/client/diagnostics/CrashAcraDialog.kt
+++ b/src/main/java/com/nextcloud/client/diagnostics/CrashAcraDialog.kt
@@ -1,0 +1,25 @@
+package com.nextcloud.client.diagnostics
+
+import android.os.Bundle
+import android.widget.Button
+import com.owncloud.android.R
+import kotlinx.android.synthetic.main.acra_crash_report_dialog.*
+import org.acra.dialog.BaseCrashReportDialog
+
+class CrashAcraDialog : BaseCrashReportDialog() {
+
+    private lateinit var ok: Button
+    private lateinit var cancel: Button
+
+    override fun init(savedInstanceState: Bundle?) {
+        super.init(savedInstanceState)
+        setContentView(R.layout.acra_crash_report_dialog)
+
+        ok = acra_crash_report_dialog_ok
+        cancel = acra_crash_report_dialog_cancel
+
+        ok.setOnClickListener { sendCrash(null, null) }
+        cancel.setOnClickListener { cancelReports() }
+    }
+
+}

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -76,6 +76,13 @@ import com.owncloud.android.utils.PermissionUtil;
 import com.owncloud.android.utils.ReceiversHelper;
 import com.owncloud.android.utils.SecurityUtils;
 
+import org.acra.ACRA;
+import org.acra.ReportField;
+import org.acra.annotation.AcraCore;
+import org.acra.annotation.AcraDialog;
+import org.acra.annotation.AcraMailSender;
+import static org.acra.ReportField.*;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -109,6 +116,9 @@ import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFER
  * Contains methods to build the "static" strings. These strings were before constants in different
  * classes
  */
+@AcraCore(buildConfigClass = BuildConfig.class, reportContent = { ReportField.STACK_TRACE })
+@AcraMailSender(mailTo = "hello@ezaquarii.com", reportAsFile = false)
+@AcraDialog(reportDialogClass = com.nextcloud.client.diagnostics.CrashAcraDialog.class)
 public class MainApp extends MultiDexApplication implements
     HasActivityInjector,
     HasSupportFragmentInjector,
@@ -172,6 +182,7 @@ public class MainApp extends MultiDexApplication implements
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
+        ACRA.init(this);
         initGlobalContext(this);
         DaggerAppComponent.builder()
             .application(this)

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -140,6 +140,8 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
         emptyContentMessage.setVisibility(View.INVISIBLE);
         emptyContentHeadline.setVisibility(View.INVISIBLE);
 
+        String z = null;
+        int x = z.length();
     }
 
     protected void onCreateSwipeToRefresh(SwipeRefreshLayout refreshLayout) {

--- a/src/main/res/layout/acra_crash_report_dialog.xml
+++ b/src/main/res/layout/acra_crash_report_dialog.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp"
+    android:background="@color/white">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="NextCloud crashed :("
+        android:textAppearance="@android:style/TextAppearance.DeviceDefault.DialogWindowTitle"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="We crashed, but we know Why. Why is in the file we captured. It would be nice to send Why to us, if you don't mind, so we can help. Why does not contain any personal data. We promise to be nice and not use Why for anything dodgy. Etc, etc..."/>
+
+    <Button
+        android:id="@+id/acra_crash_report_dialog_ok"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Send e-mail to cause Tobi a headache"/>
+
+    <Button
+        android:id="@+id/acra_crash_report_dialog_cancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="No! My precious!!!"/>
+
+</LinearLayout>


### PR DESCRIPTION
ACRA crash reporter captures stack trace and launches activity UI where user can decide what to do with it.

If user wants to send the report, it launches Android default e-mail app composer with stack trace in message body, subject and e-mail filled. Other custom actions can be implemented as needed.

Test:
1) launch the app
2) open Activities where I placed a NPE crash
3) app crashes and ACRA launches a dialog
