### PR TITLE
Stale bot shall close only bugs with "need info" and no reply

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,19 +2,17 @@
 daysUntilStale: 28
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 14
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+    - bug
+    - "needs info/discussion"
 # Issues with these labels will never be considered stale
-exemptLabels:
-    - 1. developing
-    - 2. to review
-    - 3. to release
-    - approved
-    - enhancement
-    - overview
+exemptLabels: []
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-    This request did not receive an update in the last 4 weeks.
+    This bug report did not receive an update in the last 4 weeks.
     Please take a look again and update the issue with new details,
     otherwise the issue will be automatically closed in 2 weeks. Thank you!
 # Comment to post when closing a stale issue. Set to `false` to disable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue.
 
 
 ### Bug workflow
+Every bug should be triaged in approved/needs info in a given time.
 * approved: at least one other is able to reproduce it
 * needs info: something unclear, or not able to reproduce
   * if no response within 1 months, bug will be closed


### PR DESCRIPTION
Although our bug count increases, due to more popularity, we should try to handle each bug and not close them because lack of time.

So stale bot closes bugs only if they are labeled "needs info" and have no reply.
Every other bug should be triaged into approved/needs info.

