### PR TITLE
Activity stream on dark mode

### DIFF
--- a/drawable_resources/shared_via_link.svg
+++ b/drawable_resources/shared_via_link.svg
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:cc="http://creativecommons.org/ns#"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns="http://www.w3.org/2000/svg"
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg"
     xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-    height="16"
-    width="16"
-    version="1.1"
-    id="svg8"
-    sodipodi:docname="shared_via_link.svg"
-    inkscape:version="0.92.2 2405546, 2018-03-11"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:export-ydpi="384" inkscape:export-xdpi="384"
     inkscape:export-filename="C:\DEV\src\Android\Nextcloud\greySharedIndicator\res\drawable-xxxhdpi\shared_via_link.png"
-    inkscape:export-xdpi="384"
-    inkscape:export-ydpi="384">
+    inkscape:version="1.0 (4035a4fb49, 2020-05-01)" sodipodi:docname="shared_via_link.svg" id="svg8" version="1.1"
+    width="16" height="16">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -28,37 +19,18 @@
   </metadata>
   <defs
      id="defs12" />
-  <sodipodi:namedview
-      pagecolor="#ffffff"
-      bordercolor="#666666"
-      borderopacity="1"
-      objecttolerance="10"
-      gridtolerance="10"
-      guidetolerance="10"
-      inkscape:pageopacity="0"
-      inkscape:pageshadow="2"
-      inkscape:window-width="1600"
-      inkscape:window-height="871"
-      id="namedview10"
-      showgrid="false"
-      inkscape:zoom="29.5"
-      inkscape:cx="-1.1061145"
-      inkscape:cy="7.2856262"
-      inkscape:window-x="1600"
-      inkscape:window-y="0"
-      inkscape:window-maximized="1"
-      inkscape:current-layer="svg8"/>
-  <g
-      color="#000"
-      id="g6"
-      style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.8">
-    <path
-        style="block-progression:tb;text-transform:none;text-indent:0;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+  <sodipodi:namedview inkscape:document-rotation="0" inkscape:current-layer="g6" inkscape:window-maximized="1"
+      inkscape:window-y="0" inkscape:window-x="0" inkscape:cy="8.0173062" inkscape:cx="5.9813853"
+      inkscape:zoom="41.7193" showgrid="false" id="namedview10" inkscape:window-height="1141"
+      inkscape:window-width="1920" inkscape:pageshadow="2" inkscape:pageopacity="0" guidetolerance="10"
+      gridtolerance="10" objecttolerance="10" borderopacity="1" bordercolor="#666666" pagecolor="#ffffff" />
+  <g style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.8"
+      id="g6" color="#000">
+    <path id="path2"
         d="M5.99 5.318a3.332 3.332 0 0 0 0 4.693c.116.118.226.22.355.315l1.383-1.383A1.4 1.4 0 0 1 7.33 6.66l3.352-3.352c.568-.57 1.442-.57 2.01 0s.57 1.442 0 2.01l-1.13 1.132c.34.725.464 1.518.377 2.304l2.094-2.095c1.288-1.29 1.288-3.406 0-4.694s-3.405-1.288-4.693 0L5.99 5.318z"
-        id="path2"/>
-    <path
-        style="block-progression:tb;text-transform:none;text-indent:0;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+        style="block-progression:tb;text-transform:none;text-indent:0;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path id="path4"
         d="M10.01 10.68a3.332 3.332 0 0 0 0-4.692 3.126 3.126 0 0 0-.355-.314L8.272 7.057A1.4 1.4 0 0 1 8.67 9.34l-3.35 3.35c-.57.57-1.444.57-2.013.002s-.568-1.442 0-2.01L4.44 9.55a4.288 4.288 0 0 1-.38-2.305L1.967 9.34c-1.288 1.29-1.288 3.405 0 4.693s3.405 1.29 4.693 0l3.35-3.352z"
-        id="path4"/>
+        style="block-progression:tb;text-transform:none;text-indent:0;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none" />
   </g>
 </svg>

--- a/src/main/java/com/owncloud/android/utils/svg/SvgBitmapTranscoder.java
+++ b/src/main/java/com/owncloud/android/utils/svg/SvgBitmapTranscoder.java
@@ -1,0 +1,73 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.utils.svg;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.resource.SimpleResource;
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder;
+import com.caverock.androidsvg.SVG;
+import com.caverock.androidsvg.SVGParseException;
+import com.owncloud.android.lib.common.utils.Log_OC;
+
+/**
+ * Convert the {@link SVG}'s internal representation to a Bitmap.
+ */
+public class SvgBitmapTranscoder implements ResourceTranscoder<SVG, Bitmap> {
+    private int width;
+    private int height;
+
+    public SvgBitmapTranscoder(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    @Override
+    public Resource<Bitmap> transcode(Resource<SVG> toTranscode) {
+        SVG svg = toTranscode.get();
+
+        svg.setDocumentViewBox(0, 0, svg.getDocumentWidth(), svg.getDocumentHeight());
+
+        try {
+            svg.setDocumentHeight("100%");
+            svg.setDocumentWidth("100%");
+        } catch (SVGParseException e) {
+            Log_OC.e(this, "Could not set document size. Output might have wrong size");
+        }
+
+        // Create a canvas to draw onto
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+
+        // Render our document onto our canvas
+        svg.renderToCanvas(canvas);
+
+        return new SimpleResource<>(bitmap);
+    }
+
+    @Override
+    public String getId() {
+        return "";
+    }
+}

--- a/src/main/res/drawable-night/shared_via_link.xml
+++ b/src/main/res/drawable-night/shared_via_link.xml
@@ -23,14 +23,14 @@
         android:viewportHeight="16.0">
 	<path
         android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="0.2"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="0.0"
         android:strokeMiterLimit="4"
         android:pathData="M5.99 5.318a3.332 3.332 0 0 0 0 4.693c 0.116 0.118 0.226 0.22 0.355 0.315l1.383-1.383A1.4 1.4 0 0 1 7.33 6.66l3.352-3.352c 0.568-0.57 1.442-0.57 2.01 0s 0.57 1.442 0 2.01l-1.13 1.132c 0.34 0.725 0.464 1.518 0.377 2.304l2.094-2.095c1.288-1.29 1.288-3.406 0-4.694s-3.405-1.288-4.693 0L5.99 5.318z"/>
     <path
         android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="0.2"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="0.0"
         android:strokeMiterLimit="4"
         android:pathData="M10.01 10.68a3.332 3.332 0 0 0 0-4.692 3.126 3.126 0 0 0-0.355-0.314L8.272 7.057A1.4 1.4 0 0 1 8.67 9.34l-3.35 3.35c-0.57 0.57-1.444 0.57-2.013 0.002s-0.568-1.442 0-2.01L4.44 9.55a4.288 4.288 0 0 1-0.38-2.305L1.967 9.34c-1.288 1.29-1.288 3.405 0 4.693s3.405 1.29 4.693 0l3.35-3.352z"/>
 </vector>

--- a/src/main/res/drawable/shared_via_link.xml
+++ b/src/main/res/drawable/shared_via_link.xml
@@ -23,14 +23,14 @@
         android:viewportHeight="16.0">
 	<path
         android:fillColor="#FF000000"
-        android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="0.2"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.0"
         android:strokeMiterLimit="4"
         android:pathData="M5.99 5.318a3.332 3.332 0 0 0 0 4.693c 0.116 0.118 0.226 0.22 0.355 0.315l1.383-1.383A1.4 1.4 0 0 1 7.33 6.66l3.352-3.352c 0.568-0.57 1.442-0.57 2.01 0s 0.57 1.442 0 2.01l-1.13 1.132c 0.34 0.725 0.464 1.518 0.377 2.304l2.094-2.095c1.288-1.29 1.288-3.406 0-4.694s-3.405-1.288-4.693 0L5.99 5.318z"/>
     <path
         android:fillColor="#FF000000"
-        android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="0.2"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.0"
         android:strokeMiterLimit="4"
         android:pathData="M10.01 10.68a3.332 3.332 0 0 0 0-4.692 3.126 3.126 0 0 0-0.355-0.314L8.272 7.057A1.4 1.4 0 0 1 8.67 9.34l-3.35 3.35c-0.57 0.57-1.444 0.57-2.013 0.002s-0.568-1.442 0-2.01L4.44 9.55a4.288 4.288 0 0 1-0.38-2.305L1.967 9.34c-1.288 1.29-1.288 3.405 0 4.693s3.405 1.29 4.693 0l3.35-3.352z"/>
 </vector>

--- a/src/main/res/layout/activity_list_item.xml
+++ b/src/main/res/layout/activity_list_item.xml
@@ -36,7 +36,6 @@
         android:layout_marginTop="@dimen/standard_margin"
         android:alpha="0.5"
         android:padding="2dp"
-        android:background="@drawable/round_bgnd_icons"
         android:contentDescription="@string/activity_icon"
         android:src="@drawable/ic_activity" />
 


### PR DESCRIPTION
Fix last issue on https://github.com/nextcloud/android/issues/5353

- invert activity icon on dark mode
- removed outer white border on shared_via_ink

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed

![2020-06-05-114401](https://user-images.githubusercontent.com/5836855/83862458-41a0b800-a722-11ea-85ae-be9d1702205c.png) ![2020-06-05-114408](https://user-images.githubusercontent.com/5836855/83862460-42394e80-a722-11ea-8e14-687966f9419d.png)

As we have some alpha in it, visually change is not that big…