### PR TITLE
Use android test orchestrator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ android {
         testInstrumentationRunnerArgument "TEST_SERVER_USERNAME", "${NC_TEST_SERVER_USERNAME}"
         testInstrumentationRunnerArgument "TEST_SERVER_PASSWORD", "${NC_TEST_SERVER_PASSWORD}"
         testInstrumentationRunnerArguments disableAnalytics: 'true'
+        testInstrumentationRunnerArguments clearPackageData: 'true'
 
         multiDexEnabled true
 
@@ -184,6 +185,7 @@ android {
 
         testOptions {
             unitTests.returnDefaultValues = true
+            execution 'ANDROIDX_TEST_ORCHESTRATOR'
         }
     }
 
@@ -358,6 +360,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.2.0'
     // Android JUnit Runner
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestUtil 'androidx.test:orchestrator:1.1.0'
 
     // Espresso core
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,6 @@ android {
         testInstrumentationRunnerArgument "TEST_SERVER_USERNAME", "${NC_TEST_SERVER_USERNAME}"
         testInstrumentationRunnerArgument "TEST_SERVER_PASSWORD", "${NC_TEST_SERVER_PASSWORD}"
         testInstrumentationRunnerArguments disableAnalytics: 'true'
-        testInstrumentationRunnerArguments clearPackageData: 'true'
 
         multiDexEnabled true
 
@@ -152,7 +151,7 @@ android {
 
         buildTypes {
             debug {
-                testCoverageEnabled (project.hasProperty('coverage'))
+                testCoverageEnabled true
             }
         }
 

--- a/src/androidTest/java/com/owncloud/android/ScreenshotsIT.java
+++ b/src/androidTest/java/com/owncloud/android/ScreenshotsIT.java
@@ -32,6 +32,7 @@ import tools.fastlane.screengrab.locale.LocaleTestRule;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.core.AnyOf.anyOf;
@@ -133,6 +134,7 @@ public class ScreenshotsIT extends AbstractIT {
         ActivityScenario.launch(FileDisplayActivity.class);
 
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
+        onView(withId(R.id.nav_view)).perform(swipeUp());
         onView(anyOf(withText(R.string.drawer_synced_folders), withId(R.id.nav_synced_folders))).perform(click());
 
         Screengrab.screenshot("05_autoUpload");


### PR DESCRIPTION
This should make it a bit more robust, e.g. no context is shared between different tests and if one test fails the other will still be executed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>