### PR TITLE
Initial work on v2 with activity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
     daggerVersion = "2.25.2"
     markwonVersion =  "4.2.0"
     prismVersion = "2.0.0"
-    androidLibraryVersion = "v2withActivity-SNAPSHOT"
+    androidLibraryVersion = "master-SNAPSHOT"
 
     travisBuild = System.getenv("TRAVIS") == "true"
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
         classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.6'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.2.2"
+        classpath "commons-httpclient:commons-httpclient:3.1@jar" // remove after entire switch to lib v2
     }
 }
 
@@ -60,7 +61,7 @@ ext {
     daggerVersion = "2.25.2"
     markwonVersion =  "4.2.0"
     prismVersion = "2.0.0"
-    androidLibraryVersion = "master-SNAPSHOT"
+    androidLibraryVersion = "v2withActivity-SNAPSHOT"
 
     travisBuild = System.getenv("TRAVIS") == "true"
 
@@ -273,6 +274,9 @@ dependencies {
     gplayImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
     versionDevImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
     qaImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
+    compileOnly 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2' // remove after entire switch to lib v2
+    implementation "commons-httpclient:commons-httpclient:3.1@jar" // remove after entire switch to lib v2
+    implementation 'org.apache.jackrabbit:jackrabbit-webdav:2.13.1' // remove after entire switch to lib v2
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.1.0-beta01'

--- a/src/main/java/com/nextcloud/client/network/ClientFactory.java
+++ b/src/main/java/com/nextcloud/client/network/ClientFactory.java
@@ -27,6 +27,7 @@ import android.app.Activity;
 import android.net.Uri;
 
 import com.nextcloud.client.account.User;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 
@@ -54,6 +55,8 @@ public interface ClientFactory {
     }
 
     OwnCloudClient create(User user) throws CreationException;
+
+    NextcloudClient createNextcloudClient(User user) throws CreationException;
 
     @Deprecated
     OwnCloudClient create(Account account)

--- a/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.net.Uri;
 
 import com.nextcloud.client.account.User;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientFactory;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
@@ -50,6 +51,18 @@ class ClientFactoryImpl implements ClientFactory {
                  AuthenticatorException|
                  IOException|
                  AccountUtils.AccountNotFoundException e) {
+            throw new CreationException(e);
+        }
+    }
+
+    @Override
+    public NextcloudClient createNextcloudClient(User user) throws CreationException {
+        try {
+            return OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(), context);
+        } catch (OperationCanceledException |
+            AuthenticatorException |
+            IOException |
+            AccountUtils.AccountNotFoundException e) {
             throw new CreationException(e);
         }
     }

--- a/src/main/java/com/owncloud/android/jobs/NotificationJob.java
+++ b/src/main/java/com/owncloud/android/jobs/NotificationJob.java
@@ -253,7 +253,6 @@ public class NotificationJob extends Job {
             OwnCloudAccount ocAccount = new OwnCloudAccount(currentAccount, context);
             OwnCloudClient client = OwnCloudClientManagerFactory.getDefaultSingleton()
                 .getClientFor(ocAccount, context);
-            client.setOwnCloudVersion(accountManager.getServerVersion(currentAccount));
 
             RemoteOperationResult result = new GetNotificationRemoteOperation(decryptedPushMessage.nid)
                 .execute(client);
@@ -306,7 +305,6 @@ public class NotificationJob extends Job {
                         OwnCloudAccount ocAccount = new OwnCloudAccount(currentAccount, context);
                         OwnCloudClient client = OwnCloudClientManagerFactory.getDefaultSingleton()
                             .getClientFor(ocAccount, context);
-                        client.setOwnCloudVersion(accountManager.getServerVersion(currentAccount));
 
                         String actionType = intent.getStringExtra(KEY_NOTIFICATION_ACTION_TYPE);
                         String actionLink = intent.getStringExtra(KEY_NOTIFICATION_ACTION_LINK);

--- a/src/main/java/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
+++ b/src/main/java/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
@@ -30,6 +30,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.ExistenceCheckRemoteOperation;
 
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpStatus;
 
 import java.util.ArrayList;
@@ -119,7 +120,7 @@ public class DetectAuthenticationMethodOperation extends RemoteOperation {
         Log_OC.d(TAG, "Authentication method found: " + authenticationMethodToString(authMethod));
 
         if (authMethod != AuthenticationMethod.UNKNOWN) {
-            result = new RemoteOperationResult(true, result.getHttpCode(), result.getHttpPhrase(), null);
+            result = new RemoteOperationResult(true, result.getHttpCode(), result.getHttpPhrase(), new Header[0]);
         }
         ArrayList<Object> data = new ArrayList<>();
         data.add(authMethod);

--- a/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -37,7 +37,6 @@ import android.os.Process;
 import android.text.TextUtils;
 import android.util.Pair;
 
-import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
@@ -74,8 +73,6 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
-
-import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
 
@@ -136,8 +133,6 @@ public class OperationsService extends Service {
     private ConcurrentMap<Integer, Pair<RemoteOperation, RemoteOperationResult>>
             mUndispatchedFinishedOperations = new ConcurrentHashMap<>();
 
-    @Inject UserAccountManager accountManager;
-
     private static class Target {
         public Uri mServerUrl;
         public Account mAccount;
@@ -163,7 +158,7 @@ public class OperationsService extends Service {
         HandlerThread thread = new HandlerThread("Operations thread",
                 Process.THREAD_PRIORITY_BACKGROUND);
         thread.start();
-        mOperationsHandler = new ServiceHandler(thread.getLooper(), this, accountManager);
+        mOperationsHandler = new ServiceHandler(thread.getLooper(), this);
         mOperationsBinder = new OperationsServiceBinder(mOperationsHandler);
 
         // Separated worker thread for download of folders (WIP)
@@ -399,16 +394,14 @@ public class OperationsService extends Service {
         private Target mLastTarget;
         private OwnCloudClient mOwnCloudClient;
         private FileDataStorageManager mStorageManager;
-        private UserAccountManager accountManager;
 
 
-        public ServiceHandler(Looper looper, OperationsService service, UserAccountManager accountManager) {
+        public ServiceHandler(Looper looper, OperationsService service) {
             super(looper);
             if (service == null) {
                 throw new IllegalArgumentException("Received invalid NULL in parameter 'service'");
             }
             mService = service;
-            this.accountManager = accountManager;
         }
 
         @Override

--- a/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -51,7 +51,6 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.RestoreFileVersionRemoteOperation;
 import com.owncloud.android.lib.resources.files.model.FileVersion;
 import com.owncloud.android.lib.resources.shares.ShareType;
-import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.lib.resources.users.GetUserInfoRemoteOperation;
 import com.owncloud.android.operations.CheckCurrentCredentialsOperation;
 import com.owncloud.android.operations.CopyFileOperation;
@@ -442,9 +441,6 @@ public class OperationsService extends Service {
                             OwnCloudAccount ocAccount = new OwnCloudAccount(mLastTarget.mAccount, mService);
                             mOwnCloudClient = OwnCloudClientManagerFactory.getDefaultSingleton().
                                     getClientFor(ocAccount, mService);
-
-                            OwnCloudVersion version = accountManager.getServerVersion(mLastTarget.mAccount);
-                            mOwnCloudClient.setOwnCloudVersion(version);
 
                             mStorageManager = new FileDataStorageManager(
                                 mLastTarget.mAccount,

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -29,10 +29,10 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.activities.model.RichObject;
 import com.owncloud.android.lib.resources.files.FileUtils;
@@ -238,7 +238,7 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
     }
 
     @Override
-    public void showActivities(List<Object> activities, OwnCloudClient client, int lastGiven) {
+    public void showActivities(List<Object> activities, NextcloudClient client, int lastGiven) {
         boolean clear = false;
         if (this.lastGiven == UNDEFINED) {
             clear = true;

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesContract.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesContract.java
@@ -18,8 +18,8 @@
  */
 package com.owncloud.android.ui.activities;
 
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.ui.activity.BaseActivity;
 
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.List;
 public interface ActivitiesContract {
 
     interface View {
-        void showActivities(List<Object> activities, OwnCloudClient client, int lastGiven);
+        void showActivities(List<Object> activities, NextcloudClient client, int lastGiven);
         void showActivitiesLoadError(String error);
         void showActivityDetailUI(OCFile ocFile);
         void showActivityDetailUIIsNull();

--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesPresenter.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesPresenter.java
@@ -19,8 +19,8 @@
 
 package com.owncloud.android.ui.activities;
 
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.ui.activities.data.activities.ActivitiesRepository;
 import com.owncloud.android.ui.activities.data.files.FilesRepository;
 import com.owncloud.android.ui.activity.BaseActivity;
@@ -51,7 +51,7 @@ public class ActivitiesPresenter implements ActivitiesContract.ActionListener {
         activitiesView.setProgressIndicatorState(true);
         activitiesRepository.getActivities(lastGiven, new ActivitiesRepository.LoadActivitiesCallback() {
             @Override
-            public void onActivitiesLoaded(List<Object> activities, OwnCloudClient client, int lastGiven) {
+            public void onActivitiesLoaded(List<Object> activities, NextcloudClient client, int lastGiven) {
 
                 if (!activityStopped) {
                     activitiesView.setProgressIndicatorState(false);

--- a/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesRepository.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesRepository.java
@@ -18,7 +18,7 @@
  */
 package com.owncloud.android.ui.activities.data.activities;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import androidx.annotation.NonNull;
  */
 public interface ActivitiesRepository {
     interface LoadActivitiesCallback {
-        void onActivitiesLoaded(List<Object> activities, OwnCloudClient client, int lastGiven);
+        void onActivitiesLoaded(List<Object> activities, NextcloudClient client, int lastGiven);
         void onActivitiesLoadedError(String error);
     }
 

--- a/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApi.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApi.java
@@ -18,7 +18,7 @@
  */
 package com.owncloud.android.ui.activities.data.activities;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.resources.activities.model.Activity;
 
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.List;
 public interface ActivitiesServiceApi {
 
     interface ActivitiesServiceCallback<T> {
-        void onLoaded(T activities, OwnCloudClient client, int lastGiven);
+        void onLoaded(T activities, NextcloudClient client, int lastGiven);
         void onError (String error);
     }
 

--- a/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApiImpl.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApiImpl.java
@@ -30,10 +30,10 @@ import android.os.AsyncTask;
 
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.OwnCloudAccount;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -75,7 +75,7 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
         private UserAccountManager accountManager;
         private int lastGiven;
         private String errorMessage;
-        private OwnCloudClient ownCloudClient;
+        private NextcloudClient client;
 
         private GetActivityListTask(Account account,
                                     UserAccountManager accountManager,
@@ -95,9 +95,8 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
             OwnCloudAccount ocAccount;
             try {
                 ocAccount = new OwnCloudAccount(account, context);
-                ownCloudClient = OwnCloudClientManagerFactory.getDefaultSingleton().
-                        getClientFor(ocAccount, MainApp.getAppContext());
-                ownCloudClient.setOwnCloudVersion(accountManager.getServerVersion(account));
+                client = OwnCloudClientManagerFactory.getDefaultSingleton().
+                    getNextcloudClientFor(ocAccount, MainApp.getAppContext());
 
                 GetActivitiesRemoteOperation getRemoteActivitiesOperation;
                 if (lastGiven > 0) {
@@ -106,7 +105,7 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
                     getRemoteActivitiesOperation = new GetActivitiesRemoteOperation();
                 }
 
-                final RemoteOperationResult result = getRemoteActivitiesOperation.execute(ownCloudClient);
+                final RemoteOperationResult result = getRemoteActivitiesOperation.execute(client);
 
                 if (result.isSuccess() && result.getData() != null) {
                     final ArrayList<Object> data = result.getData();
@@ -145,7 +144,7 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
         protected void onPostExecute(Boolean success) {
             super.onPostExecute(success);
             if (success) {
-                callback.onLoaded(activities, ownCloudClient, lastGiven);
+                callback.onLoaded(activities, client, lastGiven);
             } else {
                 callback.onError(errorMessage);
             }

--- a/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApiImpl.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/activities/ActivitiesServiceApiImpl.java
@@ -28,7 +28,6 @@ import android.accounts.OperationCanceledException;
 import android.content.Context;
 import android.os.AsyncTask;
 
-import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.MainApp;
@@ -59,9 +58,7 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
 
     @Override
     public void getAllActivities(int lastGiven, ActivitiesServiceCallback<List<Object>> callback) {
-        User user = accountManager.getUser();
-        GetActivityListTask getActivityListTask = new GetActivityListTask(user.toPlatformAccount(),
-                                                                          accountManager,
+        GetActivityListTask getActivityListTask = new GetActivityListTask(accountManager.getUser().toPlatformAccount(),
                                                                           lastGiven,
                                                                           callback);
         getActivityListTask.execute();
@@ -72,17 +69,14 @@ public class ActivitiesServiceApiImpl implements ActivitiesServiceApi {
         private final ActivitiesServiceCallback<List<Object>> callback;
         private List<Object> activities;
         private Account account;
-        private UserAccountManager accountManager;
         private int lastGiven;
         private String errorMessage;
         private NextcloudClient client;
 
         private GetActivityListTask(Account account,
-                                    UserAccountManager accountManager,
                                     int lastGiven,
                                     ActivitiesServiceCallback<List<Object>> callback) {
             this.account = account;
-            this.accountManager = accountManager;
             this.lastGiven = lastGiven;
             this.callback = callback;
             activities = new ArrayList<>();

--- a/src/main/java/com/owncloud/android/ui/activities/data/activities/RemoteActivitiesRepository.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/activities/RemoteActivitiesRepository.java
@@ -18,7 +18,7 @@
  */
 package com.owncloud.android.ui.activities.data.activities;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class RemoteActivitiesRepository implements ActivitiesRepository {
         activitiesServiceApi.getAllActivities(lastGiven,
                                               new ActivitiesServiceApi.ActivitiesServiceCallback<List<Object>>() {
             @Override
-            public void onLoaded(List<Object> activities, OwnCloudClient client, int lastGiven) {
+            public void onLoaded(List<Object> activities, NextcloudClient client, int lastGiven) {
                 callback.onActivitiesLoaded(activities, client, lastGiven);
             }
 

--- a/src/main/java/com/owncloud/android/ui/activities/data/files/FilesServiceApiImpl.java
+++ b/src/main/java/com/owncloud/android/ui/activities/data/files/FilesServiceApiImpl.java
@@ -97,7 +97,6 @@ public class FilesServiceApiImpl implements FilesServiceApi {
             final Context context = MainApp.getAppContext();
             try {
                 OwnCloudClient ownCloudClient = clientFactory.create(user);
-                ownCloudClient.setOwnCloudVersion(user.getServer().getVersion());
                 // always update file as it could be an old state saved in database
                 RemoteOperationResult resultRemoteFileOp = new ReadFileRemoteOperation(fileUrl).execute(ownCloudClient);
 

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -256,7 +256,6 @@ public class NotificationsActivity extends FileActivity implements Notifications
                 try {
                     User user = optionalUser.get();
                     client = clientFactory.create(user);
-                    client.setOwnCloudVersion(user.getServer().getVersion());
                 } catch (ClientFactory.CreationException e) {
                     Log_OC.e(TAG, "Error initializing client", e);
                 }

--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityAndVersionListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityAndVersionListAdapter.java
@@ -32,9 +32,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.nextcloud.client.account.CurrentAccountProvider;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.resources.activities.model.Activity;
 import com.owncloud.android.lib.resources.files.model.FileVersion;
 import com.owncloud.android.lib.resources.status.OCCapability;
@@ -69,7 +69,7 @@ public class ActivityAndVersionListAdapter extends ActivityListAdapter {
         this.versionListInterface = versionListInterface;
     }
 
-    public void setActivityAndVersionItems(List<Object> items, OwnCloudClient newClient, boolean clear) {
+    public void setActivityAndVersionItems(List<Object> items, NextcloudClient newClient, boolean clear) {
         if (client == null) {
             client = newClient;
         }

--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -52,11 +52,11 @@ import com.bumptech.glide.load.resource.file.FileToStreamDecoder;
 import com.caverock.androidsvg.SVG;
 import com.nextcloud.client.account.CurrentAccountProvider;
 import com.nextcloud.client.network.ClientFactory;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.activities.model.Activity;
 import com.owncloud.android.lib.resources.activities.model.RichElement;
@@ -91,7 +91,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     private final ActivityListInterface activityListInterface;
     private final int px;
     private static final String TAG = ActivityListAdapter.class.getSimpleName();
-    protected OwnCloudClient client;
+    protected NextcloudClient client;
 
     protected Context context;
     private CurrentAccountProvider currentAccountProvider;
@@ -119,7 +119,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         this.isDetailView = isDetailView;
     }
 
-    public void setActivityItems(List<Object> activityItems, OwnCloudClient client, boolean clear) {
+    public void setActivityItems(List<Object> activityItems, NextcloudClient client, boolean clear) {
         this.client = client;
         String sTime = "";
 

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -42,6 +42,7 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.network.ClientFactory;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
@@ -99,6 +100,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
     private ActivityAndVersionListAdapter adapter;
     private Unbinder unbinder;
     private OwnCloudClient ownCloudClient;
+    private NextcloudClient nextcloudClient;
 
     private OCFile file;
     private Account account;
@@ -313,7 +315,8 @@ public class FileDetailActivitiesFragment extends Fragment implements
         Thread t = new Thread(() -> {
             try {
                 ownCloudClient = clientFactory.create(user);
-                ownCloudClient.setOwnCloudVersion(user.getServer().getVersion());
+                nextcloudClient = clientFactory.createNextcloudClient(user);
+
                 isLoadingActivities = true;
 
                 GetActivitiesRemoteOperation getRemoteNotificationOperation;
@@ -325,7 +328,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
                 }
 
                 Log_OC.d(TAG, "BEFORE getRemoteActivitiesOperation.execute");
-                final RemoteOperationResult result = getRemoteNotificationOperation.execute(ownCloudClient);
+                final RemoteOperationResult result = getRemoteNotificationOperation.execute(nextcloudClient);
 
                 ArrayList<Object> versions = null;
                 if (restoreFileVersionSupported) {
@@ -401,7 +404,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
     }
 
     private void populateList(List<Object> activities, boolean clear) {
-        adapter.setActivityAndVersionItems(activities, ownCloudClient, clear);
+        adapter.setActivityAndVersionItems(activities, nextcloudClient, clear);
     }
 
     private void setEmptyContent(String headline, String message) {

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -328,7 +328,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
                 }
 
                 Log_OC.d(TAG, "BEFORE getRemoteActivitiesOperation.execute");
-                final RemoteOperationResult result = getRemoteNotificationOperation.execute(nextcloudClient);
+                final RemoteOperationResult result = nextcloudClient.execute(getRemoteNotificationOperation);
 
                 ArrayList<Object> versions = null;
                 if (restoreFileVersionSupported) {

--- a/src/test/java/com/owncloud/android/ui/activities/ActivitiesPresenterTest.java
+++ b/src/test/java/com/owncloud/android/ui/activities/ActivitiesPresenterTest.java
@@ -18,8 +18,8 @@
  */
 package com.owncloud.android.ui.activities;
 
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.resources.activities.model.Activity;
 import com.owncloud.android.ui.activities.data.activities.ActivitiesRepository;
 import com.owncloud.android.ui.activities.data.files.FilesRepository;
@@ -41,30 +41,30 @@ import static org.mockito.Mockito.verify;
 public class ActivitiesPresenterTest {
 
     @Mock
-    private FilesRepository mFileRepository;
+    private FilesRepository filesRepository;
 
     @Mock
-    private ActivitiesContract.View mView;
+    private ActivitiesContract.View view;
 
     @Mock
-    private ActivitiesRepository mActivitiesRepository;
+    private ActivitiesRepository activitiesRepository;
 
     @Mock
-    private BaseActivity mBaseActivity;
+    private BaseActivity baseActivity;
 
     @Mock
-    private OwnCloudClient mOwnCloudClient;
+    private NextcloudClient nextcloudClient;
 
     @Mock
-    private OCFile mOCFile;
+    private OCFile ocFile;
 
     @Captor
-    private ArgumentCaptor<FilesRepository.ReadRemoteFileCallback> mReadRemoteFilleCallbackCaptor;
+    private ArgumentCaptor<FilesRepository.ReadRemoteFileCallback> readRemoteFileCallbackArgumentCaptor;
 
     @Captor
-    private ArgumentCaptor<ActivitiesRepository.LoadActivitiesCallback> mLoadActivitiesCallbackCaptor;
+    private ArgumentCaptor<ActivitiesRepository.LoadActivitiesCallback> loadActivitiesCallbackArgumentCaptor;
 
-    private ActivitiesPresenter mPresenter;
+    private ActivitiesPresenter activitiesPresenter;
 
     private List<Object> activitiesList;
 
@@ -72,7 +72,7 @@ public class ActivitiesPresenterTest {
     @Before
     public void setupActivitiesPresenter() {
         MockitoAnnotations.initMocks(this);
-        mPresenter = new ActivitiesPresenter(mActivitiesRepository, mFileRepository, mView);
+        activitiesPresenter = new ActivitiesPresenter(activitiesRepository, filesRepository, view);
 
         activitiesList = new ArrayList<>();
         activitiesList.add(new Activity());
@@ -81,83 +81,83 @@ public class ActivitiesPresenterTest {
     @Test
     public void loadActivitiesFromRepositoryIntoView() {
         // When loading activities from repository is requested from presenter...
-        mPresenter.loadActivities(-1);
+        activitiesPresenter.loadActivities(-1);
         // Progress indicator is shown in view
-        verify(mView).setProgressIndicatorState(eq(true));
+        verify(view).setProgressIndicatorState(eq(true));
         // Repository starts retrieving activities from server
-        verify(mActivitiesRepository).getActivities(eq(-1), mLoadActivitiesCallbackCaptor.capture());
+        verify(activitiesRepository).getActivities(eq(-1), loadActivitiesCallbackArgumentCaptor.capture());
         // Repository returns data
-        mLoadActivitiesCallbackCaptor.getValue().onActivitiesLoaded(activitiesList, mOwnCloudClient, -1);
+        loadActivitiesCallbackArgumentCaptor.getValue().onActivitiesLoaded(activitiesList, nextcloudClient, -1);
         // Progress indicator is hidden
-        verify(mView).setProgressIndicatorState(eq(false));
+        verify(view).setProgressIndicatorState(eq(false));
         // List of activities is shown in view.
-        verify(mView).showActivities(eq(activitiesList), eq(mOwnCloudClient), eq(-1));
+        verify(view).showActivities(eq(activitiesList), eq(nextcloudClient), eq(-1));
     }
 
     @Test
     public void loadActivitiesFromRepositoryShowError() {
         // When loading activities from repository is requested from presenter...
-        mPresenter.loadActivities(-1);
+        activitiesPresenter.loadActivities(-1);
         // Progress indicator is shown in view
-        verify(mView).setProgressIndicatorState(eq(true));
+        verify(view).setProgressIndicatorState(eq(true));
         // Repository starts retrieving activities from server
-        verify(mActivitiesRepository).getActivities(eq(-1), mLoadActivitiesCallbackCaptor.capture());
+        verify(activitiesRepository).getActivities(eq(-1), loadActivitiesCallbackArgumentCaptor.capture());
         // Repository returns data
-        mLoadActivitiesCallbackCaptor.getValue().onActivitiesLoadedError("error");
+        loadActivitiesCallbackArgumentCaptor.getValue().onActivitiesLoadedError("error");
         // Progress indicator is hidden
-        verify(mView).setProgressIndicatorState(eq(false));
+        verify(view).setProgressIndicatorState(eq(false));
         // Correct error is shown in view
-        verify(mView).showActivitiesLoadError(eq("error"));
+        verify(view).showActivitiesLoadError(eq("error"));
     }
 
     @Test
     public void loadRemoteFileFromRepositoryShowDetailUI() {
         // When retrieving remote file from repository...
-        mPresenter.openActivity("null", mBaseActivity);
+        activitiesPresenter.openActivity("null", baseActivity);
         // Progress indicator is shown in view
-        verify(mView).setProgressIndicatorState(eq(true));
+        verify(view).setProgressIndicatorState(eq(true));
         // Repository retrieves remote file
-        verify(mFileRepository).readRemoteFile(eq("null"), eq(mBaseActivity),
-                mReadRemoteFilleCallbackCaptor.capture());
+        verify(filesRepository).readRemoteFile(eq("null"), eq(baseActivity),
+                                               readRemoteFileCallbackArgumentCaptor.capture());
         // Repository returns valid file object
-        mReadRemoteFilleCallbackCaptor.getValue().onFileLoaded(mOCFile);
+        readRemoteFileCallbackArgumentCaptor.getValue().onFileLoaded(ocFile);
         // Progress indicator is hidden
-        verify(mView).setProgressIndicatorState(eq(false));
+        verify(view).setProgressIndicatorState(eq(false));
         // File detail UI is shown
-        verify(mView).showActivityDetailUI(eq(mOCFile));
+        verify(view).showActivityDetailUI(eq(ocFile));
     }
 
     @Test
     public void loadRemoteFileFromRepositoryShowEmptyFile() {
         // When retrieving remote file from repository...
-        mPresenter.openActivity("null", mBaseActivity);
+        activitiesPresenter.openActivity("null", baseActivity);
         // Progress indicator is shown in view
-        verify(mView).setProgressIndicatorState(eq(true));
+        verify(view).setProgressIndicatorState(eq(true));
         // Repository retrieves remote file
-        verify(mFileRepository).readRemoteFile(eq("null"), eq(mBaseActivity),
-                mReadRemoteFilleCallbackCaptor.capture());
+        verify(filesRepository).readRemoteFile(eq("null"), eq(baseActivity),
+                                               readRemoteFileCallbackArgumentCaptor.capture());
         // Repository returns an valid but Null value file object.
-        mReadRemoteFilleCallbackCaptor.getValue().onFileLoaded(null);
+        readRemoteFileCallbackArgumentCaptor.getValue().onFileLoaded(null);
         // Progress indicator is hidden
-        verify(mView).setProgressIndicatorState(eq(false));
+        verify(view).setProgressIndicatorState(eq(false));
         // Returned file is null. Inform user.
-        verify(mView).showActivityDetailUIIsNull();
+        verify(view).showActivityDetailUIIsNull();
     }
 
     @Test
     public void loadRemoteFileFromRepositoryShowError() {
         // When retrieving remote file from repository...
-        mPresenter.openActivity("null", mBaseActivity);
+        activitiesPresenter.openActivity("null", baseActivity);
         // Progress indicator is shown in view
-        verify(mView).setProgressIndicatorState(eq(true));
+        verify(view).setProgressIndicatorState(eq(true));
         // Repository retrieves remote file
-        verify(mFileRepository).readRemoteFile(eq("null"), eq(mBaseActivity),
-                mReadRemoteFilleCallbackCaptor.capture());
+        verify(filesRepository).readRemoteFile(eq("null"), eq(baseActivity),
+                                               readRemoteFileCallbackArgumentCaptor.capture());
         // Repository returns valid file object
-        mReadRemoteFilleCallbackCaptor.getValue().onFileLoadError("error");
+        readRemoteFileCallbackArgumentCaptor.getValue().onFileLoadError("error");
         // Progress indicator is hidden
-        verify(mView).setProgressIndicatorState(eq(false));
+        verify(view).setProgressIndicatorState(eq(false));
         // Error message is shown to the user.
-        verify(mView).showActivityDetailError(eq("error"));
+        verify(view).showActivityDetailError(eq("error"));
     }
 }

--- a/src/test/java/com/owncloud/android/ui/activities/data/activities/RemoteActivitiesRepositoryTest.java
+++ b/src/test/java/com/owncloud/android/ui/activities/data/activities/RemoteActivitiesRepositoryTest.java
@@ -18,7 +18,7 @@
  */
 package com.owncloud.android.ui.activities.data.activities;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +42,7 @@ public class RemoteActivitiesRepositoryTest {
     ActivitiesRepository.LoadActivitiesCallback mockedLoadActivitiesCallback;
 
     @Mock
-    OwnCloudClient ownCloudClient;
+    NextcloudClient nextcloudClient;
 
     @Captor
     private ArgumentCaptor<ActivitiesServiceApi.ActivitiesServiceCallback> activitiesServiceCallbackCaptor;
@@ -62,8 +62,8 @@ public class RemoteActivitiesRepositoryTest {
     public void loadActivitiesReturnSuccess() {
         mActivitiesRepository.getActivities(-1, mockedLoadActivitiesCallback);
         verify(serviceApi).getAllActivities(eq(-1), activitiesServiceCallbackCaptor.capture());
-        activitiesServiceCallbackCaptor.getValue().onLoaded(activitiesList, ownCloudClient, -1);
-        verify(mockedLoadActivitiesCallback).onActivitiesLoaded(eq(activitiesList), eq(ownCloudClient), eq(-1));
+        activitiesServiceCallbackCaptor.getValue().onLoaded(activitiesList, nextcloudClient, -1);
+        verify(mockedLoadActivitiesCallback).onActivitiesLoaded(eq(activitiesList), eq(nextcloudClient), eq(-1));
     }
 
     @Test


### PR DESCRIPTION
This is a very very first version of our new v2 library, which uses dav4jvm and okhttp.

This uses new GetActivitiesRemoteOperation with a NextcloudClient, as this is not critical.

Please have first look at it, @AndyScherzinger @ezaquarii 
Same goes for https://github.com/nextcloud/android-library/pull/361

We use default timeouts from OKHTTP:
- connect: 10s
- read: 10s
- write: 10s
- overall 60s

Fixes #4987

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>