### PR TITLE
Added brand feature to hide notifications from Drawer in setup

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -381,6 +381,7 @@ public abstract class DrawerActivity extends ToolbarActivity
         DrawerMenuUtil.removeMenuItem(menu, R.id.nav_shared, !getResources().getBoolean(R.bool.shared_enabled));
         DrawerMenuUtil.removeMenuItem(menu, R.id.nav_contacts, !getResources().getBoolean(R.bool.contacts_backup)
                 || !getResources().getBoolean(R.bool.show_drawer_contacts_backup));
+        DrawerMenuUtil.removeMenuItem(menu, R.id.nav_notifications, !getResources().getBoolean(R.bool.notifications_enabled));
 
         DrawerMenuUtil.removeMenuItem(menu, R.id.nav_synced_folders,
                 getResources().getBoolean(R.bool.syncedFolder_light));

--- a/src/main/res/values/setup.xml
+++ b/src/main/res/values/setup.xml
@@ -109,6 +109,8 @@
     <!-- Files becomes Home -->
     <bool name="use_home">false</bool>
 
+    <!-- Determine if notifications are enabled in Drawer -->
+    <bool name="notifications_enabled">false</bool>
     <!-- Push server url -->
     <string name="push_server_url" translatable="false"></string>
 


### PR DESCRIPTION
When push server is unavailable, it's useless to have a "notifications tab", here is an enhancement :)