### PR TITLE
Bump to 3.7.0 RC1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ configurations {
 
 ext {
     jacocoVersion = "0.8.2"
-    androidLibraryVersion = "master-SNAPSHOT"
+    androidLibraryVersion = "1.5.0-rc1"
 
     travisBuild = System.getenv("TRAVIS") == "true"
 
@@ -75,7 +75,7 @@ repositories {
 def versionMajor = 3
 def versionMinor = 7
 def versionPatch = 0
-def versionBuild = 0 // 0-50=Alpha / 51-98=RC / 90-99=stable
+def versionBuild = 51 // 0-50=Alpha / 51-98=RC / 90-99=stable
 
 def taskRequest = getGradle().getStartParameter().getTaskRequests().toString()
 if (taskRequest.contains("Gplay") || taskRequest.contains("lint")) {
@@ -129,7 +129,7 @@ android {
 
         buildTypes {
             debug {
-                testCoverageEnabled (project.hasProperty('coverage') ? true : false)
+                testCoverageEnabled (project.hasProperty('coverage'))
             }
         }
 

--- a/fastlane/metadata/android/en-US/changelogs/30070051.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30070051.txt
@@ -1,0 +1,9 @@
+3.7.0 RC1 (June, 06, 2019)
+
+- Collabora enhancements
+- Chromebook support
+- delete push notifications if read on other device
+- open file from notification
+- open file from Talk app
+
+For a full list, please see https://github.com/nextcloud/android/milestone/32

--- a/fastlane/metadata/android/en-US/changelogs/30070051.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30070051.txt
@@ -5,5 +5,7 @@
 - delete push notifications if read on other device
 - open file from notification
 - open file from Talk app
+- minimum supported server: NC12
+- end of life warning: NC13 and older
 
 For a full list, please see https://github.com/nextcloud/android/milestone/32


### PR DESCRIPTION
Library 1.5.0-rc1 is also a pre-release, so if we need to change something we do not "waste" stable versions.

@AndyScherzinger @ezaquarii please feel free to add anything I might miss to changelog.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>