### PR TITLE
Provide DeckApi via dependency injection framework

### DIFF
--- a/src/androidTest/java/com/nextcloud/client/integrations/deck/DeckApiTest.kt
+++ b/src/androidTest/java/com/nextcloud/client/integrations/deck/DeckApiTest.kt
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.nextcloud.client.integration.deck
+package com.nextcloud.client.integrations.deck
 
 import android.content.Context
 import android.content.Intent

--- a/src/main/java/com/nextcloud/client/di/AppComponent.java
+++ b/src/main/java/com/nextcloud/client/di/AppComponent.java
@@ -24,6 +24,7 @@ import android.app.Application;
 
 import com.nextcloud.client.appinfo.AppInfoModule;
 import com.nextcloud.client.device.DeviceModule;
+import com.nextcloud.client.integrations.IntegrationsModule;
 import com.nextcloud.client.jobs.JobsModule;
 import com.nextcloud.client.network.NetworkModule;
 import com.nextcloud.client.onboarding.OnboardingModule;
@@ -45,7 +46,8 @@ import dagger.android.support.AndroidSupportInjectionModule;
     DeviceModule.class,
     OnboardingModule.class,
     ViewModelModule.class,
-    JobsModule.class
+    JobsModule.class,
+    IntegrationsModule.class
 })
 @Singleton
 public interface AppComponent {

--- a/src/main/java/com/nextcloud/client/di/AppModule.java
+++ b/src/main/java/com/nextcloud/client/di/AppModule.java
@@ -26,6 +26,7 @@ import android.app.NotificationManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.media.AudioManager;
 import android.os.Handler;
@@ -78,6 +79,11 @@ class AppModule {
     @Provides
     Context context(Application application) {
         return application;
+    }
+
+    @Provides
+    PackageManager packageManager(Application application) {
+        return application.getPackageManager();
     }
 
     @Provides

--- a/src/main/java/com/nextcloud/client/integrations/IntegrationsModule.kt
+++ b/src/main/java/com/nextcloud/client/integrations/IntegrationsModule.kt
@@ -1,0 +1,16 @@
+package com.nextcloud.client.integrations
+
+import android.content.Context
+import android.content.pm.PackageManager
+import com.nextcloud.client.integrations.deck.DeckApi
+import com.nextcloud.client.integrations.deck.DeckApiImpl
+import dagger.Module
+import dagger.Provides
+
+@Module
+class IntegrationsModule {
+    @Provides
+    fun deckApi(context: Context, packageManager: PackageManager): DeckApi {
+        return DeckApiImpl(context, packageManager)
+    }
+}

--- a/src/main/java/com/nextcloud/client/integrations/Package.md
+++ b/src/main/java/com/nextcloud/client/integrations/Package.md
@@ -1,0 +1,4 @@
+# Package com.nextcloud.client.integrations
+
+This package provides utilities and interfaces to integrate
+Files application with 3rd party apps.

--- a/src/main/java/com/nextcloud/client/integrations/deck/DeckApi.java
+++ b/src/main/java/com/nextcloud/client/integrations/deck/DeckApi.java
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.nextcloud.client.integration.deck;
+package com.nextcloud.client.integrations.deck;
 
 import android.app.PendingIntent;
 

--- a/src/main/java/com/nextcloud/client/integrations/deck/DeckApiImpl.java
+++ b/src/main/java/com/nextcloud/client/integrations/deck/DeckApiImpl.java
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.nextcloud.client.integration.deck;
+package com.nextcloud.client.integrations.deck;
 
 import android.app.PendingIntent;
 import android.content.Context;

--- a/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
+++ b/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
@@ -32,6 +32,7 @@ import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.device.DeviceInfo
 import com.nextcloud.client.device.PowerManagementService
+import com.nextcloud.client.integrations.deck.DeckApi
 import com.nextcloud.client.logger.Logger
 import com.nextcloud.client.network.ConnectivityService
 import com.nextcloud.client.preferences.AppPreferences
@@ -60,7 +61,8 @@ class BackgroundJobFactory @Inject constructor(
     private val uploadsStorageManager: UploadsStorageManager,
     private val connectivityService: ConnectivityService,
     private val notificationManager: NotificationManager,
-    private val eventBus: EventBus
+    private val eventBus: EventBus,
+    private val deckApi: DeckApi
 ) : WorkerFactory() {
 
     @Suppress("ComplexMethod") // it's just a trivial dispatch
@@ -173,7 +175,8 @@ class BackgroundJobFactory @Inject constructor(
             context,
             params,
             notificationManager,
-            accountManager
+            accountManager,
+            deckApi
         )
     }
 

--- a/src/main/java/com/nextcloud/client/jobs/NotificationWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/NotificationWork.kt
@@ -42,7 +42,7 @@ import androidx.work.WorkerParameters
 import com.google.gson.Gson
 import com.nextcloud.client.account.User
 import com.nextcloud.client.account.UserAccountManager
-import com.nextcloud.client.integration.deck.DeckApiImpl
+import com.nextcloud.client.integrations.deck.DeckApi
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.DecryptedPushMessage
 import com.owncloud.android.lib.common.OwnCloudClient
@@ -75,7 +75,8 @@ class NotificationWork constructor(
     private val context: Context,
     params: WorkerParameters,
     private val notificationManager: NotificationManager,
-    private val accountManager: UserAccountManager
+    private val accountManager: UserAccountManager,
+    private val deckApi: DeckApi
 ) : Worker(context, params) {
 
     companion object {
@@ -139,7 +140,6 @@ class NotificationWork constructor(
         val randomId = SecureRandom()
         val file = notification.subjectRichParameters["file"]
 
-        val deckApi = DeckApiImpl(context, context.packageManager)
         val deckActionOverrideIntent = deckApi.createForwardToDeckActionIntent(notification, user)
 
         val pendingIntent: PendingIntent

--- a/src/test/java/com/nextcloud/client/jobs/BackgroundJobFactoryTest.kt
+++ b/src/test/java/com/nextcloud/client/jobs/BackgroundJobFactoryTest.kt
@@ -29,6 +29,7 @@ import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.device.DeviceInfo
 import com.nextcloud.client.device.PowerManagementService
+import com.nextcloud.client.integrations.deck.DeckApi
 import com.nextcloud.client.logger.Logger
 import com.nextcloud.client.network.ConnectivityService
 import com.nextcloud.client.preferences.AppPreferences
@@ -94,6 +95,9 @@ class BackgroundJobFactoryTest {
     @Mock
     private lateinit var eventBus: EventBus
 
+    @Mock
+    private lateinit var deckApi: DeckApi
+
     private lateinit var factory: BackgroundJobFactory
 
     @Before
@@ -113,7 +117,8 @@ class BackgroundJobFactoryTest {
             uploadsStorageManager,
             connectivityService,
             notificationManager,
-            eventBus
+            eventBus,
+            deckApi
         )
     }
 


### PR DESCRIPTION
- renamed integration packate to integrations (plural)
- created DI module for integrations
- added provider for DeckApi
- inject DeckApi to background job factory

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] No unit tests were modified as there is no behavioral change; manual smoke test of Deck integration is advised