### PR TITLE
Make sure only 1 content observer job is scheduled

### DIFF
--- a/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -23,6 +23,7 @@ import android.os.Build
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import java.util.concurrent.TimeUnit
@@ -49,6 +50,6 @@ internal class BackgroundJobManagerImpl(private val workManager: WorkManager) : 
             .addTag(TAG_CONTENT_SYNC)
             .build()
 
-        workManager.enqueue(request)
+        workManager.enqueueUniqueWork(TAG_CONTENT_SYNC, ExistingWorkPolicy.REPLACE, request)
     }
 }


### PR DESCRIPTION
Since content observer is not unique job, each application
restart enqueues another job one-time job that will keep
itself re-scheduled when started.

This change makes sure there is only 1 instance of content
observer scheduled at any given time.

When old. accumulated one-time jobs re-schedule, they will
terminate leaving only 1 instance left, so the system will
self correct.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>