### PR TITLE
Applied a new fallback color for DarkMode

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -709,14 +709,12 @@ public abstract class DrawerActivity extends ToolbarActivity
             for (int i = 0; i < mNavigationView.getMenu().size(); i++) {
                 MenuItem menuItem = mNavigationView.getMenu().getItem(i);
                 if (menuItem.getIcon() != null) {
-                    // For the others item
-                    if (menuItem != currentItem) {
-                        ThemeUtils.tintDrawable(menuItem.getIcon(), drawerColor);
-                        ThemeUtils.tintMenuItemText(menuItem, drawerColor);
-                    } else {
-                        // For the selected item
+                    if (menuItem == currentItem) {
                         ThemeUtils.tintDrawable(currentItem.getIcon(), activeColor);
                         ThemeUtils.tintMenuItemText(currentItem, activeColor);
+                    } else {
+                        ThemeUtils.tintDrawable(menuItem.getIcon(), drawerColor);
+                        ThemeUtils.tintMenuItemText(menuItem, drawerColor);
                     }
                 }
             }

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -709,10 +709,12 @@ public abstract class DrawerActivity extends ToolbarActivity
             for (int i = 0; i < mNavigationView.getMenu().size(); i++) {
                 MenuItem menuItem = mNavigationView.getMenu().getItem(i);
                 if (menuItem.getIcon() != null) {
+                    // For the others item
                     if (menuItem != currentItem) {
                         ThemeUtils.tintDrawable(menuItem.getIcon(), drawerColor);
                         ThemeUtils.tintMenuItemText(menuItem, drawerColor);
                     } else {
+                        // For the selected item
                         ThemeUtils.tintDrawable(currentItem.getIcon(), activeColor);
                         ThemeUtils.tintMenuItemText(currentItem, activeColor);
                     }

--- a/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SortingOrderDialogFragment.java
@@ -130,7 +130,7 @@ public class SortingOrderDialogFragment extends DialogFragment {
      * tints the icon reflecting the actual sorting choice in the apps primary color.
      */
     private void setupActiveOrderSelection() {
-        final int color = ThemeUtils.primaryAccentColor(getContext());
+        final int color = ThemeUtils.elementColor(getContext());
         for (View view: mTaggedViews) {
             if (!((FileSortOrder) view.getTag()).name.equals(mCurrentSortOrderName)) {
                 continue;

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -42,6 +42,7 @@
     <color name="switch_thumb_color_unchecked">#2a2a2a</color>
     <color name="switch_track_color_unchecked">#B3FFFFFF</color>
     <color name="drawer_active_item_background">@color/white</color>
+    <color name="element_fallback_color">#EDEDED</color>
 
     <!-- App bar -->
     <color name="appbar">#1E1E1E</color>

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -36,6 +36,7 @@
     <color name="selected_item_background">#373535</color>
 
     <color name="filelist_icon_background">#222222</color>
+    <color name="standard_grey">#DADADA</color>
 
     <color name="drawer_menu_icon">#ffffff</color>
     <color name="bg_fallback_highlight">#737373</color>


### PR DESCRIPTION
Hi, 

It fixes : https://github.com/nextcloud/android/issues/6197 AND https://github.com/nextcloud/android/issues/6195

|Mode|Before|After
|---|---|---|
|Dark|![Capture d’écran 2020-06-02 à 16 40 17](https://user-images.githubusercontent.com/7050479/83533454-e5565200-a4ef-11ea-889c-aebad963a555.png)|![Capture d’écran 2020-06-02 à 16 28 26](https://user-images.githubusercontent.com/7050479/83533469-e8e9d900-a4ef-11ea-8c38-eabb8a7c1b16.png)|
Light|![Capture d’écran 2020-06-02 à 16 40 31](https://user-images.githubusercontent.com/7050479/83533497-ef785080-a4ef-11ea-853c-ed4a3dfb83b2.png)|![Capture d’écran 2020-06-02 à 16 28 17](https://user-images.githubusercontent.com/7050479/83533507-f30bd780-a4ef-11ea-9fb8-68cfe84d3cf9.png)


I just changed the fallback color for darkmode

Need @tobiasKaminsky @AndyScherzinger and @jancborchardt approbation :)

Thank you

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests written, or not not needed (just a small visual thing)
