### PR TITLE
Revert "[FIX: #5752] Upload files: too much whitespace"

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -461,7 +461,6 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
             itemLayout = itemView.findViewById(R.id.ListItemLayout);
 
             itemView.findViewById(R.id.sharedIcon).setVisibility(View.GONE);
-            itemView.findViewById(R.id.sharedAvatars).setVisibility(View.GONE);
             itemView.findViewById(R.id.favorite_action).setVisibility(View.GONE);
             itemView.findViewById(R.id.localFileIndicator).setVisibility(View.GONE);
         }

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -444,6 +444,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
             fileSeparator = itemView.findViewById(R.id.file_separator);
             lastModification = itemView.findViewById(R.id.last_mod);
 
+            itemView.findViewById(R.id.sharedAvatars).setVisibility(View.GONE);
             itemView.findViewById(R.id.overflow_menu).setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
This reverts commit b4db8d8f95c371c49da6a18dd6e7245c0666d3f3.

sharedAvatars item does not exist in layout, causing NPE.

Fixes #6133 
Fixes #6039
Fixes #5997 

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
