### PR TITLE
Test for #3301

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -40,6 +40,7 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -93,6 +94,7 @@ import com.owncloud.android.utils.ErrorMessageAdapter;
 import com.owncloud.android.utils.FileSortOrder;
 import com.owncloud.android.utils.MimeType;
 import com.owncloud.android.utils.ThemeUtils;
+import com.owncloud.android.utils.UriUtils;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -858,6 +860,18 @@ public class ReceiveExternalFilesActivity extends FileActivity
             mStreamsToUpload.add(intent.getParcelableExtra(Intent.EXTRA_STREAM));
         } else if (Intent.ACTION_SEND_MULTIPLE.equals(intent.getAction())) {
             mStreamsToUpload = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+        }
+
+        if (mStreamsToUpload != null) {
+            Log_OC.d(this, "Received: " + mStreamsToUpload.size());
+
+            for (Parcelable parcelable : mStreamsToUpload) {
+                if (parcelable instanceof Uri) {
+                    Log_OC.d(this, "URI: " + UriUtils.getDisplayNameForUri((Uri) parcelable, this));
+                } else {
+                    Log_OC.d(this, "no URI: " + parcelable.toString());
+                }
+            }
         }
 
         if (mStreamsToUpload == null || mStreamsToUpload.isEmpty() || mStreamsToUpload.get(0) == null) {


### PR DESCRIPTION
This is just adding debug:
use logcat and grep for ReceiveExternalFilesActivity.
Upon share of files to NC, it should show something like:
```
2020-04-07 23:27:32.367 15233-15233/com.nextcloud.client D/ReceiveExternalFilesActivity: Received: 2
2020-04-07 23:27:32.455 15233-15233/com.nextcloud.client D/ReceiveExternalFilesActivity: URI: showImage.png
2020-04-07 23:27:32.487 15233-15233/com.nextcloud.client D/ReceiveExternalFilesActivity: URI: test.png

```


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
