### PR TITLE
#6247 View Binding - FileDisplayActivity and partial Ssl views

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -59,6 +59,7 @@ import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.java.util.Optional;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
+import com.owncloud.android.databinding.FilesBinding;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.VirtualFolderType;
@@ -162,14 +163,14 @@ public class FileDisplayActivity extends FileActivity
     public static final String ALL_FILES = "ALL_FILES";
     public static final String PHOTO_SEARCH = "PHOTO_SEARCH";
 
+    private FilesBinding binding;
+
     private SyncBroadcastReceiver mSyncBroadcastReceiver;
     private UploadFinishReceiver mUploadFinishReceiver;
     private DownloadFinishReceiver mDownloadFinishReceiver;
     private RemoteOperationResult mLastSslUntrustedServerResult;
 
     private boolean mDualPane;
-    private View mLeftFragmentContainer;
-    private View mRightFragmentContainer;
 
     public static final String TAG_PUBLIC_LINK = "PUBLIC_LINK";
     public static final String FTAG_CHOOSER_DIALOG = "CHOOSER_DIALOG";
@@ -251,22 +252,17 @@ public class FileDisplayActivity extends FileActivity
         /// USER INTERFACE
 
         // Inflate and set the layout view
-        setContentView(R.layout.files);
+        binding = FilesBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
 
         // setup toolbar
         setupHomeSearchToolbar();
 
-        mMenuButton.setOnClickListener(v -> {
-            openDrawer();
-        });
+        mMenuButton.setOnClickListener(v -> openDrawer());
 
-        mSwitchAccountButton.setOnClickListener(v -> {
-            showManageAccountsDialog();
-        });
+        mSwitchAccountButton.setOnClickListener(v -> showManageAccountsDialog());
 
         mDualPane = getResources().getBoolean(R.bool.large_land_layout);
-        mLeftFragmentContainer = findViewById(R.id.left_fragment_container);
-        mRightFragmentContainer = findViewById(R.id.right_fragment_container);
 
         // Init Fragment without UI to retain AsyncTask across configuration changes
         FragmentManager fm = getSupportFragmentManager();
@@ -295,14 +291,10 @@ public class FileDisplayActivity extends FileActivity
             if (PermissionUtil.shouldShowRequestPermissionRationale(this,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                 // Show explanation to the user and then request permission
-                Snackbar snackbar = Snackbar.make(findViewById(R.id.ListLayout), R.string.permission_storage_access,
+                Snackbar snackbar = Snackbar.make(binding.ListLayout,
+                                                  R.string.permission_storage_access,
                         Snackbar.LENGTH_INDEFINITE)
-                        .setAction(R.string.common_ok, new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                PermissionUtil.requestWriteExternalStoreagePermission(FileDisplayActivity.this);
-                            }
-                        });
+                        .setAction(R.string.common_ok, v -> PermissionUtil.requestWriteExternalStoreagePermission(FileDisplayActivity.this));
                 ThemeUtils.colorSnackbar(this, snackbar);
                 snackbar.show();
             } else {
@@ -381,7 +373,7 @@ public class FileDisplayActivity extends FileActivity
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
         switch (requestCode) {
             case PermissionUtil.PERMISSIONS_WRITE_EXTERNAL_STORAGE: {
@@ -493,7 +485,7 @@ public class FileDisplayActivity extends FileActivity
         }
     }
 
-    //Is called with the flag FLAG_ACTIVITY_SINGLE_TOP and set the new file and intent
+    // Is called with the flag FLAG_ACTIVITY_SINGLE_TOP and set the new file and intent
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
@@ -631,27 +623,27 @@ public class FileDisplayActivity extends FileActivity
 
     private void updateFragmentsVisibility(boolean existsSecondFragment) {
         if (mDualPane) {
-            if (mLeftFragmentContainer.getVisibility() != View.VISIBLE) {
-                mLeftFragmentContainer.setVisibility(View.VISIBLE);
+            if (binding.leftFragmentContainer.getVisibility() != View.VISIBLE) {
+                binding.leftFragmentContainer.setVisibility(View.VISIBLE);
             }
-            if (mRightFragmentContainer.getVisibility() != View.VISIBLE) {
-                mRightFragmentContainer.setVisibility(View.VISIBLE);
+            if (binding.rightFragmentContainer.getVisibility() != View.VISIBLE) {
+                binding.rightFragmentContainer.setVisibility(View.VISIBLE);
             }
 
         } else if (existsSecondFragment) {
-            if (mLeftFragmentContainer.getVisibility() != View.GONE) {
-                mLeftFragmentContainer.setVisibility(View.GONE);
+            if (binding.leftFragmentContainer.getVisibility() != View.GONE) {
+                binding.leftFragmentContainer.setVisibility(View.GONE);
             }
-            if (mRightFragmentContainer.getVisibility() != View.VISIBLE) {
-                mRightFragmentContainer.setVisibility(View.VISIBLE);
+            if (binding.rightFragmentContainer.getVisibility() != View.VISIBLE) {
+                binding.rightFragmentContainer.setVisibility(View.VISIBLE);
             }
 
         } else {
-            if (mLeftFragmentContainer.getVisibility() != View.VISIBLE) {
-                mLeftFragmentContainer.setVisibility(View.VISIBLE);
+            if (binding.leftFragmentContainer.getVisibility() != View.VISIBLE) {
+                binding.leftFragmentContainer.setVisibility(View.VISIBLE);
             }
-            if (mRightFragmentContainer.getVisibility() != View.GONE) {
-                mRightFragmentContainer.setVisibility(View.GONE);
+            if (binding.rightFragmentContainer.getVisibility() != View.GONE) {
+                binding.rightFragmentContainer.setVisibility(View.GONE);
             }
         }
     }
@@ -1890,7 +1882,7 @@ public class FileDisplayActivity extends FileActivity
                     fileDetailFragment.getFileDetailSharingFragment().refreshPublicShareFromDB();
                 }
                 Snackbar snackbar = Snackbar.make(
-                        findViewById(android.R.id.content),
+                        binding.getRoot(),
                         ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
                         Snackbar.LENGTH_LONG
                 );

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -294,7 +294,7 @@ public class FileDisplayActivity extends FileActivity
                 Snackbar snackbar = Snackbar.make(binding.ListLayout,
                                                   R.string.permission_storage_access,
                         Snackbar.LENGTH_INDEFINITE)
-                        .setAction(R.string.common_ok, v -> PermissionUtil.requestWriteExternalStoreagePermission(FileDisplayActivity.this));
+                        .setAction(R.string.common_ok, v -> PermissionUtil.requestWriteExternalStoreagePermission(this));
                 ThemeUtils.colorSnackbar(this, snackbar);
                 snackbar.show();
             } else {

--- a/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
@@ -22,7 +22,7 @@ package com.owncloud.android.ui.adapter;
 
 import android.view.View;
 
-import com.owncloud.android.R;
+import com.owncloud.android.databinding.SslUntrustedCertLayoutBinding;
 import com.owncloud.android.lib.common.network.CertificateCombinedException;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 
@@ -30,44 +30,44 @@ import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
  * TODO
  */
 public class CertificateCombinedExceptionViewAdapter implements SslUntrustedCertDialog.ErrorViewAdapter {
-    
+
     //private final static String TAG = CertificateCombinedExceptionViewAdapter.class.getSimpleName();
-    
+
     private CertificateCombinedException mSslException;
-    
+
     public CertificateCombinedExceptionViewAdapter(CertificateCombinedException sslException) {
         mSslException = sslException;
     }
-    
+
     @Override
-    public void updateErrorView(View dialogView) {
+    public void updateErrorView(SslUntrustedCertLayoutBinding binding) {
         /// clean
-        dialogView.findViewById(R.id.reason_no_info_about_error).setVisibility(View.GONE);
-       
+        binding.reasonNoInfoAboutError.setVisibility(View.GONE);
+
         /// refresh
         if (mSslException.getCertPathValidatorException() != null) {
-            dialogView.findViewById(R.id.reason_cert_not_trusted).setVisibility(View.VISIBLE);
+            binding.reasonCertNotTrusted.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_cert_not_trusted).setVisibility(View.GONE);
+            binding.reasonCertNotTrusted.setVisibility(View.GONE);
         }
-        
+
         if (mSslException.getCertificateExpiredException() != null) {
-            dialogView.findViewById(R.id.reason_cert_expired).setVisibility(View.VISIBLE);
+            binding.reasonCertExpired.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_cert_expired).setVisibility(View.GONE);
+            binding.reasonCertExpired.setVisibility(View.GONE);
         }
-        
+
         if (mSslException.getCertificateNotYetValidException() != null) {
-            dialogView.findViewById(R.id.reason_cert_not_yet_valid).setVisibility(View.VISIBLE);
+            binding.reasonCertNotYetValid.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_cert_not_yet_valid).setVisibility(View.GONE);
+            binding.reasonCertNotYetValid.setVisibility(View.GONE);
         }
 
         if (mSslException.getSslPeerUnverifiedException() != null) {
-            dialogView.findViewById(R.id.reason_hostname_not_verified).setVisibility(View.VISIBLE);
+            binding.reasonHostnameNotVerified.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_hostname_not_verified).setVisibility(View.GONE);
+            binding.reasonHostnameNotVerified.setVisibility(View.GONE);
         }
-        
+
     }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/SslCertificateViewAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/SslCertificateViewAdapter.java
@@ -22,26 +22,28 @@ package com.owncloud.android.ui.adapter;
 
 import android.net.http.SslCertificate;
 import android.view.View;
-import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.databinding.SslUntrustedCertLayoutBinding;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 
 import java.text.DateFormat;
 import java.util.Date;
 
+import androidx.annotation.NonNull;
+
 /**
  * TODO
  */
 public class SslCertificateViewAdapter implements SslUntrustedCertDialog.CertificateViewAdapter {
-    
+
     //private final static String TAG = SslCertificateViewAdapter.class.getSimpleName();
-    
+
     private SslCertificate mCertificate;
-    
+
     /**
      * Constructor
-     * 
+     *
      * @param certificate the SSL certificate
      */
     public SslCertificateViewAdapter(SslCertificate certificate) {
@@ -49,77 +51,72 @@ public class SslCertificateViewAdapter implements SslUntrustedCertDialog.Certifi
     }
 
     @Override
-    public void updateCertificateView(View dialogView) {
-        TextView nullCerView = dialogView.findViewById(R.id.null_cert);
+    public void updateCertificateView(SslUntrustedCertLayoutBinding binding) {
         if (mCertificate != null) {
-            nullCerView.setVisibility(View.GONE);
-            showSubject(mCertificate.getIssuedTo(), dialogView);
-            showIssuer(mCertificate.getIssuedBy(), dialogView);
-            showValidity(mCertificate.getValidNotBeforeDate(), mCertificate.getValidNotAfterDate(), dialogView);
-            hideSignature(dialogView);
-            
+            binding.nullCert.setVisibility(View.GONE);
+            showSubject(mCertificate.getIssuedTo(), binding);
+            showIssuer(mCertificate.getIssuedBy(), binding);
+            showValidity(mCertificate.getValidNotBeforeDate(), mCertificate.getValidNotAfterDate(), binding);
+            hideSignature(binding);
+
         } else {
-            nullCerView.setVisibility(View.VISIBLE);
+            binding.nullCert.setVisibility(View.VISIBLE);
         }
     }
-    
-    private void showValidity(Date notBefore, Date notAfter, View dialogView) {
-        TextView fromView = dialogView.findViewById(R.id.value_validity_from);
-        TextView toView = dialogView.findViewById(R.id.value_validity_to);
+
+    private void showValidity(Date notBefore, Date notAfter, @NonNull SslUntrustedCertLayoutBinding binding) {
         DateFormat dateFormat = DateFormat.getDateInstance();
-        fromView.setText(dateFormat.format(notBefore));
-        toView.setText(dateFormat.format(notAfter));
+        binding.valueValidityFrom.setText(dateFormat.format(notBefore));
+        binding.valueValidityTo.setText(dateFormat.format(notAfter));
     }
 
-    
-    private void showSubject(SslCertificate.DName subject, View dialogView) {
-        TextView cnView = dialogView.findViewById(R.id.value_subject_CN);
-        cnView.setText(subject.getCName());
-        cnView.setVisibility(View.VISIBLE);
-        
-        TextView oView = dialogView.findViewById(R.id.value_subject_O);
-        oView.setText(subject.getOName());
-        oView.setVisibility(View.VISIBLE);
-        
-        TextView ouView = dialogView.findViewById(R.id.value_subject_OU);
-        ouView.setText(subject.getUName());
-        ouView.setVisibility(View.VISIBLE);
+
+    private void showSubject(SslCertificate.DName subject, @NonNull SslUntrustedCertLayoutBinding binding) {
+        binding.valueSubjectCN.setText(subject.getCName());
+        binding.valueSubjectCN.setVisibility(View.VISIBLE);
+
+        binding.valueSubjectO.setText(subject.getOName());
+        binding.valueSubjectO.setVisibility(View.VISIBLE);
+
+        binding.valueSubjectOU.setText(subject.getUName());
+        binding.valueSubjectOU.setVisibility(View.VISIBLE);
 
         // SslCertificates don't offer this information
-        dialogView.findViewById(R.id.value_subject_C).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.value_subject_ST).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.value_subject_L).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_subject_C).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_subject_ST).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_subject_L).setVisibility(View.GONE);
-    }
-    
-    private void showIssuer(SslCertificate.DName issuer, View dialogView) {
-        TextView cnView = dialogView.findViewById(R.id.value_issuer_CN);
-        cnView.setText(issuer.getCName());
-        cnView.setVisibility(View.VISIBLE);
-        
-        TextView oView = dialogView.findViewById(R.id.value_issuer_O);
-        oView.setText(issuer.getOName());
-        oView.setVisibility(View.VISIBLE);
+        binding.valueSubjectC.setVisibility(View.GONE);
+        binding.valueSubjectST.setVisibility(View.GONE);
+        binding.valueSubjectL.setVisibility(View.GONE);
 
-        TextView ouView = dialogView.findViewById(R.id.value_issuer_OU);
-        ouView.setText(issuer.getUName());
-        ouView.setVisibility(View.VISIBLE);
-        
-        // SslCertificates don't offer this information
-        dialogView.findViewById(R.id.value_issuer_C).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.value_issuer_ST).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.value_issuer_L).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_issuer_C).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_issuer_ST).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_issuer_L).setVisibility(View.GONE);
+        binding.labelSubjectC.setVisibility(View.GONE);
+        binding.labelSubjectST.setVisibility(View.GONE);
+        binding.labelSubjectL.setVisibility(View.GONE);
     }
-    
-    private void hideSignature(View dialogView) {
-        dialogView.findViewById(R.id.label_signature).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.label_signature_algorithm).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.value_signature_algorithm).setVisibility(View.GONE);
-        dialogView.findViewById(R.id.value_signature).setVisibility(View.GONE);
+
+    private void showIssuer(SslCertificate.DName issuer, @NonNull SslUntrustedCertLayoutBinding binding) {
+        binding.valueIssuerCN.setText(issuer.getCName());
+        binding.valueIssuerCN.setVisibility(View.VISIBLE);
+
+        binding.valueIssuerO.setText(issuer.getOName());
+        binding.valueIssuerO.setVisibility(View.VISIBLE);
+
+        binding.valueIssuerOU.setText(issuer.getUName());
+        binding.valueIssuerOU.setVisibility(View.VISIBLE);
+
+        // SslCertificates don't offer this information
+        binding.valueIssuerC.setVisibility(View.GONE);
+        binding.valueIssuerST.setVisibility(View.GONE);
+        binding.valueIssuerL.setVisibility(View.GONE);
+
+        binding.labelIssuerC.setVisibility(View.GONE);
+        binding.labelIssuerST.setVisibility(View.GONE);
+        binding.labelIssuerL.setVisibility(View.GONE);
+    }
+
+    private void hideSignature(@NonNull SslUntrustedCertLayoutBinding binding) {
+        binding.labelSignature.setVisibility(View.GONE);
+        binding.labelSignatureAlgorithm.setVisibility(View.GONE);
+
+        binding.valueSignatureAlgorithm.setVisibility(View.GONE);
+        // FIXME There IS no R.id.value_signature in this layout !!
+        binding.getRoot().findViewById(R.id.value_signature).setVisibility(View.GONE);
     }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/SslCertificateViewAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/SslCertificateViewAdapter.java
@@ -23,7 +23,6 @@ package com.owncloud.android.ui.adapter;
 import android.net.http.SslCertificate;
 import android.view.View;
 
-import com.owncloud.android.R;
 import com.owncloud.android.databinding.SslUntrustedCertLayoutBinding;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 
@@ -57,8 +56,6 @@ public class SslCertificateViewAdapter implements SslUntrustedCertDialog.Certifi
             showSubject(mCertificate.getIssuedTo(), binding);
             showIssuer(mCertificate.getIssuedBy(), binding);
             showValidity(mCertificate.getValidNotBeforeDate(), mCertificate.getValidNotAfterDate(), binding);
-            hideSignature(binding);
-
         } else {
             binding.nullCert.setVisibility(View.VISIBLE);
         }
@@ -109,14 +106,5 @@ public class SslCertificateViewAdapter implements SslUntrustedCertDialog.Certifi
         binding.labelIssuerC.setVisibility(View.GONE);
         binding.labelIssuerST.setVisibility(View.GONE);
         binding.labelIssuerL.setVisibility(View.GONE);
-    }
-
-    private void hideSignature(@NonNull SslUntrustedCertLayoutBinding binding) {
-        binding.labelSignature.setVisibility(View.GONE);
-        binding.labelSignatureAlgorithm.setVisibility(View.GONE);
-
-        binding.valueSignatureAlgorithm.setVisibility(View.GONE);
-        // FIXME There IS no R.id.value_signature in this layout !!
-        binding.getRoot().findViewById(R.id.value_signature).setVisibility(View.GONE);
     }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
@@ -22,52 +22,51 @@ package com.owncloud.android.ui.adapter;
 
 import android.net.http.SslError;
 import android.view.View;
-import android.widget.TextView;
 
-import com.owncloud.android.R;
+import com.owncloud.android.databinding.SslUntrustedCertLayoutBinding;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 
 /**
  * Dialog to show an Untrusted Certificate
  */
 public class SslErrorViewAdapter implements SslUntrustedCertDialog.ErrorViewAdapter {
-    
+
     //private final static String TAG = SslErrorViewAdapter.class.getSimpleName();
-    
+
     private SslError mSslError;
-    
+
     public SslErrorViewAdapter(SslError sslError) {
         mSslError = sslError;
     }
-    
+
     @Override
-    public void updateErrorView(View dialogView) {
+    public void updateErrorView(SslUntrustedCertLayoutBinding binding) {
         /// clean
-        dialogView.findViewById(R.id.reason_no_info_about_error).setVisibility(View.GONE);
-        
+        binding.reasonNoInfoAboutError.setVisibility(View.GONE);
+
         /// refresh
         if (mSslError.hasError(SslError.SSL_UNTRUSTED)) {
-            ((TextView)dialogView.findViewById(R.id.reason_cert_not_trusted)).setVisibility(View.VISIBLE);
+            binding.reasonCertNotTrusted.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_cert_not_trusted).setVisibility(View.GONE);
+            binding.reasonCertNotTrusted.setVisibility(View.GONE);
         }
-        
+
         if (mSslError.hasError(SslError.SSL_EXPIRED)) {
-            ((TextView)dialogView.findViewById(R.id.reason_cert_expired)).setVisibility(View.VISIBLE);
+            binding.reasonCertExpired.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_cert_expired).setVisibility(View.GONE);
+            binding.reasonCertExpired.setVisibility(View.GONE);
         }
-        
+
         if (mSslError.getPrimaryError() == SslError.SSL_NOTYETVALID) {
-            ((TextView)dialogView.findViewById(R.id.reason_cert_not_yet_valid)).setVisibility(View.VISIBLE);
+            binding.reasonCertNotYetValid.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_cert_not_yet_valid).setVisibility(View.GONE);
+            binding.reasonCertNotYetValid.setVisibility(View.GONE);
         }
-        
+
         if (mSslError.getPrimaryError() == SslError.SSL_IDMISMATCH) {
-            ((TextView)dialogView.findViewById(R.id.reason_hostname_not_verified)).setVisibility(View.VISIBLE);
+            binding.reasonHostnameNotVerified.setVisibility(View.VISIBLE);
         } else {
-            dialogView.findViewById(R.id.reason_hostname_not_verified).setVisibility(View.GONE);
+            binding.reasonHostnameNotVerified.setVisibility(View.GONE);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/adapter/X509CertificateViewAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/X509CertificateViewAdapter.java
@@ -22,9 +22,9 @@ package com.owncloud.android.ui.adapter;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.databinding.SslUntrustedCertLayoutBinding;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 
 import java.security.MessageDigest;
@@ -54,18 +54,16 @@ public class X509CertificateViewAdapter implements SslUntrustedCertDialog.Certif
     }
 
     @Override
-    public void updateCertificateView(View dialogView) {
-        TextView nullCerView = dialogView.findViewById(R.id.null_cert);
-
+    public void updateCertificateView(SslUntrustedCertLayoutBinding binding) {
         if (mCertificate != null) {
-            nullCerView.setVisibility(View.GONE);
-            showSubject(mCertificate.getSubjectX500Principal(), dialogView);
-            showIssuer(mCertificate.getIssuerX500Principal(), dialogView);
-            showValidity(mCertificate.getNotBefore(), mCertificate.getNotAfter(), dialogView);
-            showSignature(dialogView);
+            binding.nullCert.setVisibility(View.GONE);
+            showSubject(mCertificate.getSubjectX500Principal(), binding);
+            showIssuer(mCertificate.getIssuerX500Principal(), binding);
+            showValidity(mCertificate.getNotBefore(), mCertificate.getNotAfter(), binding);
+            showSignature(binding);
 
         } else {
-            nullCerView.setVisibility(View.VISIBLE);
+            binding.nullCert.setVisibility(View.VISIBLE);
         }
     }
 
@@ -81,20 +79,17 @@ public class X509CertificateViewAdapter implements SslUntrustedCertDialog.Certif
         return md.digest(message);
     }
 
-    private void showSignature(View dialogView) {
+    private void showSignature(@NonNull SslUntrustedCertLayoutBinding binding) {
         byte[] cert;
-
-        TextView certFingerprintView = dialogView.findViewById(R.id.value_certificate_fingerprint);
-        TextView algorithmView = dialogView.findViewById(R.id.value_signature_algorithm);
 
         try {
             cert = mCertificate.getEncoded();
             if (cert == null) {
-                certFingerprintView.setText(R.string.certificate_load_problem);
-                algorithmView.setText(R.string.certificate_load_problem);
+                binding.valueCertificateFingerprint.setText(R.string.certificate_load_problem);
+                binding.valueSignatureAlgorithm.setText(R.string.certificate_load_problem);
             } else {
-                certFingerprintView.setText(getDigestString(dialogView.getContext(), cert));
-                algorithmView.setText(mCertificate.getSigAlgName());
+                binding.valueCertificateFingerprint.setText(getDigestString(binding.valueCertificateFingerprint.getContext(), cert));
+                binding.valueSignatureAlgorithm.setText(mCertificate.getSigAlgName());
             }
         } catch (CertificateEncodingException e) {
             Log.e(TAG, "Problem while trying to decode the certificate.");
@@ -130,105 +125,91 @@ public class X509CertificateViewAdapter implements SslUntrustedCertDialog.Certif
         return digestType + ":" + newLine + hex.toString().replaceFirst("\\:$","") + newLine + newLine;
     }
 
-    private void showValidity(Date notBefore, Date notAfter, View dialogView) {
-        TextView fromView = dialogView.findViewById(R.id.value_validity_from);
-        TextView toView = dialogView.findViewById(R.id.value_validity_to);
+    private void showValidity(Date notBefore, Date notAfter, @NonNull SslUntrustedCertLayoutBinding binding) {
         DateFormat dateFormat = DateFormat.getDateInstance();
-        fromView.setText(dateFormat.format(notBefore));
-        toView.setText(dateFormat.format(notAfter));
+        binding.valueValidityFrom.setText(dateFormat.format(notBefore));
+        binding.valueValidityTo.setText(dateFormat.format(notAfter));
     }
 
-    private void showSubject(X500Principal subject, View dialogView) {
+    private void showSubject(X500Principal subject, @NonNull SslUntrustedCertLayoutBinding binding) {
         Map<String, String> s = parsePrincipal(subject);
-        TextView cnView = dialogView.findViewById(R.id.value_subject_CN);
-        TextView oView = dialogView.findViewById(R.id.value_subject_O);
-        TextView ouView = dialogView.findViewById(R.id.value_subject_OU);
-        TextView cView = dialogView.findViewById(R.id.value_subject_C);
-        TextView stView = dialogView.findViewById(R.id.value_subject_ST);
-        TextView lView = dialogView.findViewById(R.id.value_subject_L);
 
         if (s.get("CN") != null) {
-            cnView.setText(s.get("CN"));
-            cnView.setVisibility(View.VISIBLE);
+            binding.valueSubjectCN.setText(s.get("CN"));
+            binding.valueSubjectCN.setVisibility(View.VISIBLE);
         } else {
-            cnView.setVisibility(View.GONE);
+            binding.valueSubjectCN.setVisibility(View.GONE);
         }
         if (s.get("O") != null) {
-            oView.setText(s.get("O"));
-            oView.setVisibility(View.VISIBLE);
+            binding.valueSubjectO.setText(s.get("O"));
+            binding.valueSubjectO.setVisibility(View.VISIBLE);
         } else {
-            oView.setVisibility(View.GONE);
+            binding.valueSubjectO.setVisibility(View.GONE);
         }
         if (s.get("OU") != null) {
-            ouView.setText(s.get("OU"));
-            ouView.setVisibility(View.VISIBLE);
+            binding.valueSubjectOU.setText(s.get("OU"));
+            binding.valueSubjectOU.setVisibility(View.VISIBLE);
         } else {
-            ouView.setVisibility(View.GONE);
+            binding.valueSubjectOU.setVisibility(View.GONE);
         }
         if (s.get("C") != null) {
-            cView.setText(s.get("C"));
-            cView.setVisibility(View.VISIBLE);
+            binding.valueSubjectC.setText(s.get("C"));
+            binding.valueSubjectC.setVisibility(View.VISIBLE);
         } else {
-            cView.setVisibility(View.GONE);
+            binding.valueSubjectC.setVisibility(View.GONE);
         }
         if (s.get("ST") != null) {
-            stView.setText(s.get("ST"));
-            stView.setVisibility(View.VISIBLE);
+            binding.valueSubjectST.setText(s.get("ST"));
+            binding.valueSubjectST.setVisibility(View.VISIBLE);
         } else {
-            stView.setVisibility(View.GONE);
+            binding.valueSubjectST.setVisibility(View.GONE);
         }
         if (s.get("L") != null) {
-            lView.setText(s.get("L"));
-            lView.setVisibility(View.VISIBLE);
+            binding.valueSubjectL.setText(s.get("L"));
+            binding.valueSubjectL.setVisibility(View.VISIBLE);
         } else {
-            lView.setVisibility(View.GONE);
+            binding.valueSubjectL.setVisibility(View.GONE);
         }
     }
 
-    private void showIssuer(X500Principal issuer, View dialogView) {
+    private void showIssuer(X500Principal issuer, @NonNull SslUntrustedCertLayoutBinding binding) {
         Map<String, String> s = parsePrincipal(issuer);
-        TextView cnView = dialogView.findViewById(R.id.value_issuer_CN);
-        TextView oView = dialogView.findViewById(R.id.value_issuer_O);
-        TextView ouView = dialogView.findViewById(R.id.value_issuer_OU);
-        TextView cView = dialogView.findViewById(R.id.value_issuer_C);
-        TextView stView = dialogView.findViewById(R.id.value_issuer_ST);
-        TextView lView = dialogView.findViewById(R.id.value_issuer_L);
 
         if (s.get("CN") != null) {
-            cnView.setText(s.get("CN"));
-            cnView.setVisibility(View.VISIBLE);
+            binding.valueIssuerCN.setText(s.get("CN"));
+            binding.valueIssuerCN.setVisibility(View.VISIBLE);
         } else {
-            cnView.setVisibility(View.GONE);
+            binding.valueIssuerCN.setVisibility(View.GONE);
         }
         if (s.get("O") != null) {
-            oView.setText(s.get("O"));
-            oView.setVisibility(View.VISIBLE);
+            binding.valueIssuerO.setText(s.get("O"));
+            binding.valueIssuerO.setVisibility(View.VISIBLE);
         } else {
-            oView.setVisibility(View.GONE);
+            binding.valueIssuerO.setVisibility(View.GONE);
         }
         if (s.get("OU") != null) {
-            ouView.setText(s.get("OU"));
-            ouView.setVisibility(View.VISIBLE);
+            binding.valueIssuerOU.setText(s.get("OU"));
+            binding.valueIssuerOU.setVisibility(View.VISIBLE);
         } else {
-            ouView.setVisibility(View.GONE);
+            binding.valueIssuerOU.setVisibility(View.GONE);
         }
         if (s.get("C") != null) {
-            cView.setText(s.get("C"));
-            cView.setVisibility(View.VISIBLE);
+            binding.valueIssuerC.setText(s.get("C"));
+            binding.valueIssuerC.setVisibility(View.VISIBLE);
         } else {
-            cView.setVisibility(View.GONE);
+            binding.valueIssuerC.setVisibility(View.GONE);
         }
         if (s.get("ST") != null) {
-            stView.setText(s.get("ST"));
-            stView.setVisibility(View.VISIBLE);
+            binding.valueIssuerST.setText(s.get("ST"));
+            binding.valueIssuerST.setVisibility(View.VISIBLE);
         } else {
-            stView.setVisibility(View.GONE);
+            binding.valueIssuerST.setVisibility(View.GONE);
         }
         if (s.get("L") != null) {
-            lView.setText(s.get("L"));
-            lView.setVisibility(View.VISIBLE);
+            binding.valueIssuerL.setText(s.get("L"));
+            binding.valueIssuerL.setVisibility(View.VISIBLE);
         } else {
-            lView.setVisibility(View.GONE);
+            binding.valueIssuerL.setVisibility(View.GONE);
         }
     }
 

--- a/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
@@ -33,6 +33,7 @@ import android.webkit.SslErrorHandler;
 import android.widget.Button;
 
 import com.owncloud.android.R;
+import com.owncloud.android.databinding.SslUntrustedCertLayoutBinding;
 import com.owncloud.android.lib.common.network.CertificateCombinedException;
 import com.owncloud.android.lib.common.network.NetworkUtils;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -45,6 +46,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 
 /**
@@ -58,7 +60,7 @@ public class SslUntrustedCertDialog extends DialogFragment {
 
     private final static String TAG = SslUntrustedCertDialog.class.getSimpleName();
 
-    protected View mView;
+    protected SslUntrustedCertLayoutBinding binding;
     protected SslErrorHandler mHandler;
     protected X509Certificate m509Certificate;
 
@@ -110,7 +112,7 @@ public class SslUntrustedCertDialog extends DialogFragment {
 
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         Log_OC.d(TAG, "onAttach");
         super.onAttach(activity);
         if (!(activity instanceof OnSslUntrustedCertListener)) {
@@ -125,50 +127,41 @@ public class SslUntrustedCertDialog extends DialogFragment {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);    // force to keep the state of the fragment on configuration changes (such as device rotations)
         setCancelable(false);
-        mView = null;
+        binding = null;
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         Log_OC.d(TAG, "onCreateView, savedInsanceState is " + savedInstanceState);
         // Create a view by inflating desired layout
-        if (mView == null) {
-            mView = inflater.inflate(R.layout.ssl_untrusted_cert_layout, container,  false);
-            mView.findViewById(R.id.details_scroll).setVisibility(View.GONE);
-            mErrorViewAdapter.updateErrorView(mView);
+        if (binding == null) {
+            binding = SslUntrustedCertLayoutBinding.inflate(inflater, container, false);
+            binding.detailsScroll.setVisibility(View.GONE);
+            mErrorViewAdapter.updateErrorView(binding);
         } else {
-            ((ViewGroup)mView.getParent()).removeView(mView);
+            ((ViewGroup) binding.getRoot().getParent()).removeView(binding.getRoot());
         }
 
-        Button ok = mView.findViewById(R.id.ok);
-        ok.setOnClickListener(new OnCertificateTrusted());
+        binding.ok.setOnClickListener(new OnCertificateTrusted());
 
-        Button cancel = mView.findViewById(R.id.cancel);
-        cancel.setOnClickListener(new OnCertificateNotTrusted());
+        binding.cancel.setOnClickListener(new OnCertificateNotTrusted());
 
-        Button details = mView.findViewById(R.id.details_btn);
-        details.setOnClickListener(new OnClickListener() {
+        binding.detailsBtn.setOnClickListener(v -> {
+            if (binding.detailsScroll.getVisibility() == View.VISIBLE) {
+                binding.detailsScroll.setVisibility(View.GONE);
+                ((Button) v).setText(R.string.ssl_validator_btn_details_see);
 
-            @Override
-            public void onClick(View v) {
-                View detailsScroll = mView.findViewById(R.id.details_scroll);
-                if (detailsScroll.getVisibility() == View.VISIBLE) {
-                    detailsScroll.setVisibility(View.GONE);
-                    ((Button) v).setText(R.string.ssl_validator_btn_details_see);
-
-                } else {
-                    detailsScroll.setVisibility(View.VISIBLE);
-                    ((Button) v).setText(R.string.ssl_validator_btn_details_hide);
-                    mCertificateViewAdapter.updateCertificateView(mView);
-                }
+            } else {
+                binding.detailsScroll.setVisibility(View.VISIBLE);
+                ((Button) v).setText(R.string.ssl_validator_btn_details_hide);
+                mCertificateViewAdapter.updateCertificateView(binding);
             }
-
         });
 
-        return mView;
+        return binding.getRoot();
     }
 
-
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         Log_OC.d(TAG, "onCreateDialog, savedInstanceState is " + savedInstanceState);
@@ -228,10 +221,10 @@ public class SslUntrustedCertDialog extends DialogFragment {
     }
 
     public interface ErrorViewAdapter {
-        void updateErrorView(View mView);
+        void updateErrorView(SslUntrustedCertLayoutBinding binding);
     }
 
     public interface CertificateViewAdapter {
-        void updateCertificateView(View mView);
+        void updateCertificateView(SslUntrustedCertLayoutBinding binding);
     }
 }


### PR DESCRIPTION
#6247 Follow-Up Pull Request to use View Binding in

- `FileDisplayActivity`
- `CertificateCombinedExceptionViewAdapter`
- `SslCertificateViewAdapter`
- `SslErrorViewAdapter`
- `X509CertificateViewAdapter`
- `SslUntrustedCertDialog`

# Attention

While migrating to View Binding, it seems like i spotted the first potential bug in the code. There is a possible `NullPointerException` in `SslCertificateViewAdapter`!
I added a `FIXME` comment, because i don't know the code that well, but i am pretty sure that this is a copy paste mistake from `ssl_validator_layout.xml` to `ssl_untrusted_cert_layout.xml` (or their corresponding logic).