### PR TITLE
throttle avatar lookup

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ArbitraryDataProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/ArbitraryDataProvider.java
@@ -67,6 +67,9 @@ public class ArbitraryDataProvider {
         );
     }
 
+    public void storeOrUpdateKeyValue(String accountName, String key, long newValue) {
+        storeOrUpdateKeyValue(accountName, key, String.valueOf(newValue));
+    }
 
     public void storeOrUpdateKeyValue(String accountName, String key, String newValue) {
         ArbitraryDataSet data = getArbitraryDataSet(accountName, key);
@@ -106,15 +109,19 @@ public class ArbitraryDataProvider {
         }
     }
 
-
-    public Long getLongValue(Account account, String key) {
-        String value = getValue(account, key);
+    public Long getLongValue(String accountName, String key) {
+        String value = getValue(accountName, key);
 
         if (value.isEmpty()) {
             return -1l;
         } else {
             return Long.valueOf(value);
         }
+    }
+
+
+    public Long getLongValue(Account account, String key) {
+        return getLongValue(account.name, key);
     }
 
     public boolean getBooleanValue(String accountName, String key) {

--- a/src/main/java/com/owncloud/android/jobs/ContactsBackupJob.java
+++ b/src/main/java/com/owncloud/android/jobs/ContactsBackupJob.java
@@ -42,7 +42,6 @@ import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.operations.UploadFileOperation;
 import com.owncloud.android.services.OperationsService;
-import com.owncloud.android.ui.activity.ContactsPreferenceActivity;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -54,6 +53,8 @@ import java.util.Calendar;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+
+import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFERENCE_CONTACTS_LAST_BACKUP;
 
 /**
  * Job that backup contacts to /Contacts-Backup and deletes files older than x days
@@ -81,9 +82,13 @@ public class ContactsBackupJob extends Job {
 
         final Account account = accountManager.getAccountByName(bundle.getString(ACCOUNT, ""));
 
+        if (account == null) {
+            return Result.FAILURE;
+        }
+
         ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProvider(getContext().getContentResolver());
         Long lastExecution = arbitraryDataProvider.getLongValue(account,
-                ContactsPreferenceActivity.PREFERENCE_CONTACTS_LAST_BACKUP);
+                                                                PREFERENCE_CONTACTS_LAST_BACKUP);
 
         if (force || (lastExecution + 24 * 60 * 60 * 1000) < Calendar.getInstance().getTimeInMillis()) {
             Log_OC.d(TAG, "start contacts backup job");
@@ -102,8 +107,8 @@ public class ContactsBackupJob extends Job {
 
             // store execution date
             arbitraryDataProvider.storeOrUpdateKeyValue(account.name,
-                    ContactsPreferenceActivity.PREFERENCE_CONTACTS_LAST_BACKUP,
-                    String.valueOf(Calendar.getInstance().getTimeInMillis()));
+                                                        PREFERENCE_CONTACTS_LAST_BACKUP,
+                                                        Calendar.getInstance().getTimeInMillis());
         } else {
             Log_OC.d(TAG, "last execution less than 24h ago");
         }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -411,7 +411,7 @@ public class PreviewImageActivity extends FileActivity implements
                 }
 
                 // Call to reset image zoom to initial state
-                ((PreviewImagePagerAdapter) mViewPager.getAdapter()).resetZoom();
+                // ((PreviewImagePagerAdapter) mViewPager.getAdapter()).resetZoom();
             }
         }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -97,6 +97,7 @@ import pl.droidsonroids.gif.GifDrawable;
 public class PreviewImageFragment extends FileFragment implements Injectable {
 
     private static final String EXTRA_FILE = "FILE";
+    private static final String EXTRA_ZOOM = "ZOOM";
 
     private static final String ARG_FILE = "FILE";
     private static final String ARG_IGNORE_FIRST = "IGNORE_FIRST";
@@ -219,8 +220,9 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
             if (!mIgnoreFirstSavedState) {
-                OCFile file = savedInstanceState.getParcelable(PreviewImageFragment.EXTRA_FILE);
+                OCFile file = savedInstanceState.getParcelable(EXTRA_FILE);
                 setFile(file);
+                mImageView.setScale(savedInstanceState.getFloat(EXTRA_ZOOM));
             } else {
                 mIgnoreFirstSavedState = false;
             }
@@ -230,7 +232,9 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putParcelable(PreviewImageFragment.EXTRA_FILE, getFile());
+
+        outState.putFloat(EXTRA_ZOOM, mImageView.getScale());
+        outState.putParcelable(EXTRA_FILE, getFile());
     }
 
     @Override


### PR DESCRIPTION
We do eTag comparison, if available for avatars.
But this means that we still check every time when displaying an avatar.

This enhances it to check only
- if no avatar is in cache
- last lookup is >1h ago

It of course means that the avatar might be outdated, but to be honest, how often is this changed? ;-)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>