### PR TITLE
Fix NPE in OCFileListFragment when OCFile is null

### DIFF
--- a/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -138,10 +138,10 @@ public interface AppPreferences {
     /**
      * Set preferred folder display type.
      *
-     * @param folder Folder
-     * @param layout_name preference value
+     * @param folder Folder which layout is being set or null for root folder
+     * @param layoutName preference value
      */
-    void setFolderLayout(OCFile folder, String layout_name);
+    void setFolderLayout(@Nullable OCFile folder, String layoutName);
 
     /**
      * Saves the path where the user selected to do the last upload of a file shared from other app.
@@ -213,16 +213,18 @@ public interface AppPreferences {
     /**
      * Get preferred folder sort order.
      *
+     * @param folder Folder whoch order is being retrieved or null for root folder
      * @return sort order     the sort order, default is {@link FileSortOrder#sort_a_to_z} (sort by name)
      */
-    FileSortOrder getSortOrderByFolder(OCFile folder);
+    FileSortOrder getSortOrderByFolder(@Nullable OCFile folder);
 
     /**
      * Set preferred folder sort order.
      *
-     * @param sortOrder the sort order
+     * @param folder Folder which sort order is changed; if null, root folder is assumed
+     * @param sortOrder the sort order of a folder
      */
-    void setSortOrder(OCFile folder, FileSortOrder sortOrder);
+    void setSortOrder(@Nullable OCFile folder, FileSortOrder sortOrder);
 
     /**
      * Set preferred folder sort order.

--- a/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -289,12 +289,12 @@ public final class AppPreferencesImpl implements AppPreferences {
     }
 
     @Override
-    public void setFolderLayout(OCFile folder, String layout_name) {
+    public void setFolderLayout(@Nullable OCFile folder, String layoutName) {
         setFolderPreference(context,
                             currentAccountProvider.getUser(),
                             PREF__FOLDER_LAYOUT,
                             folder,
-                            layout_name);
+                            layoutName);
     }
 
     @Override
@@ -307,7 +307,7 @@ public final class AppPreferencesImpl implements AppPreferences {
     }
 
     @Override
-    public void setSortOrder(OCFile folder, FileSortOrder sortOrder) {
+    public void setSortOrder(@Nullable OCFile folder, FileSortOrder sortOrder) {
         setFolderPreference(context,
                             currentAccountProvider.getUser(),
                             PREF__FOLDER_SORT_ORDER,
@@ -607,13 +607,13 @@ public final class AppPreferencesImpl implements AppPreferences {
     private static void setFolderPreference(final Context context,
                                             final User user,
                                             final String preferenceName,
-                                            final OCFile folder,
+                                            @Nullable final OCFile folder,
                                             final String value) {
         ArbitraryDataProvider dataProvider = new ArbitraryDataProvider(context.getContentResolver());
         dataProvider.storeOrUpdateKeyValue(user.getAccountName(), getKeyFromFolder(preferenceName, folder), value);
     }
 
-    private static String getKeyFromFolder(String preferenceName, OCFile folder) {
+    private static String getKeyFromFolder(String preferenceName, @Nullable OCFile folder) {
         final String folderIdString = String.valueOf(folder != null ? folder.getFileId() :
             FileDataStorageManager.ROOT_PARENT_ID);
 

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -919,8 +919,11 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
 
 
-    public void setData(List<Object> objects, ExtendedListFragment.SearchType searchType,
-                        FileDataStorageManager storageManager, OCFile folder, boolean clear) {
+    public void setData(List<Object> objects,
+                        ExtendedListFragment.SearchType searchType,
+                        FileDataStorageManager storageManager,
+                        @Nullable OCFile folder,
+                        boolean clear) {
         if (storageManager != null && mStorageManager == null) {
             mStorageManager = storageManager;
             showShareAvatar = mStorageManager.getCapability(user.getAccountName()).getVersion().isShareesOnDavSupported();
@@ -1107,7 +1110,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
 
-    public void setSortOrder(OCFile folder, FileSortOrder sortOrder) {
+    public void setSortOrder(@Nullable OCFile folder, FileSortOrder sortOrder) {
         preferences.setSortOrder(folder, sortOrder);
         mFiles = sortOrder.sortCloudFiles(mFiles);
         notifyDataSetChanged();

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1300,7 +1300,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
 
         // FAB
-        setFabEnabled(mFile.canWrite());
+        setFabEnabled(mFile != null && mFile.canWrite());
 
         invalidateActionMode();
     }
@@ -1330,10 +1330,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
      * Determines if user set folder to grid or list view. If folder is not set itself,
      * it finds a parent that is set (at least root is set).
      *
-     * @param folder Folder to check.
+     * @param folder Folder to check or null for root folder
      * @return 'true' is folder should be shown in grid mode, 'false' if list mode is preferred.
      */
-    public boolean isGridViewPreferred(OCFile folder) {
+    public boolean isGridViewPreferred(@Nullable OCFile folder) {
         return FOLDER_LAYOUT_GRID.equals(preferences.getFolderLayout(folder));
     }
 


### PR DESCRIPTION
1. Fixed NPE
2. Audited all use of nullable field in all called APIs
3. Updated called APIs nullability documentation

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] No test as this is a speculative fix for a tricky edge case + audit changes
