### PR TITLE
Fix "Shared by null" glitch in file details view

### DIFF
--- a/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -325,7 +325,8 @@ public class UserAccountManagerImpl implements UserAccountManager {
 
     @Override
     public  boolean accountOwnsFile(OCFile file, Account account) {
-        return !TextUtils.isEmpty(file.getOwnerId()) && account.name.split("@")[0].equals(file.getOwnerId());
+        final String ownerId = file.getOwnerId();
+        return TextUtils.isEmpty(ownerId) || account.name.split("@")[0].equals(ownerId);
     }
 
     public boolean migrateUserId() {


### PR DESCRIPTION
When file is uploaded it has ownerId == null.
We shall interpret this condition file being
owned by the current user.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>