### PR TITLE
Fix build warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
     compileOnly "org.projectlombok:lombok:1.18.10"
-    annotationProcessor "org.projectlombok:lombok:1.18.10"
+    kapt "org.projectlombok:lombok:1.18.10"
 
     ktlint "com.pinterest:ktlint:0.34.2"
     implementation 'org.conscrypt:conscrypt-android:2.2.1'


### PR DESCRIPTION
> Configure project :
539	src: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'org.projectlombok:lombok:1.18.8'.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>