### PR TITLE
correct empty message for "on devices"

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1439,7 +1439,14 @@ public class FileDisplayActivity extends FileActivity
                 getFile().getFileLength() > 0 && getStorageManager().getFolderContent(getFile(), false).isEmpty()) {
                 ocFileListFragment.setEmptyListLoadingMessage();
             } else {
-                ocFileListFragment.setEmptyListMessage(ExtendedListFragment.SearchType.NO_SEARCH);
+                if (MainApp.isOnlyOnDevice()) {
+                    ocFileListFragment.setMessageForEmptyList(R.string.file_list_empty_headline,
+                                                              R.string.file_list_empty_on_device,
+                                                              R.drawable.ic_list_empty_folder,
+                                                              true);
+                } else {
+                    ocFileListFragment.setEmptyListMessage(ExtendedListFragment.SearchType.NO_SEARCH);
+                }
             }
         } else {
             Log_OC.e(TAG, "OCFileListFragment is null");

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -56,6 +56,7 @@ import com.elyeproj.loaderviewlibrary.LoaderImageView;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
@@ -822,6 +823,10 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private boolean shouldShowHeader() {
         if (currentDirectory == null) {
+            return false;
+        }
+
+        if (MainApp.isOnlyOnDevice()) {
             return false;
         }
 

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -268,7 +268,14 @@ public class ExtendedListFragment extends Fragment implements
                     if (currentVisibility == View.VISIBLE) {
                         setEmptyListMessage(SearchType.REGULAR_FILTER);
                     } else {
-                        setEmptyListMessage(SearchType.NO_SEARCH);
+                        if (MainApp.isOnlyOnDevice()) {
+                            setMessageForEmptyList(R.string.file_list_empty_headline,
+                                                   R.string.file_list_empty_on_device,
+                                                   R.drawable.ic_list_empty_folder,
+                                                   true);
+                        } else {
+                            setEmptyListMessage(ExtendedListFragment.SearchType.NO_SEARCH);
+                        }
                     }
 
                     oldVisibility = currentVisibility;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="file_list_empty_headline">No files here</string>
     <string name="folder_list_empty_headline">No folders here</string>
     <string name="file_list_empty">Upload some content or sync with your devices.</string>
+    <string name="file_list_empty_on_device">Downloaded files and folders will show up here.</string>
     <string name="file_list_empty_favorites_filter_list">Files and folders you mark as favorites will show up here.</string>
     <string name="file_list_empty_favorites_filter">Your search returned no favorited files.</string>
     <string name="file_list_loading">Loading…</string>


### PR DESCRIPTION
- go to "on devices"
- see ![2020-05-28-133023](https://user-images.githubusercontent.com/5836855/83136222-6627df00-a0e7-11ea-85c2-5eb304673367.png)
- go to any empty folder on cloud
- see 
![2020-05-28-133001](https://user-images.githubusercontent.com/5836855/83136249-7475fb00-a0e7-11ea-9dbe-0ee981247a73.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
