### PR TITLE
Fixed a bug relative to actionmode + Enhanced actionmode behaviour

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -890,7 +890,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
     public boolean onLongItemClicked(OCFile file) {
         FragmentActivity actionBarActivity = getActivity();
         if (actionBarActivity != null) {
-            // Create only once instance of action method
+            // Create only once instance of action mode
             if (mActiveActionMode != null) {
                 toggleItemToCheckedList(file);
             } else {


### PR DESCRIPTION
Hi,

It fixes : https://github.com/nextcloud/android/issues/6206
And enhance a bit the actionmode (now the long-click on an item just selects the item instead of completely reseting the selected files).

![demo](https://user-images.githubusercontent.com/7050479/83762866-4f016800-a678-11ea-81bb-721ae2bf7eea.gif)

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [X] Tests written, or not not needed
