### PR TITLE
Change IDE Kotlin code formatter to follow official recommendations

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -61,6 +61,7 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="120" />
@@ -192,9 +193,6 @@
           </section>
         </rules>
       </arrangement>
-    </codeStyleSettings>
-    <codeStyleSettings language="kotlin">
-      <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
     </codeStyleSettings>
   </code_scheme>
 </component>


### PR DESCRIPTION
From https://developer.android.com/kotlin/style-guide

> When a function signature does not fit on a single line, break each
> parameter declaration onto its own line.Parameters defined in this
> format should use a single indent (+4). The closing parenthesis ())
> and return type are placed on their own line with no additional
> indent.
> ```kotlin
> fun <T> Iterable<T>.joinToString(
>     separator: CharSequence = ", ",
>     prefix: CharSequence = "",
>     postfix: CharSequence = ""
> ): String {
>     // …
> }
> ```

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] Tests not needed - this is IDE configuration change
