### PR TITLE
Remove out of band setAccount/onAccountSet calls

### DIFF
--- a/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.java
+++ b/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.java
@@ -217,16 +217,18 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
                 return;
             }
 
-            setAccount(account);
             userAccountManager.setCurrentOwnCloudAccount(account.name);
-            onAccountSet();
 
             Intent i = new Intent(this, FileDisplayActivity.class);
             i.setAction(FileDisplayActivity.RESTART);
             i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(i);
+
+            finish();
         }
     }
+
+
 
     public static FeatureItem[] getFirstRun() {
         return new FeatureItem[]{

--- a/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.PersistableBundle;
 
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
@@ -96,9 +97,10 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         }
     }
 
-    @Override
-    protected void onPostResume() {
-        super.onPostResume();
+    public void onCreate(@Nullable Bundle savedInstanceState, @Nullable PersistableBundle persistentState) {
+        super.onCreate(savedInstanceState, persistentState);
+        Account account = accountManager.getCurrentAccount();
+        setAccount(account, false);
     }
 
     @Override
@@ -152,6 +154,11 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         } else {
             swapToDefaultAccount();
         }
+
+        if(currentAccount != null) {
+            storageManager = new FileDataStorageManager(currentAccount, getContentResolver());
+            capabilities = storageManager.getCapability(currentAccount.name);
+        }
     }
 
     /**
@@ -189,26 +196,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     }
 
     /**
-     * Called when the ownCloud {@link Account} associated to the Activity was just updated.
-     *
-     * Child classes must grant that state depending on the {@link Account} is updated.
-     */
-    @Deprecated
-    protected void onAccountSet() {
-        if (getAccount() != null) {
-            storageManager = new FileDataStorageManager(getAccount(), getContentResolver());
-            capabilities = storageManager.getCapability(currentAccount.name);
-        } else {
-            Log_OC.e(TAG, "onAccountChanged was called with NULL account associated!");
-        }
-    }
-
-    @Deprecated
-    protected void setAccount(Account account) {
-        currentAccount = account;
-    }
-
-    /**
      * Getter for the capabilities of the server where the current OC account lives.
      *
      * @return Capabilities of the server where the current OC account lives. Null if the account is not
@@ -228,16 +215,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     public Account getAccount() {
         return currentAccount;
     }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-
-        if(currentAccount != null) {
-            onAccountSet();
-        }
-    }
-
+    
     public FileDataStorageManager getStorageManager() {
         return storageManager;
     }

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1293,7 +1293,7 @@ public abstract class DrawerActivity extends ToolbarActivity
 
             // current account has changed
             if (data.getBooleanExtra(ManageAccountsActivity.KEY_CURRENT_ACCOUNT_CHANGED, false)) {
-                setAccount(accountManager.getCurrentAccount());
+                setAccount(accountManager.getCurrentAccount(), false);
                 updateAccountList();
                 restart();
             } else {

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2621,7 +2621,8 @@ public class FileDisplayActivity extends FileActivity
                 return;
             }
 
-            setAccount(newAccount);
+            setAccount(newAccount, false);
+            updateAccountList();
         }
 
         String fileId = String.valueOf(intent.getStringExtra(KEY_FILE_ID));

--- a/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -126,14 +126,11 @@ public class ManageAccountsActivity extends FileActivity implements AccountListA
         Account[] accountList = AccountManager.get(this).getAccountsByType(MainApp.getAccountType(this));
         originalAccounts = DisplayUtils.toAccountNameSet(Arrays.asList(accountList));
 
-        Account currentAccount = getUserAccountManager().getCurrentAccount();
+        Account currentAccount = getAccount();
 
         if (currentAccount != null) {
             originalCurrentAccount = currentAccount.name;
         }
-
-        setAccount(currentAccount);
-        onAccountSet();
 
         arbitraryDataProvider = new ArbitraryDataProvider(getContentResolver());
 

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -127,7 +127,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
 
             if (account != null && (currentAccount == null || !account.equalsIgnoreCase(currentAccount.name))) {
                 accountManager.setCurrentOwnCloudAccount(account);
-                setAccount(getUserAccountManager().getCurrentAccount());
+                setAccount(getUserAccountManager().getCurrentAccount(), false);
                 currentAccount = getAccount();
             }
         }

--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -208,8 +208,6 @@ public class ReceiveExternalFilesActivity extends FileActivity
             Log_OC.i(TAG, "No ownCloud account is available");
             DialogNoAccount dialog = new DialogNoAccount();
             dialog.show(getSupportFragmentManager(), null);
-        } else if (!savedAccount) {
-            setAccount(accounts[0]);
         }
 
         if (!somethingToUpload()) {
@@ -680,7 +678,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 // there is no need for checking for is there more then one
                 // account at this point
                 // since account setup can set only one account at time
-                setAccount(accounts[0]);
+                setAccount(accounts[0], false);
                 populateDirectoryList();
             }
         }

--- a/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
@@ -132,7 +132,7 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
 
             if (account != null && currentAccount != null && !account.equalsIgnoreCase(currentAccount.name)) {
                 accountManager.setCurrentOwnCloudAccount(account);
-                setAccount(getUserAccountManager().getCurrentAccount());
+                setAccount(getUserAccountManager().getCurrentAccount(), false);
             }
 
             path = getIntent().getStringExtra(MediaFoldersDetectionJob.KEY_MEDIA_FOLDER_PATH);

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -135,9 +135,6 @@ public class UserInfoActivity extends FileActivity implements Injectable {
         setContentView(R.layout.user_info_layout);
         unbinder = ButterKnife.bind(this);
 
-        setAccount(getUserAccountManager().getCurrentAccount());
-        onAccountSet();
-
         boolean useBackgroundImage = URLUtil.isValidUrl(
                 getStorageManager().getCapability(account.name).getServerBackground());
 


### PR DESCRIPTION
Activity account is set in `FilesActivity.onAccount()`,
but related components are updated in `BaseActivity.onStart()`.

1. Initialize account in `BaseActivity.onCreate()`
2. Update storage manager and capabilities immediately
   on account set, not waiting for `onStart()` lifecycle.
3. inline storage manager and capabilities update in `setAccount()`
4. Remove calls to `setAccount()`/`onAccountSet()` and replace with `setAccount(account, bool)`
that handles storage manager update

Due to the code accidental complexity the risk of minor regressions around account deletion from system's preferences is rather **high**.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>