### PR TITLE
Suppress fatal SecurityException crash when removing sticky intent

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1551,7 +1551,11 @@ public class FileDisplayActivity extends FileActivity
 
             } finally {
                 if (intent != null) {
-                    removeStickyBroadcast(intent);
+                    try {
+                        removeStickyBroadcast(intent);
+                    } catch (SecurityException ex) {
+                        Log_OC.e(TAG, "Cannot clear sticky intent.", ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #4229

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>