### PR TITLE
Fix white header with dark mode

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -254,7 +254,7 @@ public abstract class DrawerActivity extends ToolbarActivity
 
         setupDrawerToggle();
 
-        if(getSupportActionBar() != null) {
+        if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
     }
@@ -294,7 +294,7 @@ public abstract class DrawerActivity extends ToolbarActivity
         // Set the drawer toggle as the DrawerListener
         mDrawerLayout.addDrawerListener(mDrawerToggle);
         mDrawerToggle.setDrawerIndicatorEnabled(true);
-        mDrawerToggle.getDrawerArrowDrawable().setColor(ThemeUtils.fontColor(this));
+        mDrawerToggle.getDrawerArrowDrawable().setColor(ThemeUtils.fontColor(this, true));
     }
 
     /**
@@ -305,7 +305,7 @@ public abstract class DrawerActivity extends ToolbarActivity
         mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
 
         mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toggle);
-        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor(this));
+        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor(this, true));
 
         if (getResources().getBoolean(R.bool.allow_profile_click)) {
             mAccountChooserToggle.setImageResource(R.drawable.ic_down);

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -751,7 +751,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
             actionBar.setBackgroundDrawable(new ColorDrawable(ThemeUtils.primaryColor(this)));
 
             Drawable backArrow = getResources().getDrawable(R.drawable.ic_arrow_back);
-            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor(this)));
+            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor(this, true)));
         }
 
         Window window = getWindow();

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -63,7 +63,7 @@ public abstract class ToolbarActivity extends BaseActivity {
      */
     protected void setupToolbar(boolean useBackgroundImage) {
         int primaryColor = ThemeUtils.primaryColor(this, false);
-        int fontColor = ThemeUtils.fontColor(this);
+        int fontColor = ThemeUtils.fontColor(this, true);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -180,9 +180,13 @@ public final class ThemeUtils {
      * @return int font color to use
      * adapted from https://github.com/nextcloud/server/blob/master/apps/theming/lib/Util.php#L90-L102
      */
-    public static int fontColor(Context context) {
+    public static int fontColor(Context context, boolean replaceWhite) {
         if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
-            return Color.WHITE;
+            if (replaceWhite) {
+                return Color.BLACK;
+            } else {
+                return Color.WHITE;
+            }
         }
 
         try {
@@ -194,6 +198,10 @@ public final class ThemeUtils {
                 return Color.BLACK;
             }
         }
+    }
+
+    public static int fontColor(Context context) {
+        return fontColor(context, false);
     }
 
     /**
@@ -230,7 +238,7 @@ public final class ThemeUtils {
                 actionBar.setTitle(title);
             } else {
                 Spannable text = new SpannableString(title);
-                text.setSpan(new ForegroundColorSpan(fontColor(context)),
+                text.setSpan(new ForegroundColorSpan(fontColor(context, true)),
                              0,
                              text.length(),
                              Spannable.SPAN_INCLUSIVE_INCLUSIVE);
@@ -298,7 +306,7 @@ public final class ThemeUtils {
             } else {
                 String title = context.getString(titleId);
                 Spannable text = new SpannableString(title);
-                text.setSpan(new ForegroundColorSpan(fontColor(context)),
+                text.setSpan(new ForegroundColorSpan(fontColor(context, true)),
                              0,
                              text.length(),
                              Spannable.SPAN_INCLUSIVE_INCLUSIVE);
@@ -529,7 +537,7 @@ public final class ThemeUtils {
      */
     public static void themeSearchView(SearchView searchView, boolean themedBackground, Context context) {
         // hacky as no default way is provided
-        int fontColor = ThemeUtils.fontColor(context);
+        int fontColor = ThemeUtils.fontColor(context, true);
         SearchView.SearchAutoComplete editText = searchView.findViewById(R.id.search_src_text);
         themeEditText(context, editText, themedBackground);
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/4754

![2020-01-07-092854](https://user-images.githubusercontent.com/5836855/71880257-2eb49800-3130-11ea-9d4a-7b81bce19f01.png) ![2020-01-07-092844](https://user-images.githubusercontent.com/5836855/71880258-2eb49800-3130-11ea-9224-946b80c27293.png)

White background of header will not be changed, as this is desired via theming api.
But at least we can now see the text again ;-)

(also applies for all other activities)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>