### PR TITLE
Use MaterialButton for addAccount action in accounts screen

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/UserListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/UserListAdapter.java
@@ -148,8 +148,6 @@ public class UserListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private void setupAddAccountListItem(AddAccountViewHolderItem holder) {
         View actionView = holder.itemView;
 
-        holder.usernameViewItem.setTextColor(context.getResources().getColor(R.color.fontAppbar));
-
         // bind action listener
         boolean isProviderOrOwnInstallationVisible = context.getResources()
                 .getBoolean(R.bool.show_provider_or_own_installation);
@@ -333,10 +331,8 @@ public class UserListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
      * Account ViewHolderItem to get smooth scrolling.
      */
     static class AddAccountViewHolderItem extends RecyclerView.ViewHolder {
-        private TextView usernameViewItem;
         AddAccountViewHolderItem(@NonNull View view) {
             super(view);
-            this.usernameViewItem = view.findViewById(R.id.user_name);
         }
     }
 

--- a/src/main/res/layout/account_action.xml
+++ b/src/main/res/layout/account_action.xml
@@ -19,35 +19,20 @@
   You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
+
+<com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+    android:layout_width="match_parent"
     android:layout_height="@dimen/account_action_layout_height"
     android:layout_margin="@dimen/standard_quarter_margin"
-    android:orientation="horizontal"
-    android:weightSum="1"
-    tools:ignore="UseCompoundDrawables">
-
-    <ImageView
-        android:id="@+id/user_icon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_gravity="center_vertical"
-        android:layout_marginStart="20dp"
-        android:layout_marginEnd="8dp"
-        android:src="@drawable/ic_account_plus"
-        android:contentDescription="@string/prefs_add_account"/>
-
-    <TextView
-        android:id="@+id/user_name"
-        android:layout_width="0dp"
-        android:layout_height="fill_parent"
-        android:layout_weight="1"
-        android:gravity="center_vertical"
-        android:paddingEnd="@dimen/standard_padding"
-        android:paddingStart="12dp"
-        android:text="@string/prefs_add_account"
-        android:textColor="@color/primary"
-        android:textSize="@dimen/two_line_primary_text_size" />
-
-</LinearLayout>
+    android:paddingStart="20dp"
+    android:paddingEnd="8dp"
+    android:text="@string/prefs_add_account"
+    android:textAlignment="textStart"
+    android:textAllCaps="false"
+    android:textColor="@color/fontAppbar"
+    app:icon="@drawable/ic_account_plus"
+    app:iconGravity="start"
+    app:iconPadding="22dp"
+    app:iconTint="@color/fontAppbar" />


### PR DESCRIPTION
Use a MaterialButton in the "Manage Accounts" screen, similar to the chooser dialog in the main screen.

The main motivation for this is that it gives us a touch state and (in dark mode) the icon color becomes the same as the text color.

Tested on OxygenOS 10.

### Testing 
<!--
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)
-->
- [x] ~Tests written, or not~ not needed
