### PR TITLE
Properly show default/generated avatar if there is no one yet

### DIFF
--- a/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -488,23 +488,20 @@ public final class DisplayUtils {
             }
         }
 
-        // check for new avatar, eTag is compared, so only new one is downloaded
-        if (ThumbnailsCacheManager.cancelPotentialAvatarWork(userId, callContext)) {
-            final ThumbnailsCacheManager.AvatarGenerationTask task =
-                new ThumbnailsCacheManager.AvatarGenerationTask(listener,
-                                                                callContext,
-                                                                user.toPlatformAccount(),
-                                                                resources,
-                                                                avatarRadius,
-                                                                userId,
-                                                                serverName,
-                                                                context);
+        listener.avatarGenerated(avatar, callContext);
 
-            final ThumbnailsCacheManager.AsyncAvatarDrawable asyncDrawable =
-                new ThumbnailsCacheManager.AsyncAvatarDrawable(resources, avatar, task);
-            listener.avatarGenerated(asyncDrawable, callContext);
-            task.execute(userId);
-        }
+        // check for new avatar, eTag is compared, so only new one is downloaded
+        final ThumbnailsCacheManager.AvatarGenerationTask task =
+            new ThumbnailsCacheManager.AvatarGenerationTask(listener,
+                                                            callContext,
+                                                            user.toPlatformAccount(),
+                                                            resources,
+                                                            avatarRadius,
+                                                            userId,
+                                                            serverName,
+                                                            context);
+
+        task.execute(userId);
     }
 
     public static void downloadIcon(CurrentAccountProvider currentAccountProvider,


### PR DESCRIPTION
To test
- clean installation (without any cache)
- have an avatar
- put ` Thread.sleep(10000); ` in ThumbnailsCacheManager:885
- start app
- see first icon with char, e.g. N
- after ~10s see your avatar

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
