### PR TITLE
Introduced user account id type

### DIFF
--- a/src/androidTest/java/com/nextcloud/client/account/UserTest.kt
+++ b/src/androidTest/java/com/nextcloud/client/account/UserTest.kt
@@ -1,0 +1,77 @@
+package com.nextcloud.client.account
+
+import android.accounts.Account
+import android.net.Uri
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.owncloud.android.lib.common.OwnCloudAccount
+import com.owncloud.android.lib.common.OwnCloudBasicCredentials
+import com.owncloud.android.lib.resources.status.OwnCloudVersion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URI
+
+@RunWith(AndroidJUnit4::class)
+class UserTest {
+
+    @Test
+    fun anonymousUserImplementsParcelable() {
+        // GIVEN
+        //      anonymous user instance
+        val original = AnonymousUser("test_account")
+
+        // WHEN
+        //      instance is serialized into Parcel
+        //      instance is retrieved from Parcel
+        val parcel = Parcel.obtain()
+        parcel.setDataPosition(0)
+        parcel.writeParcelable(original, 0)
+        parcel.setDataPosition(0)
+        val retrieved = parcel.readParcelable<User>(User::class.java.classLoader)
+
+        // THEN
+        //      retrieved instance in distinct
+        //      instances are equal
+        assertNotSame(original, retrieved)
+        assertTrue(retrieved is AnonymousUser)
+        assertEquals(original, retrieved)
+    }
+
+    @Test
+    fun registeredUserImplementsParcelable() {
+        // GIVEN
+        //      registered user instance
+        val uri = Uri.parse("https://nextcloud.localhost.localdomain")
+        val credentials = OwnCloudBasicCredentials("user", "pass")
+        val account = Account("test@nextcloud.localhost.localdomain", "test-type")
+        val ownCloudAccount = OwnCloudAccount(uri, credentials)
+        val server = Server(
+            uri = URI(uri.toString()),
+            version = OwnCloudVersion.nextcloud_17
+        )
+        val original = RegisteredUser(
+            account = account,
+            ownCloudAccount = ownCloudAccount,
+            server = server
+        )
+
+        // WHEN
+        //      instance is serialized into Parcel
+        //      instance is retrieved from Parcel
+        val parcel = Parcel.obtain()
+        parcel.setDataPosition(0)
+        parcel.writeParcelable(original, 0)
+        parcel.setDataPosition(0)
+        val retrieved = parcel.readParcelable<User>(User::class.java.classLoader)
+
+        // THEN
+        //      retrieved instance in distinct
+        //      instances are equal
+        assertNotSame(original, retrieved)
+        assertTrue(retrieved is RegisteredUser)
+        assertEquals(original, retrieved)
+    }
+}

--- a/src/main/java/com/nextcloud/client/account/AccountId.kt
+++ b/src/main/java/com/nextcloud/client/account/AccountId.kt
@@ -1,0 +1,77 @@
+package com.nextcloud.client.account
+
+import java.io.Serializable
+import java.lang.IllegalArgumentException
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * This class represents user account ID.
+ *
+ * Account IDs are in form of <username>@<server_host> quasi-email.
+ *
+ * Parser uses RFC 2396 rules to validate ID correctness, which is
+ * not ideal. Since account ID format is more of a convention rather
+ * than strict specification, this is still good improvement over
+ * free-form strings.
+ */
+class AccountId private constructor(
+    val username: String,
+    val host: String,
+    private val accountId: String = "$username@$host"
+) : CharSequence by accountId, Serializable {
+
+    companion object {
+        @JvmStatic
+        private val serialVersionUid = 0L
+
+        /**
+         * Create account id from username and backend server URI.
+         *
+         * @throws IllegalArgumentException if input username and host are empty
+         */
+        fun create(username: CharSequence, backendUri: URI): AccountId {
+            if (username.length == 0 || backendUri.host.length == 0) {
+                throw IllegalArgumentException("Cannot create account ID with empty username or backend host")
+            }
+            return AccountId(username.toString(), backendUri.host)
+        }
+
+        /**
+         * Parse account id from free-form string.
+         *
+         * @throws IllegalArgumentException if input string is not a valid account ID
+         */
+        fun parse(accountId: CharSequence): AccountId {
+            val uri = try {
+                URI("dummy", accountId.toString(), null, null)
+            } catch (e: URISyntaxException) {
+                throw IllegalArgumentException("Malformed account id", e)
+            }
+            if (uri.host.isNullOrEmpty() || uri.host.endsWith(".") || uri.userInfo.isNullOrEmpty()) {
+                throw IllegalArgumentException("Malformed account id: [$accountId]")
+            }
+            return AccountId(
+                username = uri.userInfo,
+                host = uri.host
+            )
+        }
+    }
+
+    override fun toString(): String = accountId
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AccountId
+
+        if (accountId != other.accountId) return false
+
+        return true
+    }
+
+    fun idEquals(other: CharSequence): Boolean = accountId.contentEquals(other)
+
+    override fun hashCode(): Int = accountId.hashCode()
+}

--- a/src/main/java/com/nextcloud/client/account/RegisteredUser.kt
+++ b/src/main/java/com/nextcloud/client/account/RegisteredUser.kt
@@ -21,12 +21,14 @@
 package com.nextcloud.client.account
 
 import android.accounts.Account
+import android.os.Parcel
+import android.os.Parcelable
 import com.owncloud.android.lib.common.OwnCloudAccount
 
 /**
  * This class represents normal user logged into the Nextcloud server.
  */
-internal class RegisteredUser(
+internal data class RegisteredUser(
     private val account: Account,
     private val ownCloudAccount: OwnCloudAccount,
     override val server: Server
@@ -37,11 +39,35 @@ internal class RegisteredUser(
         return account.name
     }
 
+    override val id: AccountId = AccountId.parse(account.name)
+
     override fun toPlatformAccount(): Account {
         return account
     }
 
     override fun toOwnCloudAccount(): OwnCloudAccount {
         return ownCloudAccount
+    }
+
+    constructor(source: Parcel) : this(
+        source.readParcelable<Account>(Account::class.java.classLoader) as Account,
+        source.readParcelable<OwnCloudAccount>(OwnCloudAccount::class.java.classLoader) as OwnCloudAccount,
+        source.readParcelable<Server>(Server::class.java.classLoader) as Server
+    )
+
+    override fun describeContents() = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeParcelable(account, 0)
+        writeParcelable(ownCloudAccount, 0)
+        writeParcelable(server, 0)
+    }
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<RegisteredUser> = object : Parcelable.Creator<RegisteredUser> {
+            override fun createFromParcel(source: Parcel): RegisteredUser = RegisteredUser(source)
+            override fun newArray(size: Int): Array<RegisteredUser?> = arrayOfNulls(size)
+        }
     }
 }

--- a/src/main/java/com/nextcloud/client/account/Server.kt
+++ b/src/main/java/com/nextcloud/client/account/Server.kt
@@ -20,6 +20,8 @@
  */
 package com.nextcloud.client.account
 
+import android.os.Parcel
+import android.os.Parcelable
 import com.owncloud.android.lib.resources.status.OwnCloudVersion
 import java.net.URI
 
@@ -27,4 +29,25 @@ import java.net.URI
  * This object provides all information necessary to interact
  * with backend server.
  */
-data class Server(val uri: URI, val version: OwnCloudVersion)
+data class Server(val uri: URI, val version: OwnCloudVersion) : Parcelable {
+
+    constructor(source: Parcel) : this(
+        source.readSerializable() as URI,
+        source.readParcelable<Parcelable>(OwnCloudVersion::class.java.classLoader) as OwnCloudVersion
+    )
+
+    override fun describeContents() = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeSerializable(uri)
+        writeParcelable(version, 0)
+    }
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<Server> = object : Parcelable.Creator<Server> {
+            override fun createFromParcel(source: Parcel): Server = Server(source)
+            override fun newArray(size: Int): Array<Server?> = arrayOfNulls(size)
+        }
+    }
+}

--- a/src/main/java/com/nextcloud/client/account/User.kt
+++ b/src/main/java/com/nextcloud/client/account/User.kt
@@ -21,10 +21,13 @@
 package com.nextcloud.client.account
 
 import android.accounts.Account
+import android.os.Parcelable
 import com.owncloud.android.lib.common.OwnCloudAccount
 
-interface User {
+interface User : Parcelable {
+    @Deprecated("Use id instead")
     val accountName: String
+    val id: AccountId
     val server: Server
     val isAnonymous: Boolean
 
@@ -51,4 +54,24 @@ interface User {
      */
     @Deprecated("Temporary workaround")
     fun toOwnCloudAccount(): OwnCloudAccount
+
+    /**
+     * Check user account ID for equality, comparing string representation.
+     * Contrary to [equals] method, different types of [CharSequence] can
+     * be compared.
+     *
+     * @param other Other id representation
+     * @return true if user ID content equals other char sequence
+     */
+    fun idEquals(other: CharSequence) = id.idEquals(other)
+
+    /**
+     * Check if users have same IDs comparing string representations.
+     * This method compares only user IDs. Contrary to [equals], this
+     * method does not compare other properties.
+     *
+     * @param other Other id representation
+     * @return true if user IDs are equal, otherwise false
+     */
+    fun idEquals(user: User) = id.idEquals(user.id)
 }

--- a/src/test/java/com/nextcloud/client/account/AccountIdTest.kt
+++ b/src/test/java/com/nextcloud/client/account/AccountIdTest.kt
@@ -1,0 +1,153 @@
+package com.nextcloud.client.account
+
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+import java.lang.StringBuilder
+import java.net.URI
+import java.nio.CharBuffer
+
+/**
+ * This test does not even try to validate the "email-like" account ID.
+ * We just do bare minimum here and the test makes a nice scaffolding for
+ * future work too.
+ *
+ * RFC 2396 parsing rules seem to be doing ok here.
+ *
+ * https://emailregex.com/
+ */
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AccountIdTest.Valid::class,
+    AccountIdTest.Invalid::class,
+    AccountIdTest.Equals::class
+)
+class AccountIdTest {
+
+    class Valid {
+
+        data class Row(val username: String, val host: String, val id: String = "$username@$host")
+
+        private val validIds = listOf(
+            Row("username", "hostname.com"),
+            Row("user_name", "hostname.com"),
+            Row("user_name_100", "hostname.com"),
+            Row("username", "hostname"),
+            Row("username", "host.domain.tld"),
+            Row("name.surname", "host.domain.tld")
+        )
+
+        @Test
+        fun `parse valid account id`() {
+            validIds.forEach {
+                val id = AccountId.parse(it.id)
+                assertEquals(id.toString(), it.id)
+                assertTrue(it.id.contentEquals(id))
+                assertEquals(it.host, id.host)
+                assertEquals(it.username, id.username)
+            }
+        }
+
+        @Test
+        fun `parse from username and host uri`() {
+            validIds.forEach {
+                val backendUri = URI("https", it.host, null, null)
+                val id = AccountId.create(it.username, backendUri)
+                assertEquals(CharBuffer.wrap(it.id), CharBuffer.wrap(id))
+                assertEquals(it.host, id.host)
+                assertEquals(it.username, id.username)
+            }
+        }
+    }
+
+    class Invalid {
+
+        val invalidAccountIds = listOf(
+            "", // empty
+            "localhost.localdomain", // no user
+            "user@", // user without domain
+            "@localhost.localdomain", // empty user
+            "user:pasword@hostname.com", // user with password
+            "username@hostname.com.", // dot after
+            "username@.hostname.com", // dot before
+            "user@name@hostname..com", // double dots
+            "username#hostname.com", // illegal user separator
+            "user%name@host!name.com", // illegal chars in domain
+            "username@host:name.com" // illegal chars in domain
+        )
+
+        @Test
+        fun `parsing fails with exception`() {
+            for (id in invalidAccountIds) {
+                try {
+                    val parsed = AccountId.parse(id)
+                    fail("Expected ${IllegalArgumentException::class} exception while parsing $id. Parsed: $parsed")
+                } catch (e: IllegalArgumentException) {
+                    // pass
+                }
+            }
+        }
+    }
+
+    class Equals {
+
+        @Test
+        fun `equal ids`() {
+            // WHEN
+            //      ids are equal
+            val id1 = AccountId.parse("user@hostname")
+            val id2 = AccountId.parse("user@hostname")
+
+            // THEN
+            //      ids evaluate as equal
+            //      hash code are equal
+            assertEquals(id1, id2)
+            assertEquals(id1.hashCode(), id2.hashCode())
+        }
+
+        @Test
+        fun `not equal ids`() {
+            // WHEN
+            //      ids are different
+            val id1 = AccountId.parse("user@hostname.com")
+            val id2 = AccountId.parse("user@hostname.net")
+
+            // THEN
+            //      ids are not equal
+            //      hash codes are not equal
+            assertNotEquals(id1, id2)
+            assertNotEquals(id1.hashCode(), id2.hashCode())
+        }
+
+        @Test
+        fun `id equals other char sequence`() {
+            // WHEN
+            //      id is compared against different type
+            //      string representation is equal
+            val id = AccountId.parse("user@hostname")
+            val sb = StringBuilder("user@hostname")
+
+            // THEN
+            //      ids are equal
+            assertTrue(id.idEquals(sb))
+        }
+
+        @Test
+        fun `id not equals other char sequence`() {
+            // WHEN
+            //      id is compared against different type
+            //      string representation is different
+            val id = AccountId.parse("user@hostname.com")
+            val sb = StringBuilder("user@hostname.net")
+
+            // THEN
+            //      ids are not equal
+            assertFalse(id.idEquals(sb))
+        }
+    }
+}


### PR DESCRIPTION
Since the application logic expects account id in a
specific format and relies on it, AccountId provides
dedicated type to represent id.

It uses RFC2396-compliant parser to validate id
format. It does not cover all possible edge cases,
but offers very cheap way to improve reliability over
existing free-form String used so far.

The type also offers reliable API to access host
and username parts, allowing us to remove ad-hoc
parsing logic present in various UI places.

AccountId provides CharSequence interface, preserving
String-like semantics whenever it is needed: mostly SQL
queries but also few UI cases.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>