### PR TITLE
check if at least one account is set up, before receiving files

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -63,6 +63,7 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.android.material.button.MaterialButton;
 import com.nextcloud.client.di.Injectable;
@@ -238,6 +239,15 @@ public class ReceiveExternalFilesActivity extends FileActivity
     @Override
     protected void onStart() {
         super.onStart();
+
+        if (mAccountManager.getAccountsByType(MainApp.getAccountType(this)).length == 0) {
+            Toast.makeText(this,
+                           String.format(getString(R.string.uploader_wrn_no_account_text),
+                                         getString(R.string.app_name)),
+                           Toast.LENGTH_LONG).show();
+            return;
+        }
+
         initTargetFolder();
         populateDirectoryList();
     }


### PR DESCRIPTION
Fix #5807

This will return to LoginPage, but still shows toast message.
Having a dialog as @AndyScherzinger suggested does not work as the underlying activity stops.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
