### PR TITLE
Log exception in ContactsImportWork catch block

### DIFF
--- a/src/main/java/com/nextcloud/client/jobs/ContactsImportWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/ContactsImportWork.kt
@@ -100,7 +100,7 @@ class ContactsImportWork(
                 }
             }
         } catch (e: Exception) {
-            logger.e(TAG, "${e.message}")
+            logger.e(TAG, "${e.message}", e)
         } finally {
             cursor?.close()
         }


### PR DESCRIPTION
This is a follow-up fix for https://github.com/nextcloud/android/pull/5756 review comment about exception logging.