### PR TITLE
Fix #5213 app is excluded from recent/current apps

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -182,10 +182,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         if (newAccount == null) {
             /// no account available: force account creation
             createAccount(true);
-
-            if (enableAccountHandling) {
-                finish();
-            }
         } else {
             currentAccount = newAccount;
         }


### PR DESCRIPTION
After talking with @tobiasKaminsky, we've decided to remove this finish()
Because "onResume" is called after requestPermissionsResult for PERMISSIONS_WRITE_EXTERNAL_STORAGE

https://github.com/nextcloud/android/issues/5213