### PR TITLE
Migrate UserAccount helpers to UserAccountManager

### DIFF
--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -9,6 +9,8 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 
+import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.client.account.UserAccountManagerImpl;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientFactory;
@@ -51,15 +53,15 @@ public abstract class AbstractIT {
             String password = arguments.getString("TEST_SERVER_PASSWORD");
 
             Account temp = new Account(loginName + "@" + baseUrl, MainApp.getAccountType(targetContext));
-
-            if (!com.owncloud.android.authentication.AccountUtils.exists(temp, targetContext)) {
-                AccountManager accountManager = AccountManager.get(targetContext);
-                accountManager.addAccountExplicitly(temp, password, null);
-                accountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_ACCOUNT_VERSION,
+            UserAccountManager accountManager = UserAccountManagerImpl.fromContext(targetContext);
+            if (!accountManager.exists(temp)) {
+                AccountManager platformAccountManager = AccountManager.get(targetContext);
+                platformAccountManager.addAccountExplicitly(temp, password, null);
+                platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_ACCOUNT_VERSION,
                         Integer.toString(com.owncloud.android.authentication.AccountUtils.ACCOUNT_VERSION));
-                accountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_VERSION, "14.0.0.0");
-                accountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, baseUrl.toString());
-                accountManager.setUserData(temp, AccountUtils.Constants.KEY_USER_ID, loginName); // same as userId
+                platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_VERSION, "14.0.0.0");
+                platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, baseUrl.toString());
+                platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_USER_ID, loginName); // same as userId
             }
 
             account = com.owncloud.android.authentication.AccountUtils.getOwnCloudAccountByName(targetContext,

--- a/src/main/java/com/nextcloud/android/sso/InputStreamBinder.java
+++ b/src/main/java/com/nextcloud/android/sso/InputStreamBinder.java
@@ -36,7 +36,7 @@ import android.util.Log;
 import com.nextcloud.android.sso.aidl.IInputStreamService;
 import com.nextcloud.android.sso.aidl.NextcloudRequest;
 import com.nextcloud.android.sso.aidl.ParcelFileDescriptorUtil;
-import com.owncloud.android.authentication.AccountUtils;
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManager;
@@ -95,9 +95,11 @@ public class InputStreamBinder extends IInputStreamService.Stub {
 
     private static final char PATH_SEPARATOR = '/';
     private Context context;
+    private UserAccountManager accountManager;
 
-    public InputStreamBinder(Context context) {
+    public InputStreamBinder(Context context, UserAccountManager accountManager) {
         this.context = context;
+        this.accountManager = accountManager;
     }
 
     private NameValuePair[] convertMapToNVP(Map<String, String> map) {
@@ -252,7 +254,7 @@ public class InputStreamBinder extends IInputStreamService.Stub {
         throws UnsupportedOperationException,
         com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException,
         OperationCanceledException, AuthenticatorException, IOException {
-        Account account = AccountUtils.getOwnCloudAccountByName(context, request.getAccountName());
+        Account account = accountManager.getAccountByName(request.getAccountName());
         if (account == null) {
             throw new IllegalStateException(EXCEPTION_ACCOUNT_NOT_FOUND);
         }

--- a/src/main/java/com/nextcloud/client/account/UserAccountManager.java
+++ b/src/main/java/com/nextcloud/client/account/UserAccountManager.java
@@ -21,6 +21,7 @@ package com.nextcloud.client.account;
 
 import android.accounts.Account;
 
+import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 
@@ -41,6 +42,14 @@ public interface UserAccountManager extends CurrentAccountProvider {
     Account[] getAccounts();
 
     /**
+     * Check if Nextcloud account is registered in {@link android.accounts.AccountManager}
+     *
+     * @param account Account to check for
+     * @return true if account is registered, false otherwise
+     */
+    boolean exists(Account account);
+
+    /**
      * Verifies that every account has userId set.
      */
     void migrateUserId();
@@ -48,7 +57,33 @@ public interface UserAccountManager extends CurrentAccountProvider {
     @Nullable
     Account getAccountByName(String name);
 
+    boolean setCurrentOwnCloudAccount(String accountName);
+
+    boolean setCurrentOwnCloudAccount(int hashCode);
+
+    /**
+     * Access the version of the OC server corresponding to an account SAVED IN THE ACCOUNTMANAGER
+     *
+     * @param account ownCloud account
+     * @return Version of the OC server corresponding to account, according to the data saved
+     * in the system AccountManager
+     */
+    @NonNull
     OwnCloudVersion getServerVersion(Account account);
+
+    boolean isSearchSupported(@Nullable Account account);
+    boolean isMediaStreamingSupported(@Nullable Account account);
+
+    void resetOwnCloudAccount();
+
+    /**
+     * Checks if an account owns the file (file's ownerId is the same as account name)
+     *
+     * @param file File to check
+     * @param account account to compare
+     * @return false if ownerId is not set or owner is a different account
+     */
+    boolean accountOwnsFile(OCFile file, Account account);
 
     /**
      * Extract username from account.

--- a/src/main/java/com/nextcloud/client/di/ComponentsModule.java
+++ b/src/main/java/com/nextcloud/client/di/ComponentsModule.java
@@ -24,10 +24,14 @@ import com.nextcloud.client.whatsnew.WhatsNewActivity;
 import com.owncloud.android.authentication.AuthenticatorActivity;
 import com.owncloud.android.authentication.DeepLinkLoginActivity;
 import com.owncloud.android.files.BootupBroadcastReceiver;
+import com.owncloud.android.files.services.FileDownloader;
 import com.owncloud.android.files.services.FileUploader;
+import com.owncloud.android.jobs.NotificationJob;
 import com.owncloud.android.providers.DiskLruImageCacheFileProvider;
 import com.owncloud.android.providers.DocumentsStorageProvider;
 import com.owncloud.android.providers.UsersAndGroupsSearchProvider;
+import com.owncloud.android.services.AccountManagerService;
+import com.owncloud.android.services.OperationsService;
 import com.owncloud.android.ui.activities.ActivitiesActivity;
 import com.owncloud.android.ui.activity.BaseActivity;
 import com.owncloud.android.ui.activity.ConflictsResolveActivity;
@@ -62,11 +66,14 @@ import com.owncloud.android.ui.errorhandling.ErrorShowActivity;
 import com.owncloud.android.ui.fragment.ExtendedListFragment;
 import com.owncloud.android.ui.fragment.FileDetailActivitiesFragment;
 import com.owncloud.android.ui.fragment.FileDetailFragment;
+import com.owncloud.android.ui.fragment.FileDetailSharingFragment;
 import com.owncloud.android.ui.fragment.LocalFileListFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
 import com.owncloud.android.ui.fragment.contactsbackup.ContactListFragment;
 import com.owncloud.android.ui.preview.PreviewImageActivity;
 import com.owncloud.android.ui.preview.PreviewImageFragment;
+import com.owncloud.android.ui.preview.PreviewMediaFragment;
+import com.owncloud.android.ui.preview.PreviewTextFragment;
 import com.owncloud.android.ui.preview.PreviewVideoActivity;
 import com.owncloud.android.ui.trashbin.TrashbinActivity;
 
@@ -121,17 +128,23 @@ abstract class ComponentsModule {
     @ContributesAndroidInjector abstract LocalFileListFragment localFileListFragment();
     @ContributesAndroidInjector abstract OCFileListFragment ocFileListFragment();
     @ContributesAndroidInjector abstract FileDetailActivitiesFragment fileDetailActivitiesFragment();
+    @ContributesAndroidInjector abstract FileDetailSharingFragment fileDetailSharingFragment();
     @ContributesAndroidInjector abstract ChooseTemplateDialogFragment chooseTemplateDialogFragment();
     @ContributesAndroidInjector abstract PreviewImageFragment previewImageFragment();
-
-    @ContributesAndroidInjector
-    abstract ContactListFragment chooseContactListFragment();
+    @ContributesAndroidInjector abstract ContactListFragment chooseContactListFragment();
+    @ContributesAndroidInjector abstract PreviewMediaFragment previewMediaFragment();
+    @ContributesAndroidInjector abstract PreviewTextFragment previewTextFragment();
 
     @ContributesAndroidInjector abstract FileUploader fileUploader();
+    @ContributesAndroidInjector abstract FileDownloader fileDownloader();
 
     @ContributesAndroidInjector abstract BootupBroadcastReceiver bootupBroadcastReceiver();
+    @ContributesAndroidInjector abstract NotificationJob.NotificationReceiver notificationJobBroadcastReceiver();
 
     @ContributesAndroidInjector abstract DocumentsStorageProvider documentsStorageProvider();
     @ContributesAndroidInjector abstract UsersAndGroupsSearchProvider usersAndGroupsSearchProvider();
     @ContributesAndroidInjector abstract DiskLruImageCacheFileProvider diskLruImageCacheFileProvider();
+
+    @ContributesAndroidInjector abstract AccountManagerService accountManagerService();
+    @ContributesAndroidInjector abstract OperationsService operationsService();
 }

--- a/src/main/java/com/owncloud/android/authentication/AccountUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AccountUtils.java
@@ -39,6 +39,7 @@ import androidx.annotation.Nullable;
 /**
  * Helper class for dealing with accounts.
  */
+@Deprecated
 public final class AccountUtils {
     private static final String PREF_SELECT_OC_ACCOUNT = "select_oc_account";
 
@@ -99,29 +100,6 @@ public final class AccountUtils {
         return accountManager.getAccountsByType(MainApp.getAccountType(context));
     }
 
-
-    public static boolean exists(Account account, Context context) {
-        Account[] ocAccounts = getAccounts(context);
-
-        if (account != null && account.name != null) {
-            int lastAtPos = account.name.lastIndexOf('@');
-            String hostAndPort = account.name.substring(lastAtPos + 1);
-            String username = account.name.substring(0, lastAtPos);
-            String otherHostAndPort;
-            String otherUsername;
-            for (Account otherAccount : ocAccounts) {
-                lastAtPos = otherAccount.name.lastIndexOf('@');
-                otherHostAndPort = otherAccount.name.substring(lastAtPos + 1);
-                otherUsername = otherAccount.name.substring(0, lastAtPos);
-                if (otherHostAndPort.equals(hostAndPort) &&
-                        otherUsername.equalsIgnoreCase(username)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     /**
      * Returns owncloud account identified by accountName or null if it does not exist.
      * @param context the context
@@ -136,81 +114,5 @@ public final class AccountUtils {
             }
         }
         return null;
-    }
-
-    public static boolean setCurrentOwnCloudAccount(final Context context, String accountName) {
-        boolean result = false;
-        if (accountName != null) {
-            for (final Account account : getAccounts(context)) {
-                if (accountName.equals(account.name)) {
-                    SharedPreferences.Editor appPrefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
-                    appPrefs.putString(PREF_SELECT_OC_ACCOUNT, accountName);
-                    appPrefs.apply();
-                    result = true;
-                    break;
-                }
-            }
-        }
-        return result;
-    }
-
-    public static boolean setCurrentOwnCloudAccount(final Context context, int hashCode) {
-        boolean result = false;
-        if (hashCode != 0) {
-            for (final Account account : getAccounts(context)) {
-                if (hashCode == account.hashCode()) {
-                    SharedPreferences.Editor appPrefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
-                    appPrefs.putString(PREF_SELECT_OC_ACCOUNT, account.name);
-                    appPrefs.apply();
-                    result = true;
-                    break;
-                }
-            }
-        }
-        return result;
-    }
-
-    public static void resetOwnCloudAccount(Context context) {
-        SharedPreferences.Editor appPrefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
-        appPrefs.putString(PREF_SELECT_OC_ACCOUNT, null);
-
-        appPrefs.apply();
-    }
-
-    /**
-     * Access the version of the OC server corresponding to an account SAVED IN THE ACCOUNTMANAGER
-     *
-     * @param account ownCloud account
-     * @return Version of the OC server corresponding to account, according to the data saved
-     * in the system AccountManager
-     */
-    public static @NonNull
-    OwnCloudVersion getServerVersion(Account account) {
-        OwnCloudVersion serverVersion = MainApp.MINIMUM_SUPPORTED_SERVER_VERSION;
-
-        if (account != null) {
-            AccountManager accountMgr = AccountManager.get(MainApp.getAppContext());
-            String serverVersionStr = accountMgr.getUserData(account, Constants.KEY_OC_VERSION);
-
-            if (serverVersionStr != null) {
-                serverVersion = new OwnCloudVersion(serverVersionStr);
-            }
-        }
-
-        return serverVersion;
-    }
-
-    public static boolean hasSearchSupport(Account account) {
-        return getServerVersion(account).isSearchSupported();
-    }
-
-    /**
-     * Checks if an account owns the file (file's ownerId is the same as account name)
-     * @param file File to check
-     * @param account account to compare
-     * @return false if ownerId is not set or owner is a different account
-     */
-    public static boolean accountOwnsFile(OCFile file, Account account) {
-        return !TextUtils.isEmpty(file.getOwnerId()) && account.name.split("@")[0].equals(file.getOwnerId());
     }
 }

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -250,11 +250,8 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     private TextInputLayout mPasswordInputLayout;
     private boolean forceOldLoginMethod;
 
-    @Inject
-    UserAccountManager accountManager;
-
-    @Inject
-    protected AppPreferences preferences;
+    @Inject UserAccountManager accountManager;
+    @Inject AppPreferences preferences;
 
     /**
      * {@inheritDoc}
@@ -624,7 +621,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 mServerInfo.mBaseUrl = mAccountMgr.getUserData(mAccount, Constants.KEY_OC_BASE_URL);
                 // TODO do next in a setter for mBaseUrl
                 mServerInfo.mIsSslConn = mServerInfo.mBaseUrl.startsWith(HTTPS_PROTOCOL);
-                mServerInfo.mVersion = AccountUtils.getServerVersion(mAccount);
+                mServerInfo.mVersion = accountManager.getServerVersion(mAccount);
             } else {
                 if (!webViewLoginMethod) {
                     mServerInfo.mBaseUrl = getString(R.string.server_url).trim();
@@ -1503,7 +1500,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             if (success) {
                 finish();
 
-                AccountUtils.setCurrentOwnCloudAccount(this, mAccount.name);
+                accountManager.setCurrentOwnCloudAccount(mAccount.name);
 
                 Intent i = new Intent(this, FileDisplayActivity.class);
                 i.setAction(FileDisplayActivity.RESTART);
@@ -1656,7 +1653,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
         String accountName = com.owncloud.android.lib.common.accounts.AccountUtils.buildAccountName(uri, loginName);
         Account newAccount = new Account(accountName, accountType);
-        if (AccountUtils.exists(newAccount, getApplicationContext())) {
+        if (accountManager.exists(newAccount)) {
             // fail - not a new account, but an existing one; disallow
             RemoteOperationResult result = new RemoteOperationResult(ResultCode.ACCOUNT_NOT_NEW);
 

--- a/src/main/java/com/owncloud/android/datamodel/ArbitraryDataProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/ArbitraryDataProvider.java
@@ -31,6 +31,8 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+
 /**
  * Database provider for handling the persistence aspects of arbitrary data table.
  */
@@ -155,8 +157,9 @@ public class ArbitraryDataProvider {
      * Returns stored value as string or empty string
      * @return string if value found or empty string
      */
+    @NonNull
     public String getValue(Account account, String key) {
-        return getValue(account.name, key);
+        return account != null ? getValue(account.name, key) : "";
     }
 
     public String getValue(String accountName, String key) {

--- a/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.UploadsStorageManager;
@@ -217,8 +218,8 @@ public class OCUpload implements Parcelable {
     /**
      * Returns owncloud account as {@link Account} object.
      */
-    public Account getAccount(Context context) {
-        return AccountUtils.getOwnCloudAccountByName(context, getAccountName());
+    public Account getAccount(UserAccountManager accountManager) {
+        return accountManager.getAccountByName(getAccountName());
     }
 
     /**

--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -27,7 +27,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;
@@ -98,15 +97,16 @@ public class FileMenuFilter {
      *
      * @param menu                  Options or context menu to filter.
      * @param inSingleFileFragment  True if this is not listing, but single file fragment, like preview or details.
+     * @param isMediaSupported      True is media playback is supported for this user
      */
-    public void filter(Menu menu, boolean inSingleFileFragment) {
+    public void filter(Menu menu, boolean inSingleFileFragment, boolean isMediaSupported) {
         if (mFiles == null || mFiles.isEmpty()) {
             hideAll(menu);
         } else {
             List<Integer> toShow = new ArrayList<>();
             List<Integer> toHide = new ArrayList<>();
 
-            filter(toShow, toHide, inSingleFileFragment, menu);
+            filter(toShow, toHide, inSingleFileFragment, isMediaSupported, menu);
 
             for (int i : toShow) {
                 showMenuItem(menu.findItem(i));
@@ -161,8 +161,13 @@ public class FileMenuFilter {
      * @param toShow                List to save the options that must be shown in the menu.
      * @param toHide                List to save the options that must be shown in the menu.
      * @param inSingleFileFragment  True if this is not listing, but single file fragment, like preview or details.
+     * @param isMediaSupported      True is media playback is supported for this user
      */
-    private void filter(List<Integer> toShow, List<Integer> toHide, boolean inSingleFileFragment, Menu menu) {
+    private void filter(List<Integer> toShow,
+                        List<Integer> toHide,
+                        boolean inSingleFileFragment,
+                        boolean isMediaSupported,
+                        Menu menu) {
         boolean synchronizing = anyFileSynchronizing();
         OCCapability capability = mComponentsGetter.getStorageManager().getCapability(mAccount.name);
         boolean endToEndEncryptionEnabled = capability.getEndToEndEncryption().isTrue();
@@ -183,7 +188,7 @@ public class FileMenuFilter {
         filterEncrypt(toShow, toHide, endToEndEncryptionEnabled);
         filterUnsetEncrypted(toShow, toHide, endToEndEncryptionEnabled);
         filterSetPictureAs(toShow, toHide);
-        filterStream(toShow, toHide);
+        filterStream(toShow, toHide, isMediaSupported);
         filterOpenAsRichDocument(toShow, toHide, capability, menu);
     }
 
@@ -358,9 +363,8 @@ public class FileMenuFilter {
         }
     }
 
-    private void filterStream(List<Integer> toShow, List<Integer> toHide) {
-        if (mFiles.isEmpty() || !isSingleFile() || !isSingleMedia() ||
-                !AccountUtils.getServerVersion(mAccount).isMediaStreamingSupported()) {
+    private void filterStream(List<Integer> toShow, List<Integer> toHide, boolean isMediaSupported) {
+        if (mFiles.isEmpty() || !isSingleFile() || !isSingleMedia() || !isMediaSupported) {
             toHide.add(R.id.action_stream_media);
         } else {
             toShow.add(R.id.action_stream_media);

--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -129,8 +129,7 @@ public class FileUploader extends Service
 
     private Notification mNotification;
 
-    @Inject
-    protected UserAccountManager accountManager;
+    @Inject UserAccountManager accountManager;
 
     /**
      * Call this Service with only this Intent key if all pending uploads are to be retried.
@@ -367,14 +366,10 @@ public class FileUploader extends Service
         /**
          * Call to retry upload identified by remotePath
          */
-        public void retry (Context context, OCUpload upload) {
+        public void retry (Context context, UserAccountManager accountManager, OCUpload upload) {
             if (upload != null && context != null) {
-                Account account = AccountUtils.getOwnCloudAccountByName(
-                    context,
-                    upload.getAccountName()
-                );
+                Account account = accountManager.getAccountByName(upload.getAccountName());
                 retry(context, account, upload);
-
             } else {
                 throw new IllegalArgumentException("Null parameter!");
             }
@@ -400,9 +395,10 @@ public class FileUploader extends Service
          */
         public void retryFailedUploads(
             @NonNull final Context context,
-            @Nullable Account account,
+            @Nullable final Account account,
             @NotNull final UploadsStorageManager uploadsStorageManager,
             @NotNull final ConnectivityService connectivityService,
+            @NotNull final UserAccountManager accountManager,
             @Nullable final UploadResult uploadResult
         ) {
             OCUpload[] failedUploads = uploadsStorageManager.getFailedUploads();
@@ -421,7 +417,7 @@ public class FileUploader extends Service
                 resultMatch = uploadResult == null || uploadResult.equals(failedUpload.getLastResult());
                 if (accountMatch && resultMatch) {
                     if (currentAccount == null || !currentAccount.name.equals(failedUpload.getAccountName())) {
-                        currentAccount = failedUpload.getAccount(context);
+                        currentAccount = failedUpload.getAccount(accountManager);
                     }
 
                     if (!new File(failedUpload.getLocalPath()).exists()) {
@@ -554,7 +550,7 @@ public class FileUploader extends Service
         }
 
         Account account = intent.getParcelableExtra(KEY_ACCOUNT);
-        if (!AccountUtils.exists(account, getApplicationContext())) {
+        if (!accountManager.exists(account)) {
             return Service.START_NOT_STICKY;
         }
 
@@ -770,8 +766,7 @@ public class FileUploader extends Service
     @Override
     public void onAccountsUpdated(Account[] accounts) {
         // Review current upload, and cancel it if its account doen't exist
-        if (mCurrentUpload != null &&
-                !AccountUtils.exists(mCurrentUpload.getAccount(), getApplicationContext())) {
+        if (mCurrentUpload != null && !accountManager.exists(mCurrentUpload.getAccount())) {
             mCurrentUpload.cancel();
         }
         // The rest of uploads are cancelled when they try to start
@@ -1065,7 +1060,7 @@ public class FileUploader extends Service
         if (mCurrentUpload != null) {
 
             /// Check account existence
-            if (!AccountUtils.exists(mCurrentUpload.getAccount(), this)) {
+            if (!accountManager.exists(mCurrentUpload.getAccount())) {
                 Log_OC.w(TAG, "Account " + mCurrentUpload.getAccount().name +
                         " does not exist anymore -> cancelling all its uploads");
                 cancelUploadsForAccount(mCurrentUpload.getAccount());

--- a/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
+++ b/src/main/java/com/owncloud/android/jobs/AccountRemovalJob.java
@@ -32,6 +32,7 @@ import android.content.Context;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.util.support.PersistableBundleCompat;
+import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.authentication.AccountUtils;
@@ -67,10 +68,11 @@ public class AccountRemovalJob extends Job implements AccountManagerCallback<Boo
     public static final String ACCOUNT = "account";
 
     private UploadsStorageManager uploadsStorageManager;
+    private UserAccountManager accountManager;
 
-    public AccountRemovalJob(UploadsStorageManager uploadStorageManager) {
+    public AccountRemovalJob(UploadsStorageManager uploadStorageManager, UserAccountManager accountManager) {
         this.uploadsStorageManager = uploadStorageManager;
-
+        this.accountManager = accountManager;
     }
 
     @NonNull
@@ -78,7 +80,7 @@ public class AccountRemovalJob extends Job implements AccountManagerCallback<Boo
     protected Result onRunJob(Params params) {
         Context context = MainApp.getAppContext();
         PersistableBundleCompat bundle = params.getExtras();
-        Account account = AccountUtils.getOwnCloudAccountByName(context, bundle.getString(ACCOUNT, ""));
+        Account account = accountManager.getAccountByName(bundle.getString(ACCOUNT, ""));
         AccountManager am = (AccountManager) context.getSystemService(ACCOUNT_SERVICE);
 
         if (account != null && am != null) {

--- a/src/main/java/com/owncloud/android/jobs/ContactsBackupJob.java
+++ b/src/main/java/com/owncloud/android/jobs/ContactsBackupJob.java
@@ -34,6 +34,7 @@ import android.text.format.DateFormat;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.util.support.PersistableBundleCompat;
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -65,19 +66,23 @@ public class ContactsBackupJob extends Job {
     public static final String TAG = "ContactsBackupJob";
     public static final String ACCOUNT = "account";
     public static final String FORCE = "force";
+
     private OperationsServiceConnection operationsServiceConnection;
     private OperationsService.OperationsServiceBinder operationsServiceBinder;
+    private UserAccountManager accountManager;
 
+    public ContactsBackupJob(UserAccountManager accountManager) {
+        this.accountManager = accountManager;
+    }
 
     @NonNull
     @Override
     protected Result onRunJob(@NonNull Params params) {
-        final Context context = MainApp.getAppContext();
         PersistableBundleCompat bundle = params.getExtras();
 
         boolean force = bundle.getBoolean(FORCE, false);
 
-        final Account account = AccountUtils.getOwnCloudAccountByName(context, bundle.getString(ACCOUNT, ""));
+        final Account account = accountManager.getAccountByName(bundle.getString(ACCOUNT, ""));
 
         ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
         Long lastExecution = arbitraryDataProvider.getLongValue(account,

--- a/src/main/java/com/owncloud/android/jobs/FilesSyncJob.java
+++ b/src/main/java/com/owncloud/android/jobs/FilesSyncJob.java
@@ -38,7 +38,6 @@ import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FilesystemDataProvider;
 import com.owncloud.android.datamodel.MediaFolderType;
@@ -161,7 +160,7 @@ public class FilesSyncJob extends Job {
         boolean needsWifi;
         File file;
         ArbitraryDataProvider arbitraryDataProvider;
-        Account account = AccountUtils.getOwnCloudAccountByName(context, syncedFolder.getAccount());
+        Account account = userAccountManager.getAccountByName(syncedFolder.getAccount());
 
         if (lightVersion) {
             arbitraryDataProvider = new ArbitraryDataProvider(context.getContentResolver());

--- a/src/main/java/com/owncloud/android/jobs/NCJobCreator.java
+++ b/src/main/java/com/owncloud/android/jobs/NCJobCreator.java
@@ -65,11 +65,11 @@ public class NCJobCreator implements JobCreator {
     public Job create(@NonNull String tag) {
         switch (tag) {
             case ContactsBackupJob.TAG:
-                return new ContactsBackupJob();
+                return new ContactsBackupJob(accountManager);
             case ContactsImportJob.TAG:
                 return new ContactsImportJob();
             case AccountRemovalJob.TAG:
-                return new AccountRemovalJob(uploadsStorageManager);
+                return new AccountRemovalJob(uploadsStorageManager, accountManager);
             case FilesSyncJob.TAG:
                 return new FilesSyncJob(accountManager, preferences, uploadsStorageManager, connectivityService);
             case OfflineSyncJob.TAG:

--- a/src/main/java/com/owncloud/android/services/AccountManagerService.java
+++ b/src/main/java/com/owncloud/android/services/AccountManagerService.java
@@ -24,15 +24,27 @@ import android.content.Intent;
 import android.os.IBinder;
 
 import com.nextcloud.android.sso.InputStreamBinder;
+import com.nextcloud.client.account.UserAccountManager;
+
+import javax.inject.Inject;
+
+import dagger.android.AndroidInjection;
 
 public class AccountManagerService extends Service {
 
     private InputStreamBinder mBinder;
+    @Inject UserAccountManager accountManager;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        AndroidInjection.inject(this);
+    }
 
     @Override
     public IBinder onBind(Intent intent) {
         if(mBinder == null) {
-            mBinder = new InputStreamBinder(this);
+            mBinder = new InputStreamBinder(this, accountManager);
         }
         return mBinder;
     }

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -205,6 +205,7 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
                 getUserAccountManager().getCurrentAccount(),
                 bottomNavigationView,
                 getResources(),
+                getUserAccountManager(),
                 this,
                 -1
             );

--- a/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApiImpl.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApiImpl.java
@@ -60,7 +60,7 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
     @Override
     public void getAllActivities(String pageUrl, ActivitiesServiceCallback<List<Object>> callback) {
         Account account = accountManager.getCurrentAccount();
-        GetActivityListTask getActivityListTask = new GetActivityListTask(account, pageUrl, callback);
+        GetActivityListTask getActivityListTask = new GetActivityListTask(account, accountManager, pageUrl, callback);
         getActivityListTask.execute();
     }
 
@@ -69,12 +69,16 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
         private final ActivitiesServiceCallback<List<Object>> callback;
         private List<Object> activities;
         private Account account;
+        private UserAccountManager accountManager;
         private String pageUrl;
         private String errorMessage;
         private OwnCloudClient ownCloudClient;
 
-        private GetActivityListTask(Account account, String pageUrl, ActivitiesServiceCallback<List<Object>> callback) {
+        private GetActivityListTask(Account account,
+                                    UserAccountManager accountManager,
+                                    String pageUrl, ActivitiesServiceCallback<List<Object>> callback) {
             this.account = account;
+            this.accountManager = accountManager;
             this.pageUrl = pageUrl;
             this.callback = callback;
             activities = new ArrayList<>();
@@ -89,7 +93,7 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
                 ocAccount = new OwnCloudAccount(account, context);
                 ownCloudClient = OwnCloudClientManagerFactory.getDefaultSingleton().
                         getClientFor(ocAccount, MainApp.getAppContext());
-                ownCloudClient.setOwnCloudVersion(AccountUtils.getServerVersion(account));
+                ownCloudClient.setOwnCloudVersion(accountManager.getServerVersion(account));
 
                 GetActivitiesRemoteOperation getRemoteNotificationOperation = new GetActivitiesRemoteOperation();
                 if (pageUrl != null) {

--- a/src/main/java/com/owncloud/android/ui/activities/data/files/FilesServiceApiImpl.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/files/FilesServiceApiImpl.java
@@ -63,7 +63,7 @@ public class FilesServiceApiImpl implements FilesServiceApi {
     @Override
     public void readRemoteFile(String fileUrl, BaseActivity activity, FilesServiceCallback<OCFile> callback) {
         ReadRemoteFileTask readRemoteFileTask = new ReadRemoteFileTask(
-            accountManager.getCurrentAccount(),
+            accountManager,
             fileUrl,
             activity,
             callback
@@ -79,12 +79,17 @@ public class FilesServiceApiImpl implements FilesServiceApi {
         private final BaseActivity baseActivity;
         private final String fileUrl;
         private final Account account;
+        private final UserAccountManager accountManager;
 
-        private ReadRemoteFileTask(Account account, String fileUrl, BaseActivity baseActivity, FilesServiceCallback<OCFile> callback) {
+        private ReadRemoteFileTask(UserAccountManager accountManager,
+                                   String fileUrl,
+                                   BaseActivity baseActivity,
+                                   FilesServiceCallback<OCFile> callback) {
             this.callback = callback;
             this.baseActivity = baseActivity;
             this.fileUrl = fileUrl;
-            this.account = account;
+            this.account = accountManager.getCurrentAccount();
+            this.accountManager = accountManager;
         }
 
         @Override
@@ -96,7 +101,7 @@ public class FilesServiceApiImpl implements FilesServiceApi {
                 ocAccount = new OwnCloudAccount(account, context);
                 ownCloudClient = OwnCloudClientManagerFactory.getDefaultSingleton().
                         getClientFor(ocAccount, MainApp.getAppContext());
-                ownCloudClient.setOwnCloudVersion(AccountUtils.getServerVersion(account));
+                ownCloudClient.setOwnCloudVersion(accountManager.getServerVersion(account));
                 // always update file as it could be an old state saved in database
                 RemoteOperationResult resultRemoteFileOp = new ReadFileRemoteOperation(fileUrl).execute(ownCloudClient);
 

--- a/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -79,7 +79,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     protected void onRestart() {
         Log_OC.v(TAG, "onRestart() start");
         super.onRestart();
-        boolean validAccount = mCurrentAccount != null && AccountUtils.exists(mCurrentAccount, this);
+        boolean validAccount = mCurrentAccount != null && accountManager.exists(mCurrentAccount);
         if (!validAccount) {
             swapToDefaultAccount();
         }
@@ -99,7 +99,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     protected void setAccount(Account account, boolean savedAccount) {
         Account oldAccount = mCurrentAccount;
         boolean validAccount =
-                account != null && AccountUtils.setCurrentOwnCloudAccount(getApplicationContext(), account.name);
+                account != null && accountManager.setCurrentOwnCloudAccount(account.name);
         if (validAccount) {
             mCurrentAccount = account;
             mAccountWasSet = true;
@@ -239,7 +239,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
                     result = future.getResult();
                     String name = result.getString(AccountManager.KEY_ACCOUNT_NAME);
                     String type = result.getString(AccountManager.KEY_ACCOUNT_TYPE);
-                    if (AccountUtils.setCurrentOwnCloudAccount(getApplicationContext(), name)) {
+                    if (accountManager.setCurrentOwnCloudAccount(name)) {
                         setAccount(new Account(name, type), false);
                         accountWasSet = true;
                     }

--- a/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
@@ -113,6 +113,7 @@ public class ContactsPreferenceActivity extends FileActivity implements FileFrag
                 getUserAccountManager().getCurrentAccount(),
                 bottomNavigationView,
                 getResources(),
+                accountManager,
                 this,
                 -1
             );

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -366,9 +366,11 @@ public abstract class DrawerActivity extends ToolbarActivity
             capability = storageManager.getCapability(account.name);
         }
 
+        boolean hasSearchSupport = accountManager.getServerVersion(account).isSearchSupported();
+
         DrawerMenuUtil.filterForBottomToolbarMenuItems(menu, getResources());
-        DrawerMenuUtil.filterSearchMenuItems(menu, account, getResources());
-        DrawerMenuUtil.filterTrashbinMenuItem(menu, account, capability);
+        DrawerMenuUtil.filterSearchMenuItems(menu, account, getResources(), hasSearchSupport);
+        DrawerMenuUtil.filterTrashbinMenuItem(menu, account, capability, accountManager);
         DrawerMenuUtil.filterActivityMenuItem(menu, capability);
 
         DrawerMenuUtil.setupHomeMenuItem(menu, getResources());
@@ -554,7 +556,7 @@ public abstract class DrawerActivity extends ToolbarActivity
     private void accountClicked(int hashCode) {
         final Account currentAccount = accountManager.getCurrentAccount();
         if (currentAccount != null && currentAccount.hashCode() != hashCode &&
-            AccountUtils.setCurrentOwnCloudAccount(getApplicationContext(), hashCode)) {
+            accountManager.setCurrentOwnCloudAccount(hashCode)) {
             fetchExternalLinks(true);
             restart();
         }
@@ -1131,7 +1133,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                         };
 
                         int backgroundResource;
-                        OwnCloudVersion ownCloudVersion = AccountUtils.getServerVersion(getAccount());
+                        OwnCloudVersion ownCloudVersion = accountManager.getServerVersion(getAccount());
                         if (ownCloudVersion.compareTo(OwnCloudVersion.nextcloud_13) >= 0) {
                             backgroundResource = R.drawable.background_nc13;
                         } else {

--- a/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FirstRunActivity.java
@@ -248,7 +248,7 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
             }
 
             setAccount(account);
-            AccountUtils.setCurrentOwnCloudAccount(this, account.name);
+            accountManager.setCurrentOwnCloudAccount(account.name);
             onAccountSet(false);
 
             Intent i = new Intent(this, FileDisplayActivity.class);

--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -41,6 +41,7 @@ import android.widget.ListView;
 
 import com.evernote.android.job.JobRequest;
 import com.evernote.android.job.util.support.PersistableBundleCompat;
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -67,6 +68,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
+import javax.inject.Inject;
 
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
@@ -100,6 +103,8 @@ public class ManageAccountsActivity extends FileActivity
     private Drawable mTintedCheck;
 
     private ArbitraryDataProvider arbitraryDataProvider;
+
+    @Inject UserAccountManager accountManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -296,7 +301,7 @@ public class ManageAccountsActivity extends FileActivity
                             try {
                                 Bundle result = future.getResult();
                                 String name = result.getString(AccountManager.KEY_ACCOUNT_NAME);
-                                AccountUtils.setCurrentOwnCloudAccount(getApplicationContext(), name);
+                                accountManager.setCurrentOwnCloudAccount(name);
                                 mAccountListAdapter = new AccountListAdapter(
                                         ManageAccountsActivity.this,
                                         getUserAccountManager(),
@@ -333,7 +338,7 @@ public class ManageAccountsActivity extends FileActivity
         if (future.isDone()) {
             // after remove account
             Account account = new Account(mAccountName, MainApp.getAccountType(this));
-            if (!AccountUtils.exists(account, MainApp.getAppContext())) {
+            if (!accountManager.exists(account)) {
                 // Cancel transfers of the removed account
                 if (mUploaderBinder != null) {
                     mUploaderBinder.cancel(account);
@@ -349,7 +354,7 @@ public class ManageAccountsActivity extends FileActivity
                 if (accounts.length != 0) {
                     accountName = accounts[0].name;
                 }
-                AccountUtils.setCurrentOwnCloudAccount(this, accountName);
+                accountManager.setCurrentOwnCloudAccount(accountName);
             }
 
             List<AccountListItem> accountListItemArray = getAccountListItems();
@@ -451,10 +456,10 @@ public class ManageAccountsActivity extends FileActivity
 
         if (newAccountName.isEmpty()) {
             Log_OC.d(TAG, "new account set to null");
-            AccountUtils.resetOwnCloudAccount(this);
+            accountManager.resetOwnCloudAccount();
         } else {
             Log_OC.d(TAG, "new account set to: " + newAccountName);
-            AccountUtils.setCurrentOwnCloudAccount(this, newAccountName);
+            accountManager.setCurrentOwnCloudAccount(newAccountName);
         }
 
         // only one to be (deleted) account remaining

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -127,7 +127,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
             String account = getIntent().getExtras().getString(NotificationJob.KEY_NOTIFICATION_ACCOUNT);
 
             if (account != null && (currentAccount == null || !account.equalsIgnoreCase(currentAccount.name))) {
-                AccountUtils.setCurrentOwnCloudAccount(this, account);
+                accountManager.setCurrentOwnCloudAccount(account);
                 setAccount(getUserAccountManager().getCurrentAccount());
                 currentAccount = getAccount();
             }
@@ -250,6 +250,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
                 getUserAccountManager().getCurrentAccount(),
                 bottomNavigationView,
                 getResources(),
+                accountManager,
                 this,
                 -1);
         }
@@ -267,7 +268,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
                 try {
                     OwnCloudAccount ocAccount = new OwnCloudAccount(currentAccount, this);
                     client = OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount, this);
-                    client.setOwnCloudVersion(AccountUtils.getServerVersion(currentAccount));
+                    client.setOwnCloudVersion(accountManager.getServerVersion(currentAccount));
                 } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException |
                     IOException | OperationCanceledException | AuthenticatorException e) {
                     Log_OC.e(TAG, "Error initializing client", e);

--- a/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
@@ -132,7 +132,7 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
             currentAccount = getAccount();
 
             if (account != null && currentAccount != null && !account.equalsIgnoreCase(currentAccount.name)) {
-                AccountUtils.setCurrentOwnCloudAccount(getApplicationContext(), account);
+                accountManager.setCurrentOwnCloudAccount(account);
                 setAccount(getUserAccountManager().getCurrentAccount());
             }
 
@@ -209,6 +209,7 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
                 getUserAccountManager().getCurrentAccount(),
                 bottomNavigationView,
                 getResources(),
+                accountManager,
                 this,
                 -1
             );

--- a/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -159,6 +159,7 @@ public class UploadListActivity extends FileActivity {
                 getUserAccountManager().getCurrentAccount(),
                 bottomNavigationView,
                 getResources(),
+                accountManager,
                 this,
                 -1
             );
@@ -176,7 +177,10 @@ public class UploadListActivity extends FileActivity {
         emptyContentHeadline.setText(noResultsHeadline);
         emptyContentMessage.setText(noResultsMessage);
 
-        uploadListAdapter = new UploadListAdapter(this, uploadsStorageManager, connectivityService);
+        uploadListAdapter = new UploadListAdapter(this,
+                                                  uploadsStorageManager,
+                                                  userAccountManager,
+                                                  connectivityService);
 
         final GridLayoutManager lm = new GridLayoutManager(this, 1);
         uploadListAdapter.setLayoutManager(lm);
@@ -224,6 +228,7 @@ public class UploadListActivity extends FileActivity {
                                                       null,
                                                       uploadsStorageManager,
                                                       connectivityService,
+                                                      userAccountManager,
                                                       null)).start();
 
         // update UI

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -46,6 +46,7 @@ import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.BitmapImageViewTarget;
+import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -107,6 +108,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final String userId;
     private Context mContext;
     private AppPreferences preferences;
+    private UserAccountManager accountManager;
     private List<OCFile> mFiles = new ArrayList<>();
     private List<OCFile> mFilesAll = new ArrayList<>();
     private boolean mHideItemOptions;
@@ -135,6 +137,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         Context context,
         Account account,
         AppPreferences preferences,
+        UserAccountManager accountManager,
         ComponentsGetter transferServiceGetter,
         OCFileListFragmentInterface ocFileListFragmentInterface,
         boolean argHideItemOptions,
@@ -144,6 +147,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         this.ocFileListFragmentInterface = ocFileListFragmentInterface;
         mContext = context;
         this.preferences = preferences;
+        this.accountManager = accountManager;
         this.account = account;
         mHideItemOptions = argHideItemOptions;
         this.gridView = gridView;
@@ -154,8 +158,8 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         operationsServiceBinder = transferServiceGetter.getOperationsServiceBinder();
 
         if (account != null) {
-            AccountManager accountManager = AccountManager.get(mContext);
-            userId = accountManager.getUserData(account,
+            AccountManager platformAccountManager = AccountManager.get(mContext);
+            userId = platformAccountManager.getUserData(account,
                                                 com.owncloud.android.lib.common.accounts.AccountUtils.Constants.KEY_USER_ID);
         } else {
             userId = "";
@@ -662,7 +666,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 sharedIconView.setImageResource(R.drawable.ic_unshared);
                 sharedIconView.setContentDescription(mContext.getString(R.string.shared_icon_share));
             }
-            if (AccountUtils.accountOwnsFile(file, account)) {
+            if (accountManager.accountOwnsFile(file, account)) {
                 sharedIconView.setOnClickListener(view -> ocFileListFragmentInterface.onShareIconClick(file));
             } else {
                 sharedIconView.setOnClickListener(view -> ocFileListFragmentInterface.showShareDetailView(file));

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -60,7 +60,6 @@ import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.SearchRemoteOperation;
 import com.owncloud.android.ui.EmptyRecyclerView;
@@ -227,7 +226,7 @@ public class ExtendedListFragment extends Fragment implements
                                 setFabVisible(!hasFocus);
                             }
 
-                            boolean searchSupported = AccountUtils.hasSearchSupport(accountManager.getCurrentAccount());
+                            boolean searchSupported = accountManager.isSearchSupported(accountManager.getCurrentAccount());
 
                             if (getResources().getBoolean(R.bool.bottom_toolbar_enabled) && searchSupported) {
                                 BottomNavigationView bottomNavigationView = getActivity().
@@ -317,7 +316,7 @@ public class ExtendedListFragment extends Fragment implements
                 handler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        if (AccountUtils.hasSearchSupport(accountManager.getCurrentAccount())) {
+                        if (accountManager.isSearchSupported(accountManager.getCurrentAccount())) {
                             EventBus.getDefault().post(new SearchEvent(query,
                                 SearchRemoteOperation.SearchType.FILE_SEARCH, SearchEvent.UnsetType.NO_UNSET));
                         } else {
@@ -403,7 +402,7 @@ public class ExtendedListFragment extends Fragment implements
         mFabMain = v.findViewById(R.id.fab_main);
         ThemeUtils.tintFloatingActionButton(mFabMain, R.drawable.ic_plus, getContext());
 
-        boolean searchSupported = AccountUtils.hasSearchSupport(accountManager.getCurrentAccount());
+        boolean searchSupported = accountManager.isSearchSupported(accountManager.getCurrentAccount());
 
         if (getResources().getBoolean(R.bool.bottom_toolbar_enabled) && searchSupported) {
             RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mFabMain.getLayoutParams();

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -42,6 +42,7 @@ import android.widget.TextView;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
 import com.nextcloud.client.account.CurrentAccountProvider;
+import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -148,8 +149,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
     private FileOperationsHelper operationsHelper;
     private VersionListInterface.CommentCallback callback;
 
-    @Inject
-    protected CurrentAccountProvider accountManager;
+    @Inject UserAccountManager accountManager;
 
     public static FileDetailActivitiesFragment newInstance(OCFile file, Account account) {
         FileDetailActivitiesFragment fragment = new FileDetailActivitiesFragment();
@@ -251,7 +251,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
         operationsHelper = ((ComponentsGetter) requireActivity()).getFileOperationsHelper();
 
         OCCapability capability = storageManager.getCapability(account.name);
-        OwnCloudVersion serverVersion = AccountUtils.getServerVersion(account);
+        OwnCloudVersion serverVersion = accountManager.getServerVersion(account);
         restoreFileVersionSupported = capability.getFilesVersioning().isTrue() &&
                 serverVersion.compareTo(OwnCloudVersion.nextcloud_14) >= 0;
 
@@ -307,7 +307,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
                 ocAccount = new OwnCloudAccount(currentAccount, context);
                 ownCloudClient = OwnCloudClientManagerFactory.getDefaultSingleton().
                         getClientFor(ocAccount, MainApp.getAppContext());
-                ownCloudClient.setOwnCloudVersion(AccountUtils.getServerVersion(currentAccount));
+                ownCloudClient.setOwnCloudVersion(accountManager.getServerVersion(currentAccount));
                 isLoadingActivities = true;
 
                 GetActivitiesRemoteOperation getRemoteNotificationOperation = new GetActivitiesRemoteOperation(

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -44,6 +44,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.google.android.material.tabs.TabLayout;
+import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -148,11 +149,9 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     private ToolbarActivity activity;
     private int activeTab;
 
-    @Inject
-    AppPreferences preferences;
-
-    @Inject
-    ConnectivityService connectivityService;
+    @Inject AppPreferences preferences;
+    @Inject ConnectivityService connectivityService;
+    @Inject UserAccountManager accountManager;
 
     /**
      * Public factory method to create new FileDetailFragment instances.
@@ -413,14 +412,18 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
     private void prepareOptionsMenu(Menu menu) {
         if (containerActivity.getStorageManager() != null) {
+            Account currentAccount = containerActivity.getStorageManager().getAccount();
             FileMenuFilter mf = new FileMenuFilter(
                 getFile(),
-                containerActivity.getStorageManager().getAccount(),
+                currentAccount,
                 containerActivity,
                 getActivity(),
                 false
             );
-            mf.filter(menu, true);
+
+            mf.filter(menu,
+                      true,
+                      accountManager.isMediaStreamingSupported(currentAccount));
         }
 
         if (getFile().isFolder()) {

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -39,6 +39,8 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -64,6 +66,8 @@ import com.owncloud.android.utils.ThemeUtils;
 
 import java.util.List;
 
+import javax.inject.Inject;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatCheckBox;
@@ -77,7 +81,7 @@ import butterknife.OnClick;
 import butterknife.Unbinder;
 
 public class FileDetailSharingFragment extends Fragment implements UserListAdapter.ShareeListAdapterListener,
-    DisplayUtils.AvatarGenerationListener {
+    DisplayUtils.AvatarGenerationListener, Injectable {
 
     private static final String ARG_FILE = "FILE";
     private static final String ARG_ACCOUNT = "ACCOUNT";
@@ -131,6 +135,8 @@ public class FileDetailSharingFragment extends Fragment implements UserListAdapt
 
     @BindView(R.id.shared_with_you_note)
     TextView sharedWithYouNote;
+
+    @Inject UserAccountManager accountManager;
 
     public static FileDetailSharingFragment newInstance(OCFile file, Account account) {
         FileDetailSharingFragment fragment = new FileDetailSharingFragment();
@@ -268,7 +274,7 @@ public class FileDetailSharingFragment extends Fragment implements UserListAdapt
     }
 
     private void setShareWithYou() {
-        if (AccountUtils.accountOwnsFile(file, account)) {
+        if (accountManager.accountOwnsFile(file, account)) {
             sharedWithYouContainer.setVisibility(View.GONE);
         } else {
             sharedWithYouUsername.setText(

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -53,6 +53,7 @@ import com.caverock.androidsvg.SVG;
 import com.caverock.androidsvg.SVGParseException;
 import com.github.chrisbanes.photoview.PhotoView;
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.network.ConnectivityService;
 import com.owncloud.android.MainApp;
@@ -124,6 +125,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
     private LoadBitmapTask mLoadBitmapTask;
 
     @Inject ConnectivityService connectivityService;
+    @Inject UserAccountManager accountManager;
 
     /**
      * Public factory method to create a new fragment that previews an image.
@@ -323,14 +325,18 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
             // Update the file
             setFile(containerActivity.getStorageManager().getFileById(getFile().getFileId()));
 
+            Account currentAccount = containerActivity.getStorageManager().getAccount();
             FileMenuFilter mf = new FileMenuFilter(
                     getFile(),
-                    containerActivity.getStorageManager().getAccount(),
+                    currentAccount,
                 containerActivity,
                     getActivity(),
                     false
             );
-            mf.filter(menu, true);
+
+            mf.filter(menu,
+                      true,
+                      accountManager.isMediaStreamingSupported(currentAccount));
         }
 
         // additional restriction for this fragment

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -36,6 +36,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.FileMenuFilter;
@@ -60,6 +61,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;
 
+import javax.inject.Inject;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.MenuItemCompat;
@@ -79,15 +82,16 @@ public class PreviewTextFragment extends FileFragment implements SearchView.OnQu
     private SearchView mSearchView;
     private RelativeLayout mMultiView;
 
-    protected LinearLayout mMultiListContainer;
-    protected TextView mMultiListMessage;
-    protected TextView mMultiListHeadline;
-    protected ImageView mMultiListIcon;
-    protected ProgressBar mMultiListProgress;
+    private TextView mMultiListMessage;
+    private TextView mMultiListHeadline;
+    private ImageView mMultiListIcon;
+    private ProgressBar mMultiListProgress;
 
 
     private String mSearchQuery = "";
     private boolean mSearchOpen;
+
+    @Inject UserAccountManager accountManager;
 
     /**
      * Creates an empty fragment for previews.
@@ -126,8 +130,7 @@ public class PreviewTextFragment extends FileFragment implements SearchView.OnQu
         return ret;
     }
 
-    protected void setupMultiView(View view) {
-        mMultiListContainer = view.findViewById(R.id.empty_list_view);
+    private void setupMultiView(View view) {
         mMultiListMessage = view.findViewById(R.id.empty_list_view_text);
         mMultiListHeadline = view.findViewById(R.id.empty_list_view_headline);
         mMultiListIcon = view.findViewById(R.id.empty_list_icon);
@@ -365,14 +368,17 @@ public class PreviewTextFragment extends FileFragment implements SearchView.OnQu
         super.onPrepareOptionsMenu(menu);
 
         if (containerActivity.getStorageManager() != null) {
+            Account currentAccount = containerActivity.getStorageManager().getAccount();
             FileMenuFilter mf = new FileMenuFilter(
                     getFile(),
-                    containerActivity.getStorageManager().getAccount(),
+                    currentAccount,
                 containerActivity,
                     getActivity(),
                     false
             );
-            mf.filter(menu, true);
+            mf.filter(menu,
+                      true,
+                      accountManager.isMediaStreamingSupported(currentAccount));
         }
 
         // additional restriction for this fragment

--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -58,9 +58,9 @@ import com.caverock.androidsvg.SVG;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.CurrentAccountProvider;
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
@@ -574,13 +574,14 @@ public final class DisplayUtils {
         Account account,
         BottomNavigationView view,
         Resources resources,
+        UserAccountManager accountManager,
         final Activity activity,
         int checkedMenuItem
     ) {
 
         Menu menu = view.getMenu();
 
-        boolean searchSupported = AccountUtils.hasSearchSupport(account);
+        boolean searchSupported = accountManager.isSearchSupported(account);
 
         if (!searchSupported) {
             menu.removeItem(R.id.nav_bar_favorites);

--- a/src/main/java/com/owncloud/android/utils/DrawerMenuUtil.java
+++ b/src/main/java/com/owncloud/android/utils/DrawerMenuUtil.java
@@ -24,6 +24,7 @@ import android.accounts.Account;
 import android.content.res.Resources;
 import android.view.Menu;
 
+import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.lib.resources.status.OCCapability;
@@ -44,8 +45,10 @@ public final class DrawerMenuUtil {
         }
     }
 
-    public static void filterSearchMenuItems(Menu menu, Account account, Resources resources) {
-        boolean hasSearchSupport = AccountUtils.hasSearchSupport(account);
+    public static void filterSearchMenuItems(Menu menu,
+                                             Account account,
+                                             Resources resources,
+                                             boolean hasSearchSupport) {
         if (account != null && !hasSearchSupport) {
             filterMenuItems(menu, R.id.nav_photos, R.id.nav_favorites, R.id.nav_videos);
         }
@@ -67,9 +70,12 @@ public final class DrawerMenuUtil {
         }
     }
 
-    public static void filterTrashbinMenuItem(Menu menu, @Nullable Account account, @Nullable OCCapability capability) {
+    public static void filterTrashbinMenuItem(Menu menu,
+                                              @Nullable Account account,
+                                              @Nullable OCCapability capability,
+                                              UserAccountManager accountManager) {
         if (account != null && capability != null &&
-                (AccountUtils.getServerVersion(account).compareTo(OwnCloudVersion.nextcloud_14) < 0 ||
+                (accountManager.getServerVersion(account).compareTo(OwnCloudVersion.nextcloud_14) < 0 ||
                         capability.getFilesUndelete().isFalse() || capability.getFilesUndelete().isUnknown())) {
             filterMenuItems(menu, R.id.nav_trashbin);
         }

--- a/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -251,6 +251,7 @@ public final class FilesSyncHelper {
                                                    null,
                                                    uploadsStorageManager,
                                                    connectivityService,
+                                                   accountManager,
                                                    null);
             }
         }).start();


### PR DESCRIPTION
This change migrate remaining AccountUtils static helpers
to UserAccountManager.

It contains no functional changes - static helpers code
is just moved into manager class and all clients are
supplied with manager as a dependency.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>