### PR TITLE
Don't put User model into ConflictsResolveActivity account extra

### DIFF
--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -254,7 +254,7 @@ public class FileOperationsHelper {
             Intent i = new Intent(fileActivity, ConflictsResolveActivity.class);
             i.setFlags(i.getFlags() | Intent.FLAG_ACTIVITY_NEW_TASK);
             i.putExtra(ConflictsResolveActivity.EXTRA_FILE, file);
-            i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, user);
+            i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, user.toPlatformAccount());
             fileActivity.startActivity(i);
         } else {
             if (file.isDown()) {


### PR DESCRIPTION
User model has been put into Intent instead of Account,
causing a crash. Convert User into Account before setting
extras parameters.

Fixes #5849

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

### Testing 
- [x] Tests written, or not not needed
