### PR TITLE
Remove sticky headers from activities list view

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -175,7 +175,6 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
 
         recyclerView.setLayoutManager(layoutManager);
-        recyclerView.addItemDecoration(new StickyHeaderItemDecoration(adapter));
         recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
 
             @Override


### PR DESCRIPTION
This will prevent application from crashing on adapter update.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>