### PR TITLE
reproducable dev version: use commit instead of master snapshot for dev version

### DIFF
--- a/scripts/buildDev
+++ b/scripts/buildDev
@@ -35,8 +35,14 @@ mv latest.apk ~/apks/
 lastBuildTime=$(date --date="$(git log -1 --format=%ai $(git tag | grep dev | tail -n1))" +%s)
 changelog=$(git log --after=$lastBuildTime --pretty=oneline --abbrev-commit)
 
+libraryCommit=$(curl https://api.github.com/repos/nextcloud/android-library/commits/master | jq .sha | sed s'/\"//g')
+
+# changelog
 echo "$changelog" > src/versionDev/fastlane/metadata/android/en-US/changelogs/$date.txt
-echo "library commit: $(curl https://api.github.com/repos/nextcloud/android-library/commits/master | jq .sha | sed s'/\"//g')" >> src/versionDev/fastlane/metadata/android/en-US/changelogs/$date.txt
+echo "library commit: $libraryCommit" >> src/versionDev/fastlane/metadata/android/en-US/changelogs/$date.txt
+
+# build
+sed -i s"# androidLibraryVersion.*#androidLibraryVersion =\"$libraryCommit\"#" build.gradle
 
 git add build.gradle
 git add src/versionDev/fastlane/metadata/android/en-US/changelogs/$date.txt
@@ -45,7 +51,3 @@ git push
 
 git tag dev-$date
 git push origin dev-$date
-
-# remove all but the latest 5 tags
-git tag|grep dev | sort -r | awk 'NR>5' | xargs -n 1 git push --delete origin
-git tag|grep dev | sort -r | awk 'NR>5' | xargs -n 1 git tag -d


### PR DESCRIPTION
Fix #5215

Let us see tomorrow :-)

- it uses as described a new branch "dev", which is daily rebased onto master and only changes build.gradle
- I also disabled removing old tags, to have it easier to switch between versions.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>