### PR TITLE
Move ktlint to gh actions

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: KtLint
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up JDK 1.8
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 1.8
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+            - name: KtLint
+            run: ./gradlew ktlint

--- a/scripts/analysis/analysis-wrapper.sh
+++ b/scripts/analysis/analysis-wrapper.sh
@@ -17,10 +17,6 @@ lintValue=$?
 ruby scripts/analysis/findbugs-up.rb $1 $2 $3
 findbugsValue=$?
 
-
-./gradlew ktlint
-ktlintValue=$?
-
 ./gradlew detekt
 detektValue=$?
 
@@ -127,12 +123,6 @@ else
         findbugsMessage="<h1>SpotBugs increased!</h1>"
     fi
 
-    if ( [ $ktlintValue -eq 1 ] ) ; then
-        sed -i ':a;N;$!ba;s#\n#<br />#g;s#^<br />##g' build/ktlint.txt
-        curl -u $4:$5 -X PUT https://nextcloud.kaminsky.me/remote.php/webdav/android-ktlint/$6.html --upload-file build/ktlint.txt
-        ktlintMessage="<h1>Kotlin lint found errors</h1><a href='https://www.kaminsky.me/nc-dev/android-ktlint/$6.html'>Lint</a>"
-    fi
-
     if ( [ $detektValue -eq 1 ] ) ; then
         curl -u $4:$5 -X PUT https://nextcloud.kaminsky.me/remote.php/webdav/android-detekt/$6.html --upload-file build/reports/detekt/detekt.html
         detektMessage="<h1>Detekt errors found</h1><a href='https://www.kaminsky.me/nc-dev/android-detekt/$6.html'>Lint</a>"
@@ -145,7 +135,7 @@ else
         gplayLimitation="<h1>Following files are beyond 500 char limit:</h1><br><br>"$gplayLimitation
     fi
 
-    curl -u $1:$2 -X POST https://api.github.com/repos/nextcloud/android/issues/$7/comments -d "{ \"body\" : \"$codacyResult $lintResult $findbugsResultNew $findbugsResultOld $checkLibraryMessage $lintMessage $findbugsMessage $ktlintMessage $detektMessage $gplayLimitation \" }"
+    curl -u $1:$2 -X POST https://api.github.com/repos/nextcloud/android/issues/$7/comments -d "{ \"body\" : \"$codacyResult $lintResult $findbugsResultNew $findbugsResultOld $checkLibraryMessage $lintMessage $findbugsMessage $detektMessage $gplayLimitation \" }"
 
     if [ ! -z "$gplayLimitation" ]; then
         exit 1
@@ -157,11 +147,6 @@ else
 
     if [ ! $lintValue -eq 2 ]; then
         exit $lintValue
-    fi
-
-
-    if [ $ktlintValue -eq 1 ]; then
-        exit 1
     fi
 
     if [ $detektValue -eq 1 ]; then


### PR DESCRIPTION
If it fails, it looks like this:
https://github.com/tobiasKaminsky/android-nextcloud/pull/3/checks?check_run_id=677762137

Background is that our CI is totally overloaded and moving some parts to GH actions can help.
Aditonally we can restart independent jobs if something fails.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
