### PR TITLE
Disable android backup on the QA app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,12 @@ android {
         abortOnError false
         htmlReport true
         htmlOutput file("$project.buildDir/reports/lint/lint.html")
-        disable 'MissingTranslation', 'GradleDependency', 'VectorPath', 'IconMissingDensityFolder', 'IconDensities'
+        disable 'MissingTranslation',
+            'GradleDependency',
+            'VectorPath',
+            'IconMissingDensityFolder',
+            'IconDensities',
+            'GoogleAppIndexingWarning'
     }
 
     dexOptions {

--- a/src/qa/AndroidManifest.xml
+++ b/src/qa/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Nextcloud Android client application
+
+ Copyright (C) 2019 Nextcloud GmbH
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:allowBackup="false"
+        tools:replace="android:allowBackup" />
+</manifest>


### PR DESCRIPTION
Sometimes, there are multiple versions of the QA app that share the same database versions for different migrations. When the android backup feature is enabled by the user's devices, this leads to invalidly restored database state and then crashes that would normally not happen in production.

This PR simply disables the android backup feature for the QA version of the app.

(as seen in #4788)