### PR TITLE
Remove onAccountSet from ReceiveExternalFilesActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -231,12 +231,13 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     public void changeAccount(Account account) {
         setAccount(account, false);
-        onAccountSet(mAccountWasRestored);
+        initTargetFolder();
+        populateDirectoryList();
     }
 
     @Override
-    protected void onAccountSet(boolean stateWasRecovered) {
-        super.onAccountSet(mAccountWasRestored);
+    protected void onStart() {
+        super.onStart();
         initTargetFolder();
         populateDirectoryList();
     }


### PR DESCRIPTION
1. `onAccountSet` logic inlined in `onStart` and `changeAccount`
2. call to `onAccountSet` eliminated

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>