### PR TITLE
change command order

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,10 +66,10 @@ steps:
       ORG_GRADLE_PROJECT_coverage: ''
     commands:
       - scripts/checkIfRunDrone.sh $GIT_USERNAME $GIT_TOKEN $DRONE_PULL_REQUEST || exit 0
-      - ./gradlew assembleGplay
       - emulator-headless -avd android-27 -no-snapshot -gpu swiftshader_indirect -no-window -no-audio &
-      - ./wait_for_emulator.sh
+      - ./gradlew assembleGplay
       - ./gradlew assembleGplayDebug
+      - ./wait_for_emulator.sh
       - ./gradlew jacocoTestGplayDebugUnitTestReport || scripts/uploadReport.sh $LOG_USERNAME $LOG_PASSWORD $DRONE_BUILD_NUMBER "Unit" $DRONE_PULL_REQUEST $GIT_USERNAME $GIT_TOKEN
       - ./gradlew installGplayDebugAndroidTest
       - ./gradlew createGplayDebugCoverageReport || scripts/uploadReport.sh $LOG_USERNAME $LOG_PASSWORD $DRONE_BUILD_NUMBER "IT" $DRONE_PULL_REQUEST $GIT_USERNAME $GIT_TOKEN


### PR DESCRIPTION
Idea is that first emulator starts and while this is booting up we assembleGplay, so that ideally after that emulator is directly up and running.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>