### PR TITLE
Do not tint dialog

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
@@ -49,7 +49,6 @@ import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.EncryptionUtils;
-import com.owncloud.android.utils.ThemeUtils;
 
 import java.util.UUID;
 
@@ -125,10 +124,6 @@ public class SsoGrantPermissionActivity extends BaseActivity {
         } catch (PackageManager.NameNotFoundException e) {
             Log.e(TAG, e.getMessage());
         }
-
-        int fontColor = ThemeUtils.fontColor(getApplicationContext(), !ThemeUtils.darkTheme(getApplicationContext()));
-        grantPermissionButton.setTextColor(fontColor);
-        declinePermissionButton.setTextColor(fontColor);
     }
 
     @Override


### PR DESCRIPTION
Fix https://github.com/nextcloud/Android-SingleSignOn/issues/195

Previously this was tinted, then it was adjusted to use font color, but i think it is best to stick with default NC blue.
Otherwise, depending on the current active account (not the account you want connect to) you have different colors.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
