### PR TITLE
remove document (with relation to parent)

### DIFF
--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -529,6 +529,11 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     @Override
+    public void removeDocument(String documentId, String parentDocumentId) throws FileNotFoundException {
+        deleteDocument(documentId);
+    }
+
+    @Override
     public void deleteDocument(String documentId) throws FileNotFoundException {
         long docId = Long.parseLong(documentId);
         updateCurrentStorageManagerIfNeeded(docId);


### PR DESCRIPTION
This was missing (and is only used when opening via DOCUMENT_TREE)

@grote
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>