### PR TITLE
Remove DI from NContentObserverJob

### DIFF
--- a/src/main/java/com/nextcloud/client/di/ComponentsModule.java
+++ b/src/main/java/com/nextcloud/client/di/ComponentsModule.java
@@ -27,10 +27,8 @@ import com.owncloud.android.authentication.DeepLinkLoginActivity;
 import com.owncloud.android.files.BootupBroadcastReceiver;
 import com.owncloud.android.files.services.FileDownloader;
 import com.owncloud.android.files.services.FileUploader;
-import com.owncloud.android.jobs.NContentObserverJob;
 import com.owncloud.android.jobs.NotificationJob;
 import com.owncloud.android.providers.DiskLruImageCacheFileProvider;
-import com.owncloud.android.providers.DocumentsStorageProvider;
 import com.owncloud.android.providers.UsersAndGroupsSearchProvider;
 import com.owncloud.android.services.AccountManagerService;
 import com.owncloud.android.services.OperationsService;
@@ -145,11 +143,9 @@ abstract class ComponentsModule {
     @ContributesAndroidInjector abstract BootupBroadcastReceiver bootupBroadcastReceiver();
     @ContributesAndroidInjector abstract NotificationJob.NotificationReceiver notificationJobBroadcastReceiver();
 
-    @ContributesAndroidInjector abstract DocumentsStorageProvider documentsStorageProvider();
     @ContributesAndroidInjector abstract UsersAndGroupsSearchProvider usersAndGroupsSearchProvider();
     @ContributesAndroidInjector abstract DiskLruImageCacheFileProvider diskLruImageCacheFileProvider();
 
     @ContributesAndroidInjector abstract AccountManagerService accountManagerService();
     @ContributesAndroidInjector abstract OperationsService operationsService();
-    @ContributesAndroidInjector abstract NContentObserverJob contentObserverJob();
 }

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -175,6 +175,22 @@ public class MainApp extends MultiDexApplication implements
         mContext = context;
     }
 
+    /**
+     * Temporary getter replacing Dagger DI
+     * TODO: remove when cleaning DI in NContentObserverJob
+     */
+    public AppPreferences getPreferences() {
+        return preferences;
+    }
+
+    /**
+     * Temporary getter replacing Dagger DI
+     * TODO: remove when cleaning DI in NContentObserverJob
+     */
+    public PowerManagementService getPowerManagementService() {
+        return powerManagementService;
+    }
+
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);

--- a/src/main/java/com/owncloud/android/jobs/NContentObserverJob.java
+++ b/src/main/java/com/owncloud/android/jobs/NContentObserverJob.java
@@ -29,13 +29,11 @@ import com.evernote.android.job.JobRequest;
 import com.evernote.android.job.util.support.PersistableBundleCompat;
 import com.nextcloud.client.device.PowerManagementService;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.utils.FilesSyncHelper;
 
-import javax.inject.Inject;
-
 import androidx.annotation.RequiresApi;
-import dagger.android.AndroidInjection;
 
 /*
     Job that triggers new FilesSyncJob in case new photo or video were detected
@@ -44,13 +42,18 @@ import dagger.android.AndroidInjection;
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class NContentObserverJob extends JobService {
 
-    @Inject PowerManagementService powerManagementService;
-    @Inject AppPreferences preferences;
+    private PowerManagementService powerManagementService;
+    private AppPreferences preferences;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        AndroidInjection.inject(this);
+
+        // Temporary workaround for https://github.com/nextcloud/android/issues/4147
+        // TODO: this must be fixed properly
+        MainApp app = (MainApp) getApplication();
+        powerManagementService = app.getPowerManagementService();
+        preferences = app.getPreferences();
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -46,6 +46,7 @@ import android.widget.Toast;
 import com.evernote.android.job.JobRequest;
 import com.evernote.android.job.util.Device;
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.client.account.UserAccountManagerImpl;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.owncloud.android.MainApp;
@@ -84,10 +85,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
-
-import dagger.android.AndroidInjection;
-
 import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
 import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
 
@@ -100,9 +97,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     private Map<Long, FileDataStorageManager> rootIdToStorageManager;
     private OwnCloudClient client;
 
-    @Inject UserAccountManager accountManager;
-
-
+    UserAccountManager accountManager;
 
     @Override
     public Cursor queryRoots(String[] projection) throws FileNotFoundException {
@@ -301,7 +296,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
     @Override
     public boolean onCreate() {
-        AndroidInjection.inject(this);
+        accountManager = UserAccountManagerImpl.fromContext(getContext());
         return true;
     }
 


### PR DESCRIPTION
Removing DI from the service fixes DI crash on older
devices when JobService is not provided by the system,
prevending ClassNotFoundException.

A proper fix for this issue must follow.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>