### PR TITLE
Fix #2753 "Unresponsive App" error popup when syncing

### DIFF
--- a/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -494,11 +494,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
         intent.setAction(OperationsService.ACTION_SYNC_FOLDER);
         intent.putExtra(OperationsService.EXTRA_ACCOUNT, mAccount);
         intent.putExtra(OperationsService.EXTRA_REMOTE_PATH, path);
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            mContext.startForegroundService(intent);
-        } else {
-            mContext.startService(intent);
-        }
+        mContext.startService(intent);
     }
 
     public String getRemotePath() {


### PR DESCRIPTION
Always start SyncFolderOperations as background services to prevent
ANRs when they take a little more time to complete.