### PR TITLE
Fixing picture "set as wallpaper" issue in properties

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -468,6 +468,10 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                 containerActivity.getFileOperationsHelper().syncFile(getFile());
                 return true;
             }
+            case R.id.action_set_as_wallpaper:  {
+                containerActivity.getFileOperationsHelper().setPictureAs(getFile(), getView());
+                return true;
+            }
             case R.id.action_encrypted: {
                 // TODO implement or remove
                 return true;


### PR DESCRIPTION
Fixing issue [#4764](https://github.com/nextcloud/android/issues/4764)
To allow using of `set as` in picture properties