### PR TITLE
FIDO U2F Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,6 +284,8 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.jetbrains:annotations:17.0.0'
 
+    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido:2.4.1'
+
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.9.0'
     spotbugsPlugins 'com.mebigfatguy.fb-contrib:fb-contrib:7.4.6'
 

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -94,6 +94,8 @@ import androidx.multidex.MultiDexApplication;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
+import de.cotech.hw.SecurityKeyManager;
+import de.cotech.hw.SecurityKeyManagerConfig;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFERENCE_CONTACTS_AUTOMATIC_BACKUP;
@@ -210,6 +212,13 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        SecurityKeyManager securityKeyManager = SecurityKeyManager.getInstance();
+        SecurityKeyManagerConfig config = new SecurityKeyManagerConfig.Builder()
+            .setEnableDebugLogging(BuildConfig.DEBUG)
+            .build();
+        securityKeyManager.init(this, config);
+
         registerActivityLifecycleCallbacks(new ActivityInjector());
 
         Thread t = new Thread(() -> {


### PR DESCRIPTION
As discussed by email, this is our FIDO U2F implementation for Android, which is 100% GPLv3 and not depending on Google Play Services.

This implementation works by adding the Javascript FIDO API to the WebView and bridging it to our Java calls. More details: https://hwsecurity.dev/guide/fido-webview/

I tried this with two different nextloud instances where the nextcloud-twofactor_u2f plugin is activated.

I am interested in Feedback and discussions around this PR.

## Source Code
https://github.com/cotechde/hwsecurity

## Context regarding FIDO Support on Android
* Google's proposes to use their [Google Play Services for FIDO](https://developers.google.com/android/reference/com/google/android/gms/fido/u2f/U2fApiClient). These are closed source and not available on phones that do not ship Google Play. Especially due to the recent US sanctions, this is even more important.
* The WebView itself will probably not support FIDO in the near future: ["This feature will be supported on all platforms except for Android WebView."](https://groups.google.com/a/chromium.org/d/msg/blink-dev/wfIVkXvQ7kQ/VfuOr_FhBwAJ)