### PR TITLE
npe in file owner after upgrade

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -49,7 +49,6 @@ import com.bumptech.glide.request.target.BitmapImageViewTarget;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
@@ -366,7 +365,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     ArrayList<String> sharees = (ArrayList<String>) file.getSharees();
 
                     // use fileOwner if not oneself, then add at first
-                    if (!fileOwner.equals(userId) && !sharees.contains(fileOwner)) {
+                    if (fileOwner != null && !fileOwner.equals(userId) && !sharees.contains(fileOwner)) {
                         sharees.add(fileOwner);
                     }
 


### PR DESCRIPTION
Directly after upgrade a race condition can happen:
file.getOwnerId() is is used, but maybe not synced (yet)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>