### PR TITLE
if parent is null, then do a regular check, no early exit

### DIFF
--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -206,7 +206,7 @@ public class FileOperationsHelper {
 
             // check if latest sync is >30s ago
             OCFile parent = storageManager.getFileById(file.getParentId());
-            if (parent.getLastSyncDateForData() + 30 * 1000 > System.currentTimeMillis()) {
+            if (parent != null && parent.getLastSyncDateForData() + 30 * 1000 > System.currentTimeMillis()) {
                 EventBus.getDefault().post(new SyncEventFinished(intent));
 
                 return;


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/4549

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>