### PR TITLE
Migate file details and share details to User model

### DIFF
--- a/src/main/java/com/nextcloud/client/account/UserAccountManager.java
+++ b/src/main/java/com/nextcloud/client/account/UserAccountManager.java
@@ -137,7 +137,17 @@ public interface UserAccountManager extends CurrentAccountProvider {
      * @param account account to compare
      * @return false if ownerId is not set or owner is a different account
      */
+    @Deprecated
     boolean accountOwnsFile(OCFile file, Account account);
+
+    /**
+     * Checks if an account owns the file (file's ownerId is the same as account name)
+     *
+     * @param file File to check
+     * @param user user to check against
+     * @return false if ownerId is not set or owner is a different account
+     */
+    boolean userOwnsFile(OCFile file, User user);
 
     /**
      * Extract username from account.

--- a/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -340,6 +340,11 @@ public class UserAccountManagerImpl implements UserAccountManager {
         return TextUtils.isEmpty(ownerId) || account.name.split("@")[0].equals(ownerId);
     }
 
+    @Override
+    public boolean userOwnsFile(OCFile file, User user) {
+        return accountOwnsFile(file, user.toPlatformAccount());
+    }
+
     public boolean migrateUserId() {
         Account[] ocAccounts = accountManager.getAccountsByType(MainApp.getAccountType(context));
         String userId;

--- a/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -25,6 +25,8 @@ import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 
+import com.nextcloud.client.account.User;
+import com.nextcloud.java.util.Optional;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.ShareActivityBinding;
 import com.owncloud.android.datamodel.OCFile;
@@ -92,11 +94,16 @@ public class ShareActivity extends FileActivity {
         // Size
         binding.shareFileSize.setText(DisplayUtils.bytesToHumanReadable(file.getFileLength()));
 
-        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        Optional<User> optionalUser = getUser();
+        if (!optionalUser.isPresent()) {
+            finish();
+            return;
+        }
 
         if (savedInstanceState == null) {
             // Add Share fragment on first creation
-            Fragment fragment = FileDetailSharingFragment.newInstance(getFile(), getAccount());
+            FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+            Fragment fragment = FileDetailSharingFragment.newInstance(getFile(), optionalUser.get());
             ft.replace(R.id.share_fragment_container, fragment, TAG_SHARE_FRAGMENT);
             ft.commit();
         }

--- a/src/main/java/com/owncloud/android/ui/adapter/FileDetailTabAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/FileDetailTabAdapter.java
@@ -22,6 +22,7 @@ package com.owncloud.android.ui.adapter;
 
 import android.accounts.Account;
 
+import com.nextcloud.client.account.User;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.ui.fragment.FileDetailActivitiesFragment;
 import com.owncloud.android.ui.fragment.FileDetailSharingFragment;
@@ -35,26 +36,25 @@ import androidx.fragment.app.FragmentStatePagerAdapter;
  */
 public class FileDetailTabAdapter extends FragmentStatePagerAdapter {
     private OCFile file;
-    private Account account;
+    private User user;
 
     private FileDetailSharingFragment fileDetailSharingFragment;
     private FileDetailActivitiesFragment fileDetailActivitiesFragment;
 
-    public FileDetailTabAdapter(FragmentManager fm, OCFile file, Account account) {
+    public FileDetailTabAdapter(FragmentManager fm, OCFile file, User user) {
         super(fm);
-
         this.file = file;
-        this.account = account;
+        this.user = user;
     }
 
     @Override
     public Fragment getItem(int position) {
         switch (position) {
             case 0:
-                fileDetailActivitiesFragment = FileDetailActivitiesFragment.newInstance(file, account);
+                fileDetailActivitiesFragment = FileDetailActivitiesFragment.newInstance(file, user);
                 return fileDetailActivitiesFragment;
             case 1:
-                fileDetailSharingFragment = FileDetailSharingFragment.newInstance(file, account);
+                fileDetailSharingFragment = FileDetailSharingFragment.newInstance(file, user);
                 return fileDetailSharingFragment;
             default:
                 return null;


### PR DESCRIPTION
Migate file details and share details to User model

`UserAccountManager`:
 - added `userOwnsFile` API that replaces `accountOwnsFile`
 - deprecated accountOwnsFile

`FileDisplayActivity`:
 - simplified `initFragmentWithFile` by passing non-null instanecs
   of user and file and thus avoiding numerous redundant null-checks
 - fragments are initialized using `User` model instead of `Account`
 - transfer and	download callbacks use `getUser()` instead of `getAccount()`
   and pass user instance to framents

`ShareActivity`:
 - initlize fragment using `User` model instead of `Account`
 - close acivity immediately if	current	user is	not available
   (cannot reach such state not, but historically account was nullable)

`FileDetailTabAdapter`
 - framents are	initialized using `User` model instead of	`Account`

`FileDetailActivitiesFragment`
 - migrated to User
 - removed dependency on constants from FileActivity

`FileDetailFragment`:
 - migrated to User
 - removed dependency on constants from FileActivity

`FileDetailsSharingFragment`:
 - migrated to User
 - removed dependency on constants from FileActivity

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] Manual tests only as the code has no unit tests