### PR TITLE
Fixed account extra argument passed to OperationsService when starting sync

### DIFF
--- a/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -491,7 +491,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
     private void startSyncFolderOperation(String path){
         Intent intent = new Intent(mContext, OperationsService.class);
         intent.setAction(OperationsService.ACTION_SYNC_FOLDER);
-        intent.putExtra(OperationsService.EXTRA_ACCOUNT, user);
+        intent.putExtra(OperationsService.EXTRA_ACCOUNT, user.toPlatformAccount());
         intent.putExtra(OperationsService.EXTRA_REMOTE_PATH, path);
         mContext.startService(intent);
     }


### PR DESCRIPTION
Fixes #6020