### PR TITLE
[stable-3.12] Fix crash when starting ContactsPreferenceActivity with user extra

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
@@ -93,7 +93,7 @@ public class ContactsPreferenceActivity extends FileActivity implements FileFrag
                 transaction.add(R.id.frame_container, fragment);
             } else {
                 OCFile file = Parcels.unwrap(intent.getParcelableExtra(ContactListFragment.FILE_NAME));
-                User user = Parcels.unwrap(intent.getParcelableExtra(ContactListFragment.USER));
+                User user = intent.getParcelableExtra(ContactListFragment.USER);
                 ContactListFragment contactListFragment = ContactListFragment.newInstance(file, user);
                 transaction.add(R.id.frame_container, contactListFragment);
             }


### PR DESCRIPTION
Fix crash when starting ContactsPreferenceActivity with user extra
    
This fixes a class cast exception when contacts is launched
from files list when clicking on archived .vcf file.
    
Activity is launched with file and user extras and user
being parcelled using Parceler API cannot be retrieved
on ContactsPreferenceActivity.onCreate().
    
This minimal change fixes the crash issue.
    
Fixes #6277
    
Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] manual test needed, no automate test possible
