### PR TITLE
Provide a banal 'paste' postmessage implementation.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/RichDocumentsWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/RichDocumentsWebView.java
@@ -35,8 +35,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.View;
 import android.view.KeyEvent;
+import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
@@ -423,8 +423,10 @@ public class RichDocumentsWebView extends ExternalSiteWebView {
         @JavascriptInterface
         public void paste() {
            // Javascript cannot do this by itself, so help out.
-            webview.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_PASTE));
-            webview.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_PASTE));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                webview.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_PASTE));
+                webview.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_PASTE));
+            }
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/RichDocumentsWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/RichDocumentsWebView.java
@@ -36,6 +36,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.KeyEvent;
 import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
@@ -417,6 +418,13 @@ public class RichDocumentsWebView extends ExternalSiteWebView {
             } catch (JSONException e) {
                 Log_OC.e(this, "Failed to parse rename json message: " + e);
             }
+        }
+
+        @JavascriptInterface
+        public void paste() {
+           // Javascript cannot do this by itself, so help out.
+            webview.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_PASTE));
+            webview.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_PASTE));
         }
     }
 


### PR DESCRIPTION
Browsers will allow apps to populate the clipboard, but not read
from it without user input. This patch makes it possible for
context menus with 'Paste' in them to trigger a real OS paste
when hosted inside the webview.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>