### PR TITLE
Make Android v16/JellyBean the new min-supported Android version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 28
 
         // arguments to be passed to functional tests

--- a/src/test/java/com/nextcloud/client/device/TestPowerManagementService.kt
+++ b/src/test/java/com/nextcloud/client/device/TestPowerManagementService.kt
@@ -180,7 +180,7 @@ class TestPowerManagementService {
             // GIVEN
             //      device has API level 16 or below
             //      battery status sticky intent is available
-            whenever(deviceInfo.apiLevel).thenReturn(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+            whenever(deviceInfo.apiLevel).thenReturn(Build.VERSION_CODES.JELLY_BEAN)
             val powerSources = setOf(
                 BatteryManager.BATTERY_PLUGGED_AC,
                 BatteryManager.BATTERY_PLUGGED_USB


### PR DESCRIPTION
Resolves #2923