### PR TITLE
Check state of upload

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -975,24 +975,28 @@ public class FileUploader extends Service
                                        long totalToTransfer, String fileName) {
             String key = buildRemoteName(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath());
             OnDatatransferProgressListener boundListener = mBoundListeners.get(key);
+
             if (boundListener != null) {
                 boundListener.onTransferProgress(progressRate, totalTransferredSoFar,
-                        totalToTransfer, fileName);
+                                                 totalToTransfer, fileName);
+            }
 
-                if (MainApp.getAppContext() != null) {
-                    if (mCurrentUpload.isWifiRequired() && !Device.getNetworkType(MainApp.getAppContext()).
-                            equals(JobRequest.NetworkType.UNMETERED)) {
-                        cancel(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath()
-                                , ResultCode.DELAYED_FOR_WIFI);
-                    } else if (mCurrentUpload.isChargingRequired() &&
-                        !Device.getBatteryStatus(MainApp.getAppContext()).isCharging()) {
-                        cancel(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath()
-                                , ResultCode.DELAYED_FOR_CHARGING);
-                    } else if (!mCurrentUpload.isIgnoringPowerSaveMode() &&
-                        powerManagementService.isPowerSavingEnabled()) {
-                        cancel(mCurrentUpload.getAccount().name, mCurrentUpload.getFile().getRemotePath()
-                                , ResultCode.DELAYED_IN_POWER_SAVE_MODE);
-                    }
+            if (MainApp.getAppContext() != null) {
+                if (mCurrentUpload.isWifiRequired() &&
+                    !Device.getNetworkType(MainApp.getAppContext()).equals(JobRequest.NetworkType.UNMETERED)) {
+                    cancel(mCurrentUpload.getAccount().name,
+                           mCurrentUpload.getFile().getRemotePath(),
+                           ResultCode.DELAYED_FOR_WIFI);
+                } else if (mCurrentUpload.isChargingRequired() &&
+                    !Device.getBatteryStatus(MainApp.getAppContext()).isCharging()) {
+                    cancel(mCurrentUpload.getAccount().name,
+                           mCurrentUpload.getFile().getRemotePath(),
+                           ResultCode.DELAYED_FOR_CHARGING);
+                } else if (!mCurrentUpload.isIgnoringPowerSaveMode() &&
+                    powerManagementService.isPowerSavingEnabled()) {
+                    cancel(mCurrentUpload.getAccount().name,
+                           mCurrentUpload.getFile().getRemotePath(),
+                           ResultCode.DELAYED_IN_POWER_SAVE_MODE);
                 }
             }
         }


### PR DESCRIPTION
Sometimes boundListener is null, but still it makes sense to check state of network, battery or power save.

This means these states get checked on every transfer progress change.
(same like before but also if boundListener is null)

This can be as a bug fix in RC2 or in 3.7.1.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>