### PR TITLE
Add theming logic for share link icons

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/PublicShareViewHolder.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/PublicShareViewHolder.java
@@ -23,13 +23,12 @@
 package com.owncloud.android.ui.adapter;
 
 import android.content.Context;
-import android.graphics.PorterDuff;
 import android.text.TextUtils;
 import android.view.View;
 
-import com.owncloud.android.R;
 import com.owncloud.android.databinding.FileDetailsSharePublicLinkItemBinding;
 import com.owncloud.android.lib.resources.shares.OCShare;
+import com.owncloud.android.utils.ThemeUtils;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -52,15 +51,8 @@ class PublicShareViewHolder extends RecyclerView.ViewHolder {
         if (!TextUtils.isEmpty(publicShare.getLabel())) {
             binding.publicShareLabel.setText(publicShare.getLabel());
         }
-        binding.copyInternalLinkIcon
-            .getBackground()
-            .setColorFilter(context.getResources().getColor(R.color.primary_button_background_color),
-                            PorterDuff.Mode.SRC_IN);
-        binding.copyInternalLinkIcon
-            .getDrawable()
-            .mutate()
-            .setColorFilter(context.getResources().getColor(R.color.black),
-                            PorterDuff.Mode.SRC_IN);
+
+        ThemeUtils.colorIconImageViewWithBackground(binding.copyInternalLinkIcon, context);
 
         binding.shareLinkCopyIcon.setOnClickListener(v -> listener.copyLink(publicShare));
 

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -688,15 +688,9 @@ public final class ThemeUtils {
     public static void colorFloatingActionButton(FloatingActionButton button, @DrawableRes int drawable,
                                                  Context context) {
         int primaryColor = ThemeUtils.primaryColor(null, true, false, context);
-        colorFloatingActionButton(button, context, primaryColor);
 
-        if (Color.BLACK == primaryColor) {
-            button.setImageDrawable(ThemeUtils.tintDrawable(drawable, Color.WHITE));
-        } else if (Color.WHITE == primaryColor) {
-            button.setImageDrawable(ThemeUtils.tintDrawable(drawable, Color.BLACK));
-        } else {
-            button.setImageDrawable(ThemeUtils.tintDrawable(drawable, ThemeUtils.fontColor(context, false)));
-        }
+        colorFloatingActionButton(button, context, primaryColor);
+        button.setImageDrawable(ThemeUtils.tintDrawable(drawable, getColorForPrimary(primaryColor, context)));
     }
 
     public static void colorFloatingActionButton(FloatingActionButton button, Context context) {
@@ -710,6 +704,29 @@ public final class ThemeUtils {
     public static void colorFloatingActionButton(FloatingActionButton button, int backgroundColor, int rippleColor) {
         button.setBackgroundTintList(ColorStateList.valueOf(backgroundColor));
         button.setRippleColor(rippleColor);
+    }
+
+    public static void colorIconImageViewWithBackground(ImageView imageView, Context context) {
+        int primaryColor = ThemeUtils.primaryColor(null, true, false, context);
+
+        imageView.getBackground().setColorFilter(primaryColor, PorterDuff.Mode.SRC_IN);
+        imageView.getDrawable().mutate().setColorFilter(getColorForPrimary(primaryColor, context),
+                                                        PorterDuff.Mode.SRC_IN);
+    }
+
+    /**
+     * returns a primary color matching color for texts/icons on top of a primary-colored element (like buttons).
+     *
+     * @param primaryColor the primary color
+     */
+    private static int getColorForPrimary(int primaryColor, Context context) {
+        if (Color.BLACK == primaryColor) {
+            return Color.WHITE;
+        } else if (Color.WHITE == primaryColor) {
+            return Color.BLACK;
+        } else {
+            return ThemeUtils.fontColor(context, false);
+        }
     }
 
     private static OCCapability getCapability(Context context) {


### PR DESCRIPTION
Resolve #6399

As a follow-up for #6332 and #6358 the link icon/background should be themed like the fab/primary-action-buttons now available via the #6332 theming logic.