### PR TITLE
Bump to 3.10 final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
     daggerVersion = "2.25.4"
     markwonVersion = "4.2.0"
     prismVersion = "2.0.0"
-    androidLibraryVersion = "rc-2.0.0-03"
+    androidLibraryVersion = "2.0.0"
 
     travisBuild = System.getenv("TRAVIS") == "true"
 
@@ -86,7 +86,7 @@ repositories {
 def versionMajor = 3
 def versionMinor = 10
 def versionPatch = 0
-def versionBuild = 53 // 0-50=Alpha / 51-98=RC / 90-99=stable
+def versionBuild = 90 // 0-50=Alpha / 51-98=RC / 90-99=stable
 
 for (TaskExecutionRequest tr : getGradle().getStartParameter().getTaskRequests()) {
     for (String arg : tr.args) {

--- a/fastlane/metadata/android/en-US/changelogs/30100090.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30100090.txt
@@ -1,0 +1,12 @@
+3.10.0 (January, 17, 2020)
+
+- Dark theme (@dan0xii, @AndyScherzinger)
+- Rich workspace (NC18+)
+- collaborative text editor (NC18+)
+- links in Markdown previews clickable (@AndyScherzinger)
+- Show/Hide auto upload list items (@AndyScherzinger)
+- drop 4.0.x support
+- outdated server warning set to NC15
+- latest supported version NC13
+
+For a full list, please see https://github.com/nextcloud/android/milestone/40


### PR DESCRIPTION
This will fail for now, I plan to release 2.0.0 stable library this afternoon, in case of any late hofixes.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>