### PR TITLE
Improve dev edition changelog generation

### DIFF
--- a/scripts/buildDev
+++ b/scripts/buildDev
@@ -33,13 +33,33 @@ mv latest.apk ~/apks/
 /bin/ls -t ~/apks/*.apk | awk 'NR>6' | xargs rm -f
 
 lastBuildTime=$(date --date="$(git log -1 --format=%ai $(git tag | grep dev | tail -n1))" +%s)
-changelog=$(git log --after=$lastBuildTime --pretty=oneline --abbrev-commit)
+# Show only the commit subject in the changelog and filter out:
+#  * Merges
+#  * Dependabot commits
+#  * Commits touching only non-user-facing stuff like tests
+#  * Version bump commits
+changelog=$(git log --no-merges --after=$lastBuildTime --invert-grep --author=dependabot --pretty='format:%s' -- ':!src/androidTest' ':!.*' ':!scripts/analysis' | grep -vE '^daily dev [[:digit:]]{8}$')
+# Make Transifex updates have a nicer description
+if echo "$changelog" | grep -q 'tx-robot'; then
+	changelog=$(echo "$changelog" | grep -v 'tx-robot')
+	# This is a funky bashism - preceding a single-quote string with $ lets you put escape chars in it
+	changelog="${changelog}"$'\nUpdate translations'
+fi
 
 libraryCommit=$(curl https://api.github.com/repos/nextcloud/android-library/commits/master | jq .sha | sed s'/\"//g')
 
+# Check if the library was updated
+if ! grep -q libraryCommit build.gradle; then
+	changelog="${changelog}"$'\nUpdate Nextcloud Android library'
+fi
+
+# Collapse dependency updates into a single "Update dependencies" entry
+if git log --after=$lastBuildTime --pretty='format:%an' | grep -q dependabot; then
+	changelog="${changelog}"$'\nUpdate 3rd-party dependencies'
+fi
+
 # changelog
 echo "$changelog" > src/versionDev/fastlane/metadata/android/en-US/changelogs/$date.txt
-echo "library commit: $libraryCommit" >> src/versionDev/fastlane/metadata/android/en-US/changelogs/$date.txt
 
 # build
 sed -i s"# androidLibraryVersion.*#androidLibraryVersion =\"$libraryCommit\"#" build.gradle


### PR DESCRIPTION
We:

* No longer include commit ids
* Exclude merges, individual Dependabot commits, commits including only non-user-facing changes, or version bump commits
* Collapse all Dependabot commits into a single "Update dependencies" changelog entry
* Do the same for Transifex updates, which get turned into a single "Update translations" changelog entry
* Say if the Android Nextcloud library has changed instead of including its commit id

The list of paths to ignore is probably incomplete, but it's easier to just revisit this script over time and add to it as new contenders pop up, rather than trying to find everything now.

Fixes #5525

### Testing 

N/A; I manually tested this
