### PR TITLE
New design (UI) - Removed old options menu items from FileDisplayActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -31,13 +31,11 @@ import android.accounts.AuthenticatorException;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
-import android.content.SyncRequest;
 import android.content.pm.PackageManager;
 import android.content.res.Resources.NotFoundException;
 import android.net.Uri;
@@ -145,14 +143,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
-import androidx.core.content.ContextCompat;
 import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
 import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
-import static com.owncloud.android.utils.DisplayUtils.openSortingOrderDialogFragment;
 
 /**
  * Displays, what files the user has available in his ownCloud. This is the main view.
@@ -764,10 +760,6 @@ public class FileDisplayActivity extends FileActivity
             menuItem.setVisible(!drawerOpen);
         }
 
-        // Hiding unused elements
-        menu.findItem(R.id.action_sort).setVisible(false);
-        menu.findItem(R.id.action_switch_view).setVisible(false);
-
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -775,7 +767,6 @@ public class FileDisplayActivity extends FileActivity
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.activity_file_display, menu);
-        menu.findItem(R.id.action_create_dir).setVisible(false);
 
         menu.findItem(R.id.action_select_all).setVisible(false);
         MenuItem searchMenuItem = menu.findItem(R.id.action_search);
@@ -789,9 +780,7 @@ public class FileDisplayActivity extends FileActivity
         ThemeUtils.themeSearchView(searchView, this);
 
         // populate list of menu items to show/hide when drawer is opened/closed
-        mDrawerMenuItemstoShowHideList = new ArrayList<>(3);
-        mDrawerMenuItemstoShowHideList.add(menu.findItem(R.id.action_sort));
-        mDrawerMenuItemstoShowHideList.add(menu.findItem(R.id.action_switch_view));
+        mDrawerMenuItemstoShowHideList = new ArrayList<>(1);
         mDrawerMenuItemstoShowHideList.add(searchMenuItem);
 
         //focus the SearchView
@@ -862,23 +851,6 @@ public class FileDisplayActivity extends FileActivity
 
                 } else {
                     openDrawer();
-                }
-                break;
-            }
-            case R.id.action_sort: {
-                openSortingOrderDialogFragment(getSupportFragmentManager(),
-                                               preferences.getSortOrderByFolder(getListOfFilesFragment().getCurrentFile()));
-                break;
-            }
-            case R.id.action_switch_view: {
-                if (isGridView()) {
-                    item.setTitle(getString(R.string.action_switch_grid_view));
-                    item.setIcon(ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_view_module));
-                    getListOfFilesFragment().setListAsPreferred();
-                } else {
-                    item.setTitle(getApplicationContext().getString(R.string.action_switch_list_view));
-                    item.setIcon(ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_view_list));
-                    getListOfFilesFragment().setGridAsPreferred();
                 }
                 break;
             }

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2474,6 +2474,8 @@ public class FileDisplayActivity extends FileActivity
     @Override
     public void onRefresh(boolean ignoreETag) {
         syncAndUpdateFolder(ignoreETag);
+        // Synchronize account during swipe refresh
+        startSynchronization();
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -893,38 +893,6 @@ public class FileDisplayActivity extends FileActivity
         return retval;
     }
 
-    private void startSynchronization() {
-        Log_OC.d(TAG, "Got to start sync");
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
-            Log_OC.d(TAG, "Canceling all syncs for " + MainApp.getAuthority());
-            ContentResolver.cancelSync(null, MainApp.getAuthority());
-            // cancel the current synchronizations of any ownCloud account
-            Bundle bundle = new Bundle();
-            bundle.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
-            bundle.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
-            Log_OC.d(TAG, "Requesting sync for " + getAccount().name + " at " +
-                    MainApp.getAuthority());
-            ContentResolver.requestSync(
-                    getAccount(),
-                    MainApp.getAuthority(), bundle);
-        } else {
-            Log_OC.d(TAG, "Requesting sync for " + getAccount().name + " at " +
-                    MainApp.getAuthority() + " with new API");
-            SyncRequest.Builder builder = new SyncRequest.Builder();
-            builder.setSyncAdapter(getAccount(), MainApp.getAuthority());
-            builder.setExpedited(true);
-            builder.setManual(true);
-            builder.syncOnce();
-
-            // Fix bug in Android Lollipop when you click on refresh the whole account
-            Bundle extras = new Bundle();
-            builder.setExtras(extras);
-
-            SyncRequest request = builder.build();
-            ContentResolver.requestSync(request);
-        }
-    }
-
     /**
      * Called, when the user selected something for uploading
      */
@@ -2473,8 +2441,6 @@ public class FileDisplayActivity extends FileActivity
     @Override
     public void onRefresh(boolean ignoreETag) {
         syncAndUpdateFolder(ignoreETag);
-        // Synchronize account during swipe refresh
-        startSynchronization();
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -764,6 +764,10 @@ public class FileDisplayActivity extends FileActivity
             menuItem.setVisible(!drawerOpen);
         }
 
+        // Hiding unused elements
+        menu.findItem(R.id.action_sort).setVisible(false);
+        menu.findItem(R.id.action_switch_view).setVisible(false);
+
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -785,9 +789,8 @@ public class FileDisplayActivity extends FileActivity
         ThemeUtils.themeSearchView(searchView, this);
 
         // populate list of menu items to show/hide when drawer is opened/closed
-        mDrawerMenuItemstoShowHideList = new ArrayList<>(4);
+        mDrawerMenuItemstoShowHideList = new ArrayList<>(3);
         mDrawerMenuItemstoShowHideList.add(menu.findItem(R.id.action_sort));
-        mDrawerMenuItemstoShowHideList.add(menu.findItem(R.id.action_sync_account));
         mDrawerMenuItemstoShowHideList.add(menu.findItem(R.id.action_switch_view));
         mDrawerMenuItemstoShowHideList.add(searchMenuItem);
 
@@ -848,10 +851,6 @@ public class FileDisplayActivity extends FileActivity
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean retval = true;
         switch (item.getItemId()) {
-            case R.id.action_sync_account: {
-                startSynchronization();
-                break;
-            }
             case android.R.id.home: {
                 FileFragment second = getSecondFragment();
                 OCFile currentDir = getCurrentDir();

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -221,8 +221,7 @@ public class ExtendedListFragment extends Fragment implements
                 searchView.setMaxWidth((int) (width * 0.4));
             } else {
                 if (activity instanceof FolderPickerActivity) {
-                    searchView.
-                        setMaxWidth((int) (width * 0.8));
+                    searchView.setMaxWidth((int) (width * 0.8));
                 } else {
                     searchView.setMaxWidth(width);
                 }

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -221,9 +221,10 @@ public class ExtendedListFragment extends Fragment implements
                 searchView.setMaxWidth((int) (width * 0.4));
             } else {
                 if (activity instanceof FolderPickerActivity) {
-                    searchView.setMaxWidth((int) (width * 0.8));
+                    searchView.
+                        setMaxWidth((int) (width * 0.8));
                 } else {
-                    searchView.setMaxWidth((int) (width * 0.7));
+                    searchView.setMaxWidth(width);
                 }
             }
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -432,13 +432,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             FileMenuFilter.hideMenuItems(menu.findItem(R.id.action_send_file));
             FileMenuFilter.hideMenuItems(menu.findItem(R.id.action_sync_file));
         }
-
-        // dual pane restrictions
-        if (!getResources().getBoolean(R.bool.large_land_layout)){
-            FileMenuFilter.hideMenuItems(menu.findItem(R.id.action_sync_account));
-        }
-
-
     }
 
     private boolean optionsItemSelected(MenuItem item) {

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -825,7 +825,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
             case REMOVE_ALL_EXCEPT_SEARCH:
                 menu.removeItem(R.id.action_sort);
                 menu.removeItem(R.id.action_switch_view);
-                menu.removeItem(R.id.action_sync_account);
                 mSwitchGridViewButton.setVisibility(View.VISIBLE);
                 mSortButton.setVisibility(View.VISIBLE);
                 break;

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -769,8 +769,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
 
         if (mOriginalMenuItems.size() == 0) {
-            mOriginalMenuItems.add(menu.findItem(R.id.action_switch_view));
-            mOriginalMenuItems.add(menu.findItem(R.id.action_sort));
+            if (!(getActivity() instanceof FileDisplayActivity)) {
+                mOriginalMenuItems.add(menu.findItem(R.id.action_switch_view));
+                mOriginalMenuItems.add(menu.findItem(R.id.action_sort));
+            }
             mOriginalMenuItems.add(menu.findItem(R.id.action_search));
         }
 
@@ -789,18 +791,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
             case ADD_GRID_AND_SORT:
             case ADD_GRID_AND_SORT_WITH_SEARCH:
-                if (menu.findItem(R.id.action_switch_view) == null) {
-                    menuItemOrig = mOriginalMenuItems.get(0);
-                    menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                             menuItemOrig.getTitle());
-                }
                 mSwitchGridViewButton.setVisibility(View.VISIBLE);
-
-                if (menu.findItem(R.id.action_sort) == null) {
-                    menuItemOrig = mOriginalMenuItems.get(1);
-                    menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                             menuItemOrig.getTitle());
-                }
                 mSortButton.setVisibility(View.VISIBLE);
                 break;
 

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -201,10 +201,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
     protected enum MenuItemAddRemove {
         DO_NOTHING, REMOVE_SORT, REMOVE_GRID_AND_SORT, ADD_SORT, ADD_GRID_AND_SORT, ADD_GRID_AND_SORT_WITH_SEARCH,
-        REMOVE_SEARCH
+        REMOVE_SEARCH, REMOVE_ALL_EXCEPT_SEARCH
     }
 
-    protected MenuItemAddRemove menuItemAddRemoveValue = MenuItemAddRemove.DO_NOTHING;
+    protected MenuItemAddRemove menuItemAddRemoveValue = MenuItemAddRemove.REMOVE_ALL_EXCEPT_SEARCH;
 
     private List<MenuItem> mOriginalMenuItems = new ArrayList<>();
 
@@ -775,63 +775,65 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
 
         changeGridIcon(menu);   // this is enough if the option stays out of the action bar
-
         MenuItem menuItemOrig;
 
-        if (menuItemAddRemoveValue == MenuItemAddRemove.ADD_SORT) {
-            if (menu.findItem(R.id.action_sort) == null) {
-                menuItemOrig = mOriginalMenuItems.get(1);
-                menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                         menuItemOrig.getTitle());
-            }
-            mSortButton.setVisibility(View.VISIBLE);
+        switch (menuItemAddRemoveValue) {
+            case ADD_SORT:
+                if (menu.findItem(R.id.action_sort) == null) {
+                    menuItemOrig = mOriginalMenuItems.get(1);
+                    menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
+                             menuItemOrig.getTitle());
+                }
+                mSortButton.setVisibility(View.VISIBLE);
+                break;
 
-        } else if (menuItemAddRemoveValue == MenuItemAddRemove.ADD_GRID_AND_SORT) {
-            if (menu.findItem(R.id.action_switch_view) == null) {
-                menuItemOrig = mOriginalMenuItems.get(0);
-                menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                         menuItemOrig.getTitle());
-            }
-            mSwitchGridViewButton.setVisibility(View.VISIBLE);
+            case ADD_GRID_AND_SORT:
+            case ADD_GRID_AND_SORT_WITH_SEARCH:
+                if (menu.findItem(R.id.action_switch_view) == null) {
+                    menuItemOrig = mOriginalMenuItems.get(0);
+                    menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
+                             menuItemOrig.getTitle());
+                }
+                mSwitchGridViewButton.setVisibility(View.VISIBLE);
 
-            if (menu.findItem(R.id.action_sort) == null) {
-                menuItemOrig = mOriginalMenuItems.get(1);
-                menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                         menuItemOrig.getTitle());
-            }
-            mSortButton.setVisibility(View.VISIBLE);
-        } else if (menuItemAddRemoveValue == MenuItemAddRemove.REMOVE_SEARCH) {
-            menu.removeItem(R.id.action_search);
-        } else if (menuItemAddRemoveValue == MenuItemAddRemove.ADD_GRID_AND_SORT_WITH_SEARCH) {
-            if (menu.findItem(R.id.action_switch_view) == null) {
-                menuItemOrig = mOriginalMenuItems.get(0);
-                menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                         menuItemOrig.getTitle());
-            }
-            mSwitchGridViewButton.setVisibility(View.VISIBLE);
+                if (menu.findItem(R.id.action_sort) == null) {
+                    menuItemOrig = mOriginalMenuItems.get(1);
+                    menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
+                             menuItemOrig.getTitle());
+                }
+                mSortButton.setVisibility(View.VISIBLE);
+                break;
 
-            if (menu.findItem(R.id.action_sort) == null) {
-                menuItemOrig = mOriginalMenuItems.get(1);
-                menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                         menuItemOrig.getTitle());
-            }
-            mSortButton.setVisibility(View.VISIBLE);
+            case REMOVE_SEARCH:
+                menu.removeItem(R.id.action_search);
+                break;
 
-            if (menu.findItem(R.id.action_search) == null) {
-                menuItemOrig = mOriginalMenuItems.get(2);
-                menu.add(menuItemOrig.getGroupId(), menuItemOrig.getItemId(), menuItemOrig.getOrder(),
-                         menuItemOrig.getTitle());
-            }
-        } else if (menuItemAddRemoveValue == MenuItemAddRemove.REMOVE_SORT) {
-            menu.removeItem(R.id.action_sort);
-            menu.removeItem(R.id.action_search);
-            mSortButton.setVisibility(View.GONE);
-        } else if (menuItemAddRemoveValue == MenuItemAddRemove.REMOVE_GRID_AND_SORT) {
-            menu.removeItem(R.id.action_sort);
-            menu.removeItem(R.id.action_switch_view);
-            menu.removeItem(R.id.action_search);
-            mSortButton.setVisibility(View.GONE);
-            mSwitchGridViewButton.setVisibility(View.GONE);
+            case REMOVE_SORT:
+                menu.removeItem(R.id.action_sort);
+                menu.removeItem(R.id.action_search);
+                mSortButton.setVisibility(View.GONE);
+                break;
+
+            case REMOVE_GRID_AND_SORT:
+                menu.removeItem(R.id.action_sort);
+                menu.removeItem(R.id.action_switch_view);
+                menu.removeItem(R.id.action_search);
+                mSortButton.setVisibility(View.GONE);
+                mSwitchGridViewButton.setVisibility(View.GONE);
+                break;
+
+            case REMOVE_ALL_EXCEPT_SEARCH:
+                menu.removeItem(R.id.action_sort);
+                menu.removeItem(R.id.action_switch_view);
+                menu.removeItem(R.id.action_sync_account);
+                mSwitchGridViewButton.setVisibility(View.VISIBLE);
+                mSortButton.setVisibility(View.VISIBLE);
+                break;
+
+            case DO_NOTHING:
+            default:
+                Log_OC.v(TAG, "Kept the options menu default structure");
+                break;
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
@@ -283,7 +283,6 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
             menu.findItem(R.id.action_move),
             menu.findItem(R.id.action_download_file),
             menu.findItem(R.id.action_sync_file),
-            menu.findItem(R.id.action_sync_account),
             menu.findItem(R.id.action_favorite),
             menu.findItem(R.id.action_unset_favorite)
         );

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -144,7 +144,6 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
 
-        menu.findItem(R.id.action_sync_account).setVisible(false);
         menu.findItem(R.id.action_sort).setVisible(false);
         menu.findItem(R.id.action_switch_view).setVisible(false);
     }

--- a/src/main/res/menu/activity_file_display.xml
+++ b/src/main/res/menu/activity_file_display.xml
@@ -40,13 +40,6 @@
         android:orderInCategory="2"
         app:showAsAction="never"
         android:title="@string/action_switch_grid_view" />
-    <item
-        android:id="@+id/action_sync_account"
-        android:icon="@drawable/ic_action_refresh"
-        android:orderInCategory="1"
-        app:showAsAction="never"
-        android:title="@string/actionbar_sync"
-        android:contentDescription="@string/actionbar_sync"/>
 	<item
         android:id="@+id/action_sort"
         android:icon="@drawable/ic_sort_variant"

--- a/src/main/res/menu/activity_file_display.xml
+++ b/src/main/res/menu/activity_file_display.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
@@ -18,41 +17,22 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:id="@+id/action_search"
-          android:icon="@drawable/ic_search"
-          android:title="@string/actionbar_search"
-          android:contentDescription="@string/actionbar_search"
+    <item
+        android:id="@+id/action_search"
+        android:contentDescription="@string/actionbar_search"
+        android:icon="@drawable/ic_search"
+        android:title="@string/actionbar_search"
         app:actionViewClass="androidx.appcompat.widget.SearchView"
-          app:showAsAction="ifRoom"/>
-    <item
-        android:id="@+id/action_create_dir"
-        android:icon="@drawable/ic_action_create_dir"
-        android:orderInCategory="1"
-        app:showAsAction="never"
-        android:title="@string/actionbar_mkdir"
-        android:contentDescription="@string/actionbar_mkdir"/>
-    <item
-        android:id="@+id/action_switch_view"
-        android:icon="@drawable/ic_view_module"
-        android:orderInCategory="2"
-        app:showAsAction="never"
-        android:title="@string/action_switch_grid_view" />
-	<item
-        android:id="@+id/action_sort"
-        android:icon="@drawable/ic_sort_variant"
-        android:orderInCategory="1"
-        app:showAsAction="never"
-        android:title="@string/actionbar_sort"
-        android:contentDescription="@string/actionbar_sort"/>
+        app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/action_select_all"
+        android:contentDescription="@string/select_all"
         android:icon="@drawable/ic_select_all"
         android:orderInCategory="1"
-        app:showAsAction="never"
         android:title="@string/select_all"
-        android:contentDescription="@string/select_all"/>
+        app:showAsAction="never" />
 
 </menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <string name="about_version">version %1$s</string>
     <string name="about_version_with_build">version %1$s, build #%2$s</string>
     <string name="appbar_search_in">Search in %s</string>
-    <string name="actionbar_sync">Refresh account</string>
     <string name="actionbar_open_with">Open with</string>
     <string name="actionbar_mkdir">New folder</string>
     <string name="actionbar_settings">Settings</string>


### PR DESCRIPTION
Hi,

It removes the old menu items from FileDisplayActivity (and FolderPickerActivity) which fixes this issue : https://github.com/nextcloud/android/issues/6059, which belongs to this one : https://github.com/nextcloud/android/issues/5207#issuecomment-617270183

|Before|After|
|---|---|
|![Screenshot_1590664584](https://user-images.githubusercontent.com/7050479/83135421-1a286a80-a0e6-11ea-9aaf-1362a21cec0c.png)|![Screenshot_1590664735](https://user-images.githubusercontent.com/7050479/83135426-1b599780-a0e6-11ea-8c74-023b16388c5e.png)|
|![Screenshot_1590664587](https://user-images.githubusercontent.com/7050479/83135424-1b599780-a0e6-11ea-9ab9-f2c7bdfda8aa.png)|![Screenshot_1590664740](https://user-images.githubusercontent.com/7050479/83135427-1bf22e00-a0e6-11ea-8112-f6ba7d6e620a.png)

The "Refresh/Sync account" action is now relative to the Swipe Refresh (it'll be done at each refresh). 

_About dev, I changed this weird (and not so beautiful) function which allows to chose the display mode by a switch-case._

Thank you.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests written, or not not needed
