### PR TITLE
Fix crash when displaying video files 

### DIFF
--- a/src/main/java/com/nextcloud/client/di/ComponentsModule.java
+++ b/src/main/java/com/nextcloud/client/di/ComponentsModule.java
@@ -136,11 +136,8 @@ abstract class ComponentsModule {
     @ContributesAndroidInjector abstract PreviewMediaFragment previewMediaFragment();
     @ContributesAndroidInjector abstract PreviewTextFragment previewTextFragment();
 
-    @ContributesAndroidInjector
-    abstract ReceiveExternalFilesActivity.DialogMultipleAccount dialogMultipleAccount();
-
-    @ContributesAndroidInjector
-    abstract ReceiveExternalFilesActivity.DialogInputUploadFilename dialogInputUploadFilename();
+    @ContributesAndroidInjector abstract ReceiveExternalFilesActivity.DialogMultipleAccount dialogMultipleAccount();
+    @ContributesAndroidInjector abstract ReceiveExternalFilesActivity.DialogInputUploadFilename dialogInputUploadFilename();
 
     @ContributesAndroidInjector abstract FileUploader fileUploader();
     @ContributesAndroidInjector abstract FileDownloader fileDownloader();

--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -1047,8 +1047,8 @@ public final class ThumbnailsCacheManager {
     }
 
     public static Bitmap addVideoOverlay(Bitmap thumbnail){
-        Bitmap playButton = BitmapFactory.decodeResource(MainApp.getAppContext().getResources(),
-                R.drawable.view_play);
+        Drawable playButtonDrawable = MainApp.getAppContext().getResources().getDrawable(R.drawable.view_play);
+        Bitmap playButton = BitmapUtils.drawableToBitmap(playButtonDrawable);
 
         Bitmap resizedPlayButton = Bitmap.createScaledBitmap(playButton,
                 (int) (thumbnail.getWidth() * 0.3),

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -55,6 +55,7 @@ import android.widget.Toast;
 import android.widget.VideoView;
 
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.FileMenuFilter;
@@ -92,7 +93,7 @@ import androidx.annotation.StringRes;
  * By now, if the {@link OCFile} passed is not downloaded, an {@link IllegalStateException} is
  * generated on instantiation too.
  */
-public class PreviewMediaFragment extends FileFragment implements OnTouchListener {
+public class PreviewMediaFragment extends FileFragment implements OnTouchListener, Injectable {
 
     private static final String TAG = PreviewMediaFragment.class.getSimpleName();
 


### PR DESCRIPTION
1) Bitmap decoder does not work with vector drawables directly
2) Dependency injection in PreviewMediaFragment

Fixes #4121
Fixes #4129
Fixes #4150

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>