### PR TITLE
Remove onAccountSet from ShareActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -88,8 +88,9 @@ public class ShareActivity extends FileActivity implements ShareFragmentListener
         }
     }
 
-    protected void onAccountSet(boolean stateWasRecovered) {
-        super.onAccountSet(stateWasRecovered);
+    @Override
+    protected void onStart() {
+        super.onStart();
 
         // Load data into the list
         Log_OC.d(TAG, "Refreshing lists on account set");


### PR DESCRIPTION
Since onAccountSet is called directly from onStart,
we can inline the code in onStart safely.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
