### PR TITLE
Enhance synced folder dialog, if disabled

### DIFF
--- a/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -24,6 +24,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
@@ -298,6 +299,12 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
     }
 
     private void checkWritableFolder() {
+        if (!mSyncedFolder.isEnabled()) {
+            mView.findViewById(R.id.setting_instant_behaviour_container).setEnabled(false);
+            mView.findViewById(R.id.setting_instant_behaviour_container).setAlpha(alphaDisabled);
+            return;
+        }
+
         if (mSyncedFolder.getLocalPath() != null && new File(mSyncedFolder.getLocalPath()).canWrite()) {
             mView.findViewById(R.id.setting_instant_behaviour_container).setEnabled(true);
             mView.findViewById(R.id.setting_instant_behaviour_container).setAlpha(alphaEnabled);
@@ -339,6 +346,22 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
 
         view.findViewById(R.id.local_folder_container).setEnabled(enable);
         view.findViewById(R.id.local_folder_container).setAlpha(alpha);
+
+        view.findViewById(R.id.setting_instant_name_collision_policy_container).setEnabled(enable);
+        view.findViewById(R.id.setting_instant_name_collision_policy_container).setAlpha(alpha);
+
+        if (enable) {
+            int accentColor = ThemeUtils.primaryAccentColor(getContext());
+            ThemeUtils.tintCheckbox(mUploadOnWifiCheckbox, accentColor);
+            ThemeUtils.tintCheckbox(mUploadOnChargingCheckbox, accentColor);
+            ThemeUtils.tintCheckbox(mUploadExistingCheckbox, accentColor);
+            ThemeUtils.tintCheckbox(mUploadUseSubfoldersCheckbox, accentColor);
+        } else {
+            ThemeUtils.tintCheckbox(mUploadOnWifiCheckbox, Color.GRAY);
+            ThemeUtils.tintCheckbox(mUploadOnChargingCheckbox, Color.GRAY);
+            ThemeUtils.tintCheckbox(mUploadExistingCheckbox, Color.GRAY);
+            ThemeUtils.tintCheckbox(mUploadUseSubfoldersCheckbox, Color.GRAY);
+        }
 
         checkWritableFolder();
     }


### PR DESCRIPTION
Fix #5279

- do not allow to click on any item
- checkboxes are grey

![2020-05-28-152029](https://user-images.githubusercontent.com/5836855/83146743-033e4400-a0f7-11ea-97da-4d2ccfaac6c6.png) ![2020-05-28-152033](https://user-images.githubusercontent.com/5836855/83146747-03d6da80-a0f7-11ea-8d08-79fd68029a98.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
