### PR TITLE
Bump to 3.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ repositories {
 def versionMajor = 3
 def versionMinor = 7
 def versionPatch = 0
-def versionBuild = 54 // 0-50=Alpha / 51-98=RC / 90-99=stable
+def versionBuild = 90 // 0-50=Alpha / 51-98=RC / 90-99=stable
 
 def taskRequest = getGradle().getStartParameter().getTaskRequests().toString()
 if (taskRequest.contains("Gplay") || taskRequest.contains("lint")) {

--- a/fastlane/metadata/android/en-US/changelogs/30070090.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30070090.txt
@@ -1,0 +1,12 @@
+3.7.0 (July, 09, 2019)
+
+- Collabora enhancements
+- Chromebook support
+- delete push notifications if read on other device (NC 18 and newer)
+- open file from notification
+- open file from Talk app
+- minimum supported server: NC12
+- end of life warning: NC13 and older
+- lots of bugfixes and refinements under the hood to provide an even more stable app
+
+For a full list, please see https://github.com/nextcloud/android/milestone/32

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -118,7 +118,7 @@ public class MainApp extends MultiDexApplication implements
     HasContentProviderInjector,
     HasBroadcastReceiverInjector {
 
-    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = OwnCloudVersion.nextcloud_13;
+    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = new OwnCloudVersion("13.99.99");
     public static final OwnCloudVersion MINIMUM_SUPPORTED_SERVER_VERSION = OwnCloudVersion.nextcloud_12;
 
     private static final String TAG = MainApp.class.getSimpleName();


### PR DESCRIPTION
use latest NC13 for outdated server comparison

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>