### PR TITLE
First use preferred mimetypes, then editor for optional mimetypes

### DIFF
--- a/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -315,7 +315,13 @@ public class FileMenuFilter {
         DirectEditing directEditing = new Gson().fromJson(json, DirectEditing.class);
 
         for (Editor editor : directEditing.editors.values()) {
-            if (editor.mimetypes.contains(mimeType) || editor.optionalMimetypes.contains(mimeType)) {
+            if (editor.mimetypes.contains(mimeType)) {
+                return editor;
+            }
+        }
+
+        for (Editor editor : directEditing.editors.values()) {
+            if (editor.optionalMimetypes.contains(mimeType)) {
                 return editor;
             }
         }


### PR DESCRIPTION
Fix part of #5545 

Have e.g.
- txt as main for Text app
- txt as optional for OO

Previously, whatever editor was first, picked it
Now it would be Text, then OO.

@juliushaertl 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
