### PR TITLE
Migrate ContactsPreferenceActivity startup to type-safe API

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
@@ -22,6 +22,7 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -32,8 +33,6 @@ import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.ui.fragment.contactsbackup.ContactListFragment;
 import com.owncloud.android.ui.fragment.contactsbackup.ContactsBackupFragment;
-
-import org.parceler.Parcels;
 
 import javax.inject.Inject;
 
@@ -46,12 +45,33 @@ import androidx.fragment.app.FragmentTransaction;
  */
 public class ContactsPreferenceActivity extends FileActivity implements FileFragment.ContainerActivity {
     public static final String TAG = ContactsPreferenceActivity.class.getSimpleName();
-
-
+    private static final String EXTRA_FILE = "FILE";
+    private static final String EXTRA_USER = "USER";
+    /**
+     * Warning: default for this extra is different between this activity and {@link ContactsBackupFragment}
+     */
+    public static final String EXTRA_SHOW_SIDEBAR = "SHOW_SIDEBAR";
     public static final String PREFERENCE_CONTACTS_AUTOMATIC_BACKUP = "PREFERENCE_CONTACTS_AUTOMATIC_BACKUP";
     public static final String PREFERENCE_CONTACTS_LAST_BACKUP = "PREFERENCE_CONTACTS_LAST_BACKUP";
     public static final String BACKUP_TO_LIST = "BACKUP_TO_LIST";
-    public static final String EXTRA_SHOW_SIDEBAR = "SHOW_SIDEBAR";
+
+    public static void startActivity(Context context) {
+        Intent intent = new Intent(context, ContactsPreferenceActivity.class);
+        context.startActivity(intent);
+    }
+
+    public static void startActivityWithContactsFile(Context context, User user, OCFile file) {
+        Intent intent = new Intent(context, ContactsPreferenceActivity.class);
+        intent.putExtra(EXTRA_FILE, file);
+        intent.putExtra(EXTRA_USER, user);
+        context.startActivity(intent);
+    }
+
+    public static void startActivityWithoutSidebar(Context context) {
+        Intent intent = new Intent(context, ContactsPreferenceActivity.class);
+        intent.putExtra(EXTRA_SHOW_SIDEBAR, false);
+        context.startActivity(intent);
+    }
 
     @Inject BackgroundJobManager backgroundJobManager;
 
@@ -86,14 +106,11 @@ public class ContactsPreferenceActivity extends FileActivity implements FileFrag
             FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
             if (intent == null || intent.getParcelableExtra(ContactListFragment.FILE_NAME) == null ||
                     intent.getParcelableExtra(ContactListFragment.USER) == null) {
-                ContactsBackupFragment fragment = new ContactsBackupFragment();
-                Bundle bundle = new Bundle();
-                bundle.putBoolean(EXTRA_SHOW_SIDEBAR, showSidebar);
-                fragment.setArguments(bundle);
+                ContactsBackupFragment fragment = ContactsBackupFragment.create(showSidebar);
                 transaction.add(R.id.frame_container, fragment);
             } else {
-                OCFile file = Parcels.unwrap(intent.getParcelableExtra(ContactListFragment.FILE_NAME));
-                User user = Parcels.unwrap(intent.getParcelableExtra(ContactListFragment.USER));
+                OCFile file = intent.getParcelableExtra(ContactListFragment.FILE_NAME);
+                User user = intent.getParcelableExtra(ContactListFragment.USER);
                 ContactListFragment contactListFragment = ContactListFragment.newInstance(file, user);
                 transaction.add(R.id.frame_container, contactListFragment);
             }

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -368,7 +368,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                 startActivity(SyncedFoldersActivity.class);
                 break;
             case R.id.nav_contacts:
-                startActivity(ContactsPreferenceActivity.class);
+                ContactsPreferenceActivity.startActivity(this);
                 break;
             case R.id.nav_settings:
                 startActivity(SettingsActivity.class);

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -105,7 +105,6 @@ import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
 import com.owncloud.android.ui.fragment.PhotoFragment;
 import com.owncloud.android.ui.fragment.TaskRetainerFragment;
-import com.owncloud.android.ui.fragment.contactsbackup.ContactListFragment;
 import com.owncloud.android.ui.helpers.FileOperationsHelper;
 import com.owncloud.android.ui.helpers.UriUploader;
 import com.owncloud.android.ui.preview.PreviewImageActivity;
@@ -2357,10 +2356,7 @@ public class FileDisplayActivity extends FileActivity
 
     public void startContactListFragment(OCFile file) {
         final User user = getUser().orElseThrow(RuntimeException::new);
-        Intent intent = new Intent(this, ContactsPreferenceActivity.class);
-        intent.putExtra(ContactListFragment.FILE_NAME, Parcels.wrap(file));
-        intent.putExtra(ContactListFragment.USER, user);
-        startActivity(intent);
+        ContactsPreferenceActivity.startActivityWithContactsFile(this, user, file);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -459,9 +459,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
         if (pContactsBackup != null) {
             if (contactsBackupEnabled) {
                 pContactsBackup.setOnPreferenceClickListener(preference -> {
-                    Intent contactsIntent = new Intent(getApplicationContext(), ContactsPreferenceActivity.class);
-                    contactsIntent.putExtra(ContactsPreferenceActivity.EXTRA_SHOW_SIDEBAR, false);
-                    startActivity(contactsIntent);
+                    ContactsPreferenceActivity.startActivityWithoutSidebar(this);
                     return true;
                 });
             } else {

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactsBackupFragment.java
@@ -78,6 +78,11 @@ import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFER
 
 public class ContactsBackupFragment extends FileFragment implements DatePickerDialog.OnDateSetListener, Injectable {
     public static final String TAG = ContactsBackupFragment.class.getSimpleName();
+    private static final String ARG_SHOW_SIDEBAR = "SHOW_SIDEBAR";
+    private static final String KEY_CALENDAR_PICKER_OPEN = "IS_CALENDAR_PICKER_OPEN";
+    private static final String KEY_CALENDAR_DAY = "CALENDAR_DAY";
+    private static final String KEY_CALENDAR_MONTH = "CALENDAR_MONTH";
+    private static final String KEY_CALENDAR_YEAR = "CALENDAR_YEAR";
 
     @BindView(R.id.contacts_automatic_backup)
     public SwitchCompat backupSwitch;
@@ -99,15 +104,17 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
     private DatePickerDialog datePickerDialog;
 
     private CompoundButton.OnCheckedChangeListener onCheckedChangeListener;
-
-    private static final String KEY_CALENDAR_PICKER_OPEN = "IS_CALENDAR_PICKER_OPEN";
-    private static final String KEY_CALENDAR_DAY = "CALENDAR_DAY";
-    private static final String KEY_CALENDAR_MONTH = "CALENDAR_MONTH";
-    private static final String KEY_CALENDAR_YEAR = "CALENDAR_YEAR";
     private ArbitraryDataProvider arbitraryDataProvider;
     private Account account;
     private boolean showSidebar = true;
 
+    public static ContactsBackupFragment create(boolean showSidebar) {
+        ContactsBackupFragment fragment = new ContactsBackupFragment();
+        Bundle bundle = new Bundle();
+        bundle.putBoolean(ARG_SHOW_SIDEBAR, showSidebar);
+        fragment.setArguments(bundle);
+        return fragment;
+    }
 
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -122,7 +129,7 @@ public class ContactsBackupFragment extends FileFragment implements DatePickerDi
         setHasOptionsMenu(true);
 
         if (getArguments() != null) {
-            showSidebar = getArguments().getBoolean(ContactsPreferenceActivity.EXTRA_SHOW_SIDEBAR);
+            showSidebar = getArguments().getBoolean(ARG_SHOW_SIDEBAR);
         }
 
         final ContactsPreferenceActivity contactsPreferenceActivity = (ContactsPreferenceActivity) getActivity();


### PR DESCRIPTION
This change addresses #6277 bug in more comprehensible way.
All calls to Context.startActivity(...) starthing
ContactsPreferenceActivity are replaced with type-safe
calls to static ContactsPreferenceActivity.startActivity*
sets of APIs.

No client code should be calling `Intent(..., ContactsPreferenceActivity.class)`
constructor anymore.

See #5866 for discussion about the pattern used in this PR.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] Manual test only: follow #6277 bug reproduction scenario
- [x] Fix `ContactsBackupFragment` us of sidebar extra  - default values are different
- [x] Move `ContactsBackupFragment` to type-safe API as well