### PR TITLE
Fixed crash in Activities tab.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -27,7 +27,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.R;
@@ -44,6 +43,7 @@ import com.owncloud.android.ui.adapter.ActivityListAdapter;
 import com.owncloud.android.ui.interfaces.ActivityListInterface;
 import com.owncloud.android.ui.preview.PreviewImageActivity;
 import com.owncloud.android.ui.preview.PreviewImageFragment;
+import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.ThemeUtils;
 
 import java.util.List;
@@ -260,7 +260,7 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
 
     @Override
     public void showActivitiesLoadError(String error) {
-        Toast.makeText(getBaseContext(), error, Toast.LENGTH_LONG).show();
+        DisplayUtils.showSnackMessage(this, error);
     }
 
     @Override
@@ -279,12 +279,12 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
 
     @Override
     public void showActivityDetailUIIsNull() {
-        Toast.makeText(getBaseContext(), R.string.file_not_found, Toast.LENGTH_LONG).show();
+        DisplayUtils.showSnackMessage(this, R.string.file_not_found);
     }
 
     @Override
     public void showActivityDetailError(String error) {
-        Toast.makeText(getBaseContext(), error, Toast.LENGTH_LONG).show();
+        DisplayUtils.showSnackMessage(this, error);
     }
 
     @Override


### PR DESCRIPTION
Replaced `Toast.makeText()` methods to `DisplayUtils.showSnackMessage()`.

Fixes #5504 

> I think the crash was introduced in the 'implementation androidx.appcompat:appcompat:1.2.0-alpha02'
dependecy. Reverting it to the previously used 'appcompat:1.1.0' fixes the crash.

> At the moment any Toast.makeText() would cause a crash on my phone (however, I only tested the ones in Activities). Chances are Google fix this in the production ready '1.2.0'.