### PR TITLE
Use interceptor to mock any network request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
     daggerVersion = "2.27"
     markwonVersion =  "4.4.0"
     prismVersion = "2.0.0"
-    androidLibraryVersion = "master-SNAPSHOT"
+    androidLibraryVersion = "interceptor-SNAPSHOT"
 
     travisBuild = System.getenv("TRAVIS") == "true"
 
@@ -368,6 +368,8 @@ dependencies {
     testImplementation 'org.json:json:20200518'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "androidx.arch.core:core-testing:2.1.0"
+    kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
+    kaptTest "com.google.dagger:dagger-compiler:$daggerVersion"
 
     // dependencies for instrumented tests
     // JUnit4 Rules

--- a/src/androidTest/AndroidManifest.xml
+++ b/src/androidTest/AndroidManifest.xml
@@ -31,4 +31,6 @@
     android:sharedUserId="${applicationId}.uid">
 
     <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator, tools.fastlane.screengrab" />
+
+    <application android:name="com.owncloud.android.TestApp"></application>
 </manifest>

--- a/src/androidTest/java/com/nextcloud/client/ScreenshotTestRunner.java
+++ b/src/androidTest/java/com/nextcloud/client/ScreenshotTestRunner.java
@@ -22,13 +22,21 @@
 
 package com.nextcloud.client;
 
+import android.app.Application;
+import android.content.Context;
 import android.os.Bundle;
 
 import com.facebook.testing.screenshot.ScreenshotRunner;
+import com.owncloud.android.TestApp;
 
 import androidx.test.runner.AndroidJUnitRunner;
 
 public class ScreenshotTestRunner extends AndroidJUnitRunner {
+
+    @Override
+    public Application newApplication(ClassLoader cl, String className, Context context) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        return super.newApplication(cl, TestApp.class.getName(), context);
+    }
 
     @Override
     public void onCreate(Bundle args) {

--- a/src/androidTest/java/com/owncloud/android/MockInterceptor.kt
+++ b/src/androidTest/java/com/owncloud/android/MockInterceptor.kt
@@ -1,0 +1,44 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android
+
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+class MockInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(chain.request())
+            .newBuilder()
+            .code(200)
+            .protocol(Protocol.HTTP_2)
+            .message("123")
+            .body(ResponseBody.create(MediaType.parse("application/json"),
+                "responseString".toByteArray()))
+            .addHeader("content-type", "application/json")
+            .build()
+    }
+}
+

--- a/src/androidTest/java/com/owncloud/android/MockedNetworkModule.java
+++ b/src/androidTest/java/com/owncloud/android/MockedNetworkModule.java
@@ -1,8 +1,10 @@
 /*
+ *
  * Nextcloud Android client application
  *
- * @author Chris Narkiewicz
- * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -15,16 +17,21 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.nextcloud.client.network;
+package com.owncloud.android;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
 
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.logger.Logger;
+import com.nextcloud.client.network.ClientFactory;
+import com.nextcloud.client.network.ClientFactoryImpl;
+import com.nextcloud.client.network.ConnectivityService;
+import com.nextcloud.client.network.ConnectivityServiceImpl;
+import com.owncloud.android.lib.common.utils.Log_OC;
 
 import javax.inject.Singleton;
 
@@ -32,7 +39,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-public class NetworkModule {
+public class MockedNetworkModule {
 
     @Provides
     ConnectivityService connectivityService(ConnectivityManager connectivityManager,
@@ -49,12 +56,13 @@ public class NetworkModule {
     @Provides
     @Singleton
     ClientFactory clientFactory(Context context) {
-        return new ClientFactoryImpl(context, null);
+        Log_OC.d("MOCK", "c");
+        return new ClientFactoryImpl(context, new MockInterceptor());
     }
 
     @Provides
     @Singleton
     ConnectivityManager connectivityManager(Context context) {
-        return (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        return (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     }
 }

--- a/src/androidTest/java/com/owncloud/android/TestApp.kt
+++ b/src/androidTest/java/com/owncloud/android/TestApp.kt
@@ -1,0 +1,33 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android
+
+
+class TestApp : MainApp() {
+    override fun setupDagger() {
+        DaggerTestAppComponent.builder()
+            .application(this)
+            .build()
+            .inject(this);
+    }
+}

--- a/src/androidTest/java/com/owncloud/android/TestAppComponent.java
+++ b/src/androidTest/java/com/owncloud/android/TestAppComponent.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android;
+
+import android.app.Application;
+
+import com.nextcloud.client.appinfo.AppInfoModule;
+import com.nextcloud.client.device.DeviceModule;
+import com.nextcloud.client.di.AppModule;
+import com.nextcloud.client.di.ViewModelModule;
+import com.nextcloud.client.jobs.JobsModule;
+import com.nextcloud.client.onboarding.OnboardingModule;
+import com.nextcloud.client.preferences.PreferencesModule;
+
+import javax.inject.Singleton;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.android.support.AndroidSupportInjectionModule;
+
+@Singleton
+@Component(modules = {
+    AndroidSupportInjectionModule.class,
+    AppModule.class,
+    PreferencesModule.class,
+    AppInfoModule.class,
+    MockedNetworkModule.class,
+    DeviceModule.class,
+    OnboardingModule.class,
+    ViewModelModule.class,
+    JobsModule.class
+})
+
+public interface TestAppComponent {
+
+    void inject(TestApp app);
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        Builder application(Application application);
+
+        TestAppComponent build();
+    }
+
+//@Component.Factory
+//interface Factory {
+//    TestAppComponent create(@BindsInstance Application application);
+//}
+}

--- a/src/main/java/com/nextcloud/client/di/AppModule.java
+++ b/src/main/java/com/nextcloud/client/di/AppModule.java
@@ -68,7 +68,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module(includes = {ComponentsModule.class, VariantComponentsModule.class})
-class AppModule {
+public class AppModule {
 
     @Provides
     AccountManager accountManager(Application application) {

--- a/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
@@ -36,12 +36,16 @@ import com.owncloud.android.lib.common.accounts.AccountUtils;
 
 import java.io.IOException;
 
-class ClientFactoryImpl implements ClientFactory {
+import okhttp3.Interceptor;
+
+public class ClientFactoryImpl implements ClientFactory {
 
     private Context context;
+    private Interceptor interceptor;
 
-    ClientFactoryImpl(Context context) {
+    public ClientFactoryImpl(Context context, Interceptor interceptor) {
         this.context = context;
+        this.interceptor = interceptor;
     }
 
     @Override
@@ -58,7 +62,7 @@ class ClientFactoryImpl implements ClientFactory {
     @Override
     public NextcloudClient createNextcloudClient(User user) throws CreationException {
         try {
-            return OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(), context);
+            return OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(), context, interceptor);
         } catch (OperationCanceledException |
             AuthenticatorException |
             IOException |

--- a/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import androidx.core.net.ConnectivityManagerCompat;
 import kotlin.jvm.functions.Function1;
 
-class ConnectivityServiceImpl implements ConnectivityService {
+public class ConnectivityServiceImpl implements ConnectivityService {
 
     private final static String TAG = ConnectivityServiceImpl.class.getName();
 
@@ -48,18 +48,18 @@ class ConnectivityServiceImpl implements ConnectivityService {
     private final GetRequestBuilder requestBuilder;
     private final Logger logger;
 
-    static class GetRequestBuilder implements Function1<String, GetMethod> {
+    public static class GetRequestBuilder implements Function1<String, GetMethod> {
         @Override
         public GetMethod invoke(String url) {
             return new GetMethod(url);
         }
     }
 
-    ConnectivityServiceImpl(ConnectivityManager platformConnectivityManager,
-                            UserAccountManager accountManager,
-                            ClientFactory clientFactory,
-                            GetRequestBuilder requestBuilder,
-                            Logger logger) {
+    public ConnectivityServiceImpl(ConnectivityManager platformConnectivityManager,
+                                   UserAccountManager accountManager,
+                                   ClientFactory clientFactory,
+                                   GetRequestBuilder requestBuilder,
+                                   Logger logger) {
         this.platformConnectivityManager = platformConnectivityManager;
         this.accountManager = accountManager;
         this.clientFactory = clientFactory;

--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -98,6 +98,7 @@ import javax.net.ssl.SSLEngine;
 
 import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.util.Pair;
@@ -222,10 +223,7 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
         super.attachBaseContext(base);
 
         initGlobalContext(this);
-        DaggerAppComponent.builder()
-            .application(this)
-            .build()
-            .inject(this);
+        setupDagger();
 
         // we don't want to handle crashes occurring inside crash reporter activity/process;
         // let the platform deal with those
@@ -238,6 +236,14 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
                                                                         defaultPlatformHandler);
             Thread.setDefaultUncaughtExceptionHandler(crashReporter);
         }
+    }
+
+    @VisibleForTesting
+    public void setupDagger() {
+        DaggerAppComponent.builder()
+            .application(this)
+            .build()
+            .inject(this);
     }
 
     @SuppressFBWarnings("ST")

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -40,10 +40,10 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.jobs.NotificationWork;
 import com.nextcloud.client.network.ClientFactory;
+import com.nextcloud.common.NextcloudClient;
 import com.nextcloud.java.util.Optional;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -107,7 +107,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
 
     private NotificationListAdapter adapter;
     private Snackbar snackbar;
-    private OwnCloudClient client;
+    private NextcloudClient client;
     private Optional<User> optionalUser;
 
     @Inject ClientFactory clientFactory;
@@ -258,7 +258,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
             if (client == null && optionalUser.isPresent()) {
                 try {
                     User user = optionalUser.get();
-                    client = clientFactory.create(user);
+                    client = clientFactory.createNextcloudClient(user);
                 } catch (ClientFactory.CreationException e) {
                     Log_OC.e(TAG, "Error initializing client", e);
                 }
@@ -266,7 +266,7 @@ public class NotificationsActivity extends FileActivity implements Notifications
 
             if (adapter == null) {
                 adapter = new NotificationListAdapter(client, this);
-                recyclerView.setAdapter(adapter);
+                // recyclerView.setAdapter(adapter);
             }
 
             RemoteOperation getRemoteNotificationOperation = new GetNotificationsRemoteOperation();

--- a/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -20,7 +20,6 @@
 package com.owncloud.android.ui.adapter;
 
 import android.content.Intent;
-import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.graphics.drawable.PictureDrawable;
@@ -45,8 +44,8 @@ import com.bumptech.glide.load.model.StreamEncoder;
 import com.bumptech.glide.load.resource.file.FileToStreamDecoder;
 import com.caverock.androidsvg.SVG;
 import com.google.android.material.button.MaterialButton;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.R;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.resources.notifications.models.Action;
 import com.owncloud.android.lib.resources.notifications.models.Notification;
 import com.owncloud.android.lib.resources.notifications.models.RichObject;
@@ -79,10 +78,10 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
     private ForegroundColorSpan foregroundColorSpanBlack;
 
     private List<Notification> notificationsList;
-    private OwnCloudClient client;
+    private NextcloudClient client;
     private NotificationsActivity notificationsActivity;
 
-    public NotificationListAdapter(OwnCloudClient client, NotificationsActivity notificationsActivity) {
+    public NotificationListAdapter(NextcloudClient client, NotificationsActivity notificationsActivity) {
         this.notificationsList = new ArrayList<>();
         this.client = client;
         this.notificationsActivity = notificationsActivity;
@@ -143,7 +142,9 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
 
         setButtons(holder, notification);
 
-        holder.dismiss.setOnClickListener(v -> new DeleteNotificationTask(client, notification, holder,
+        holder.dismiss.setOnClickListener(v -> new DeleteNotificationTask(client,
+                                                                          notification,
+                                                                          holder,
                                                                           notificationsActivity).execute());
     }
 

--- a/src/main/java/com/owncloud/android/ui/asynctasks/DeleteAllNotificationsTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/DeleteAllNotificationsTask.java
@@ -23,7 +23,7 @@ package com.owncloud.android.ui.asynctasks;
 
 import android.os.AsyncTask;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.resources.notifications.DeleteAllNotificationsRemoteOperation;
 import com.owncloud.android.lib.resources.notifications.models.Action;
@@ -31,10 +31,10 @@ import com.owncloud.android.ui.activity.NotificationsActivity;
 import com.owncloud.android.ui.notifications.NotificationsContract;
 
 public class DeleteAllNotificationsTask extends AsyncTask<Action, Void, Boolean> {
-    private OwnCloudClient client;
+    private NextcloudClient client;
     private NotificationsContract.View notificationsActivity;
 
-    public DeleteAllNotificationsTask(OwnCloudClient client, NotificationsActivity notificationsActivity) {
+    public DeleteAllNotificationsTask(NextcloudClient client, NotificationsActivity notificationsActivity) {
         this.client = client;
         this.notificationsActivity = notificationsActivity;
     }

--- a/src/main/java/com/owncloud/android/ui/asynctasks/DeleteNotificationTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/DeleteNotificationTask.java
@@ -23,7 +23,7 @@ package com.owncloud.android.ui.asynctasks;
 
 import android.os.AsyncTask;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.resources.notifications.DeleteNotificationRemoteOperation;
 import com.owncloud.android.lib.resources.notifications.models.Action;
@@ -35,10 +35,11 @@ import com.owncloud.android.ui.notifications.NotificationsContract;
 public class DeleteNotificationTask extends AsyncTask<Action, Void, Boolean> {
     private Notification notification;
     private NotificationListAdapter.NotificationViewHolder holder;
-    private OwnCloudClient client;
+    private NextcloudClient client;
     private NotificationsContract.View notificationsActivity;
 
-    public DeleteNotificationTask(OwnCloudClient client, Notification notification,
+    public DeleteNotificationTask(NextcloudClient client,
+                                  Notification notification,
                                   NotificationListAdapter.NotificationViewHolder holder,
                                   NotificationsActivity notificationsActivity) {
         this.client = client;

--- a/src/main/java/com/owncloud/android/ui/asynctasks/NotificationExecuteActionTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/NotificationExecuteActionTask.java
@@ -2,9 +2,8 @@ package com.owncloud.android.ui.asynctasks;
 
 import android.os.AsyncTask;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
-import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.notifications.models.Action;
 import com.owncloud.android.lib.resources.notifications.models.Notification;
 import com.owncloud.android.ui.activity.NotificationsActivity;
@@ -17,16 +16,14 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.Utf8PostMethod;
 
-import java.io.IOException;
-
 public class NotificationExecuteActionTask extends AsyncTask<Action, Void, Boolean> {
 
     private NotificationListAdapter.NotificationViewHolder holder;
-    private OwnCloudClient client;
+    private NextcloudClient client;
     private Notification notification;
     private NotificationsActivity notificationsActivity;
 
-    public NotificationExecuteActionTask(OwnCloudClient client,
+    public NotificationExecuteActionTask(NextcloudClient client,
                                          NotificationListAdapter.NotificationViewHolder holder,
                                          Notification notification,
                                          NotificationsActivity notificationsActivity) {
@@ -66,14 +63,16 @@ public class NotificationExecuteActionTask extends AsyncTask<Action, Void, Boole
         method.setRequestHeader(RemoteOperation.OCS_API_HEADER, RemoteOperation.OCS_API_HEADER_VALUE);
 
         int status;
-        try {
-            status = client.executeMethod(method);
-        } catch (IOException e) {
-            Log_OC.e(this, "Execution of notification action failed: " + e);
-            return Boolean.FALSE;
-        } finally {
-            method.releaseConnection();
-        }
+//        try {
+        // TODO
+        status = -1;
+        //status = method.eclient.executeMethod(method);
+//        } catch (IOException e) {
+//            Log_OC.e(this, "Execution of notification action failed: " + e);
+//            return Boolean.FALSE;
+//        } finally {
+//            method.releaseConnection();
+//        }
 
         return status == HttpStatus.SC_OK || status == HttpStatus.SC_ACCEPTED;
     }


### PR DESCRIPTION
Similar to https://github.com/nextcloud/android-library/pull/454

This approach let us mock any network request when run an instrumented test (for now).
I am unsure about this concept:
+ it helps to mock any request, even requests to check if firewall is blocked
+ it tests client usage
- it is heavily included in code
- we can use other approaches to mock client entirely

What do you think?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
