### PR TITLE
Do not advertise bountyscource, but NC include

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 # You can add one username per supported platform and one custom link
-custom: https://www.bountysource.com/teams/nextcloud/issues?tracker_ids=38838206
+custom: https://nextcloud.com/include/


### PR DESCRIPTION
NC lost trust in Bountysource due to their strange policy, so we instead recommend our own NC Include.