### PR TITLE
Fix improper deleting synced folder by OfflineSyncWork

### DIFF
--- a/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -94,7 +94,7 @@ class OfflineSyncWork constructor(
         Log_OC.d(TAG, folderName + ": currentEtag: " + ocFolder.etag)
         // check for etag change, if false, skip
         val checkEtagOperation = CheckEtagRemoteOperation(
-            ocFolder.encryptedFileName,
+            ocFolder.remotePath,
             ocFolder.etagOnServer
         )
         val result = checkEtagOperation.execute(user.toPlatformAccount(), context)


### PR DESCRIPTION
The CheckEtagRemoteOperation (PROPFIND operation) must use the remote path (e.g. folder/sub) instead of the encrypted file name (which is only the last part of the file name, e.g. "sub").
Admittedly, I don't use encryption, so I hope someone with more knowledge of the code or a setup with encryption can review/test this.
This solves #6334 as far as I can tell from testing with my own instance.