### PR TITLE
Replace media scanner on newer Android versions

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -31,6 +31,7 @@ import android.content.Intent;
 import android.content.OperationApplicationException;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.RemoteException;
 import android.provider.MediaStore;
 import android.text.TextUtils;
@@ -1735,7 +1736,7 @@ public class FileDataStorageManager {
     }
 
     public static void triggerMediaScan(String path) {
-        if (path != null) {
+        if (path != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
             intent.setData(Uri.fromFile(new File(path)));
             MainApp.getAppContext().sendBroadcast(intent);

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -381,7 +381,7 @@ public class FileDataStorageManager {
                     if (file.isDown()) {
                         String path = file.getStoragePath();
                         if (new File(path).delete() && MimeTypeUtil.isMedia(file.getMimeType())) {
-                            triggerMediaScan(path); // notify MediaScanner about removed file
+                            triggerMediaScan(path, file); // notify MediaScanner about removed file
                         }
                     }
                 }

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1736,10 +1736,28 @@ public class FileDataStorageManager {
     }
 
     public static void triggerMediaScan(String path) {
-        if (path != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-            intent.setData(Uri.fromFile(new File(path)));
-            MainApp.getAppContext().sendBroadcast(intent);
+        triggerMediaScan(path, null);
+    }
+
+    public static void triggerMediaScan(String path, OCFile file) {
+        if (path != null) {
+            ContentValues values = new ContentValues();
+            ContentResolver contentResolver = MainApp.getAppContext().getContentResolver();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                if (file != null) {
+                    values.put(MediaStore.Images.Media.MIME_TYPE, file.getMimeType());
+                    values.put(MediaStore.Images.Media.TITLE, file.getFileName());
+                    values.put(MediaStore.Images.Media.DISPLAY_NAME, file.getFileName());
+                }
+                values.put(MediaStore.Images.Media.DATE_ADDED, System.currentTimeMillis() / 1000);
+                values.put(MediaStore.Images.Media.RELATIVE_PATH, path);
+                values.put(MediaStore.Images.Media.IS_PENDING, 0);
+                contentResolver.insert(MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY), values);
+            } else {
+                Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                intent.setData(Uri.fromFile(new File(path)));
+                MainApp.getAppContext().sendBroadcast(intent);
+            }
         }
     }
 

--- a/src/main/java/com/owncloud/android/files/services/FileDownloader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileDownloader.java
@@ -518,7 +518,7 @@ public class FileDownloader extends Service
         file.setRemoteId(mCurrentDownload.getFile().getRemoteId());
         mStorageManager.saveFile(file);
         if (MimeTypeUtil.isMedia(mCurrentDownload.getMimeType())) {
-            FileDataStorageManager.triggerMediaScan(file.getStoragePath());
+            FileDataStorageManager.triggerMediaScan(file.getStoragePath(), file);
         }
         mStorageManager.saveConflict(file, null);
     }

--- a/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -131,7 +131,7 @@ public class RenameFileOperation extends SyncOperation {
                 getStorageManager().deleteFileInMediaScan(oldPath);
                 // notify to scan about new file, if it is a media file
                 if (MimeTypeUtil.isMedia(file.getMimeType())) {
-                    FileDataStorageManager.triggerMediaScan(newPath);
+                    FileDataStorageManager.triggerMediaScan(newPath, file);
                 }
             }
             // else - NOTHING: the link to the local file is kept although the local name

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -1348,7 +1348,7 @@ public class UploadFileOperation extends SyncOperation {
         getStorageManager().saveConflict(file, null);
 
         if (MimeTypeUtil.isMedia(file.getMimeType())) {
-            FileDataStorageManager.triggerMediaScan(file.getStoragePath());
+            FileDataStorageManager.triggerMediaScan(file.getStoragePath(), file);
         }
 
         // generate new Thumbnail


### PR DESCRIPTION
- Fix #5039 
- do not use media scanner on newer Android
- [x] find and add replacement

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
