### PR TITLE
new approach for tinted cursors

### DIFF
--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -474,7 +474,7 @@ public final class ThemeUtils {
         }
 
         editText.setHighlightColor(context.getResources().getColor(R.color.fg_contrast));
-        setTextViewCursorColor(editText, color);
+        setEditTextCursorColor(editText, color);
         setTextViewHandlesColor(context, editText, color);
     }
 
@@ -575,34 +575,54 @@ public final class ThemeUtils {
      * Lifted from SO.
      * FindBugs surpressed because of lack of public API to alter the cursor color.
      *
-     * @param view      TextView to be styled
+     * @param editText  TextView to be styled
      * @param color     The desired cursor colour
-     * @see             <a href="https://stackoverflow.com/questions/25996032/how-to-change-programmatically-edittext-cursor-color-in-android#26543290">StackOverflow url</a>
+     * @see             <a href="https://stackoverflow.com/a/52564925">StackOverflow url</a>
      */
     @SuppressFBWarnings
-    private static void setTextViewCursorColor(EditText view, @ColorInt int color) {
+    public static void setEditTextCursorColor(EditText editText, int color) {
         try {
             // Get the cursor resource id
-            Field field = TextView.class.getDeclaredField("mCursorDrawableRes");
-            field.setAccessible(true);
-            int drawableResId = field.getInt(view);
+            if (Build.VERSION.SDK_INT >= 28) {//set differently in Android P (API 28)
+                Field field = TextView.class.getDeclaredField("mCursorDrawableRes");
+                field.setAccessible(true);
+                int drawableResId = field.getInt(editText);
 
-            // Get the editor
-            field = TextView.class.getDeclaredField("mEditor");
-            field.setAccessible(true);
-            Object editor = field.get(view);
+                // Get the editor
+                field = TextView.class.getDeclaredField("mEditor");
+                field.setAccessible(true);
+                Object editor = field.get(editText);
 
-            // Get the drawable and set a color filter
-            Drawable drawable = ContextCompat.getDrawable(view.getContext(), drawableResId);
-            drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
-            Drawable[] drawables = {drawable, drawable};
+                // Get the drawable and set a color filter
+                Drawable drawable = ContextCompat.getDrawable(editText.getContext(), drawableResId);
+                drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
 
-            // Set the drawables
-            field = editor.getClass().getDeclaredField("mCursorDrawable");
-            field.setAccessible(true);
-            field.set(editor, drawables);
-        } catch (Exception e) {
-            Log_OC.e(TAG, "setTextViewCursorColor", e);
+                // Set the drawables
+                field = editor.getClass().getDeclaredField("mDrawableForCursor");
+                field.setAccessible(true);
+                field.set(editor, drawable);
+            } else {
+                Field field = TextView.class.getDeclaredField("mCursorDrawableRes");
+                field.setAccessible(true);
+                int drawableResId = field.getInt(editText);
+
+                // Get the editor
+                field = TextView.class.getDeclaredField("mEditor");
+                field.setAccessible(true);
+                Object editor = field.get(editText);
+
+                // Get the drawable and set a color filter
+                Drawable drawable = ContextCompat.getDrawable(editText.getContext(), drawableResId);
+                drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+                Drawable[] drawables = {drawable, drawable};
+
+                // Set the drawables
+                field = editor.getClass().getDeclaredField("mCursorDrawable");
+                field.setAccessible(true);
+                field.set(editor, drawables);
+            }
+        } catch (Exception exception) {
+            // we do not log this
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/4038

![2019-07-19-120359](https://user-images.githubusercontent.com/5836855/61527683-50548280-aa1d-11e9-919f-ef00e2b3042c.png)

I tested it on Android P and older, so it should be good on all API level right now.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>