### PR TITLE
get rename message from RichDocuments

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/RichDocumentsWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/RichDocumentsWebView.java
@@ -405,6 +405,19 @@ public class RichDocumentsWebView extends ExternalSiteWebView {
 
             downloadmanager.enqueue(request);
         }
+
+        @JavascriptInterface
+        public void fileRename(String renameString) {
+            // when shared file is renamed in another instance, we will get notified about it
+            // need to change filename for sharing
+            try {
+                JSONObject renameJson = new JSONObject(renameString);
+                String newName = renameJson.getString("NewName");
+                file.setFileName(newName);
+            } catch (JSONException e) {
+                Log_OC.e(this, "Failed to parse rename json message: " + e);
+            }
+        }
     }
 
 


### PR DESCRIPTION
Needs https://github.com/nextcloud/richdocuments/pull/529

When a shared file is renamed on another instance, RichDocuments will notify us.
The new file name is needed to have sharing working again.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>