### PR TITLE
Delete temp file on receive external files

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -949,13 +949,13 @@ public class ReceiveExternalFilesActivity extends FileActivity
     public void uploadFiles() {
 
         UriUploader uploader = new UriUploader(
-                this,
-                mStreamsToUpload,
-                mUploadPath,
-                getAccount(),
-                FileUploader.LOCAL_BEHAVIOUR_FORGET,
-                true, // Show waiting dialog while file is being copied from private storage
-                this  // Copy temp task listener
+            this,
+            mStreamsToUpload,
+            mUploadPath,
+            getAccount(),
+            FileUploader.LOCAL_BEHAVIOUR_DELETE,
+            true, // Show waiting dialog while file is being copied from private storage
+            this  // Copy temp task listener
         );
 
         UriUploader.UriUploaderResultCode resultCode = uploader.uploadUris();


### PR DESCRIPTION
Fix #4341

This happens only when sharing a file to NC app:
- temp file is created
- file is uploaded from this temp file
- temp file was not deleted

I set it now to "delete", meaning that the temp file is deleted.
We would also use "copy" so that the temporal file is being copied to NC app folder.
As we cannot ask user, I decided to simply do an upload.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>