### PR TITLE
Brand feature to hide provider buttons but keep slider

### DIFF
--- a/src/main/java/com/nextcloud/client/onboarding/OnboardingServiceImpl.kt
+++ b/src/main/java/com/nextcloud/client/onboarding/OnboardingServiceImpl.kt
@@ -72,8 +72,9 @@ internal class OnboardingServiceImpl constructor(
     }
 
     override fun launchFirstRunIfNeeded(activity: Activity): Boolean {
-        val isProviderOrOwnInstallationVisible = resources.getBoolean(R.bool.show_provider_or_own_installation)
-        val canLaunch = isProviderOrOwnInstallationVisible && isFirstRun && activity is AuthenticatorActivity
+        val isFistRunSliderVisible = resources.getBoolean(R.bool.show_first_run_slider)
+
+        val canLaunch = isFistRunSliderVisible && isFirstRun && activity is AuthenticatorActivity
         if (canLaunch) {
             val intent = Intent(activity, FirstRunActivity::class.java)
             activity.startActivityForResult(intent, AuthenticatorActivity.REQUEST_CODE_FIRST_RUN)

--- a/src/main/res/values/setup.xml
+++ b/src/main/res/values/setup.xml
@@ -23,6 +23,7 @@
     <string name="server_url"></string>
     <bool name="show_server_url_input">true</bool>
     <bool name="show_provider_or_own_installation">true</bool>
+    <bool name="show_first_run_slider">true</bool>
     <string name="provider_registration_server">https://www.nextcloud.com/register</string>
 
     <!-- Flags to enable/disable some features -->


### PR DESCRIPTION
Why hide the slider step if you want to just hide the buttons through `show_provider_or_own_installation` ? 

Here is a suggestion