### PR TITLE
New design (UI) - Folders icons are now smaller

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -37,6 +37,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -626,6 +627,11 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                                     Context context,
                                     LoaderImageView shimmerThumbnail) {
         if (file.isFolder()) {
+            // Applying a smaller size for thumbnail, if it's a folder
+            if (!gridView) {
+                int folderThumbnailSize = (int) context.getResources().getDimension(R.dimen.folder_thumbnail_size);
+                thumbnailView.setLayoutParams(new FrameLayout.LayoutParams(folderThumbnailSize, folderThumbnailSize));
+            }
             thumbnailView.setImageDrawable(MimeTypeUtil
                                                .getFolderTypeIcon(file.isSharedWithMe() || file.isSharedWithSharee(),
                                                                   file.isSharedViaLink(), file.isEncrypted(),

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -37,7 +37,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/src/main/res/layout/list_item.xml
+++ b/src/main/res/layout/list_item.xml
@@ -54,7 +54,6 @@
                 android:id="@+id/thumbnail"
                 android:layout_width="@dimen/file_icon_size"
                 android:layout_height="@dimen/file_icon_size"
-                android:layout_marginStart="@dimen/standard_half_margin"
                 android:contentDescription="@null"
                 android:src="@drawable/folder"/>
         </FrameLayout>

--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -142,4 +142,5 @@
     <dimen name="button_corner_radius">24dp</dimen>
     <integer name="media_grid_width">4</integer>
     <dimen name="copy_internal_link_padding">10dp</dimen>
+    <dimen name="folder_thumbnail_size">30dp</dimen>
 </resources>


### PR DESCRIPTION
Hi,

All is in the title. Based on this : https://github.com/nextcloud/android/issues/5207#issuecomment-617270183. 

|Before|After|
|---|---|
|![Capture d’écran 2020-05-08 à 15 16 24](https://user-images.githubusercontent.com/7050479/81409288-2486c280-913f-11ea-9ee7-078cf94d334f.png)|![Capture d’écran 2020-05-08 à 15 15 13](https://user-images.githubusercontent.com/7050479/81409271-1d5fb480-913f-11ea-8bad-91d8ba2a622a.png)

It'll be enhanced by other changes to come.

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests written, or not not needed
