### PR TITLE
Drop Android 4.2 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 18
         targetSdkVersion 29
 
         // arguments to be passed to functional tests

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -473,12 +473,10 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
                                                       connectivityService,
                                                       powerManagementService);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            ReceiversHelper.registerPowerChangeReceiver(uploadsStorageManager,
-                                                        accountManager,
-                                                        connectivityService,
-                                                        powerManagementService);
-        }
+        ReceiversHelper.registerPowerChangeReceiver(uploadsStorageManager,
+                                                    accountManager,
+                                                    connectivityService,
+                                                    powerManagementService);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             ReceiversHelper.registerPowerSaveReceiver(uploadsStorageManager,

--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -449,11 +449,8 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             return DisplayUtils.getRelativeDateTimeString(context, modificationTimestamp, DateUtils.DAY_IN_MILLIS,
                                                           DateUtils.WEEK_IN_MILLIS, 0);
         } else {
-            String pattern = "EEEE, MMMM d";
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                pattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), "EEEE, MMMM d");
-            }
-            return DateFormat.format(pattern, modificationTimestamp);
+            return DateFormat.format(DateFormat.getBestDateTimePattern(
+                Locale.getDefault(), "EEEE, MMMM d"), modificationTimestamp);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -230,9 +230,8 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         }
 
         mUploadOnWifiCheckbox.setChecked(mSyncedFolder.isWifiOnly());
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            mUploadOnChargingCheckbox.setChecked(mSyncedFolder.isChargingOnly());
-        }
+        mUploadOnChargingCheckbox.setChecked(mSyncedFolder.isChargingOnly());
+
         mUploadExistingCheckbox.setChecked(mSyncedFolder.isExisting());
         mUploadUseSubfoldersCheckbox.setChecked(mSyncedFolder.isSubfolderByDate());
 
@@ -330,10 +329,8 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         view.findViewById(R.id.setting_instant_upload_on_wifi_container).setEnabled(enable);
         view.findViewById(R.id.setting_instant_upload_on_wifi_container).setAlpha(alpha);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            view.findViewById(R.id.setting_instant_upload_on_charging_container).setEnabled(enable);
-            view.findViewById(R.id.setting_instant_upload_on_charging_container).setAlpha(alpha);
-        }
+        view.findViewById(R.id.setting_instant_upload_on_charging_container).setEnabled(enable);
+        view.findViewById(R.id.setting_instant_upload_on_charging_container).setAlpha(alpha);
 
         view.findViewById(R.id.setting_instant_upload_existing_container).setEnabled(enable);
         view.findViewById(R.id.setting_instant_upload_existing_container).setAlpha(alpha);
@@ -377,25 +374,22 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment {
         view.findViewById(R.id.delete).setOnClickListener(new OnSyncedFolderDeleteClickListener());
 
         view.findViewById(R.id.setting_instant_upload_on_wifi_container).setOnClickListener(
-                new OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        mSyncedFolder.setWifiOnly(!mSyncedFolder.isWifiOnly());
-                        mUploadOnWifiCheckbox.toggle();
-                    }
-                });
+            new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mSyncedFolder.setWifiOnly(!mSyncedFolder.isWifiOnly());
+                    mUploadOnWifiCheckbox.toggle();
+                }
+            });
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-
-            view.findViewById(R.id.setting_instant_upload_on_charging_container).setOnClickListener(
-                    new OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            mSyncedFolder.setChargingOnly(!mSyncedFolder.isChargingOnly());
-                            mUploadOnChargingCheckbox.toggle();
-                        }
-                    });
-        }
+        view.findViewById(R.id.setting_instant_upload_on_charging_container).setOnClickListener(
+            new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mSyncedFolder.setChargingOnly(!mSyncedFolder.isChargingOnly());
+                    mUploadOnChargingCheckbox.toggle();
+                }
+            });
 
         view.findViewById(R.id.setting_instant_upload_existing_container).setOnClickListener(
               new OnClickListener() {

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -428,10 +428,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
     public void uploadFromApp() {
         Intent action = new Intent(Intent.ACTION_GET_CONTENT);
         action = action.setType("*/*").addCategory(Intent.CATEGORY_OPENABLE);
-        //Intent.EXTRA_ALLOW_MULTIPLE is only supported on api level 18+, Jelly Bean
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            action.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-        }
+        action.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+
         getActivity().startActivityForResult(
                 Intent.createChooser(action, getString(R.string.upload_chooser_title)),
                 FileDisplayActivity.REQUEST_CODE__SELECT_CONTENT_FROM_APPS

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -1057,14 +1057,6 @@ public class FileOperationsHelper {
             return -1L;
         }
 
-        long availableBytesOnDevice;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            availableBytesOnDevice = stat.getBlockSizeLong() * stat.getAvailableBlocksLong();
-        } else {
-            availableBytesOnDevice = (long) stat.getBlockSize() * (long) stat.getAvailableBlocks();
-        }
-
-        return availableBytesOnDevice;
+        return stat.getBlockSizeLong() * stat.getAvailableBlocksLong();
     }
-
 }


### PR DESCRIPTION
Resolves #6276

Bumping min. Android version from 4.2 to 4.3 as a follow-up to release 3.12.0

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
