### PR TITLE
Fix appbar color in ReceiveExternalFilesActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -775,11 +775,6 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 btnChooseFolder.setBackgroundTintList(ColorStateList.valueOf(Color.GRAY));
             }
 
-            if (getSupportActionBar() != null) {
-                getSupportActionBar().setBackgroundDrawable(new ColorDrawable(
-                        ThemeUtils.primaryColor(getAccount(), false, this)));
-            }
-
             ThemeUtils.colorStatusBar(this);
 
             ThemeUtils.tintBackButton(actionBar, this);


### PR DESCRIPTION
Remove useless setcolor. Otherwise the appbar was the wrong color.