### PR TITLE
Add touch states to file_list_actions_bottom_sheet

### DIFF
--- a/src/main/res/layout/file_list_actions_bottom_sheet_creator.xml
+++ b/src/main/res/layout/file_list_actions_bottom_sheet_creator.xml
@@ -25,6 +25,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
+    android:background="?android:attr/selectableItemBackground"
     android:paddingLeft="@dimen/standard_padding"
     android:paddingTop="@dimen/standard_half_padding"
     android:paddingRight="@dimen/standard_padding"

--- a/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
+++ b/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
@@ -38,6 +38,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:background="?android:attr/selectableItemBackground"
         android:paddingLeft="@dimen/standard_padding"
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingRight="@dimen/standard_padding"
@@ -68,6 +69,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:background="?android:attr/selectableItemBackground"
         android:paddingLeft="@dimen/standard_padding"
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingRight="@dimen/standard_padding"
@@ -98,6 +100,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:background="?android:attr/selectableItemBackground"
         android:paddingLeft="@dimen/standard_padding"
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingRight="@dimen/standard_padding"
@@ -138,6 +141,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:background="?android:attr/selectableItemBackground"
         android:paddingLeft="@dimen/standard_padding"
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingRight="@dimen/standard_padding"
@@ -184,6 +188,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:background="?android:attr/selectableItemBackground"
             android:paddingLeft="@dimen/standard_padding"
             android:paddingTop="@dimen/standard_half_padding"
             android:paddingRight="@dimen/standard_padding"
@@ -212,6 +217,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:background="?android:attr/selectableItemBackground"
             android:paddingLeft="@dimen/standard_padding"
             android:paddingTop="@dimen/standard_half_padding"
             android:paddingRight="@dimen/standard_padding"
@@ -240,6 +246,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:background="?android:attr/selectableItemBackground"
             android:paddingLeft="@dimen/standard_padding"
             android:paddingTop="@dimen/standard_half_padding"
             android:paddingRight="@dimen/standard_padding"
@@ -285,7 +292,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
-
         </LinearLayout>
 
         <View
@@ -303,6 +309,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:background="?android:attr/selectableItemBackground"
         android:paddingLeft="@dimen/standard_padding"
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingRight="@dimen/standard_padding"


### PR DESCRIPTION
This PR adds touch states to the elements of the bottom sheet in the app's main screen.

Tested on OxygenOS 10.

<img src=https://user-images.githubusercontent.com/33295590/84801606-ad770080-afff-11ea-8717-33b95e0b501a.jpg width=200>


### Testing 

<!--
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)
-->

- [x] ~Tests written, or~ not not needed
