### PR TITLE
New design (UI) - Replaced Toolbar Loader by SwipeRefreshLayout

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -53,7 +53,6 @@ public abstract class EditorWebView extends ExternalSiteWebView {
     protected Snackbar loadingSnackbar;
 
     protected String fileName;
-    protected String mimeType;
 
     @BindView(R.id.progressBar2)
     ProgressBar progressBar;

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1505,7 +1505,7 @@ public class FileDisplayActivity extends FileActivity
                         // TODO what about other kind of previews?
                     }
                 }
-                getListOfFilesFragment().setLoading(Boolean.FALSE);
+                getListOfFilesFragment().setLoading(false);
             } finally {
                 if (intent != null) {
                     removeStickyBroadcast(intent);
@@ -2218,7 +2218,7 @@ public class FileDisplayActivity extends FileActivity
                                         null
                                 );
 
-                                getListOfFilesFragment().setLoading(Boolean.TRUE);
+                                getListOfFilesFragment().setLoading(true);
 
                                 setBackgroundText();
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1505,7 +1505,7 @@ public class FileDisplayActivity extends FileActivity
                         // TODO what about other kind of previews?
                     }
                 }
-                getListOfFilesFragment().setLoading(false);
+                getListOfFilesFragment().setLoading(Boolean.FALSE);
             } finally {
                 if (intent != null) {
                     removeStickyBroadcast(intent);
@@ -2218,7 +2218,7 @@ public class FileDisplayActivity extends FileActivity
                                         null
                                 );
 
-                                getListOfFilesFragment().setLoading(true);
+                                getListOfFilesFragment().setLoading(Boolean.TRUE);
 
                                 setBackgroundText();
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -329,9 +329,6 @@ public class FileDisplayActivity extends FileActivity
             syncAndUpdateFolder(true);
         }
 
-        showProgressBar(mSyncInProgress);
-        // always AFTER setContentView(...) in onCreate(); to work around bug in its implementation
-
         upgradeNotificationForInstantUpload();
         checkOutdatedServer();
     }
@@ -1199,6 +1196,8 @@ public class FileDisplayActivity extends FileActivity
     protected void onResume() {
         Log_OC.v(TAG, "onResume() start");
         super.onResume();
+        // Instead of onPostCreate, starting the loading in onResume for children fragments
+        getListOfFilesFragment().setLoading(mSyncInProgress);
         syncAndUpdateFolder(false);
 
         OCFile startFile = null;
@@ -1389,8 +1388,7 @@ public class FileDisplayActivity extends FileActivity
                         DataHolderUtil.getInstance().delete(intent.getStringExtra(FileSyncAdapter.EXTRA_RESULT));
 
                         Log_OC.d(TAG, "Setting progress visibility to " + mSyncInProgress);
-                        showProgressBar(mSyncInProgress);
-
+                        getListOfFilesFragment().setLoading(mSyncInProgress);
                         setBackgroundText();
                     }
                 }
@@ -1507,9 +1505,7 @@ public class FileDisplayActivity extends FileActivity
                         // TODO what about other kind of previews?
                     }
                 }
-
-                showProgressBar(false);
-
+                getListOfFilesFragment().setLoading(false);
             } finally {
                 if (intent != null) {
                     removeStickyBroadcast(intent);
@@ -2222,7 +2218,7 @@ public class FileDisplayActivity extends FileActivity
                                         null
                                 );
 
-                                showProgressBar(true);
+                                getListOfFilesFragment().setLoading(true);
 
                                 setBackgroundText();
 

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -28,7 +28,6 @@ import android.content.IntentFilter;
 import android.content.res.ColorStateList;
 import android.content.res.Resources.NotFoundException;
 import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.Log;
@@ -69,7 +68,6 @@ import javax.inject.Inject;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
 import static com.owncloud.android.utils.DisplayUtils.openSortingOrderDialogFragment;
@@ -264,7 +262,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                                                                             getApplicationContext());
 
         refreshFolderOperation.execute(getAccount(), this, null, null);
-        getListOfFilesFragment().setLoading(Boolean.TRUE);
+        getListOfFilesFragment().setLoading(true);
         setBackgroundText();
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -154,7 +154,6 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
             ThemeUtils.setColoredTitle(getSupportActionBar(), caption, this);
         }
 
-        showProgressBar(mSyncInProgress);
         // always AFTER setContentView(...) ; to work around bug in its implementation
 
         // sets message for empty list of folders
@@ -265,7 +264,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                                                                             getApplicationContext());
 
         refreshFolderOperation.execute(getAccount(), this, null, null);
-        showProgressBar(true);
+        getListOfFilesFragment().setLoading(true);
         setBackgroundText();
     }
 
@@ -273,6 +272,8 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     protected void onResume() {
         super.onResume();
         Log_OC.e(TAG, "onResume() start");
+        getListOfFilesFragment().setLoading(mSyncInProgress);
+
 
         // refresh list of files
         refreshListOfFilesFragment(false);
@@ -544,7 +545,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                     DataHolderUtil.getInstance().delete(intent.getStringExtra(FileSyncAdapter.EXTRA_RESULT));
                     Log_OC.d(TAG, "Setting progress visibility to " + mSyncInProgress);
 
-                    showProgressBar(mSyncInProgress);
+                    getListOfFilesFragment().setLoading(mSyncInProgress);
 
                     setBackgroundText();
                 }

--- a/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -264,7 +264,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                                                                             getApplicationContext());
 
         refreshFolderOperation.execute(getAccount(), this, null, null);
-        getListOfFilesFragment().setLoading(true);
+        getListOfFilesFragment().setLoading(Boolean.TRUE);
         setBackgroundText();
     }
 

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -30,7 +30,6 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
@@ -46,7 +45,6 @@ import androidx.appcompat.widget.Toolbar;
  * Base class providing toolbar registration functionality, see {@link #setupToolbar()}.
  */
 public abstract class ToolbarActivity extends BaseActivity {
-    private ProgressBar mProgressBar;
     private ImageView mPreviewImage;
     private FrameLayout mPreviewImageContainer;
     private LinearLayout mInfoBox;
@@ -67,9 +65,6 @@ public abstract class ToolbarActivity extends BaseActivity {
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-
-        mProgressBar = findViewById(R.id.toolbar_progressBar);
-        setProgressBarBackgroundColor();
 
         mInfoBox = findViewById(R.id.info_box);
         mInfoBoxMessage = findViewById(R.id.info_box_message);
@@ -161,17 +156,6 @@ public abstract class ToolbarActivity extends BaseActivity {
     }
 
     /**
-     * Change the visibility for the toolbar's progress bar.
-     *
-     * @param isVisible visibility of the progress bar
-     */
-    public void showProgressBar(boolean isVisible) {
-        if (mProgressBar != null) {
-            mProgressBar.setVisibility(isVisible? View.VISIBLE : View.GONE);
-        }
-    }
-
-    /**
      * Change the visibility for the toolbar's preview image.
      *
      * @param visibility visibility of the preview image
@@ -209,17 +193,5 @@ public abstract class ToolbarActivity extends BaseActivity {
      */
     public ImageView getPreviewImageView() {
             return mPreviewImage;
-    }
-
-    /**
-     * Set the background to to progress bar of the toolbar. The resource should refer to
-     * a Drawable object or 0 to remove the background.#
-     *
-     */
-    private void setProgressBarBackgroundColor() {
-        if (mProgressBar != null) {
-            mProgressBar.setBackgroundColor(ThemeUtils.primaryAppbarColor(this));
-            mProgressBar.getIndeterminateDrawable().setColorFilter(ThemeUtils.primaryColor(this), PorterDuff.Mode.SRC_IN);
-        }
     }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -56,7 +56,6 @@ import com.elyeproj.loaderviewlibrary.LoaderImageView;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.preferences.AppPreferences;
-import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
@@ -741,7 +740,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         try {
             final Point screenSize = getScreenSize(thumbnailShimmer.getContext());
-            final int marginLeftAndRight = Math.round(targetLayoutParams.leftMargin + targetLayoutParams.rightMargin);
+            final int marginLeftAndRight = targetLayoutParams.leftMargin + targetLayoutParams.rightMargin;
             final int size = Math.round(screenSize.x / gridColumns - marginLeftAndRight);
 
             FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(size, size);

--- a/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
@@ -28,7 +28,6 @@ import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.SearchRemoteOperation;
-import com.owncloud.android.ui.activity.ToolbarActivity;
 import com.owncloud.android.ui.adapter.OCFileListAdapter;
 import com.owncloud.android.ui.fragment.ExtendedListFragment;
 import com.owncloud.android.ui.fragment.PhotoFragment;
@@ -98,6 +97,7 @@ public class PhotoSearchTask extends AsyncTask<Void, Void, RemoteOperationResult
     @Override
     protected void onPostExecute(RemoteOperationResult result) {
         if (photoFragmentWeakReference.get() != null) {
+            Boolean loadingStatus = false;
             PhotoFragment photoFragment = photoFragmentWeakReference.get();
 
             if (result.isSuccess() && result.getData() != null && !isCancelled()) {
@@ -116,9 +116,7 @@ public class PhotoSearchTask extends AsyncTask<Void, Void, RemoteOperationResult
                 }
             }
 
-            final ToolbarActivity fileDisplayActivity = (ToolbarActivity) photoFragment.getActivity();
-
-                photoFragment.setLoading(false);
+            photoFragment.setLoading(false);
 
             if (!result.isSuccess() && !isCancelled()) {
                 photoFragment.setEmptyListMessage(ExtendedListFragment.SearchType.PHOTO_SEARCH);

--- a/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
@@ -116,7 +116,7 @@ public class PhotoSearchTask extends AsyncTask<Void, Void, RemoteOperationResult
                 }
             }
 
-            photoFragment.setLoading(false);
+            photoFragment.setLoading(Boolean.FALSE);
 
             if (!result.isSuccess() && !isCancelled()) {
                 photoFragment.setEmptyListMessage(ExtendedListFragment.SearchType.PHOTO_SEARCH);

--- a/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
@@ -118,9 +118,7 @@ public class PhotoSearchTask extends AsyncTask<Void, Void, RemoteOperationResult
 
             final ToolbarActivity fileDisplayActivity = (ToolbarActivity) photoFragment.getActivity();
 
-            if (fileDisplayActivity != null) {
-                fileDisplayActivity.showProgressBar(false);
-            }
+                photoFragment.setLoading(false);
 
             if (!result.isSuccess() && !isCancelled()) {
                 photoFragment.setEmptyListMessage(ExtendedListFragment.SearchType.PHOTO_SEARCH);

--- a/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/PhotoSearchTask.java
@@ -116,7 +116,7 @@ public class PhotoSearchTask extends AsyncTask<Void, Void, RemoteOperationResult
                 }
             }
 
-            photoFragment.setLoading(Boolean.FALSE);
+            photoFragment.setLoading(false);
 
             if (!result.isSuccess() && !isCancelled()) {
                 photoFragment.setEmptyListMessage(ExtendedListFragment.SearchType.PHOTO_SEARCH);

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -178,7 +178,7 @@ public class ExtendedListFragment extends Fragment implements
         return mFabMain;
     }
 
-    public void setLoading(Boolean enabled) {
+    public void setLoading(boolean enabled) {
         mRefreshListLayout.setRefreshing(enabled);
     }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -178,6 +178,10 @@ public class ExtendedListFragment extends Fragment implements
         return mFabMain;
     }
 
+    public void setLoading(Boolean enabled) {
+        mRefreshListLayout.setRefreshing(enabled);
+    }
+
     public void switchToGridView() {
         if (!isGridEnabled()) {
             getRecyclerView().setLayoutManager(new GridLayoutManager(getContext(), getColumnsCount()));
@@ -549,9 +553,6 @@ public class ExtendedListFragment extends Fragment implements
                 fileDisplayActivity.setDrawerIndicatorEnabled(fileDisplayActivity.isDrawerIndicatorAvailable());
             }
         }
-
-        mRefreshListLayout.setRefreshing(false);
-
         if (mOnRefreshListener != null) {
             mOnRefreshListener.onRefresh();
         }
@@ -794,8 +795,6 @@ public class ExtendedListFragment extends Fragment implements
 
     @Override
     public void onRefresh(boolean ignoreETag) {
-        mRefreshListLayout.setRefreshing(false);
-
         if (mOnRefreshListener != null) {
             mOnRefreshListener.onRefresh();
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -241,7 +241,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     private void activatePreviewImage() {
         if (activity != null) {
             activity.setPreviewImageVisibility(View.VISIBLE);
-            activity.showProgressBar(false);
             ThemeUtils.setStatusBarColor(activity, activity.getResources().getColor(R.color.background_color_inverse));
             if (activity.getSupportActionBar() != null) {
                 activity.getSupportActionBar().setTitle(null);
@@ -378,7 +377,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         if(activity != null) {
             activity.setupToolbar();
             activity.setPreviewImageVisibility(View.GONE);
-            activity.showProgressBar(true);
         }
 
         super.onStop();

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1625,7 +1625,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                                 @Override
                                 public void run() {
                                     if (fileDisplayActivity != null) {
-                                        setLoading(Boolean.FALSE);
+                                        setLoading(false);
                                     }
                                 }
                             });

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1625,7 +1625,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                                 @Override
                                 public void run() {
                                     if (fileDisplayActivity != null) {
-                                        setLoading(false);
+                                        setLoading(Boolean.FALSE);
                                     }
                                 }
                             });

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -28,7 +28,6 @@ import android.accounts.Account;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -1626,7 +1625,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                                 @Override
                                 public void run() {
                                     if (fileDisplayActivity != null) {
-                                        fileDisplayActivity.showProgressBar(false);
+                                        setLoading(false);
                                     }
                                 }
                             });

--- a/src/main/res/layout/toolbar_standard.xml
+++ b/src/main/res/layout/toolbar_standard.xml
@@ -56,16 +56,6 @@
             android:layout_height="?attr/actionBarSize"
             app:popupTheme="@style/Theme.AppCompat.DayNight.NoActionBar" />
 
-        <ProgressBar
-            android:id="@+id/toolbar_progressBar"
-            style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/toolbar"
-            android:layout_marginTop="-7dp"
-            android:layout_marginBottom="-7dp"
-            android:indeterminate="true"
-            android:visibility="gone" />
     </RelativeLayout>
 
     <include layout="@layout/info_box" />


### PR DESCRIPTION
Hi,

The Loader is no longer in Toolbar Activity when refreshing.
It's now a circular loader within the SwipeRefreshLayout instead of a Progress Bar. 

![xzHiZZVS9A](https://user-images.githubusercontent.com/7050479/81835532-a95c4c80-9542-11ea-814d-f7babfddcfd7.gif)
(The record is a bit long, only the first few seconds are interesting :))

This PR is relative to : https://github.com/nextcloud/android/issues/5207#issuecomment-617270183

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests not needed
