### PR TITLE
New design (UI) - Favorite and "downloaded" icons alignment

### DIFF
--- a/src/main/res/layout/list_item.xml
+++ b/src/main/res/layout/list_item.xml
@@ -22,65 +22,73 @@
     android:layout_width="match_parent"
     android:layout_height="@dimen/standard_list_item_size"
     android:background="@drawable/list_selector"
+    android:baselineAligned="false"
     android:descendantFocusability="blocksDescendants"
     android:foreground="?android:attr/selectableItemBackground"
-    android:baselineAligned="false"
     android:orientation="horizontal">
 
-    <RelativeLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="@dimen/standard_list_item_size"
         android:layout_height="@dimen/standard_list_item_size"
-        android:paddingStart="@dimen/zero"
-        android:paddingTop="@dimen/standard_padding"
-        android:paddingEnd="@dimen/standard_quarter_padding"
-        android:paddingBottom="@dimen/standard_padding">
+        android:layout_marginStart="@dimen/zero"
+        android:layout_marginEnd="@dimen/standard_quarter_padding"
+        android:layout_marginBottom="@dimen/standard_padding">
 
-        <FrameLayout
+        <ImageView
+            android:id="@+id/thumbnail"
+            android:layout_width="@dimen/file_icon_size"
+            android:layout_height="@dimen/file_icon_size"
+            android:contentDescription="@null"
+            android:src="@drawable/folder"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <RelativeLayout
             android:id="@+id/shimmer_view_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:layout_marginStart="@dimen/standard_half_margin">
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <com.elyeproj.loaderviewlibrary.LoaderImageView
                 android:id="@+id/thumbnail_shimmer"
-                android:layout_width="@dimen/file_icon_size"
-                android:layout_height="@dimen/file_icon_size"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/standard_half_margin"
                 android:visibility="gone"
                 app:corners="8" />
 
-            <ImageView
-                android:id="@+id/thumbnail"
-                android:layout_width="@dimen/file_icon_size"
-                android:layout_height="@dimen/file_icon_size"
-                android:layout_marginStart="@dimen/standard_half_margin"
-                android:contentDescription="@null"
-                android:src="@drawable/folder"/>
-        </FrameLayout>
+        </RelativeLayout>
+
+        <ImageView
+            android:id="@+id/localFileIndicator"
+            android:layout_width="@dimen/list_item_local_file_indicator_layout_width"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/downloader_download_succeeded_ticker"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_synced"
+            app:layout_constraintBottom_toBottomOf="@+id/thumbnail"
+            app:layout_constraintEnd_toEndOf="@+id/thumbnail"
+            app:layout_constraintStart_toEndOf="@+id/thumbnail"
+            app:layout_constraintTop_toBottomOf="@+id/thumbnail" />
 
         <ImageView
             android:id="@+id/favorite_action"
             android:layout_width="@dimen/list_item_favorite_action_layout_width"
             android:layout_height="@dimen/list_item_favorite_action_layout_height"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginEnd="@dimen/standard_quarter_margin"
             android:contentDescription="@string/favorite"
-            android:src="@drawable/favorite" />
+            android:src="@drawable/favorite"
+            app:layout_constraintBottom_toTopOf="@+id/thumbnail"
+            app:layout_constraintEnd_toEndOf="@+id/thumbnail"
+            app:layout_constraintStart_toEndOf="@+id/thumbnail"
+            app:layout_constraintTop_toTopOf="@+id/thumbnail" />
 
-        <ImageView
-            android:id="@+id/localFileIndicator"
-            android:layout_width="@dimen/list_item_local_file_indicator_layout_width"
-            android:layout_height="@dimen/list_item_local_file_indicator_layout_height"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentBottom="true"
-            android:layout_marginEnd="@dimen/standard_quarter_margin"
-            android:contentDescription="@string/downloader_download_succeeded_ticker"
-            android:scaleType="fitCenter"
-            android:src="@drawable/ic_synced" />
-
-    </RelativeLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:layout_width="0dp"

--- a/src/main/res/layout/list_item.xml
+++ b/src/main/res/layout/list_item.xml
@@ -68,7 +68,7 @@
         <ImageView
             android:id="@+id/localFileIndicator"
             android:layout_width="@dimen/list_item_local_file_indicator_layout_width"
-            android:layout_height="wrap_content"
+            android:layout_height="@dimen/list_item_local_file_indicator_layout_height"
             android:contentDescription="@string/downloader_download_succeeded_ticker"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_synced"

--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -121,8 +121,8 @@
     <dimen name="grid_item_local_file_indicator_layout_height">16dp</dimen>
     <dimen name="grid_sync_item_layout_next_text_size">22sp</dimen>
     <dimen name="grid_sync_item_layout_counter_text_size">22sp</dimen>
-    <dimen name="list_item_favorite_action_layout_width">16dp</dimen>
-    <dimen name="list_item_favorite_action_layout_height">16dp</dimen>
+    <dimen name="list_item_favorite_action_layout_width">14dp</dimen>
+    <dimen name="list_item_favorite_action_layout_height">14dp</dimen>
     <dimen name="list_item_local_file_indicator_layout_width">12dp</dimen>
     <dimen name="list_item_local_file_indicator_layout_height">12dp</dimen>
     <dimen name="preview_error_image_layout_width">72dp</dimen>


### PR DESCRIPTION
Hi, 

Always based on the following mockups : https://github.com/nextcloud/android/issues/5207#issuecomment-617270183. 

The favorite icon is now aligned on the top right, and the downloaded icon on the bottom right of the thumbnail. 
The "Floating" effect is normal for folders, because the folder icon doesn't take all the thumbnail reserved/available space.

Here is the alignment proof : 
![Capture d’écran 2020-05-11 à 10 32 27](https://user-images.githubusercontent.com/7050479/81541241-1a4d0a00-9373-11ea-8093-8bef5083f6f4.png)

And here is the difference with "now":  

|Before|After|
|---|---|
|![Capture d’écran 2020-05-11 à 10 11 16](https://user-images.githubusercontent.com/7050479/81541333-3b155f80-9373-11ea-9a75-d9a6924a9b50.png)|![Capture d’écran 2020-05-11 à 10 12 50](https://user-images.githubusercontent.com/7050479/81541563-93e4f800-9373-11ea-8525-c4d74b55d7cd.png)|

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests written, or not not needed
