### PR TITLE
Opt-out of scoped storage

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -96,6 +96,7 @@
         android:installLocation="internalOnly"
         android:manageSpaceActivity="com.owncloud.android.ui.activity.ManageSpaceActivity"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
 
         <uses-library


### PR DESCRIPTION
Fix denied access (throwing FileNotFoundExceptions) to "out of scoped storage" files.

https://developer.android.com/training/data-storage/compatibility

The Nextcloud android app needs to access any external storage in the case of a custom folder sync or external media file folders.

While I named the branch "-workaround", it looks like the app will never use scoped storage unless it implements some on-demand by path access permission (correct me if I'm wrong).