### PR TITLE
Fix crash when drawing play icon on video thumbnail

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -1047,8 +1047,8 @@ public final class ThumbnailsCacheManager {
     }
 
     public static Bitmap addVideoOverlay(Bitmap thumbnail){
-        Bitmap playButton = BitmapFactory.decodeResource(MainApp.getAppContext().getResources(),
-                R.drawable.view_play);
+        Drawable playButtonDrawable = MainApp.getAppContext().getResources().getDrawable(R.drawable.view_play);
+        Bitmap playButton = BitmapUtils.drawableToBitmap(playButtonDrawable);
 
         Bitmap resizedPlayButton = Bitmap.createScaledBitmap(playButton,
                 (int) (thumbnail.getWidth() * 0.3),


### PR DESCRIPTION
Bitmap decoder does not work with vector drawables.

Fixes #4129
Fixes #4150

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>