### PR TITLE
bump material to 1.1.0RC2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,7 +288,7 @@ dependencies {
     implementation 'org.apache.jackrabbit:jackrabbit-webdav:2.13.1' // remove after entire switch to lib v2
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0-beta02'
+    implementation 'com.google.android.material:material:1.1.0-rc02'
     implementation 'com.jakewharton:disklrucache:2.0.2'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'


### PR DESCRIPTION
dependabot ignores 1.1.0 updates since there is already 1.2.0-alpha :/ So this PR updates to the latest 1.1.0 release (being RC2)