### PR TITLE
Fix crash: Caused by: java.lang.ClassCastException: java.lang.Object[…

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
@@ -535,7 +535,7 @@ public class ContactListFragment extends FileFragment implements Injectable {
 
     }
 
-    private AsyncTask loadContactsTask = new AsyncTask<Void, Void, Boolean>() {
+    private AsyncTask<Void, Void, Boolean> loadContactsTask = new AsyncTask<Void, Void, Boolean>() {
 
         @Override
         protected void onPreExecute() {


### PR DESCRIPTION
…] cannot be cast to java.lang.Void[]

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
This is unfortunately too complex to test it in an easy way…