### PR TITLE
Fix upload and delete to actually delete

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1051,14 +1051,7 @@ public class FileDisplayActivity extends FileActivity
 
     private void requestUploadOfFilesFromFileSystem(Intent data, int resultCode) {
         String[] filePaths = data.getStringArrayExtra(UploadFilesActivity.EXTRA_CHOSEN_FILES);
-        int behaviour;
-
-        if (resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE) {
-            behaviour = FileUploader.LOCAL_BEHAVIOUR_MOVE;
-        } else {
-            behaviour = FileUploader.LOCAL_BEHAVIOUR_COPY;
-        }
-        requestUploadOfFilesFromFileSystem(filePaths, behaviour);
+        requestUploadOfFilesFromFileSystem(filePaths, resultCode);
     }
 
     private void requestUploadOfFilesFromFileSystem(String[] filePaths, int resultCode) {


### PR DESCRIPTION
The removed logic results in falling back to LOCAL_BEHAVIOUR_FORGET and was introduced here: https://github.com/nextcloud/android/pull/3467/files#diff-ecdca245e1aa615e4581732a6606684bR1038-R1044

It seems like this is a left over from the logic below:
https://github.com/nextcloud/android/blob/ea44c595a8d7b43bb9f1e6787b1540cd85791a8f/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java#L1073-L1089

Fixes #3840