### PR TITLE
Fix recurring synced folder notifications

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -189,7 +189,7 @@ public class SyncedFolderProvider extends Observable {
         Cursor cursor = mContentResolver.query(
             ProviderMeta.ProviderTableMeta.CONTENT_URI_SYNCED_FOLDERS,
             null,
-            ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH + "LIKE ? AND " +
+            ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH + " LIKE ? AND " +
                 ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + " =? ",
             new String[]{localPath + "%", account.name},
             null

--- a/src/main/java/com/owncloud/android/jobs/MediaFoldersDetectionJob.java
+++ b/src/main/java/com/owncloud/android/jobs/MediaFoldersDetectionJob.java
@@ -111,6 +111,19 @@ public class MediaFoldersDetectionJob extends Job {
         if (!TextUtils.isEmpty(arbitraryDataString)) {
             mediaFoldersModel = gson.fromJson(arbitraryDataString, MediaFoldersModel.class);
 
+            // merge new detected paths with already notified ones
+            for (String existingImageFolderPath : mediaFoldersModel.getImageMediaFolders()) {
+                if (!imageMediaFolderPaths.contains(existingImageFolderPath)) {
+                    imageMediaFolderPaths.add(existingImageFolderPath);
+                }
+            }
+
+            for (String existingVideoFolderPath : mediaFoldersModel.getVideoMediaFolders()) {
+                if (!videoMediaFolderPaths.contains(existingVideoFolderPath)) {
+                    videoMediaFolderPaths.add(existingVideoFolderPath);
+                }
+            }
+
             // Store updated values
             arbitraryDataProvider.storeOrUpdateKeyValue(ACCOUNT_NAME_GLOBAL, KEY_MEDIA_FOLDERS, gson.toJson(new
                 MediaFoldersModel(imageMediaFolderPaths, videoMediaFolderPaths)));


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/4492
- remember every media folder where a notification was shown
- fix wrong sql to detect already existing synced folder

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>