### PR TITLE
Fix NPE on weakref in ThumbnailsCacheManger

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -841,10 +841,11 @@ public final class ThumbnailsCacheManager {
         protected void onPostExecute(Drawable drawable) {
             if (drawable != null) {
                 AvatarGenerationListener listener = mAvatarGenerationListener.get();
-                AvatarGenerationTask avatarWorkerTask = getAvatarWorkerTask(mCallContext);
-
-                if (this == avatarWorkerTask && listener.shouldCallGeneratedCallback(mUserId, mCallContext)) {
-                    listener.avatarGenerated(drawable, mCallContext);
+                if (listener != null) {
+                    AvatarGenerationTask avatarWorkerTask = getAvatarWorkerTask(mCallContext);
+                    if (this == avatarWorkerTask && listener.shouldCallGeneratedCallback(mUserId, mCallContext)) {
+                        listener.avatarGenerated(drawable, mCallContext);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Listener reference was weak and there was no check for null,
causing an NPE.

Fixes #3994

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>