### PR TITLE
Add wake lock API to power management service

### DIFF
--- a/src/main/java/com/nextcloud/client/device/PowerManagementService.kt
+++ b/src/main/java/com/nextcloud/client/device/PowerManagementService.kt
@@ -48,4 +48,14 @@ interface PowerManagementService {
      * Checks if battery is charging using any hardware supported means.
      */
     val isBatteryCharging: Boolean
+
+    /**
+     * Try acquiring partial WakeLock. If wake lock could not be acquired,
+     * the returned lock is disabled and [WakeLock.isHeld] will evaluate to false.
+     *
+     * On API <21 (Lollipop) returned wake lock is always disabled.
+     *
+     * @return Wake lock. Caller should check [WakeLock.isHeld] to evaluate lock state.
+     */
+    fun acquirePartialWakeLock(timeout: Long, tag: String): WakeLock
 }

--- a/src/main/java/com/nextcloud/client/device/PowerManagementServiceImpl.kt
+++ b/src/main/java/com/nextcloud/client/device/PowerManagementServiceImpl.kt
@@ -28,6 +28,7 @@ import android.content.IntentFilter
 import android.os.BatteryManager
 import android.os.Build
 import android.os.PowerManager
+import com.owncloud.android.R
 
 internal class PowerManagementServiceImpl(
     private val context: Context,
@@ -68,4 +69,15 @@ internal class PowerManagementServiceImpl(
                 else -> false
             }
         }
+
+    override fun acquirePartialWakeLock(timeout: Long, tag: String): WakeLock {
+        if (deviceInfo.apiLevel < Build.VERSION_CODES.LOLLIPOP) {
+            val wakeLockTag = "${context.getString(R.string.authority)}.WAKE_LOCK.${tag}"
+            val lock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, wakeLockTag)
+            lock.acquire(timeout)
+            return WakeLockWrapper(lock)
+        } else {
+            return WakeLockWrapper(null)
+        }
+    }
 }

--- a/src/main/java/com/nextcloud/client/device/WakeLock.kt
+++ b/src/main/java/com/nextcloud/client/device/WakeLock.kt
@@ -1,0 +1,47 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Chris Narkiewicz
+ *
+ * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.client.device
+
+/**
+ * This is a safe wrapper around platform [android.os.PowerManager.WakeLock].
+ */
+interface WakeLock {
+
+    /**
+     * Check if wake lock is held.
+     */
+    val isHeld: Boolean
+
+    /**
+     * Release wake lock.
+     */
+    fun release()
+
+    /**
+     * Run runnable under the wakelock and release it when the runnable
+     * finishes. It is safe to run the runnable when wake lock is not
+     * held.
+     *
+     * When runnable throws exception, the wake lock is also released.
+     */
+    fun runAndRelease(runnable: Runnable)
+}

--- a/src/main/java/com/nextcloud/client/device/WakeLockWrapper.kt
+++ b/src/main/java/com/nextcloud/client/device/WakeLockWrapper.kt
@@ -1,0 +1,42 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Chris Narkiewicz
+ *
+ * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.client.device
+
+import android.os.PowerManager
+
+internal class WakeLockWrapper(val lock: PowerManager.WakeLock?) : WakeLock {
+
+    override val isHeld: Boolean
+        get() = lock?.isHeld ?: false
+
+    override fun release() {
+        lock?.release()
+    }
+
+    override fun runAndRelease(runnable: Runnable) {
+        try {
+            runnable.run()
+        } finally {
+            lock?.release()
+        }
+    }
+}

--- a/src/test/java/com/nextcloud/client/device/TestWakeLockWrapper.kt
+++ b/src/test/java/com/nextcloud/client/device/TestWakeLockWrapper.kt
@@ -1,0 +1,142 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Chris Narkiewicz
+ *
+ * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.client.device
+
+import android.os.PowerManager
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.lang.RuntimeException
+
+class TestWakeLockWrapper {
+
+    internal lateinit var nativeLock: PowerManager.WakeLock
+    internal lateinit var wrapper: WakeLockWrapper
+    internal lateinit var emptyWrapper: WakeLockWrapper
+
+    @Before
+    fun setUp() {
+        nativeLock = mock()
+        wrapper = WakeLockWrapper(nativeLock)
+        emptyWrapper = WakeLockWrapper(null)
+    }
+
+    @Test
+    fun `wake lock wrapper delegates status check to native lock`() {
+        // GIVEN
+        //      native lock is held
+        whenever(nativeLock.isHeld).thenReturn(true)
+
+        // WHEN
+        //      lock wrapper is checked
+        val status = wrapper.isHeld
+
+        // THEN
+        //      native lock status is retrieved
+        assertTrue(status)
+        verify(nativeLock).isHeld
+    }
+
+    @Test
+    fun `empty wake lock wrapper is not held`() {
+        // GIVEN
+        //      wake lock wrapper is empty (no native lock)
+        val emptyLock = WakeLockWrapper(null)
+        assertNull(emptyLock.lock)
+
+        // WHEN
+        //      lock status is checked
+        val status = emptyLock.isHeld
+
+        // THEN
+        //      lock status is false
+        //      native lock is null
+        assertFalse(status)
+    }
+
+    @Test
+    fun `lock is released after runnable`() {
+        // GIVEN
+        //      lock wrapper is not empty
+        assertNotNull(wrapper.lock)
+
+        // WHEN
+        //      block of code is run on a lock
+        var called = false
+        wrapper.runAndRelease(Runnable {
+            called = true
+        })
+
+        // THEN
+        //      block is invoked
+        //      native lock is released
+        assertTrue(called)
+        verify(wrapper.lock!!).release()
+    }
+
+    @Test
+    fun `lock is released after runnable throws exception`() {
+        // GIVEN
+        //      lock wrapper is not empty
+        assertNotNull(wrapper.lock)
+
+        // WHEN
+        //      block of code is run on a lock
+        //      runnable throws
+        var exceptionThrown = false
+        try {
+            wrapper.runAndRelease(Runnable {
+                throw RuntimeException("dummy")
+            })
+        } catch (ex: RuntimeException) {
+            exceptionThrown = true
+        }
+
+        // THEN
+        //      exception is not consumed
+        //      lock is released
+        assertTrue(exceptionThrown)
+        verify(wrapper.lock!!).release()
+    }
+
+    @Test
+    fun `can run block on empty wake lock wrapper`() {
+        // GIVEN
+        //      lock wrapper is empty
+        assertNull(emptyWrapper.lock)
+
+        // WHEN
+        //      block of code is run on a lock
+        var called = false
+        wrapper.runAndRelease(Runnable {
+            called = true
+        })
+
+        // THEN
+        //      block is invoked
+        //      no NPE crash
+        assertTrue(called)
+    }
+}


### PR DESCRIPTION
The purpose of this API is to hide logic details, API-level differences and provide simple interface to run block of code under wake lock.

The main motivation is to eliminate multi-level if-ology in sync jobs that must deal with wakelock nullability and can leak wake locks on exceptions.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>