### PR TITLE
Fix for sso Allow/Deny dialog text color in dark mode.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
@@ -126,9 +126,9 @@ public class SsoGrantPermissionActivity extends BaseActivity {
             Log.e(TAG, e.getMessage());
         }
 
-        int primaryColor = ThemeUtils.primaryColor(this, true);
-        grantPermissionButton.setTextColor(primaryColor);
-        declinePermissionButton.setTextColor(primaryColor);
+        int fontColor = ThemeUtils.fontColor(getApplicationContext(), !ThemeUtils.darkTheme(getApplicationContext()));
+        grantPermissionButton.setTextColor(fontColor);
+        declinePermissionButton.setTextColor(fontColor);
     }
 
     @Override


### PR DESCRIPTION
Small fix that uses the 'fontColor' rather than 'primaryColor' for the Allow/Deny buttons in the SSO "Allow [app] to access your Nextcloud account [username]" dialog to deal with device dark mode and dark server theme.

Signed-off-by: Daniel Bailey <daniel.bailey@grappleIT.co.uk>

### Testing 
- [x] Tests written, or not not needed
