### PR TITLE
disable google test tracking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ android {
         testInstrumentationRunnerArgument "TEST_SERVER_URL", "${NC_TEST_SERVER_BASEURL}"
         testInstrumentationRunnerArgument "TEST_SERVER_USERNAME", "${NC_TEST_SERVER_USERNAME}"
         testInstrumentationRunnerArgument "TEST_SERVER_PASSWORD", "${NC_TEST_SERVER_PASSWORD}"
+        testInstrumentationRunnerArguments disableAnalytics: 'true'
 
         multiDexEnabled true
 


### PR DESCRIPTION
Thanks to @grote for https://blog.grobox.de/2019/disable-google-android-instrumentation-test-tracking/

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>