### PR TITLE
refresh favorites result in actually reloading favorites

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1760,7 +1760,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
             event.getSearchType() != null &&
             (!TextUtils.isEmpty(event.getSearchQuery()) ||
                 event.searchType == SearchRemoteOperation.SearchType.SHARED_SEARCH ||
-                event.searchType == SearchRemoteOperation.SearchType.SHARED_FILTER);
+                event.searchType == SearchRemoteOperation.SearchType.SHARED_FILTER ||
+                event.searchType == SearchRemoteOperation.SearchType.FAVORITE_SEARCH);
     }
 
     private void syncAndCheckFiles(Collection<OCFile> files) {


### PR DESCRIPTION
Fix #4664

- open favorites
- wait for them to be loaded
- swipe to refresh
- see favorites again (previously it was all files)
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
