### PR TITLE
Fix crash when adding new ODS file

### DIFF
--- a/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
@@ -235,9 +235,9 @@ public class ChooseTemplateDialogFragment extends DialogFragment implements Dial
 
         @Override
         protected void onPostExecute(String url) {
-            ChooseTemplateDialogFragment fragment = chooseTemplateDialogFragmentWeakReference.get();
+            final ChooseTemplateDialogFragment fragment = chooseTemplateDialogFragmentWeakReference.get();
 
-            if (fragment != null) {
+            if (fragment != null && fragment.isAdded()) {
                 if (url.isEmpty()) {
                     DisplayUtils.showSnackMessage(fragment.listView, "Error creating file from template");
                 } else {
@@ -247,7 +247,6 @@ public class ChooseTemplateDialogFragment extends DialogFragment implements Dial
                     collaboraWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_SHOW_SIDEBAR, false);
                     collaboraWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_TEMPLATE, Parcels.wrap(template));
                     fragment.startActivity(collaboraWebViewIntent);
-
                     fragment.dismiss();
                 }
             } else {


### PR DESCRIPTION
Crash was caused by async task callback firing when
Fragment is not attached to activity.

Check if fragment is attached before invoking
callback logic.

Fixes: #5020

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>