### PR TITLE
Improve synced folder dialog

### DIFF
--- a/src/main/res/layout/synced_folders_settings.xml
+++ b/src/main/res/layout/synced_folders_settings.xml
@@ -19,7 +19,6 @@
   License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"


### PR DESCRIPTION
- switch to viewBindings
- fix wrongly clicklable upload behaviour

@AndyScherzinger fix for #3984 is not working, maybe you want to try it in line 364:
```
binding.syncEnabled.setOnCheckedChangeListener((buttonView, isChecked) -> setEnabled(!mSyncedFolder.isEnabled()));
```

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
/