### PR TITLE
add passwordless WebAuthn logins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido:2.5.1'
+    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido:4.1.0'
+    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido2:4.1.0'
 
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.10.1'
     spotbugsPlugins 'com.mebigfatguy.fb-contrib:fb-contrib:7.4.7'

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -147,6 +147,9 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import de.cotech.hw.fido.WebViewFidoBridge;
+import de.cotech.hw.fido.ui.FidoDialogOptions;
+import de.cotech.hw.fido2.WebViewWebauthnBridge;
+import de.cotech.hw.fido2.ui.WebauthnDialogOptions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -219,7 +222,8 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     private TextView mAuthStatusView;
     private WebView mLoginWebView;
 
-    private WebViewFidoBridge webViewFidoBridge;
+    private WebViewFidoBridge webViewFidoU2fBridge;
+    private WebViewWebauthnBridge webViewWebauthnBridge;
 
     private String mAuthStatusText = EMPTY_STRING;
     private int mAuthStatusIcon;
@@ -361,7 +365,16 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         mLoginWebView.getSettings().setSaveFormData(false);
         mLoginWebView.getSettings().setSavePassword(false);
 
-        webViewFidoBridge = WebViewFidoBridge.createInstanceForWebView(this, mLoginWebView);
+        FidoDialogOptions.Builder dialogOptionsBuilder = FidoDialogOptions.builder();
+        dialogOptionsBuilder.setShowSdkLogo(true);
+        dialogOptionsBuilder.setTheme(R.style.FidoDialog);
+        webViewFidoU2fBridge = WebViewFidoBridge.createInstanceForWebView(this, mLoginWebView, dialogOptionsBuilder);
+
+        WebauthnDialogOptions.Builder webauthnOptionsBuilder = WebauthnDialogOptions.builder();
+        webauthnOptionsBuilder.setShowSdkLogo(true);
+        webauthnOptionsBuilder.setAllowSkipPin(true);
+        webauthnOptionsBuilder.setTheme(R.style.FidoDialog);
+        webViewWebauthnBridge = WebViewWebauthnBridge.createInstanceForWebView(this, mLoginWebView, webauthnOptionsBuilder);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(RemoteOperation.OCS_API_HEADER, RemoteOperation.OCS_API_HEADER_VALUE);
@@ -396,14 +409,16 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         mLoginWebView.setWebViewClient(new WebViewClient() {
             @Override
             public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-                webViewFidoBridge.delegateShouldInterceptRequest(view, request);
+                webViewFidoU2fBridge.delegateShouldInterceptRequest(view, request);
+                webViewWebauthnBridge.delegateShouldInterceptRequest(view, request);
                 return super.shouldInterceptRequest(view, request);
             }
 
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
                 super.onPageStarted(view, url, favicon);
-                webViewFidoBridge.delegateOnPageStarted(view, url, favicon);
+                webViewFidoU2fBridge.delegateOnPageStarted(view, url, favicon);
+                webViewWebauthnBridge.delegateOnPageStarted(view, url, favicon);
             }
 
             @Override

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -329,4 +329,10 @@
         <item name="iconGravity">textStart</item>
         <item name="iconPadding">0dp</item>
     </style>
+
+    <!-- Custom colors for the FIDO dialog -->
+    <style name="FidoDialog" parent="HwSecurity.Dialog">
+        <item name="hwSecurityButtonColor">@color/color_accent</item>
+        <item name="hwSecuritySurfaceColor">@color/primary</item>
+    </style>
 </resources>


### PR DESCRIPTION
This implements passwordless WebAuthn logins using our Hardware Security SDK. Passwordless WebAuthn logins work with Nextcloud 19 out of the box.

As in our previous [PR](https://github.com/nextcloud/android/pull/4286):
* source code is here: https://github.com/cotechde/hwsecurity
* 100% GPLv3
* not depending on Google Play Services

### Thanks
Thanks to https://portknox.net for providing a Nextcloud 19 test instance!

### Screenshots
1. Click on small link "Log in with a device"
![Screenshot_20200630-194030-2](https://user-images.githubusercontent.com/321888/86159421-9d384880-bb0a-11ea-9846-7cbb61ffd5ca.png)
2. Enter username, press "Log in". Our dialog comes up: Enter your security key PIN
![Screenshot_20200630-194047-2](https://user-images.githubusercontent.com/321888/86159424-9e697580-bb0a-11ea-8dfb-26245cbd898c.png)
3. Hold security key against NFC or plug in USB
![Screenshot_20200630-194056-2](https://user-images.githubusercontent.com/321888/86159427-9f020c00-bb0a-11ea-859c-46e008c55cf3.png)
4. You are logged in without entering your password
![Screenshot_20200630-194109-2](https://user-images.githubusercontent.com/321888/86159429-9f9aa280-bb0a-11ea-93a0-c06c02e6048f.png)
