### PR TITLE
Fix NPE crash in OCFileListFragment when action mode is destroyed

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -643,8 +643,11 @@ public class OCFileListFragment extends ExtendedListFragment implements
             mActiveActionMode = null;
 
             // reset to previous color
-            ThemeUtils.colorStatusBar(getActivity(), mSystemBarColor);
-            ThemeUtils.colorToolbarProgressBar(getActivity(), mProgressBarColor);
+            final FragmentActivity activity = getActivity();
+            if (activity != null) {
+                ThemeUtils.colorStatusBar(activity, mSystemBarColor);
+                ThemeUtils.colorToolbarProgressBar(activity, mProgressBarColor);
+            }
 
             // show FAB on multi selection mode exit
             if (!mHideFab && !searchFragment) {


### PR DESCRIPTION
Since destruction callback can happen after fragment is detached, activity might not be available at that time. 

Fixes #4438

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>