### PR TITLE
fix #5281: click on conflict notification opens conflict dialog directly

### DIFF
--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -233,11 +233,11 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                     if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {
                         // ISSUE 5: if the user is not running the app (this is a service!),
                         // this can be very intrusive; a notification should be preferred
-                        Intent i = new Intent(context, ConflictsResolveActivity.class);
-                        i.setFlags(i.getFlags() | Intent.FLAG_ACTIVITY_NEW_TASK);
-                        i.putExtra(ConflictsResolveActivity.EXTRA_FILE, finalFile);
-                        i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, user.toPlatformAccount());
-                        context.startActivity(i);
+                        Intent intent = ConflictsResolveActivity.createIntent(finalFile,
+                                                                              user.toPlatformAccount(),
+                                                                              Intent.FLAG_ACTIVITY_NEW_TASK,
+                                                                              context);
+                        context.startActivity(intent);
                     } else {
                         FileStorageUtils.checkIfFileFinishedSaving(finalFile);
                         if (!result.isSuccess()) {

--- a/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
@@ -17,6 +17,8 @@
 
 package com.owncloud.android.ui.activity;
 
+import android.accounts.Account;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
@@ -68,6 +70,17 @@ public class ConflictsResolveActivity extends FileActivity implements OnConflict
     private OCFile newFile;
     private int localBehaviour = FileUploader.LOCAL_BEHAVIOUR_FORGET;
     protected OnConflictDecisionMadeListener listener;
+
+    public static Intent createIntent(OCFile file, Account account, Integer flag, Context context) {
+        Intent intent = new Intent(context, ConflictsResolveActivity.class);
+        if (flag != null) {
+            intent.setFlags(intent.getFlags() | flag);
+        }
+        intent.putExtra(ConflictsResolveActivity.EXTRA_FILE, file);
+        intent.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, account);
+
+        return intent;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -470,10 +470,8 @@ public abstract class FileActivity extends DrawerActivity
         OCFile syncedFile = operation.getLocalFile();
         if (!result.isSuccess()) {
             if (result.getCode() == ResultCode.SYNC_CONFLICT) {
-                Intent i = new Intent(this, ConflictsResolveActivity.class);
-                i.putExtra(ConflictsResolveActivity.EXTRA_FILE, syncedFile); // must be new file
-                i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, getAccount());
-                startActivity(i);
+                Intent intent = ConflictsResolveActivity.createIntent(syncedFile, getAccount(), null, this);
+                startActivity(intent);
             }
 
         } else {

--- a/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -37,15 +37,14 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.core.Clock;
 import com.nextcloud.client.device.PowerManagementService;
 import com.nextcloud.client.jobs.BackgroundJobManager;
 import com.nextcloud.client.network.ConnectivityService;
-import com.nextcloud.java.util.Optional;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadListLayoutBinding;
+import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.UploadsStorageManager;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;
@@ -97,6 +96,17 @@ public class UploadListActivity extends FileActivity {
     BackgroundJobManager backgroundJobManager;
 
     private UploadListLayoutBinding binding;
+
+    public static Intent createIntent(OCFile file, Account account, Integer flag, Context context) {
+        Intent intent = new Intent(context, UploadListActivity.class);
+        if (flag != null) {
+            intent.setFlags(intent.getFlags() | flag);
+        }
+        intent.putExtra(ConflictsResolveActivity.EXTRA_FILE, file);
+        intent.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, account);
+
+        return intent;
+    }
 
     @Override
     public void showFiles(boolean onDeviceOnly) {

--- a/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -566,12 +566,12 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         file.setStoragePath(upload.getLocalPath());
 
         Context context = MainApp.getAppContext();
-        Intent i = new Intent(context, ConflictsResolveActivity.class);
-        i.setFlags(i.getFlags() | Intent.FLAG_ACTIVITY_NEW_TASK);
-        i.putExtra(ConflictsResolveActivity.EXTRA_FILE, file);
-        i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, upload.getAccount(accountManager));
-        i.putExtra(ConflictsResolveActivity.EXTRA_CONFLICT_UPLOAD, upload);
-        context.startActivity(i);
+        Intent intent = ConflictsResolveActivity.createIntent(file,
+                                                              upload.getAccount(accountManager),
+                                                              Intent.FLAG_ACTIVITY_NEW_TASK,
+                                                              context);
+
+        context.startActivity(intent);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -249,11 +249,12 @@ public class FileOperationsHelper {
         if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {
             // ISSUE 5: if the user is not running the app (this is a service!),
             // this can be very intrusive; a notification should be preferred
-            Intent i = new Intent(fileActivity, ConflictsResolveActivity.class);
-            i.setFlags(i.getFlags() | Intent.FLAG_ACTIVITY_NEW_TASK);
-            i.putExtra(ConflictsResolveActivity.EXTRA_FILE, file);
-            i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, user.toPlatformAccount());
-            fileActivity.startActivity(i);
+            Intent intent = ConflictsResolveActivity.createIntent(file,
+                                                                  user.toPlatformAccount(),
+                                                                  Intent.FLAG_ACTIVITY_NEW_TASK,
+                                                                  fileActivity);
+
+            fileActivity.startActivity(intent);
         } else {
             if (file.isDown()) {
                 FileStorageUtils.checkIfFileFinishedSaving(file);
@@ -317,11 +318,11 @@ public class FileOperationsHelper {
                     if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {
                         // ISSUE 5: if the user is not running the app (this is a service!),
                         // this can be very intrusive; a notification should be preferred
-                        Intent i = new Intent(fileActivity, ConflictsResolveActivity.class);
-                        i.setFlags(i.getFlags() | Intent.FLAG_ACTIVITY_NEW_TASK);
-                        i.putExtra(ConflictsResolveActivity.EXTRA_FILE, file);
-                        i.putExtra(ConflictsResolveActivity.EXTRA_ACCOUNT, user.toPlatformAccount());
-                        fileActivity.startActivity(i);
+                        Intent intent = ConflictsResolveActivity.createIntent(file,
+                                                                              user.toPlatformAccount(),
+                                                                              Intent.FLAG_ACTIVITY_NEW_TASK,
+                                                                              fileActivity);
+                        fileActivity.startActivity(intent);
                     } else {
                         if (!launchables.isEmpty()) {
                             try {


### PR DESCRIPTION
fix #5281

centralize intent creation for
- FileUploader
- ConflictsResolveActivity



Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
