### PR TITLE
Fix appbar photos view when enter in background

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -218,6 +218,7 @@ public class FileDisplayActivity extends FileActivity
     private SearchView searchView;
     private PlayerServiceConnection mPlayerConnection;
     private Account mLastDisplayedAccount;
+    private int menuItemId = -1;
 
     @Inject
     AppPreferences preferences;
@@ -1185,7 +1186,7 @@ public class FileDisplayActivity extends FileActivity
         registerReceiver(mDownloadFinishReceiver, downloadIntentFilter);
 
         // setup drawer
-        int menuItemId = getIntent().getIntExtra(FileDisplayActivity.DRAWER_MENU_ID, -1);
+        menuItemId = getIntent().getIntExtra(FileDisplayActivity.DRAWER_MENU_ID, menuItemId);
 
         if (menuItemId == -1) {
             if (MainApp.isOnlyOnDevice()) {


### PR DESCRIPTION
Actually if we're on the photo view. Exit and return to the application. We had the wrong appbar