### PR TITLE
Fix crash when creating client

### DIFF
--- a/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
@@ -31,6 +31,7 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientFactory;
+import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 
 import java.io.IOException;
@@ -46,11 +47,10 @@ class ClientFactoryImpl implements ClientFactory {
     @Override
     public OwnCloudClient create(User user) throws CreationException {
         try {
-            return OwnCloudClientFactory.createOwnCloudClient(user.toPlatformAccount(), context);
+            return OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(user.toOwnCloudAccount(), context);
         } catch (OperationCanceledException|
                  AuthenticatorException|
-                 IOException|
-                 AccountUtils.AccountNotFoundException e) {
+            IOException e) {
             throw new CreationException(e);
         }
     }


### PR DESCRIPTION
Fix #6212

This is not an ideal solution, but it works for now.
I will open & assign an issue to me, that all client creations must be centralized & non blocking, so that they can used on ui thread.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
