### PR TITLE
switch to gplay connected tests, to not run both generic and gplay on drone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ def versionBuild = 0 // 0-50=Alpha / 51-98=RC / 90-99=stable
 for (TaskExecutionRequest tr : getGradle().getStartParameter().getTaskRequests()) {
     for (String arg : tr.args) {
         // any gplay, but only exact "build", as e.g. buildGeneric shall not apply gplay.grade
-        if (arg.contains("Gplay") || arg.contains("lint") || arg == "build") {
+        if (arg.contains("Gplay") || arg.contains("lint") || arg.contains("executeScreenshot") || arg == "build") {
             apply from: 'gplay.gradle'
             System.console().println("Applying gplay.gradle")
             break
@@ -105,7 +105,7 @@ spotbugs {
 
 shot {
     appId = 'com.nextcloud.client'
-    instrumentationTestTask = 'connectedGenericDebugAndroidTest'
+    instrumentationTestTask = 'connectedGplayDebugAndroidTest'
 }
 
 android {


### PR DESCRIPTION
This should speed up gplay step, as 
./gradlew createGplayDebugCoverageReport runs :connectedGplayDebugAndroidTest
and
./gradlew executeScreenshotTests now runs it too, so it should(tm) be cached

previously ./gradlew executeScreenshotTests was running :connectedGenericDebugAndroidTest