### PR TITLE
Fix #5208 Remove double check in FileContentProvider

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -335,7 +335,7 @@ public class FileDataStorageManager {
         return contentValues;
     }
 
-    public boolean saveFile(OCFile ocFile) {
+    public synchronized boolean saveFile(OCFile ocFile) {
         boolean overridden = false;
 
         ContentValues contentValues = createContentValueForFile(ocFile);
@@ -436,7 +436,7 @@ public class FileDataStorageManager {
      * @param updatedFiles
      * @param filesToRemove
      */
-    public void saveFolder(OCFile folder, ArrayList<OCFile> updatedFiles, Collection<OCFile> filesToRemove) {
+    public synchronized void saveFolder(OCFile folder, ArrayList<OCFile> updatedFiles, Collection<OCFile> filesToRemove) {
         Log_OC.d(TAG, "Saving folder " + folder.getRemotePath() + " with " + updatedFiles.size()
             + " children and " + filesToRemove.size() + " files to remove");
 
@@ -1304,7 +1304,6 @@ public class FileDataStorageManager {
 
         // apply operations in batch
         applyBatch(operations);
-
     }
 
     /**

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -266,39 +266,14 @@ public class FileContentProvider extends ContentProvider {
         switch (mUriMatcher.match(uri)) {
             case ROOT_DIRECTORY:
             case SINGLE_FILE:
-                String[] projection = new String[]{
-                    ProviderTableMeta._ID, ProviderTableMeta.FILE_PATH,
-                    ProviderTableMeta.FILE_ACCOUNT_OWNER
-                };
-                String where = ProviderTableMeta.FILE_PATH + "=? AND " + ProviderTableMeta.FILE_ACCOUNT_OWNER + "=?";
-
-                String remotePath = values.getAsString(ProviderTableMeta.FILE_PATH);
-                String accountName = values.getAsString(ProviderTableMeta.FILE_ACCOUNT_OWNER);
-                String[] whereArgs = {remotePath, accountName};
-
-                Cursor doubleCheck = query(db, uri, projection, where, whereArgs, null);
-                // TODO better implementation is needed
-                // ugly patch; serious refactorization is needed to reduce work in
-                // FileDataStorageManager and bring it to FileContentProvider
-                if (doubleCheck.moveToFirst()) {
-                    // file is already inserted; race condition, let's avoid a duplicated entry
-                    Uri insertedFileUri = ContentUris.withAppendedId(
-                        ProviderTableMeta.CONTENT_URI_FILE,
-                        doubleCheck.getLong(doubleCheck.getColumnIndex(ProviderTableMeta._ID))
-                    );
-                    doubleCheck.close();
-
-                    return insertedFileUri;
+                Uri insertedFileUri;
+                long idFile = db.insert(ProviderTableMeta.FILE_TABLE_NAME, null, values);
+                if (idFile > 0) {
+                    insertedFileUri = ContentUris.withAppendedId(ProviderTableMeta.CONTENT_URI_FILE, idFile);
                 } else {
-                    doubleCheck.close();
-
-                    long rowId = db.insert(ProviderTableMeta.FILE_TABLE_NAME, null, values);
-                    if (rowId > 0) {
-                        return ContentUris.withAppendedId(ProviderTableMeta.CONTENT_URI_FILE, rowId);
-                    } else {
-                        throw new SQLException(ERROR + uri);
-                    }
+                    throw new SQLException(ERROR + uri);
                 }
+                return insertedFileUri;
 
             case SHARES:
                 Uri insertedShareUri;

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -396,7 +396,6 @@ public class FileDisplayActivity extends FileActivity
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted
                     EventBus.getDefault().post(new TokenPushEvent());
-                    syncAndUpdateFolder(true);
                     // toggle on is save since this is the only scenario this code gets accessed
                 } else {
                     // permission denied --> do nothing


### PR DESCRIPTION
I have remove doubleCheck if insert file.
syncAndUpdateFolder is called twice on the first time the application is started, the WRITE_EXTERNAL_STORAGE permission is requested. syncAndUpdateFolder is remove in onRequestPermissionsResult
And I added a synchronized for saveFolder and saveFile, because we're already checking if the file already exists. I check this with syncAndUpdateFolder called twice