### PR TITLE
show all files when clicking on show files

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -348,7 +348,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                         pendingRunnable = new Runnable() {
                             @Override
                             public void run() {
-                                selectNavigationItem(menuItem);
+                                onNavigationItemClicked(menuItem);
                             }
                         };
                         return true;
@@ -394,8 +394,7 @@ public abstract class DrawerActivity extends ToolbarActivity
     }
 
 
-    private void selectNavigationItem(final MenuItem menuItem) {
-
+    private void onNavigationItemClicked(final MenuItem menuItem) {
         setDrawerMenuItemChecked(menuItem.getItemId());
 
         if (menuItem.getGroupId() == R.id.drawer_menu_accounts) {
@@ -414,6 +413,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                         startActivity(intent);
                     } else {
                         ((FileDisplayActivity) this).browseToRoot();
+                        showFiles(false);
                         EventBus.getDefault().post(new ChangeMenuEvent());
                     }
                 } else {


### PR DESCRIPTION
Fix #5704 

Tested
- go into subfolder
- click "all files"
--> goes to root folder

- click "on device"
- click "all files"
--> shows all files in root again

- click "on device"
- go into one subfolder
- click "all files"
--> shows all files in root again

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
