### PR TITLE
Fix and test against IllegalStateException in FileDisplayActivity

### DIFF
--- a/src/androidTest/java/com/owncloud/android/ui/activity/FileDisplayActivityTest.java
+++ b/src/androidTest/java/com/owncloud/android/ui/activity/FileDisplayActivityTest.java
@@ -1,0 +1,23 @@
+package com.owncloud.android.ui.activity;
+
+import com.owncloud.android.AbstractIT;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.rule.GrantPermissionRule;
+
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
+public class FileDisplayActivityTest extends AbstractIT {
+
+    @Rule public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule.grant(WRITE_EXTERNAL_STORAGE);
+
+    @Test
+    public void testSetupToolbar() {
+        try (ActivityScenario<FileDisplayActivity> scenario = ActivityScenario.launch(FileDisplayActivity.class)) {
+            scenario.recreate();
+        }
+    }
+}

--- a/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -101,7 +101,7 @@ public final class PassCodeManager {
             i.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             activity.startActivityForResult(i, PASSCODE_ACTIVITY);
         } else {
-            if (preferences.getLockTimestamp() != 0) {
+            if (!askedForPin && preferences.getLockTimestamp() != 0) {
                 preferences.setLockTimestamp(System.currentTimeMillis());
             }
         }

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -228,10 +228,11 @@ public class FileDisplayActivity extends FileActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log_OC.v(TAG, "onCreate() start");
-        super.onCreate(savedInstanceState); // this calls onAccountChanged() when ownCloud Account is valid
 
         // Set the default theme to replace the launch screen theme.
         setTheme(R.style.Theme_ownCloud_Toolbar_Drawer);
+
+        super.onCreate(savedInstanceState); // this calls onAccountChanged() when ownCloud Account is valid
 
         /// Load of saved instance state
         if (savedInstanceState != null) {


### PR DESCRIPTION
Introduced in https://github.com/nextcloud/android/pull/3966/files#diff-ecdca245e1aa615e4581732a6606684b

Calling `setTheme` after `onCreate` seems to be too late.

Fixes #4026 

