### PR TITLE
Disable old login method

### DIFF
--- a/src/main/res/values/setup.xml
+++ b/src/main/res/values/setup.xml
@@ -112,7 +112,7 @@
     <!-- url for webview login, with the protocol prefix and with full url (normally /index.php/login/flow)
     If set, will replace all other login methods available -->
     <string name="webview_login_url" translatable="false"></string>
-    <bool name="show_old_login">true</bool>
+    <bool name="show_old_login">false</bool>
 
     <!-- Files becomes Home -->
     <bool name="use_home">false</bool>


### PR DESCRIPTION
This disables the "revert to old login" snackbar.
We can then see how this works out.
I scheduled mid of May to remove it from code and simplify AuthenticatorActivity.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

