### PR TITLE
Enable coverage only in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,6 +53,7 @@ steps:
         from_secret: GIT_USERNAME
       GIT_TOKEN:
         from_secret: GIT_TOKEN
+      ORG_GRADLE_PROJECT_coverage: ''
     commands:
       - ./gradlew assembleGplay
       - emulator -avd android-27 -no-window -no-audio &

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ android {
 
         buildTypes {
             debug {
-                testCoverageEnabled true
+                testCoverageEnabled (project.hasProperty('coverage') ? true : false)
             }
         }
 


### PR DESCRIPTION
See https://jeroenmols.com/blog/2016/09/01/coveragecost/

This is just unnecessary for local builds.
