### PR TITLE
use new Android docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: generic
 
 steps:
   - name: generic
-    image: nextcloudci/android:android-49
+    image: nextcloudci/android:android-51
     environment:
       GIT_USERNAME:
         from_secret: GIT_USERNAME
@@ -52,7 +52,7 @@ name: gplay
 
 steps:
   - name: gplay
-    image: nextcloudci/android:android-49
+    image: nextcloudci/android:android-51
     privileged: true
     environment:
       LOG_USERNAME:
@@ -114,7 +114,7 @@ name: analysis
 
 steps:
   - name: analysis
-    image: nextcloudci/android:android-49
+    image: nextcloudci/android:android-51
     environment:
       GIT_USERNAME:
         from_secret: GIT_USERNAME
@@ -163,7 +163,7 @@ name: qa
 
 steps:
   - name: qa
-    image: nextcloudci/android:android-49
+    image: nextcloudci/android:android-51
     privileged: true
     environment:
       LOG_USERNAME:


### PR DESCRIPTION
This is a bit shrinked as it does not need to have any X11 library.
Unfortunately the benefit is rather small…
Nevertheless it is also an update to include latest deps.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>