### PR TITLE
Ignore CHANGELOG.md while generating changelogs

### DIFF
--- a/scripts/buildDev
+++ b/scripts/buildDev
@@ -44,7 +44,7 @@ lastBuildTag=$(git tag | grep dev | tail -n1)
 #  * Commits touching only non-user-facing stuff like tests
 #  * Version bump commits
 #  * Anything reachable from the previous dev edition tag
-changelog=$(git log --no-merges --invert-grep --author=dependabot --pretty='format:%s' HEAD "^$lastBuildTag" -- ':!src/androidTest' ':!.*' ':!scripts/' ':!screenshots' | grep -vE '^daily dev [[:digit:]]{8}$')
+changelog=$(git log --no-merges --invert-grep --author=dependabot --pretty='format:%s' HEAD "^$lastBuildTag" -- ':!src/androidTest' ':!.*' ':!scripts/' ':!screenshots' ':!CHANGELOG.md' | grep -vE '^daily dev [[:digit:]]{8}$')
 # Make Transifex updates have a nicer description
 if echo "$changelog" | grep -q 'tx-robot'; then
 	changelog=$(echo "$changelog" | grep -v 'tx-robot')


### PR DESCRIPTION
I heard you liked changelogs, so I put a changelog in your changelog... or something. How meta.

Full disclosure, I didn't test this because I couldn't quite figure out how to get it to generate the changelog in the latest F-Droid build (which prompted me to write this patch), and it was so trivial I figured it wasn't worth bothering with.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextbutt/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextbutt/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextbutt/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
