### PR TITLE
If we cancel by user, we pass a reason, so app can handle it correctly

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -555,7 +555,7 @@ public class FileUploader extends Service
     public void onAccountsUpdated(Account[] accounts) {
         // Review current upload, and cancel it if its account doesn't exist
         if (mCurrentUpload != null && !accountManager.exists(mCurrentUpload.getAccount())) {
-            mCurrentUpload.cancel();
+            mCurrentUpload.cancel(ResultCode.ACCOUNT_NOT_FOUND);
         }
         // The rest of uploads are cancelled when they try to start
     }
@@ -1127,7 +1127,7 @@ public class FileUploader extends Service
             }
 
             if (upload != null) {
-                upload.cancel();
+                upload.cancel(resultCode);
                 // need to update now table in mUploadsStorageManager,
                 // since the operation will not get to be run by FileUploader#uploadFile
                 if (resultCode != null) {
@@ -1150,7 +1150,7 @@ public class FileUploader extends Service
             if (mCurrentUpload != null) {
                 Log_OC.d(TAG, "Current Upload Account= " + mCurrentUpload.getAccount().name);
                 if (mCurrentUpload.getAccount().name.equals(account.name)) {
-                    mCurrentUpload.cancel();
+                    mCurrentUpload.cancel(ResultCode.CANCELLED);
                 }
             }
 
@@ -1288,7 +1288,7 @@ public class FileUploader extends Service
             if (context != null) {
                 ResultCode cancelReason = null;
                 Connectivity connectivity = connectivityService.getConnectivity();
-                if (mCurrentUpload.isWifiRequired() && connectivity.isWifi()) {
+                if (mCurrentUpload.isWifiRequired() && !connectivity.isWifi()) {
                     cancelReason = ResultCode.DELAYED_FOR_WIFI;
                 } else if (mCurrentUpload.isChargingRequired() && !powerManagementService.getBattery().isCharging()) {
                     cancelReason = ResultCode.DELAYED_FOR_CHARGING;

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -1109,7 +1109,7 @@ public class UploadFileOperation extends SyncOperation {
      * is in progress it is cancelled, if upload preparation is being performed
      * upload will not take place.
      */
-    public void cancel() {
+    public void cancel(ResultCode cancellationReason) {
         if (mUploadOperation == null) {
             if (mUploadStarted.get()) {
                 Log_OC.d(TAG, "Cancelling upload during upload preparations.");
@@ -1119,7 +1119,7 @@ public class UploadFileOperation extends SyncOperation {
             }
         } else {
             Log_OC.d(TAG, "Cancelling upload during actual upload operation.");
-            mUploadOperation.cancel();
+            mUploadOperation.cancel(cancellationReason);
         }
     }
 


### PR DESCRIPTION
This also fixed a bug for auto upload: 
Previously it directly killed & removed all pendings uploads when "on wifi only" was checked, due to wrong https://github.com/nextcloud/android/pull/6128/files#diff-6686c0c6fc81fc7d178a8f307ed47a83R1291

Needs library: https://github.com/nextcloud/android-library/pull/439

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
