### PR TITLE
baseURL might be null

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -656,7 +656,12 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         boolean isUrlInputAllowed = getResources().getBoolean(R.bool.show_server_url_input);
         if (savedInstanceState == null) {
             if (mAccount != null) {
-                mServerInfo.mBaseUrl = mAccountMgr.getUserData(mAccount, Constants.KEY_OC_BASE_URL);
+                String baseUrl = mAccountMgr.getUserData(mAccount, Constants.KEY_OC_BASE_URL);
+                if (TextUtils.isEmpty(baseUrl)) {
+                    mServerInfo.mBaseUrl = "";
+                } else {
+                    mServerInfo.mBaseUrl = baseUrl;
+                }
                 // TODO do next in a setter for mBaseUrl
                 mServerInfo.mIsSslConn = mServerInfo.mBaseUrl.startsWith(HTTPS_PROTOCOL);
                 mServerInfo.mVersion = accountManager.getServerVersion(mAccount);

--- a/src/test/java/com/owncloud/android/utils/DisplayUtilsTest.java
+++ b/src/test/java/com/owncloud/android/utils/DisplayUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  * Nextcloud Android client application
+ *  *
+ *  * @author Tobias Kaminsky
+ *  * Copyright (C) 2019 Tobias Kaminsky
+ *  * Copyright (C) 2019 Nextcloud GmbH
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU Affero General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  * GNU Affero General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Affero General Public License
+ *  * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisplayUtilsTest {
+
+    @Test
+    public void testConvertIdn() {
+        assertEquals("", DisplayUtils.convertIdn("", true));
+        assertEquals("", DisplayUtils.convertIdn("", false));
+        assertEquals("http://www.nextcloud.com", DisplayUtils.convertIdn("http://www.nextcloud.com", true));
+        assertEquals("http://www.xn--wlkchen-90a.com", DisplayUtils.convertIdn("http://www.wölkchen.com", true));
+        assertEquals("http://www.wölkchen.com", DisplayUtils.convertIdn("http://www.xn--wlkchen-90a.com", false));
+    }
+
+}


### PR DESCRIPTION
Fix #4443 
Assumed scenario:
- retrigger credential check
- somehow base url is null
--> NPE

I cannot reproduce it, but according to gplay this happens quite a lot.
Maybe this is linked to login loop (which might explain why the url is null, when retrieving from account manager)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>