### PR TITLE
Fix local state if fragment is initialized before services

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -101,9 +101,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     implements DisplayUtils.AvatarGenerationListener {
 
     private static final int showFilenameColumnThreshold = 4;
-    private final FileDownloader.FileDownloaderBinder downloaderBinder;
-    private final FileUploader.FileUploaderBinder uploaderBinder;
-    private final OperationsService.OperationsServiceBinder operationsServiceBinder;
+    private final ComponentsGetter transferServiceGetter;
     private final String userId;
     private Context mContext;
     private AppPreferences preferences;
@@ -152,9 +150,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         this.gridView = gridView;
         checkedFiles = new HashSet<>();
 
-        downloaderBinder = transferServiceGetter.getFileDownloaderBinder();
-        uploaderBinder = transferServiceGetter.getFileUploaderBinder();
-        operationsServiceBinder = transferServiceGetter.getOperationsServiceBinder();
+        this.transferServiceGetter = transferServiceGetter;
 
         if (account != null) {
             AccountManager platformAccountManager = AccountManager.get(mContext);
@@ -442,17 +438,20 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             gridViewHolder.localFileIndicator.setVisibility(View.INVISIBLE);   // default first
 
+            OperationsService.OperationsServiceBinder operationsServiceBinder = transferServiceGetter.getOperationsServiceBinder();
+            FileDownloader.FileDownloaderBinder fileDownloaderBinder = transferServiceGetter.getFileDownloaderBinder();
+            FileUploader.FileUploaderBinder fileUploaderBinder = transferServiceGetter.getFileUploaderBinder();
             if (operationsServiceBinder != null && operationsServiceBinder.isSynchronizing(account, file)) {
                 //synchronizing
                 gridViewHolder.localFileIndicator.setImageResource(R.drawable.ic_synchronizing);
                 gridViewHolder.localFileIndicator.setVisibility(View.VISIBLE);
 
-            } else if (downloaderBinder != null && downloaderBinder.isDownloading(account, file)) {
+            } else if (fileDownloaderBinder != null && fileDownloaderBinder.isDownloading(account, file)) {
                 // downloading
                 gridViewHolder.localFileIndicator.setImageResource(R.drawable.ic_synchronizing);
                 gridViewHolder.localFileIndicator.setVisibility(View.VISIBLE);
 
-            } else if (uploaderBinder != null && uploaderBinder.isUploading(account, file)) {
+            } else if (fileUploaderBinder != null && fileUploaderBinder.isUploading(account, file)) {
                 //uploading
                 gridViewHolder.localFileIndicator.setImageResource(R.drawable.ic_synchronizing);
                 gridViewHolder.localFileIndicator.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Download, upload and operations services can be null at initialization of fragment and adapter:

https://github.com/nextcloud/android/blob/3949238de048ec18fba2e0bb518268d1738134ef/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java#L155-L157

Behavior before (without syncing status):
![before](https://user-images.githubusercontent.com/4938650/61867597-e3872f80-aed7-11e9-98ce-b8f2ef4206f4.gif)

With this PR (with syncing status):
![after](https://user-images.githubusercontent.com/4938650/61867620-ebdf6a80-aed7-11e9-9aef-cb536a26389d.gif)
The sync icon is finally there :)