### PR TITLE
Remove onAccountSet from ConflictsResolveActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
@@ -82,8 +82,8 @@ public class ConflictsResolveActivity extends FileActivity implements OnConflict
     }
 
     @Override
-    protected void onAccountSet(boolean stateWasRecovered) {
-        super.onAccountSet(stateWasRecovered);
+    protected void onStart() {
+        super.onStart();
         if (getAccount() != null) {
             OCFile file = getFile();
             if (getFile() == null) {


### PR DESCRIPTION
Deprecated onAccountSet logic simply inlined in onStart.
No change of control flow.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>