### PR TITLE
Use ExceptionHandler not on debug builds

### DIFF
--- a/src/main/java/com/nextcloud/client/appinfo/AppInfo.java
+++ b/src/main/java/com/nextcloud/client/appinfo/AppInfo.java
@@ -34,4 +34,6 @@ public interface AppInfo {
      */
     String getFormattedVersionCode();
 
+    boolean isDebugBuild();
+
 }

--- a/src/main/java/com/nextcloud/client/appinfo/AppInfoImpl.java
+++ b/src/main/java/com/nextcloud/client/appinfo/AppInfoImpl.java
@@ -27,4 +27,9 @@ class AppInfoImpl implements AppInfo {
     public String getFormattedVersionCode() {
         return Integer.toString(BuildConfig.VERSION_CODE);
     }
+
+    @Override
+    public boolean isDebugBuild() {
+        return BuildConfig.DEBUG;
+    }
 }


### PR DESCRIPTION
With our new exception handler this is happening
- start an emulator within Android Studio
- select Logcat, select NC app
- trigger an Exception/Crash
- see shortly Exception message
- then Exception Handler pops in, which is also from NC process
- this clear logView of Android Studio

To get now the real exception I have to choose "all processes" and scroll up to the crash.
Previously (of course) it just remained there.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>