### PR TITLE
Enhance failed uploads

### DIFF
--- a/src/androidTest/java/com/owncloud/android/datamodel/UploadStorageManagerTest.java
+++ b/src/androidTest/java/com/owncloud/android/datamodel/UploadStorageManagerTest.java
@@ -26,12 +26,14 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import androidx.test.InstrumentationRegistry;
 import androidx.test.filters.SmallTest;
 import androidx.test.runner.AndroidJUnit4;
 
+import static com.owncloud.android.datamodel.UploadsStorageManager.UploadStatus.UPLOAD_FAILED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -94,7 +96,7 @@ public class UploadStorageManagerTest extends AbstractIT {
         int size = 3000;
         ArrayList<OCUpload> uploads = new ArrayList<>();
 
-        assertEquals(0, uploadsStorageManager.getAllStoredUploads().length);
+        assertEquals(0, uploadsStorageManager.getAllStoredUploads().size());
 
         for (int i = 0; i < size; i++) {
             OCUpload upload = createUpload(account);
@@ -103,11 +105,11 @@ public class UploadStorageManagerTest extends AbstractIT {
             uploadsStorageManager.storeUpload(upload);
         }
 
-        OCUpload[] storedUploads = uploadsStorageManager.getAllStoredUploads();
-        assertEquals(size, uploadsStorageManager.getAllStoredUploads().length);
+        List<OCUpload> storedUploads = uploadsStorageManager.getAllStoredUploads();
+        assertEquals(size, uploadsStorageManager.getAllStoredUploads().size());
 
         for (int i = 0; i < size; i++) {
-            assertTrue(contains(uploads, storedUploads[i]));
+            assertTrue(contains(uploads, storedUploads.get(i)));
         }
     }
 
@@ -127,15 +129,6 @@ public class UploadStorageManagerTest extends AbstractIT {
         assertFalse(upload1.isSame(new OCFile("/test")));
     }
 
-    private boolean contains(ArrayList<OCUpload> uploads, OCUpload storedUpload) {
-        for (int i = 0; i < uploads.size(); i++) {
-            if (storedUpload.isSame(uploads.get(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void corruptedUpload() {
         OCUpload corruptUpload = new OCUpload(File.separator + "LocalPath",
@@ -147,6 +140,192 @@ public class UploadStorageManagerTest extends AbstractIT {
         uploadsStorageManager.storeUpload(corruptUpload);
 
         uploadsStorageManager.getAllStoredUploads();
+    }
+
+    @Test
+    public void testConstraintsWithFailedUploads() {
+        // no constraints
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(false));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setLastResult(UploadResult.LOCK_FAILED)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(false));
+
+        // wifi only
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(true)
+                                              .setWhileChargingOnly(false));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(true)
+                                              .setWhileChargingOnly(false));
+
+        // charging only
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(true));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(true));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(true));
+
+        // wifi only, charging only
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(true)
+                                              .setWhileChargingOnly(true));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(true)
+                                              .setWhileChargingOnly(true));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(true)
+                                              .setWhileChargingOnly(true));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setUseWifiOnly(true)
+                                              .setWhileChargingOnly(true));
+
+        // should not automatically retried
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setLastResult(UploadResult.SYNC_CONFLICT)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(false));
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED)
+                                              .setLastResult(UploadResult.FILE_NOT_FOUND)
+                                              .setUseWifiOnly(false)
+                                              .setWhileChargingOnly(false));
+
+        assertEquals(11, uploadsStorageManager.getFailedUploads().size());
+        assertEquals(2, uploadsStorageManager.getFailedUploads(false, false).size());
+        assertEquals(2, uploadsStorageManager.getFailedUploads(true, false).size());
+        assertEquals(3, uploadsStorageManager.getFailedUploads(false, true).size());
+        assertEquals(4, uploadsStorageManager.getFailedUploads(true, true).size());
+
+        // scenario "no wifi, no charging"
+        List<OCUpload> failedUploads;
+        failedUploads = uploadsStorageManager.getFailedUploads(false, false);
+        assertEquals(2, failedUploads.size());
+        failedUploads.clear();
+
+        // scenario "wifi, no charging"
+        failedUploads = uploadsStorageManager.getFailedUploads(false, false);
+        failedUploads.addAll(uploadsStorageManager.getFailedUploads(true, false));
+        assertEquals(4, failedUploads.size());
+        failedUploads.clear();
+
+        // scenario "no wifi, charging"
+        failedUploads = uploadsStorageManager.getFailedUploads(false, false);
+        failedUploads.addAll(uploadsStorageManager.getFailedUploads(false, true));
+        assertEquals(5, failedUploads.size());
+        failedUploads.clear();
+
+        // scenario "wifi, charging"
+        failedUploads = uploadsStorageManager.getFailedUploads(false, false);
+        failedUploads.addAll(uploadsStorageManager.getFailedUploads(true, false));
+        failedUploads.addAll(uploadsStorageManager.getFailedUploads(false, true));
+        failedUploads.addAll(uploadsStorageManager.getFailedUploads(true, true));
+        assertEquals(11, failedUploads.size());
+        failedUploads.clear();
+    }
+
+    @Test
+    public void testDeleteUploadsWithOneValidAccount() {
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount1")
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount2")
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount3")
+                                              .setUploadStatus(UPLOAD_FAILED));
+
+        assertEquals(4, uploadsStorageManager.getFailedUploads().size());
+
+        ArrayList<Account> accountList = new ArrayList<>();
+        accountList.add(account);
+        uploadsStorageManager.removeUploadsWithExpiredUsers(accountList);
+
+        assertEquals(1, uploadsStorageManager.getFailedUploads().size());
+    }
+
+    @Test
+    public void testDeleteUploadsWithTwoValidAccount() {
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account2.name)
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount1")
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount2")
+                                              .setUploadStatus(UPLOAD_FAILED));
+
+        assertEquals(4, uploadsStorageManager.getFailedUploads().size());
+
+        ArrayList<Account> accountList = new ArrayList<>();
+        accountList.add(account);
+        accountList.add(account2);
+        uploadsStorageManager.removeUploadsWithExpiredUsers(accountList);
+
+        assertEquals(2, uploadsStorageManager.getFailedUploads().size());
+    }
+
+    @Test
+    public void testDeleteUploadsWithManyValidAccount() {
+        Account account3 = new Account("test3@server.com", "Test-Type");
+
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account.name)
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account2.name)
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", account3.name)
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount1")
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount2")
+                                              .setUploadStatus(UPLOAD_FAILED));
+        uploadsStorageManager.storeUpload(new OCUpload("/test", "/test", "oldAccount3")
+                                              .setUploadStatus(UPLOAD_FAILED));
+
+        assertEquals(6, uploadsStorageManager.getFailedUploads().size());
+
+        ArrayList<Account> accountList = new ArrayList<>();
+        accountList.add(account);
+        accountList.add(account2);
+        accountList.add(account3);
+        uploadsStorageManager.removeUploadsWithExpiredUsers(accountList);
+
+        assertEquals(3, uploadsStorageManager.getFailedUploads().size());
+    }
+
+    private boolean contains(ArrayList<OCUpload> uploads, OCUpload storedUpload) {
+        for (int i = 0; i < uploads.size(); i++) {
+            if (storedUpload.isSame(uploads.get(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void insertUploads(Account account, int rowsToInsert) {
@@ -177,9 +356,7 @@ public class UploadStorageManagerTest extends AbstractIT {
 
     @After
     public void tearDown() {
-        for (Account account : getAllAccounts()) {
-            uploadsStorageManager.removeAccountUploads(account);
-        }
+        uploadsStorageManager.removeAllUploads();
 
         AccountManager platformAccountManager = AccountManager.get(targetContext);
         platformAccountManager.removeAccountExplicitly(account2);

--- a/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -194,16 +194,20 @@ public class OCUpload implements Parcelable {
      * Sets uploadStatus AND SETS lastResult = null;
      * @param uploadStatus the uploadStatus to set
      */
-    public void setUploadStatus(UploadStatus uploadStatus) {
+    public OCUpload setUploadStatus(UploadStatus uploadStatus) {
         this.uploadStatus = uploadStatus;
         setLastResult(UploadResult.UNKNOWN);
+
+        return this;
     }
 
     /**
      * @param lastResult the lastResult to set
      */
-    public void setLastResult(UploadResult lastResult) {
+    public OCUpload setLastResult(UploadResult lastResult) {
         this.lastResult = lastResult != null ? lastResult : UploadResult.UNKNOWN;
+
+        return this;
     }
 
     public UploadStatus getFixedUploadStatus() {
@@ -440,12 +444,16 @@ public class OCUpload implements Parcelable {
         this.uploadEndTimestamp = uploadEndTimestamp;
     }
 
-    public void setUseWifiOnly(boolean useWifiOnly) {
+    public OCUpload setUseWifiOnly(boolean useWifiOnly) {
         this.useWifiOnly = useWifiOnly;
+
+        return this;
     }
 
-    public void setWhileChargingOnly(boolean whileChargingOnly) {
+    public OCUpload setWhileChargingOnly(boolean whileChargingOnly) {
         this.whileChargingOnly = whileChargingOnly;
+
+        return this;
     }
 
     public void setFolderUnlockToken(String folderUnlockToken) {

--- a/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -182,12 +182,10 @@ public class UploadListActivity extends FileActivity {
         // retry failed uploads
         new Thread(() -> FileUploader.retryFailedUploads(
             this,
-            null,
             uploadsStorageManager,
             connectivityService,
             userAccountManager,
-            powerManagementService,
-            null
+            powerManagementService
         )).start();
 
         // update UI

--- a/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -71,7 +71,9 @@ import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.ThemeUtils;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import androidx.annotation.NonNull;
 import butterknife.BindView;
@@ -101,7 +103,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
     @Override
     public int getItemCount(int section) {
-        return uploadGroups[section].getItems().length;
+        return uploadGroups[section].getItems().size();
     }
 
     @Override
@@ -145,12 +147,10 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 case FAILED:
                     new Thread(() -> FileUploader.retryFailedUploads(
                         parentActivity,
-                        null,
                         uploadsStorageManager,
                         connectivityService,
                         accountManager,
-                        powerManagementService,
-                        null
+                        powerManagementService
                     )).start();
                     break;
 
@@ -810,44 +810,44 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
     abstract class UploadGroup implements Refresh {
         private Type type;
-        private OCUpload[] items;
+        private List<OCUpload> items;
         private String name;
 
         UploadGroup(Type type, String groupName) {
             this.type = type;
             this.name = groupName;
-            items = new OCUpload[0];
+            items = new ArrayList<>();
         }
 
         private String getGroupName() {
             return name;
         }
 
-        public OCUpload[] getItems() {
+        public List<OCUpload> getItems() {
             return items;
         }
 
         public OCUpload getItem(int position) {
-            return items[position];
+            return items.get(position);
         }
 
-        public void setItems(OCUpload... items) {
+        public void setItems(List<OCUpload> items) {
             this.items = items;
         }
 
-        void fixAndSortItems(OCUpload... array) {
+        void fixAndSortItems(List<OCUpload> list) {
             FileUploader.FileUploaderBinder binder = parentActivity.getFileUploaderBinder();
 
-            for (OCUpload upload : array) {
+            for (OCUpload upload : list) {
                 upload.setDataFixed(binder);
             }
-            Arrays.sort(array, new OCUploadComparator());
+            Collections.sort(list, new OCUploadComparator());
 
-            setItems(array);
+            setItems(list);
         }
 
         private int getGroupItemCount() {
-            return items == null ? 0 : items.length;
+            return items == null ? 0 : items.size();
         }
     }
 }

--- a/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -23,7 +23,6 @@
  */
 package com.owncloud.android.utils;
 
-import android.accounts.Account;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
@@ -43,7 +42,6 @@ import com.owncloud.android.datamodel.MediaFolderType;
 import com.owncloud.android.datamodel.SyncedFolder;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.UploadsStorageManager;
-import com.owncloud.android.db.OCUpload;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
@@ -183,36 +181,14 @@ public final class FilesSyncHelper {
                                            final PowerManagementService powerManagementService) {
         final Context context = MainApp.getAppContext();
 
-        boolean accountExists;
-
-        OCUpload[] failedUploads = uploadsStorageManager.getFailedUploads();
-
-        for (OCUpload failedUpload : failedUploads) {
-            accountExists = false;
-
-            // check if accounts still exists
-            for (Account account : accountManager.getAccounts()) {
-                if (account.name.equals(failedUpload.getAccountName())) {
-                    accountExists = true;
-                    break;
-                }
-            }
-
-            if (!accountExists) {
-                uploadsStorageManager.removeUpload(failedUpload);
-            }
-        }
-
         new Thread(() -> {
             if (connectivityService.getConnectivity().isConnected() && !connectivityService.isInternetWalled()) {
                 FileUploader.retryFailedUploads(
                     context,
-                    null,
                     uploadsStorageManager,
                     connectivityService,
                     accountManager,
-                    powerManagementService,
-                    null
+                    powerManagementService
                 );
             }
         }).start();


### PR DESCRIPTION
- first check constraints, then get failed uploads based on this constraints only

- enhanced remove uploads with no accounts associated
- use List<OCUpload> instead of OCUpload[]

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
