### PR TITLE
Fix the dev edition changelog excluding stuff

### DIFF
--- a/scripts/buildDev
+++ b/scripts/buildDev
@@ -44,7 +44,7 @@ lastBuildTag=$(git tag | grep dev | tail -n1)
 #  * Commits touching only non-user-facing stuff like tests
 #  * Version bump commits
 #  * Anything reachable from the previous dev edition tag
-changelog=$(git log --no-merges --invert-grep --author=dependabot --pretty='format:%s' HEAD "^$lastBuildTag" -- ':!src/androidTest' ':!.*' ':!scripts/analysis' | grep -vE '^daily dev [[:digit:]]{8}$')
+changelog=$(git log --no-merges --invert-grep --author=dependabot --pretty='format:%s' HEAD "^$lastBuildTag" -- ':!src/androidTest' ':!.*' ':!scripts/' ':!screenshots' | grep -vE '^daily dev [[:digit:]]{8}$')
 # Make Transifex updates have a nicer description
 if echo "$changelog" | grep -q 'tx-robot'; then
 	changelog=$(echo "$changelog" | grep -v 'tx-robot')

--- a/scripts/buildDev
+++ b/scripts/buildDev
@@ -37,13 +37,14 @@ mv latest.apk ~/apks/
 # remove all but the latest 5 apks
 /bin/ls -t ~/apks/*.apk | awk 'NR>6' | xargs rm -f
 
-lastBuildTime=$(date --date="$(git log -1 --format=%ai $(git tag | grep dev | tail -n1))" +%s)
+lastBuildTag=$(git tag | grep dev | tail -n1)
 # Show only the commit subject in the changelog and filter out:
 #  * Merges
 #  * Dependabot commits
 #  * Commits touching only non-user-facing stuff like tests
 #  * Version bump commits
-changelog=$(git log --no-merges --after=$lastBuildTime --invert-grep --author=dependabot --pretty='format:%s' -- ':!src/androidTest' ':!.*' ':!scripts/analysis' | grep -vE '^daily dev [[:digit:]]{8}$')
+#  * Anything reachable from the previous dev edition tag
+changelog=$(git log --no-merges --invert-grep --author=dependabot --pretty='format:%s' HEAD "^$lastBuildTag" -- ':!src/androidTest' ':!.*' ':!scripts/analysis' | grep -vE '^daily dev [[:digit:]]{8}$')
 # Make Transifex updates have a nicer description
 if echo "$changelog" | grep -q 'tx-robot'; then
 	changelog=$(echo "$changelog" | grep -v 'tx-robot')
@@ -57,7 +58,7 @@ if ! echo $oldLibraryCommit | grep -q $libraryCommit; then
 fi
 
 # Collapse dependency updates into a single "Update dependencies" entry
-if git log --after=$lastBuildTime --pretty='format:%an' | grep -q dependabot; then
+if git log --pretty='format:%an' HEAD "^$lastBuildTag" | grep -q dependabot; then
 	changelog="${changelog}"$'\nUpdate 3rd-party dependencies'
 fi
 


### PR DESCRIPTION
Should fix the issue @tobiasKaminsky raised in https://github.com/nextcloud/android/issues/5525#issuecomment-595617048.

One problem: after this bugfix the list of commits is much more verbose. I see three options:

* Do nothing and just deal with it
* Go back to the previous method (i.e. exclude by date again) and remove `--no-merges` - unideal IMO since the autogenerated merge commit messages look really bad in the changelog (maybe we could use the first commit in the merged branch or something...? _Maybe?_ That would be a lot more code...)
* Use some kind of keyword which would cause a commit to be included in the dev edition changelog - e.g. `[dev changelog]` or something like that. Obviously this is more work for you all so I don't know how you feel about that, but it would look a lot better.

For reference, here is the changelog that is generated by this branch's script since the last dev edition on February 25th:

```
remove unused dimens value
remove unneeded call
use correct dimens id
remove sdk17 checks
Remove outdated right/left as now only start/end is needed
change minimum supported Android version to 4.2
Properly signal error when user id migration fails
Enabled migration manager in MainApp
Removed MigrationManager Robolectric tests
Support for optional migrations
Migrations manager
remove ununsed raw files
remove unused class
Fix test
Use proper dialog instantiation
Fixes during CR
Remove unneeded strings
Fixe during CR
Enhance conflict dialog - fix bug - add ui tests - add instrumented tests
use app namespace instead of android
delombok everything
Update to AS 3.6.1
Update to AS3.6
remove unneeded strings
Disable old login method
Fixed crash in Activities tab.
Update english
Show slideshow as new activity
Split up share internal link
Change to better english
Allows deep linking to open files
properly colorize text preview gradient based on theme (day/night) improve preview textview size/gradient position
Update translations
Update 3rd-party dependencies
```