### PR TITLE
merge commit should always run drone

### DIFF
--- a/scripts/checkIfRunDrone.sh
+++ b/scripts/checkIfRunDrone.sh
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ -z $3 ] ; then
+    echo "Merge commit to master -> continue with CI"
+    exit 0
+fi
+
 export BRANCH=$(scripts/analysis/getBranchBase.sh $1 $2 $3 | sed s'/"//'g)
 if [ $(git diff --name-only origin/$BRANCH | grep -cE "^src|build.gradle") -eq 0 ] ; then
     echo "No source files changed"


### PR DESCRIPTION
Expectation: https://drone.nextcloud.com/nextcloud/android/10080 will skip, but merge commit will work.

- [ ] also change for SSO
 
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>