### PR TITLE
Show "add folder info" only if text app is available

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.java
@@ -39,6 +39,7 @@ import com.nextcloud.client.device.DeviceInfo;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.lib.common.Creator;
 import com.owncloud.android.lib.common.DirectEditing;
 import com.owncloud.android.lib.resources.status.OCCapability;
@@ -170,7 +171,11 @@ public class OCFileListBottomSheetDialog extends BottomSheetDialog {
         }
 
         // create rich workspace
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && file != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            FileMenuFilter.isEditorAvailable(getContext().getContentResolver(),
+                                             user,
+                                             MimeTypeUtil.MIMETYPE_TEXT_MARKDOWN) &&
+            file != null) {
             if (TextUtils.isEmpty(file.getRichWorkspace())) {
                 createRichWorkspace.setVisibility(View.VISIBLE);
             } else {


### PR DESCRIPTION
Fix #5467 

@juliushaertl I test if an editor is available for "text/markdown" and then show/not show the "add folder info".
This should be correct for any scenario
- old server
- 18 server, but text disabled

Is my assumption correct?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

