### PR TITLE
OCFileListFragment: Only scroll to top if directory changed

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -122,6 +122,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.util.ObjectsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -1190,6 +1191,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     onlyOnDevice,
                     mLimitToMimeType
                 );
+
+                boolean changedDirectory = !ObjectsCompat.equals(mFile, directory);
                 mFile = directory;
 
                 updateLayout();
@@ -1197,7 +1200,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 mAdapter.setHighlightedItem(file);
                 int position = mAdapter.getItemPosition(file);
                 if (position == -1) {
-                    getRecyclerView().scrollToPosition(0);
+                    if (changedDirectory) {
+                        getRecyclerView().scrollToPosition(0);
+                    }
                 } else {
                     getRecyclerView().scrollToPosition(position);
                 }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -122,7 +122,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
-import androidx.core.util.ObjectsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -1192,7 +1191,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     mLimitToMimeType
                 );
 
-                boolean changedDirectory = !ObjectsCompat.equals(mFile, directory);
+                OCFile previousDirectory = mFile;
                 mFile = directory;
 
                 updateLayout();
@@ -1200,7 +1199,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 mAdapter.setHighlightedItem(file);
                 int position = mAdapter.getItemPosition(file);
                 if (position == -1) {
-                    if (changedDirectory) {
+                    if (previousDirectory == null || !previousDirectory.equals(directory)) {
                         getRecyclerView().scrollToPosition(0);
                     }
                 } else {


### PR DESCRIPTION
Fixes jumping to top everytime the listview is updated, since 3.6.1.

TODO

- [x] This needs to be tested with talk app