### PR TITLE
Eliminate account status flags from BaseActivity

### DIFF
--- a/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.java
+++ b/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.java
@@ -220,7 +220,7 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
 
             setAccount(account);
             userAccountManager.setCurrentOwnCloudAccount(account.name);
-            onAccountSet(false);
+            onAccountSet();
 
             Intent i = new Intent(this, FileDisplayActivity.class);
             i.setAction(FileDisplayActivity.RESTART);

--- a/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -38,11 +38,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     private OCCapability mCapabilities;
 
     /**
-     * Flag to signal when the value of mAccount was restored from a saved state.
-     */
-    protected boolean mAccountWasRestored;
-
-    /**
      * Access point to the cached database for the current ownCloud {@link Account}.
      */
     private FileDataStorageManager mStorageManager;
@@ -85,18 +80,14 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
      *
      * If not valid, tries to swap it for other valid and existing ownCloud {@link Account}.
      *
-     * POSTCONDITION: updates {@link #mAccountWasRestored}.
-     *
      * @param account      New {@link Account} to set.
      * @param savedAccount When 'true', account was retrieved from a saved instance state.
      */
     @Deprecated
     protected void setAccount(Account account, boolean savedAccount) {
-        Account oldAccount = mCurrentAccount;
         boolean validAccount = account != null && accountManager.setCurrentOwnCloudAccount(account.name);
         if (validAccount) {
             mCurrentAccount = account;
-            mAccountWasRestored = savedAccount || mCurrentAccount.equals(oldAccount);
         } else {
             swapToDefaultAccount();
         }
@@ -107,8 +98,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
      *
      * If no valid ownCloud {@link Account} exists, then the user is requested
      * to create a new ownCloud {@link Account}.
-     *
-     * POSTCONDITION: updates {@link #mAccountWasRestored}.
      */
     protected void swapToDefaultAccount() {
         // default to the most recently used account
@@ -116,9 +105,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         if (newAccount == null) {
             /// no account available: force account creation
             createAccount(true);
-            mAccountWasRestored = false;
         } else {
-            mAccountWasRestored = newAccount.equals(mCurrentAccount);
             mCurrentAccount = newAccount;
         }
     }
@@ -146,7 +133,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
      * Child classes must grant that state depending on the {@link Account} is updated.
      */
     @Deprecated
-    protected void onAccountSet(boolean stateWasRecovered) {
+    protected void onAccountSet() {
         if (getAccount() != null) {
             mStorageManager = new FileDataStorageManager(getAccount(), getContentResolver());
             mCapabilities = mStorageManager.getCapability(mCurrentAccount.name);
@@ -186,7 +173,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         super.onStart();
 
         if(mCurrentAccount != null) {
-            onAccountSet(mAccountWasRestored);
+            onAccountSet();
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -133,7 +133,7 @@ public class ManageAccountsActivity extends FileActivity implements AccountListA
         }
 
         setAccount(currentAccount);
-        onAccountSet(false);
+        onAccountSet();
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
 

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -136,7 +136,7 @@ public class UserInfoActivity extends FileActivity implements Injectable {
         unbinder = ButterKnife.bind(this);
 
         setAccount(getUserAccountManager().getCurrentAccount());
-        onAccountSet(false);
+        onAccountSet();
 
         boolean useBackgroundImage = URLUtil.isValidUrl(
                 getStorageManager().getCapability(account.name).getServerBackground());


### PR DESCRIPTION
onAccountSet(stateWasRecovered) is no longer used anywhere,
so the flag mAccountWasRestored can be safely removed.

This intermediary step opens path to eliminating
out of band calls to onAccountSet().

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>