### PR TITLE
mHostUrlInput can be null if used with direct login

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -505,7 +505,9 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
         if (loginUrlInfo != null) {
             try {
-                mHostUrlInput.setText("");
+                if (mHostUrlInput != null) {
+                    mHostUrlInput.setText("");
+                }
                 mServerInfo.mBaseUrl = AuthenticatorUrlUtils.normalizeUrlSuffix(loginUrlInfo.serverAddress);
                 webViewUser = loginUrlInfo.username;
                 webViewPassword = loginUrlInfo.password;


### PR DESCRIPTION
Introdced in https://github.com/nextcloud/android/pull/4254

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>