### PR TITLE
Fix exception on computing available space

### DIFF
--- a/src/androidTest/java/com/owncloud/android/ui/helpers/FileOperationsHelperIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/helpers/FileOperationsHelperIT.kt
@@ -1,0 +1,48 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.ui.helpers
+
+import com.owncloud.android.MainApp
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertTrue
+import org.junit.Test
+
+class FileOperationsHelperIT {
+
+    @Test
+    fun testNull() {
+        MainApp.setStoragePath(null)
+        assertEquals(-1L, FileOperationsHelper.getAvailableSpaceOnDevice())
+    }
+
+    @Test
+    fun testNonExistingPath() {
+        MainApp.setStoragePath("/123/123")
+        assertEquals(-1L, FileOperationsHelper.getAvailableSpaceOnDevice())
+    }
+
+    @Test
+    fun testExistingPath() {
+        MainApp.setStoragePath("/sdcard/")
+        assertTrue(FileOperationsHelper.getAvailableSpaceOnDevice() > 0L)
+    }
+}

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1710,11 +1710,14 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
     private void syncAndCheckFiles(Collection<OCFile> files) {
         for (OCFile file : files) {
-            // Get the remaining space on device (after file download)
+            // Get the remaining space on device
             long availableSpaceOnDevice = FileOperationsHelper.getAvailableSpaceOnDevice();
 
-            // Determine if space is enough to download the file
-            boolean isSpaceEnough = availableSpaceOnDevice > file.getFileLength();
+            // Determine if space is enough to download the file, -1 available space if there in error while computing
+            boolean isSpaceEnough = true;
+            if (availableSpaceOnDevice >= 0) {
+                isSpaceEnough = availableSpaceOnDevice > file.getFileLength();
+            }
 
             if (isSpaceEnough) {
                 mContainerActivity.getFileOperationsHelper().syncFile(file);

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -1038,10 +1038,18 @@ public class FileOperationsHelper {
         return new SimpleDateFormat("yyyy-MM-dd_HHmmss", Locale.US).format(new Date()) + ".jpg";
     }
 
+    /**
+     * @return -1 if no space could computed, otherwise available space in bytes
+     */
     public static Long getAvailableSpaceOnDevice() {
-        StatFs stat = new StatFs(MainApp.getStoragePath());
-        long availableBytesOnDevice;
+        StatFs stat;
+        try {
+            stat = new StatFs(MainApp.getStoragePath());
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return -1L;
+        }
 
+        long availableBytesOnDevice;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
             availableBytesOnDevice = stat.getBlockSizeLong() * stat.getAvailableBlocksLong();
         } else {
@@ -1050,6 +1058,5 @@ public class FileOperationsHelper {
 
         return availableBytesOnDevice;
     }
-
 
 }


### PR DESCRIPTION
Found via gplay dev console.
Idea is to not prevent sync/downloading if space computation is not working.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 

If you need help, please do not hesitate to ask in this PR for help.

- [x] [unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
- [x] [instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
- [x] [UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)
