### PR TITLE
Upload button: disable/grey when folder is read-only

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -757,11 +757,12 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
             if (mFile.canWrite()) {
                 btnChooseFolder.setEnabled(true);
-                ThemeUtils.tintDrawable(btnChooseFolder.getBackground(),
-                                        ThemeUtils.primaryColor(getAccount(), true, this));
+                btnChooseFolder.setBackgroundTintList(ColorStateList.valueOf(ThemeUtils.primaryColor(getAccount(),
+                                                                                                     true,
+                                                                                                     this)));
             } else {
                 btnChooseFolder.setEnabled(false);
-                ThemeUtils.tintDrawable(btnChooseFolder.getBackground(), Color.GRAY);
+                btnChooseFolder.setBackgroundTintList(ColorStateList.valueOf(Color.GRAY));
             }
 
             if (getSupportActionBar() != null) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/5190

![2020-01-14-162810](https://user-images.githubusercontent.com/5836855/72357360-1f62bb00-36eb-11ea-9095-5fcc92cad386.png) ![2020-01-14-162805](https://user-images.githubusercontent.com/5836855/72357361-1f62bb00-36eb-11ea-8b2e-9d9c21f5bc6b.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>