### PR TITLE
Fix NPE in PreviewMediaFragment

### DIFF
--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -82,6 +82,7 @@ import javax.inject.Inject;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.fragment.app.Fragment;
 
 
 /**
@@ -552,9 +553,9 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
 
         @Override
         protected void onPostExecute(Uri uri) {
-            PreviewMediaFragment previewMediaFragment = previewMediaFragmentWeakReference.get();
-
-            if (previewMediaFragment != null) {
+            final PreviewMediaFragment previewMediaFragment = previewMediaFragmentWeakReference.get();
+            final Context context = previewMediaFragment != null ? previewMediaFragment.getContext() : null;
+            if (previewMediaFragment != null && context != null) {
                 if (uri != null) {
                     previewMediaFragment.mVideoUri = uri;
                     previewMediaFragment.mVideoPreview.setVideoURI(uri);


### PR DESCRIPTION
Fragment can be detached when async task finishes.
Detached fragment has no context and getString() fails with NPE.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>