### PR TITLE
Fix #5736 Readd enableAccountHandling for show slider

### DIFF
--- a/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.java
+++ b/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.java
@@ -72,6 +72,8 @@ public class FirstRunActivity extends BaseActivity implements ViewPager.OnPageCh
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        enableAccountHandling = false;
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.first_run_activity);
 

--- a/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -34,6 +34,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
      */
     private boolean themeChangePending;
     private boolean paused;
+    protected boolean enableAccountHandling = true;
 
     private MixinRegistry mixinRegistry = new MixinRegistry();
     private SessionMixin sessionMixin;
@@ -59,7 +60,10 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
                                         getContentResolver(),
                                         accountManager);
         mixinRegistry.add(sessionMixin);
-        mixinRegistry.onCreate(savedInstanceState);
+
+        if (enableAccountHandling) {
+            mixinRegistry.onCreate(savedInstanceState);
+        }
     }
 
     @Override


### PR DESCRIPTION
Hello,

Quick fix for https://github.com/nextcloud/android/issues/5736
I put enableAccountHandling back on, so I can see the slider from the beginning again. This is not a permanent fix. Because it doesn't fix when the application is paused.
Maybe @ezaquarii has imagined a good solution to fix it permanently?
