### PR TITLE
Fix vanishing images

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -343,10 +343,16 @@ public class FileDataStorageManager {
             ContentValues cv = createContentValueForFile(file, folder);
 
             if (fileExists(file.getFileId()) || fileExists(file.getRemotePath())) {
+                long fileId;
+                if (file.getFileId() != -1) {
+                    fileId = file.getFileId();
+                } else {
+                    fileId = getFileByPath(file.getRemotePath()).getFileId();
+                }
                 // updating an existing file
                 operations.add(ContentProviderOperation.newUpdate(ProviderTableMeta.CONTENT_URI)
                         .withValues(cv)
-                        .withSelection(ProviderTableMeta._ID + "=?", new String[]{String.valueOf(file.getFileId())})
+                                   .withSelection(ProviderTableMeta._ID + "=?", new String[]{String.valueOf(fileId)})
                         .build());
             } else {
                 // adding a new file

--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -416,6 +416,10 @@ public class RefreshFolderOperation extends RemoteOperation {
             // retrieve local data for the read file
             localFile = localFilesMap.remove(remoteFile.getRemotePath());
 
+            if (localFile == null) {
+                localFile = mStorageManager.getFileByPath(updatedFile.getRemotePath());
+            }
+
             // add to updatedFile data about LOCAL STATE (not existing in server)
             updatedFile.setLastSyncDateForProperties(mCurrentSyncTime);
 


### PR DESCRIPTION
Fix #4502 

OCFiles can be retrieved also by photo search, which then do not have a parent, nor a fileId as the are only virtual files

upon refreshing folder
- they were found in database, but only updated with fileId=-1.
- they were not found in parent folder, so we have to search them manually via file path

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>