### PR TITLE
Dark theme enhancements

### DIFF
--- a/src/main/res/drawable/uploader_list_separator.xml
+++ b/src/main/res/drawable/uploader_list_separator.xml
@@ -19,5 +19,8 @@
 -->
 <shape
   xmlns:android="http://schemas.android.com/apk/res/android">
-    <gradient android:startColor="@color/filelist_icon_background" android:endColor="@color/filelist_icon_background" android:angle="0" />
+    <gradient
+        android:startColor="@color/uploader_list_separator_color"
+        android:endColor="@color/uploader_list_separator_color"
+        android:angle="0" />
 </shape>

--- a/src/main/res/layout/uploader_layout.xml
+++ b/src/main/res/layout/uploader_layout.xml
@@ -35,8 +35,8 @@
 		<ListView android:id="@android:id/list"
 			android:layout_width="fill_parent"
 			android:layout_height="fill_parent"
-			android:divider="@color/list_divider_background"
-			android:dividerHeight="1dip">
+            android:divider="@color/transparent"
+            android:dividerHeight="0dip">
 		</ListView>
 
 		<include layout="@layout/empty_list"/>

--- a/src/main/res/layout/uploader_list_item_layout.xml
+++ b/src/main/res/layout/uploader_list_item_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -24,8 +24,10 @@
     <color name="text_color_inverse">#000000</color>
 
     <!-- Colors -->
-    <color name="bg_default">#222222</color>
+    <color name="bg_default">#151515</color>
     <color name="primary_button_text_color">#000000</color>
+
+    <color name="uploader_list_separator_color">#2a2a2a</color>
 
     <!-- Multiselect backgrounds -->
     <color name="action_mode_status_bar_background">#ECECEC</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -66,6 +66,8 @@
 
     <color name="background_color_png">#FFFFFF</color>
 
+    <color name="uploader_list_separator_color">#ededed</color>
+
     <!-- special transparent action bar colors for image preview -->
     <color name="color_transparent">#201D2D44</color>
     <color name="color_dark_transparent">#40162233</color>


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/5188

dark background to #151515
minor design changes for dark theme

![2020-01-14-141931](https://user-images.githubusercontent.com/5836855/72350749-4fa45c80-36df-11ea-948b-d4c9a00199f0.png) ![2020-01-14-141925](https://user-images.githubusercontent.com/5836855/72350750-4fa45c80-36df-11ea-83c4-e2958edd543c.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>