### PR TITLE
Properly align 3-dot menu of folder items

### DIFF
--- a/src/main/res/layout/synced_folders_item_header.xml
+++ b/src/main/res/layout/synced_folders_item_header.xml
@@ -68,7 +68,7 @@
         <ImageButton
             android:id="@+id/syncStatusButton"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:background="@color/transparent"
             android:clickable="true"
             android:contentDescription="@string/sync_status_button"
@@ -79,15 +79,13 @@
         <ImageButton
             android:id="@+id/settingsButton"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:background="@color/transparent"
             android:clickable="true"
             android:contentDescription="@string/synced_folder_settings_button"
             android:focusable="true"
-            android:paddingBottom="@dimen/standard_half_padding"
-            android:paddingEnd="@dimen/standard_padding"
+            android:paddingEnd="@dimen/synced_folder_padding_end"
             android:paddingStart="@dimen/standard_half_padding"
-            android:paddingTop="@dimen/standard_half_padding"
-            android:src="@drawable/ic_dots_vertical" />
+            android:src="@drawable/ic_dots_vertical"/>
     </LinearLayout>
 </RelativeLayout>

--- a/src/main/res/layout/trashbin_item.xml
+++ b/src/main/res/layout/trashbin_item.xml
@@ -144,8 +144,6 @@
                 android:contentDescription="@string/overflow_menu"
                 android:focusable="true"
                 android:paddingEnd="@dimen/alternate_padding"
-                android:paddingLeft="@dimen/standard_half_padding"
-                android:paddingRight="@dimen/standard_half_padding"
                 android:paddingStart="@dimen/standard_half_padding"
                 android:src="@drawable/ic_dots_vertical"/>
 

--- a/src/main/res/values/dims.xml
+++ b/src/main/res/values/dims.xml
@@ -53,6 +53,7 @@
     <dimen name="alternate_margin">10dp</dimen>
     <dimen name="alternate_half_margin">5dp</dimen>
     <dimen name="alternate_padding">10dp</dimen>
+    <dimen name="synced_folder_padding_end">10dp</dimen>
     <dimen name="alternate_half_padding">5dp</dimen>
     <dimen name="alternate_padding_right">55dp</dimen>
     <dimen name="display_text_min_height">32dp</dimen>


### PR DESCRIPTION
Fixes #6259

<img width="540" alt="device-2020-06-10-175440" src="https://user-images.githubusercontent.com/1315170/84290114-9342ab80-ab43-11ea-87b7-4131849f768e.png">
