### PR TITLE
Show "photos" in title

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -439,6 +439,7 @@ public abstract class DrawerActivity extends ToolbarActivity
 
     private void startPhotoSearch(MenuItem menuItem) {
         SearchEvent searchEvent = new SearchEvent("image/%", SearchRemoteOperation.SearchType.PHOTO_SEARCH);
+        MainApp.showOnlyFilesOnDevice(false);
 
         Intent intent = new Intent(getApplicationContext(), FileDisplayActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1204,6 +1204,10 @@ public class FileDisplayActivity extends FileActivity
             setDrawerMenuItemChecked(menuItemId);
         }
 
+        if (getListOfFilesFragment() instanceof PhotoFragment) {
+            updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_item_photos));
+        }
+
         Log_OC.v(TAG, "onResume() end");
     }
 


### PR DESCRIPTION
The title in photo is wrong. Actually show cloud name or "On device" if "on device" is preview view.
I show "Photos" now, like all another view in drawer
|Before|After|
|---|---|
|![Screenshot_1591968505](https://user-images.githubusercontent.com/2796439/84507606-5f8d9000-acc1-11ea-87f8-48fbbf6ed114.png)|![Screenshot_1591968288](https://user-images.githubusercontent.com/2796439/84507568-513f7400-acc1-11ea-9f4b-eafb55bac9b4.png)|