### PR TITLE
Fix - bad profile picture

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -56,7 +56,7 @@ import androidx.core.view.ViewCompat;
 public abstract class ToolbarActivity extends BaseActivity {
     protected MaterialButton mMenuButton;
     protected MaterialTextView mSearchText;
-    protected MaterialButton mSwitchAccountButton;
+    protected ImageView mSwitchAccountButton;
 
     private AppBarLayout mAppBar;
     private RelativeLayout mDefaultToolbar;

--- a/src/main/res/layout/toolbar_standard.xml
+++ b/src/main/res/layout/toolbar_standard.xml
@@ -59,6 +59,16 @@
             android:background="@color/appbar"
             app:popupTheme="@style/Theme.AppCompat.DayNight.NoActionBar" />
 
+        <ProgressBar
+            android:id="@+id/toolbar_progressBar"
+            style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/toolbar"
+            android:layout_marginTop="-7dp"
+            android:layout_marginBottom="-7dp"
+            android:indeterminate="true"
+            android:visibility="gone" />
     </RelativeLayout>
 
     <com.google.android.material.card.MaterialCardView
@@ -107,17 +117,18 @@
                 app:layout_constraintRight_toLeftOf="@id/switch_account_button"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.button.MaterialButton
+            <ImageView
                 android:id="@+id/switch_account_button"
                 style="@style/Widget.AppTheme.Button.IconButton"
-                android:layout_width="38dp"
-                android:layout_height="38dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_marginEnd="8dp"
-                app:cornerRadius="@dimen/button_corner_radius"
-                app:iconSize="28dp"
+                android:foreground="?android:attr/selectableItemBackground"
+                android:src="@drawable/account_circle_white"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                android:contentDescription="@string/common_choose_account" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Hi, 

It fixes a bug relative to : https://github.com/nextcloud/android/pull/6067 

If you see on the right of the below screenshot, you can see a "blue circle" which should contain the profile pic on the left... but it doesn't : 
![Capture d’écran 2020-05-15 à 15 25 42](https://user-images.githubusercontent.com/7050479/82069726-06d3d300-96d4-11ea-9cae-aee85881426f.png)

It's due to the MaterialButton `setIcon` method, I don't know why but it creates a bug. 
So this MaterialButton has been replaced by an ImageView. 

And now it works :) 

![Capture d’écran 2020-05-15 à 17 44 40](https://user-images.githubusercontent.com/7050479/82069852-35ea4480-96d4-11ea-9f3e-6d3b5969e627.png) 

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests written, or not not needed
