### PR TITLE
Dark Mode Improvements II

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -116,7 +116,7 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
         // setup toolbar
         setupToolbar();
 
-        onCreateSwipeToRefresh(swipeListRefreshLayout);
+        ThemeUtils.colorSwipeRefreshLayout(this, swipeListRefreshLayout);
 
         // setup drawer
         setupDrawer(R.id.nav_activity);
@@ -137,15 +137,6 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
         emptyContentProgressBar.setVisibility(View.GONE);
         emptyContentMessage.setVisibility(View.INVISIBLE);
         emptyContentHeadline.setVisibility(View.INVISIBLE);
-    }
-
-    protected void onCreateSwipeToRefresh(SwipeRefreshLayout refreshLayout) {
-        int primaryColor = ThemeUtils.primaryColor(this);
-        int darkColor = ThemeUtils.primaryDarkColor(this);
-        int accentColor = ThemeUtils.primaryAccentColor(this);
-
-        // Colors in animations
-        refreshLayout.setColorSchemeColors(accentColor, primaryColor, darkColor);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -288,6 +288,9 @@ public abstract class DrawerActivity extends ToolbarActivity
             }
         };
 
+        // proper coloring of drawer menu icon
+        mDrawerToggle.getDrawerArrowDrawable().setColor(ThemeUtils.toolbarTextColor(this));
+
         // Set the drawer toggle as the DrawerListener
         mDrawerLayout.addDrawerListener(mDrawerToggle);
         mDrawerToggle.setDrawerIndicatorEnabled(true);

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -302,7 +302,7 @@ public abstract class DrawerActivity extends ToolbarActivity
         mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
 
         mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toggle);
-        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor(this, true));
+        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor(this, !ThemeUtils.darkTheme(getApplicationContext())));
 
         if (getResources().getBoolean(R.bool.allow_profile_click)) {
             mAccountChooserToggle.setImageResource(R.drawable.ic_down);

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -302,7 +302,6 @@ public abstract class DrawerActivity extends ToolbarActivity
         mAccountEndAccountAvatar = (ImageView) findNavigationViewChildById(R.id.drawer_account_end);
 
         mAccountChooserToggle = (ImageView) findNavigationViewChildById(R.id.drawer_account_chooser_toggle);
-        mAccountChooserToggle.setColorFilter(ThemeUtils.fontColor(this, !ThemeUtils.darkTheme(getApplicationContext())));
 
         if (getResources().getBoolean(R.bool.allow_profile_click)) {
             mAccountChooserToggle.setImageResource(R.drawable.ic_down);

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -140,6 +140,8 @@ public class NotificationsActivity extends FileActivity implements Notifications
 
         swipeEmptyListRefreshLayout = findViewById(R.id.swipe_containing_empty);
         swipeListRefreshLayout = findViewById(R.id.swipe_containing_list);
+        ThemeUtils.colorSwipeRefreshLayout(this, swipeListRefreshLayout);
+        ThemeUtils.colorSwipeRefreshLayout(this, swipeEmptyListRefreshLayout);
 
         // setup drawer
         setupDrawer(R.id.nav_notifications);

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -751,8 +751,8 @@ public class SettingsActivity extends ThemedPreferenceActivity
             actionBar.setBackgroundDrawable(new ColorDrawable(ThemeUtils.primaryColor(this)));
 
             Drawable backArrow = getResources().getDrawable(R.drawable.ic_arrow_back);
-            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow, ThemeUtils.fontColor(this,
-                                                                                                   !ThemeUtils.darkTheme(this))));
+            actionBar.setHomeAsUpIndicator(ThemeUtils.tintDrawable(backArrow,
+                                                                   ThemeUtils.toolbarTextColor(this)));
         }
 
         Window window = getWindow();

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -65,7 +65,7 @@ public abstract class ToolbarActivity extends BaseActivity {
      */
     protected void setupToolbar(boolean useBackgroundImage) {
         int primaryColor = ThemeUtils.primaryColor(this, false);
-        int fontColor = ThemeUtils.fontColor(this, !ThemeUtils.darkTheme(getApplicationContext()));
+        int toolbarTextColor = ThemeUtils.toolbarTextColor(this);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -86,11 +86,11 @@ public abstract class ToolbarActivity extends BaseActivity {
         ThemeUtils.colorStatusBar(this, primaryColor);
 
         if (toolbar.getOverflowIcon() != null) {
-            ThemeUtils.tintDrawable(toolbar.getOverflowIcon(), fontColor);
+            ThemeUtils.tintDrawable(toolbar.getOverflowIcon(), toolbarTextColor);
         }
 
         if (toolbar.getNavigationIcon() != null) {
-            ThemeUtils.tintDrawable(toolbar.getNavigationIcon(), fontColor);
+            ThemeUtils.tintDrawable(toolbar.getNavigationIcon(), toolbarTextColor);
         }
 
         if (!useBackgroundImage) {

--- a/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -164,6 +164,7 @@ public class UploadListActivity extends FileActivity {
         binding.list.setLayoutManager(lm);
         binding.list.setAdapter(uploadListAdapter);
 
+        ThemeUtils.colorSwipeRefreshLayout(this, swipeListRefreshLayout);
         swipeListRefreshLayout.setOnRefreshListener(this::refresh);
 
         loadItems();

--- a/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -167,10 +167,7 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
                 button.setTextColor(ThemeUtils.fontColor(notificationsActivity));
                 button.setTypeface(button.getTypeface(), Typeface.BOLD);
             } else {
-                button.setStrokeColor(ColorStateList.valueOf(resources.getColor(R.color.grey_200)));
-                button.setStrokeWidth(3);
-
-                button.setBackgroundColor(resources.getColor(R.color.transparent));
+                button.setBackgroundColor(resources.getColor(R.color.grey_200));
                 button.setTextColor(primaryColor);
                 button.setTypeface(button.getTypeface(), Typeface.BOLD);
             }

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -428,6 +428,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
                         if (i == 0 && sharees.size() > 3) {
                             avatar.setImageResource(R.drawable.ic_people);
+                            ThemeUtils.setIconColor(avatar.getDrawable());
                         } else {
                             if (sharee.getShareType().equals(ShareType.GROUP)) {
                                 try {
@@ -436,9 +437,12 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                                 } catch (Exception e) {
                                     Log_OC.e(TAG, "Error calculating RGB value for active account icon.", e);
                                     avatar.setImageResource(R.drawable.ic_people);
+                                    ThemeUtils.setIconColor(avatar.getDrawable());
                                 }
                             } else if (sharee.getShareType().equals(ShareType.CIRCLE)) {
                                 avatar.setImageResource(R.drawable.ic_circles);
+                                ThemeUtils.setIconColor(avatar.getDrawable());
+
                             } else if (sharee.getUserId().contains("@")) {
                                 showFederatedShareAvatar(sharee.getUserId(), avatarRadius, resources, avatar);
                             } else {

--- a/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
@@ -27,7 +27,6 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -51,6 +50,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
@@ -151,8 +151,11 @@ public class ConflictsResolveDialog extends DialogFragment {
         View view = inflater.inflate(R.layout.conflict_resolve_dialog, null);
         int accentColor = ThemeUtils.primaryAccentColor(getContext());
 
-        CheckBox newFileCheckbox = view.findViewById(R.id.new_checkbox);
-        CheckBox existingFileCheckbox = view.findViewById(R.id.existing_checkbox);
+        AppCompatCheckBox newFileCheckbox = view.findViewById(R.id.new_checkbox);
+        AppCompatCheckBox existingFileCheckbox = view.findViewById(R.id.existing_checkbox);
+
+        ThemeUtils.tintCheckbox(newFileCheckbox, ThemeUtils.primaryColor(getContext()));
+        ThemeUtils.tintCheckbox(existingFileCheckbox, ThemeUtils.primaryColor(getContext()));
 
         // Build the dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -381,7 +381,8 @@ public class ExtendedListFragment extends Fragment implements
 
         // Pull-down to refresh layout
         mRefreshListLayout = v.findViewById(R.id.swipe_containing_list);
-        onCreateSwipeToRefresh(mRefreshListLayout);
+        ThemeUtils.colorSwipeRefreshLayout(getContext(), mRefreshListLayout);
+        mRefreshListLayout.setOnRefreshListener(this);
 
         mFabMain = v.findViewById(R.id.fab_main);
         ThemeUtils.tintFloatingActionButton(mFabMain, R.drawable.ic_plus, getContext());
@@ -771,17 +772,6 @@ public class ExtendedListFragment extends Fragment implements
      */
     public String getEmptyViewText() {
         return (mEmptyListContainer != null && mEmptyListMessage != null) ? mEmptyListMessage.getText().toString() : "";
-    }
-
-    protected void onCreateSwipeToRefresh(SwipeRefreshLayout refreshLayout) {
-        int primaryColor = ThemeUtils.primaryColor(getContext());
-        int darkColor = ThemeUtils.primaryDarkColor(getContext());
-        int accentColor = ThemeUtils.primaryAccentColor(getContext());
-
-        // Colors in animations
-        // TODO change this to use darker and lighter color, again.
-        refreshLayout.setColorSchemeColors(accentColor, primaryColor, darkColor);
-        refreshLayout.setOnRefreshListener(this);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -175,8 +175,8 @@ public class FileDetailActivitiesFragment extends Fragment implements
 
         setupView();
 
-        onCreateSwipeToRefresh(swipeEmptyListRefreshLayout);
-        onCreateSwipeToRefresh(swipeListRefreshLayout);
+        ThemeUtils.colorSwipeRefreshLayout(getContext(), swipeEmptyListRefreshLayout);
+        ThemeUtils.colorSwipeRefreshLayout(getContext(), swipeListRefreshLayout);
 
         fetchAndSetData(-1);
 
@@ -446,15 +446,6 @@ public class FileDetailActivitiesFragment extends Fragment implements
             }
             isLoadingActivities = false;
         });
-    }
-
-    protected void onCreateSwipeToRefresh(SwipeRefreshLayout refreshLayout) {
-        int primaryColor = ThemeUtils.primaryColor(getContext());
-        int darkColor = ThemeUtils.primaryDarkColor(getContext());
-        int accentColor = ThemeUtils.primaryAccentColor(getContext());
-
-        // Colors in animations
-        refreshLayout.setColorSchemeColors(accentColor, primaryColor, darkColor);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -144,6 +144,7 @@ public class TrashbinActivity extends FileActivity implements
         recyclerView.setHasFooter(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
+        ThemeUtils.colorSwipeRefreshLayout(this, swipeListRefreshLayout);
         swipeListRefreshLayout.setOnRefreshListener(this::loadFolder);
 
         loadFolder();

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -71,6 +71,7 @@ import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.widget.CompoundButtonCompat;
 import androidx.fragment.app.FragmentActivity;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -412,6 +413,15 @@ public final class ThemeUtils {
 
         colorHorizontalProgressBar(seekBar, color);
         seekBar.getThumb().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+    }
+
+    public static void colorSwipeRefreshLayout(Context context, SwipeRefreshLayout swipeRefreshLayout) {
+        int primaryColor = ThemeUtils.primaryColor(context);
+        int darkColor = ThemeUtils.primaryDarkColor(context);
+        int accentColor = ThemeUtils.primaryAccentColor(context);
+
+        swipeRefreshLayout.setColorSchemeColors(accentColor, primaryColor, darkColor);
+        swipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.bg_elevation_one);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -188,8 +188,11 @@ public final class ThemeUtils {
     }
 
     /**
+     * returns the font color based on the server side theming and uses black/white as a fallback based on replaceWhite.
+     *
+     * @param context the context
+     * @param replaceWhite FLAG to return white/black if server side color isn't available
      * @return int font color to use
-     * adapted from https://github.com/nextcloud/server/blob/master/apps/theming/lib/Util.php#L90-L102
      */
     public static int fontColor(Context context, boolean replaceWhite) {
         if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
@@ -200,6 +203,10 @@ public final class ThemeUtils {
             }
         }
 
+        return toolbarTextColor(context);
+    }
+
+    public static int toolbarTextColor(Context context) {
         try {
             return Color.parseColor(getCapability(context).getServerTextColor());
         } catch (Exception e) {
@@ -249,7 +256,7 @@ public final class ThemeUtils {
                 actionBar.setTitle(title);
             } else {
                 Spannable text = new SpannableString(title);
-                text.setSpan(new ForegroundColorSpan(fontColor(context, !darkTheme(context))),
+                text.setSpan(new ForegroundColorSpan(toolbarTextColor(context)),
                              0,
                              text.length(),
                              Spannable.SPAN_INCLUSIVE_INCLUSIVE);
@@ -612,7 +619,7 @@ public final class ThemeUtils {
             drawable, Context context) {
         button.setBackgroundTintList(ColorStateList.valueOf(ThemeUtils.primaryColor(context)));
         button.setRippleColor(ThemeUtils.primaryDarkColor(context));
-        button.setImageDrawable(ThemeUtils.tintDrawable(drawable, ThemeUtils.fontColor(context)));
+        button.setImageDrawable(ThemeUtils.tintDrawable(drawable, ThemeUtils.toolbarTextColor(context)));
     }
 
     private static OCCapability getCapability(Context context) {

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -627,6 +627,14 @@ public final class ThemeUtils {
         }
     }
 
+    public static Drawable setIconColor(Drawable drawable) {
+        int color = Color.BLACK;
+        if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
+            color = Color.WHITE;
+        }
+        return tintDrawable(drawable, color);
+    }
+
     /**
      * Lifted from SO.
      * FindBugs surpressed because of lack of public API to alter the cursor color.

--- a/src/main/res/drawable-night/favorite.xml
+++ b/src/main/res/drawable-night/favorite.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16dp"
+        android:height="16dp"
+        android:viewportWidth="16"
+        android:viewportHeight="16">
+
+    <path
+        android:fillColor="#ffcc00"
+        android:strokeColor="#121212"
+        android:strokeWidth="0.46367699"
+        android:pathData="M 7.9999993,1.0934068 10.040178,6.0083827 15.418832,6.4256921 11.245738,9.9032694 12.636769,15.003716 7.9999993,12.128919 3.3632295,15.003716 4.7542604,9.9032694 0.5811676,6.4256921 5.9598206,6.0083827 Z"/>
+</vector>

--- a/src/main/res/drawable/uploader_list_separator.xml
+++ b/src/main/res/drawable/uploader_list_separator.xml
@@ -20,7 +20,7 @@
 <shape
   xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:startColor="@color/uploader_list_separator_color"
-        android:endColor="@color/uploader_list_separator_color"
+        android:startColor="@color/list_divider_background"
+        android:endColor="@color/list_divider_background"
         android:angle="0" />
 </shape>

--- a/src/main/res/layout/activity_list_item.xml
+++ b/src/main/res/layout/activity_list_item.xml
@@ -36,7 +36,7 @@
         android:layout_marginTop="@dimen/standard_margin"
         android:alpha="0.5"
         android:padding="2dp"
-        android:background="@drawable/round_bgnd_icons"
+        android:background="@drawable/round_bgnd"
         android:contentDescription="@string/activity_icon"
         android:src="@drawable/ic_activity" />
 

--- a/src/main/res/layout/activity_list_item.xml
+++ b/src/main/res/layout/activity_list_item.xml
@@ -36,7 +36,7 @@
         android:layout_marginTop="@dimen/standard_margin"
         android:alpha="0.5"
         android:padding="2dp"
-        android:background="@drawable/round_bgnd"
+        android:background="@drawable/round_bgnd_icons"
         android:contentDescription="@string/activity_icon"
         android:src="@drawable/ic_activity" />
 

--- a/src/main/res/layout/conflict_resolve_dialog.xml
+++ b/src/main/res/layout/conflict_resolve_dialog.xml
@@ -45,7 +45,7 @@
             android:layout_weight="1"
             android:orientation="vertical">
 
-            <CheckBox
+            <androidx.appcompat.widget.AppCompatCheckBox
                 android:id="@+id/new_checkbox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -79,7 +79,7 @@
             android:layout_weight="1"
             android:orientation="vertical">
 
-            <CheckBox
+            <androidx.appcompat.widget.AppCompatCheckBox
                 android:id="@+id/existing_checkbox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
+++ b/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
@@ -127,9 +127,9 @@
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
+        android:layout_marginStart="@dimen/bottom_sheet_menu_item_divider_standard_margin"
         android:layout_marginTop="@dimen/standard_half_margin"
-        android:layout_marginRight="@dimen/standard_margin"
+        android:layout_marginEnd="@dimen/standard_margin"
         android:layout_marginBottom="@dimen/standard_half_margin"
         android:background="@color/list_divider_background"/>
 
@@ -166,9 +166,9 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
+        android:layout_marginStart="@dimen/bottom_sheet_menu_item_divider_standard_margin"
         android:layout_marginTop="@dimen/standard_half_margin"
-        android:layout_marginRight="@dimen/standard_margin"
+        android:layout_marginEnd="@dimen/standard_margin"
         android:layout_marginBottom="@dimen/standard_half_margin"
         android:background="@color/list_divider_background" />
 
@@ -266,9 +266,9 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
+            android:layout_marginStart="@dimen/bottom_sheet_menu_item_divider_standard_margin"
             android:layout_marginTop="@dimen/standard_half_margin"
-            android:layout_marginRight="@dimen/standard_margin"
+            android:layout_marginEnd="@dimen/standard_margin"
             android:layout_marginBottom="@dimen/standard_half_margin"
             android:background="@color/list_divider_background" />
     </LinearLayout>
@@ -291,9 +291,9 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
+            android:layout_marginStart="@dimen/bottom_sheet_menu_item_divider_standard_margin"
             android:layout_marginTop="@dimen/standard_half_margin"
-            android:layout_marginRight="@dimen/standard_margin"
+            android:layout_marginEnd="@dimen/standard_margin"
             android:layout_marginBottom="@dimen/standard_half_margin"
             android:background="@color/list_divider_background" />
     </LinearLayout>

--- a/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
+++ b/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
@@ -127,7 +127,7 @@
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginLeft="@dimen/standard_margin"
+        android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
         android:layout_marginTop="@dimen/standard_half_margin"
         android:layout_marginRight="@dimen/standard_margin"
         android:layout_marginBottom="@dimen/standard_half_margin"
@@ -166,7 +166,7 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginLeft="@dimen/standard_margin"
+        android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
         android:layout_marginTop="@dimen/standard_half_margin"
         android:layout_marginRight="@dimen/standard_margin"
         android:layout_marginBottom="@dimen/standard_half_margin"
@@ -266,7 +266,7 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/standard_margin"
+            android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
             android:layout_marginTop="@dimen/standard_half_margin"
             android:layout_marginRight="@dimen/standard_margin"
             android:layout_marginBottom="@dimen/standard_half_margin"
@@ -291,7 +291,7 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/standard_margin"
+            android:layout_marginLeft="@dimen/bottom_sheet_menu_item_divider_standard_margin"
             android:layout_marginTop="@dimen/standard_half_margin"
             android:layout_marginRight="@dimen/standard_margin"
             android:layout_marginBottom="@dimen/standard_half_margin"

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -29,8 +29,6 @@
     <color name="fg_contrast">#717171</color>
     <color name="primary_button_text_color">#000000</color>
 
-    <color name="uploader_list_separator_color">#2a2a2a</color>
-
     <!-- Multiselect backgrounds -->
     <color name="action_mode_status_bar_background">#ECECEC</color>
     <color name="selected_item_background">#757575</color>

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -28,6 +28,7 @@
     <color name="bg_default">#121212</color>
     <color name="fg_contrast">#717171</color>
     <color name="primary_button_text_color">#000000</color>
+    <color name="bg_elevation_one">#2D2D2D</color>
 
     <!-- Multiselect backgrounds -->
     <color name="action_mode_status_bar_background">#ECECEC</color>

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -25,7 +25,7 @@
     <color name="list_divider_background">#222222</color>
 
     <!-- Colors -->
-    <color name="bg_default">#151515</color>
+    <color name="bg_default">#121212</color>
     <color name="fg_contrast">#717171</color>
     <color name="primary_button_text_color">#000000</color>
 

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -22,6 +22,7 @@
 
     <color name="text_color">#ffffff</color>
     <color name="text_color_inverse">#000000</color>
+    <color name="list_divider_background">#222</color>
 
     <!-- Colors -->
     <color name="bg_default">#151515</color>
@@ -41,5 +42,4 @@
     <color name="switch_thumb_color_unchecked">#2a2a2a</color>
     <color name="switch_track_color_unchecked">#B3FFFFFF</color>
     <color name="drawer_active_item_background">@color/white</color>
-
 </resources>

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -22,7 +22,7 @@
 
     <color name="text_color">#ffffff</color>
     <color name="text_color_inverse">#000000</color>
-    <color name="list_divider_background">#222</color>
+    <color name="list_divider_background">#222222</color>
 
     <!-- Colors -->
     <color name="bg_default">#151515</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -64,8 +64,6 @@
 
     <color name="background_color_png">#FFFFFF</color>
 
-    <color name="uploader_list_separator_color">#ededed</color>
-
     <!-- special transparent action bar colors for image preview -->
     <color name="color_transparent">#201D2D44</color>
     <color name="color_dark_transparent">#40162233</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -52,6 +52,7 @@
     <color name="login_btn_tint">#ffffff</color>
     <color name="login_btn_stroke">#ffffff</color>
     <color name="bg_default">#FFFFFF</color>
+    <color name="bg_elevation_one">#FFFFFF</color>
     <color name="background_color_inverse">#000000</color>
     <color name="primary_button_background_color">@color/color_accent</color>
     <color name="primary_button_text_color">#ffffff</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -27,7 +27,7 @@
     <color name="text_color">#000000</color>
     <color name="text_color_inverse">#ffffff</color>
     <color name="disabled_text">#ff888888</color>
-    <color name="list_divider_background">#eee</color>
+    <color name="list_divider_background">#eeeeee</color>
     <color name="fg_contrast">#656565</color>
     <color name="fg_inverse">#FFFFFF</color>
     <color name="filelist_icon_background">#DDDDDD</color>

--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -28,6 +28,7 @@
     <dimen name="nav_drawer_header_avatar_second_account_margin">56dp</dimen>
     <dimen name="nav_drawer_menu_avatar_radius">12sp</dimen>
     <dimen name="list_item_avatar_icon_radius">20dp</dimen>
+    <dimen name="bottom_sheet_menu_item_divider_standard_margin">56dp</dimen>
     <dimen name="file_icon_size">40dp</dimen>
     <dimen name="file_icon_size_grid">128dp</dimen>
     <dimen name="file_icon_rounded_corner_radius">8dp</dimen>


### PR DESCRIPTION
* Fix list divider in upload file dialog
* The drawer account chooser toggle reacts to dark server themes
* ic_people in the file list changes depending on device dark mode
* file detail sharing: above act/sharing -> white line should be same like receive external files line 
* In the file list, the favorite icon needs a dark outline instead of white
* fix theming of swipe refresh layout
* fix theming of text/icons in toolbar
* grey background for secondary action button in in-app display of notifications)

relates to #5353. 