### PR TITLE
Add rule to rety failing tests

### DIFF
--- a/src/androidTest/java/com/nextcloud/client/RetryTestRule.kt
+++ b/src/androidTest/java/com/nextcloud/client/RetryTestRule.kt
@@ -1,0 +1,65 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.client
+
+import android.util.Log
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * C&p from https://stackoverflow.com/questions/45635833/how-can-i-use-flakytest-annotation-now on 18.03.2020
+ */
+class RetryTestRule(val retryCount: Int = 5) : TestRule {
+
+    private val TAG = RetryTestRule::class.java.simpleName
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return statement(base, description)
+    }
+
+    private fun statement(base: Statement, description: Description): Statement {
+        return object : Statement() {
+
+            override fun evaluate() {
+                Log.e(TAG, "Evaluating ${description.methodName}")
+
+                var caughtThrowable: Throwable? = null
+
+                for (i in 0 until retryCount) {
+                    try {
+                        base.evaluate()
+                        return
+                    } catch (t: Throwable) {
+                        caughtThrowable = t
+                        Log.e(TAG, description.methodName + ": run " + (i + 1) + " failed")
+                    }
+                }
+
+                Log.e(TAG, description.methodName + ": giving up after " + retryCount + " failures")
+                if (caughtThrowable != null)
+                    throw caughtThrowable
+            }
+        }
+    }
+}

--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import com.facebook.testing.screenshot.Screenshot;
+import com.nextcloud.client.RetryTestRule;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.account.UserAccountManagerImpl;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -29,7 +30,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
+import org.junit.Rule;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -39,7 +40,6 @@ import java.util.Collection;
 
 import androidx.test.espresso.contrib.DrawerActions;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.runner.lifecycle.Stage;
@@ -54,8 +54,9 @@ import static org.junit.Assert.assertTrue;
  * Common base for all integration tests
  */
 
-@RunWith(AndroidJUnit4.class)
+//@RunWith(AndroidJUnit4.class)
 public abstract class AbstractIT {
+    @Rule public RetryTestRule retryTestRule = new RetryTestRule();
 
     protected static OwnCloudClient client;
     protected static Account account;


### PR DESCRIPTION
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

Good test:
```
2020-03-18 16:15:37.257 9147-9186/com.nextcloud.client E/RetryTestRule: Evaluating openDrawer
```

Failing two times, then working:
```
2020-03-18 16:15:37.720 9147-9186/com.nextcloud.client E/RetryTestRule: openDrawer: run 1 failed
2020-03-18 16:15:38.108 9147-9186/com.nextcloud.client E/RetryTestRule: openDrawer: run 2 failed
```

Failing 5 times, then bailing out:
```
2020-03-18 16:19:13.445 9858-9900/com.nextcloud.client E/RetryTestRule: Evaluating openDrawer
2020-03-18 16:19:13.981 9858-9900/com.nextcloud.client E/RetryTestRule: openDrawer: run 1 failed
2020-03-18 16:19:14.369 9858-9900/com.nextcloud.client E/RetryTestRule: openDrawer: run 2 failed
2020-03-18 16:19:14.742 9858-9900/com.nextcloud.client E/RetryTestRule: openDrawer: run 3 failed
2020-03-18 16:19:15.097 9858-9900/com.nextcloud.client E/RetryTestRule: openDrawer: run 4 failed
2020-03-18 16:19:15.474 9858-9900/com.nextcloud.client E/RetryTestRule: openDrawer: run 5 failed
2020-03-18 16:19:15.474 9858-9900/com.nextcloud.client E/RetryTestRule: openDrawer: giving up after 5 failures
2020-03-18 16:19:15.475 9858-9900/com.nextcloud.client E/TestRunner: java.lang.InterruptedException
```

### Testing 
This is about testing ;-)