### PR TITLE
Theming Refactoring

### DIFF
--- a/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
+++ b/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
@@ -258,34 +258,34 @@ public final class ColorsUtils {
     }
 
     /**
-     * Tests if light color is set
-     *
-     * @param color the color
-     * @return true if primaryColor is lighter than MAX_LIGHTNESS
-     */
-    public static boolean lightTheme(int color) {
-        float[] hsl = ColorsUtils.colorToHSL(color);
-
-        return hsl[INDEX_LUMINATION] >= MAX_LIGHTNESS;
-    }
-
-    /**
      * Tests if dark color is set
      *
      * @return true if dark theme -> e.g.use light font color, darker accent color
      */
     public static boolean darkColor(Context context) {
-        int primaryColor = ColorsUtils.elementColor(context);
-        float[] hsl = ColorsUtils.colorToHSL(primaryColor);
+        int elementColor = ColorsUtils.elementColor(context);
+        float[] hsl = ColorsUtils.colorToHSL(elementColor);
 
         return hsl[INDEX_LUMINATION] <= 0.55;
     }
 
-    private static float[] colorToHSL(int color) {
+    public static float[] colorToHSL(int color) {
         float[] hsl = new float[3];
         ColorUtils.RGBToHSL(Color.red(color), Color.green(color), Color.blue(color), hsl);
 
         return hsl;
+    }
+
+    /**
+     * Tests if color is light
+     *
+     * @param color the color
+     * @return true if color is lighter than MAX_LIGHTNESS
+     */
+    public static boolean isLightColor(int color) {
+        float[] hsl = colorToHSL(color);
+
+        return hsl[INDEX_LUMINATION] >= MAX_LIGHTNESS;
     }
 
     private static boolean isDarkModeActive(Context context) {

--- a/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
+++ b/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
@@ -1,0 +1,318 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * @author Andy Scherzinger
+ * Copyright (C) 2017 Tobias Kaminsky
+ * Copyright (C) 2017 Nextcloud GmbH
+ * Copyright (C) 2018 Andy Scherzinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.ui.theming;
+
+import android.accounts.Account;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Color;
+import android.text.TextUtils;
+
+import com.nextcloud.client.account.UserAccountManagerImpl;
+import com.owncloud.android.R;
+import com.owncloud.android.datamodel.FileDataStorageManager;
+import com.owncloud.android.lib.resources.status.OCCapability;
+import com.owncloud.android.utils.NextcloudServer;
+
+import androidx.annotation.Nullable;
+import androidx.core.graphics.ColorUtils;
+
+/**
+ * Utility class with methods for color values used for theming.
+ */
+public final class ColorsUtils {
+
+    private static final int INDEX_LUMINATION = 2;
+    private static final double MAX_LIGHTNESS = 0.92;
+    public static final double LUMINATION_THRESHOLD = 0.8;
+
+    private ColorsUtils() {
+        // utility class -> private constructor
+    }
+
+    /**
+     * return the element color defined in the server-side theming respecting Android dark/light theming and edge case
+     * scenarios.
+     *
+     * @param context the context (needed to load client-side colors and capability infos)
+     * @return the color
+     */
+    public static int elementColor(@Nullable Context context) {
+        return elementColor(null, context, true);
+    }
+
+    /**
+     * return the element color defined in the server-side theming respecting Android dark/light theming and edge case
+     * scenarios.
+     *
+     * @param account the Nextcloud user
+     * @param context the context (needed to load client-side colors and capability infos)
+     * @return the color
+     */
+    public static int elementColor(@Nullable Account account,
+                                   @Nullable Context context) {
+        return elementColor(account, context, true);
+    }
+
+    /**
+     * return the element color defined in the server-side theming respecting Android dark/light theming and edge case
+     * scenarios.
+     *
+     * @param account           the Nextcloud user
+     * @param replaceEdgeColors flag if edge case color scenarios should be handled
+     * @param context           the context (needed to load client-side colors and capability infos)
+     * @return the color
+     */
+    public static int elementColor(@Nullable Account account,
+                                   @Nullable Context context,
+                                   boolean replaceEdgeColors) {
+        return elementColor(account, context, replaceEdgeColors, false);
+    }
+
+    /**
+     * return the element color defined in the server-side theming respecting Android dark/light theming and edge case
+     * scenarios including drawer menu.
+     *
+     * @param account                          the Nextcloud user
+     * @param replaceEdgeColors                flag if edge case color scenarios should be handled
+     * @param replaceEdgeColorsByInvertedColor flag in edge case handling should be done via color inversion
+     *                                         (black/white)
+     * @param context                          the context (needed to load client-side colors and capability infos)
+     * @return the color
+     */
+    public static int elementColor(@Nullable Account account,
+                                   @Nullable Context context,
+                                   boolean replaceEdgeColors,
+                                   boolean replaceEdgeColorsByInvertedColor) {
+
+        if (context == null) {
+            return Color.GRAY;
+        }
+
+        if (account == null) {
+            return context.getResources().getColor(R.color.primary);
+        }
+
+        OCCapability capability = getCapability(account, context);
+
+        if (!TextUtils.isEmpty(capability.getServerElementColorDark())
+            && !TextUtils.isEmpty(capability.getServerElementColorBright())) {
+            // Dark/Light contrast aware background available
+            try {
+                if (isDarkModeActive(context)) {
+                    return Color.parseColor(capability.getServerElementColorDark());
+                } else {
+                    return Color.parseColor(capability.getServerElementColorBright());
+                }
+            } catch (Exception e) {
+                return elementColorLegacy(account, context, replaceEdgeColors, replaceEdgeColorsByInvertedColor);
+            }
+        } else if (!TextUtils.isEmpty(capability.getServerElementColor())) {
+            return elementColorLegacy(account, context, replaceEdgeColors, replaceEdgeColorsByInvertedColor);
+        } else if (!TextUtils.isEmpty(capability.getServerColor())) {
+            return serverColor(account, context);
+        }
+
+        return context.getResources().getColor(R.color.primary);
+    }
+
+    @NextcloudServer(max = 19)
+    private static int elementColorLegacy(@Nullable Account account,
+                                          @Nullable Context context,
+                                          boolean replaceEdgeColors,
+                                          boolean replaceEdgeColorsByInvertedColor) {
+        if (context == null) {
+            return Color.GRAY;
+        }
+
+        if (account == null) {
+            return context.getResources().getColor(R.color.primary);
+        }
+
+        OCCapability capability = getCapability(account, context);
+
+        try {
+            return Color.parseColor(capability.getServerElementColor());
+        } catch (Exception e) {
+            if (replaceEdgeColors) {
+                return replaceEdgeColor(context, serverColor(account, context), replaceEdgeColorsByInvertedColor);
+            } else {
+                return luminationAwareColor(context, serverColor(account, context));
+            }
+        }
+    }
+
+    @NextcloudServer(max = 19)
+    private static int serverColor(@Nullable Account account, @Nullable Context context) {
+        try {
+            return Color.parseColor(getCapability(account, context).getServerColor());
+        } catch (Exception e) {
+            if (context != null) {
+                return context.getResources().getColor(R.color.primary);
+            } else {
+                return Color.GRAY;
+            }
+        }
+    }
+
+    private static int replaceEdgeColor(Context context, int color, boolean replaceEdgeColorsByInvertedColor) {
+        if (isDarkModeActive(context)) {
+            if (Color.BLACK == color) {
+                if (replaceEdgeColorsByInvertedColor) {
+                    return Color.WHITE;
+                } else {
+                    return getNeutralGrey(context);
+                }
+            } else {
+                return color;
+            }
+        } else {
+            if (Color.WHITE == color) {
+                if (replaceEdgeColorsByInvertedColor) {
+                    return Color.BLACK;
+                } else {
+                    return getNeutralGrey(context);
+                }
+            } else {
+                return color;
+            }
+        }
+    }
+
+    public static String colorToHexString(int color) {
+        return String.format("#%06X", 0xFFFFFF & color);
+    }
+
+    public static int elementTextColor(Context context) {
+        try {
+            return Color.parseColor(getCapability(null, context).getServerTextColor());
+        } catch (Exception e) {
+            if (ColorsUtils.darkColor(context)) {
+                return Color.WHITE;
+            } else {
+                return Color.BLACK;
+            }
+        }
+    }
+
+    public static int calculateDarkColor(int color, Context context) {
+        try {
+            return adjustLightness(-0.2f, color, -1f);
+        } catch (Exception e) {
+            if (context != null) {
+                return context.getResources().getColor(R.color.primary_dark);
+            } else {
+                return Color.DKGRAY;
+            }
+        }
+    }
+
+    private static int luminationAwareColor(Context context, int color) {
+        float[] hsl = colorToHSL(color);
+
+        if (hsl[INDEX_LUMINATION] > LUMINATION_THRESHOLD) {
+            return getNeutralGrey(context);
+        } else {
+            return color;
+        }
+    }
+
+    /**
+     * Adjust lightness of given color
+     *
+     * @param lightnessDelta values -1..+1
+     * @param color          original color
+     * @param threshold      0..1 as maximum value, -1 to disable
+     * @return color adjusted by lightness
+     */
+    public static int adjustLightness(float lightnessDelta, int color, float threshold) {
+        float[] hsl = colorToHSL(color);
+
+        if (threshold == -1f) {
+            hsl[INDEX_LUMINATION] += lightnessDelta;
+        } else {
+            hsl[INDEX_LUMINATION] = Math.min(hsl[INDEX_LUMINATION] + lightnessDelta, threshold);
+        }
+
+        return ColorUtils.HSLToColor(hsl);
+    }
+
+    /**
+     * Tests if light color is set
+     *
+     * @param color the color
+     * @return true if primaryColor is lighter than MAX_LIGHTNESS
+     */
+    public static boolean lightTheme(int color) {
+        float[] hsl = ColorsUtils.colorToHSL(color);
+
+        return hsl[INDEX_LUMINATION] >= MAX_LIGHTNESS;
+    }
+
+    /**
+     * Tests if dark color is set
+     *
+     * @return true if dark theme -> e.g.use light font color, darker accent color
+     */
+    public static boolean darkColor(Context context) {
+        int primaryColor = ColorsUtils.elementColor(context);
+        float[] hsl = ColorsUtils.colorToHSL(primaryColor);
+
+        return hsl[INDEX_LUMINATION] <= 0.55;
+    }
+
+    private static float[] colorToHSL(int color) {
+        float[] hsl = new float[3];
+        ColorUtils.RGBToHSL(Color.red(color), Color.green(color), Color.blue(color), hsl);
+
+        return hsl;
+    }
+
+    private static boolean isDarkModeActive(Context context) {
+        int nightModeFlag = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+
+        return Configuration.UI_MODE_NIGHT_YES == nightModeFlag;
+    }
+
+    public static int getNeutralGrey(Context context) {
+        return ColorsUtils.darkColor(context) ? context.getResources().getColor(R.color.fg_contrast) : Color.GRAY;
+    }
+
+    private static OCCapability getCapability(Account acc, Context context) {
+        Account account = null;
+
+        if (acc != null) {
+            account = acc;
+        } else if (context != null) {
+            // TODO: refactor when dark theme work is completed
+            account = UserAccountManagerImpl.fromContext(context).getCurrentAccount();
+        }
+
+        if (account != null) {
+            FileDataStorageManager storageManager = new FileDataStorageManager(account, context.getContentResolver());
+            return storageManager.getCapability(account.name);
+        } else {
+            return new OCCapability();
+        }
+    }
+}

--- a/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
+++ b/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
@@ -36,6 +36,7 @@ import com.owncloud.android.utils.NextcloudServer;
 
 import androidx.annotation.Nullable;
 import androidx.core.graphics.ColorUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Utility class with methods for color values used for theming.
@@ -227,6 +228,7 @@ public final class ColorsUtils {
         }
     }
 
+    @SuppressFBWarnings("CLI_CONSTANT_LIST_INDEX")
     private static int luminationAwareColor(Context context, int color) {
         float[] hsl = colorToHSL(color);
 
@@ -245,6 +247,7 @@ public final class ColorsUtils {
      * @param threshold      0..1 as maximum value, -1 to disable
      * @return color adjusted by lightness
      */
+    @SuppressFBWarnings("CLI_CONSTANT_LIST_INDEX")
     public static int adjustLightness(float lightnessDelta, int color, float threshold) {
         float[] hsl = colorToHSL(color);
 
@@ -262,6 +265,7 @@ public final class ColorsUtils {
      *
      * @return true if dark theme -> e.g.use light font color, darker accent color
      */
+    @SuppressFBWarnings("CLI_CONSTANT_LIST_INDEX")
     public static boolean darkColor(Context context) {
         int elementColor = ColorsUtils.elementColor(context);
         float[] hsl = ColorsUtils.colorToHSL(elementColor);
@@ -282,6 +286,7 @@ public final class ColorsUtils {
      * @param color the color
      * @return true if color is lighter than MAX_LIGHTNESS
      */
+    @SuppressFBWarnings("CLI_CONSTANT_LIST_INDEX")
     public static boolean isLightColor(int color) {
         float[] hsl = colorToHSL(color);
 

--- a/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
+++ b/src/main/java/com/nextcloud/ui/theming/ColorsUtils.java
@@ -110,10 +110,6 @@ public final class ColorsUtils {
             return Color.GRAY;
         }
 
-        if (account == null) {
-            return context.getResources().getColor(R.color.primary);
-        }
-
         OCCapability capability = getCapability(account, context);
 
         if (!TextUtils.isEmpty(capability.getServerElementColorDark())
@@ -144,10 +140,6 @@ public final class ColorsUtils {
                                           boolean replaceEdgeColorsByInvertedColor) {
         if (context == null) {
             return Color.GRAY;
-        }
-
-        if (account == null) {
-            return context.getResources().getColor(R.color.primary);
         }
 
         OCCapability capability = getCapability(account, context);

--- a/src/main/java/com/nextcloud/ui/theming/ThemeFabUtils.kt
+++ b/src/main/java/com/nextcloud/ui/theming/ThemeFabUtils.kt
@@ -1,0 +1,63 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * @author Andy Scherzinger
+ * Copyright (C) 2017 Tobias Kaminsky
+ * Copyright (C) 2017 Nextcloud GmbH
+ * Copyright (C) 2018 Andy Scherzinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.ui.theming
+
+import android.content.Context
+import android.content.res.ColorStateList
+import androidx.annotation.DrawableRes
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.owncloud.android.utils.ThemeUtils
+
+/**
+ * Utility class with methods for client side FAB theming.
+ */
+object ThemeFabUtils {
+    /**
+     * themes a given FAB including the FAB's icon based on the primary color.
+     *
+     * @param fab     the FAB to be themed
+     * @param icon    the FAB's icon
+     * @param context the context to load colors
+     */
+    @JvmStatic
+    fun colorFloatingActionButton(fab: FloatingActionButton, @DrawableRes icon: Int, context: Context?) {
+        colorFloatingActionButton(fab, context)
+        fab.setImageDrawable(ThemeUtils.tintDrawable(icon, ColorsUtils.elementTextColor(context)))
+    }
+
+    /**
+     * themes a given FAB.
+     *
+     * @param button          the FAB to be themed
+     * @param context         the context to load colors
+     * @param backgroundColor the FABs color to be used
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun colorFloatingActionButton(fab: FloatingActionButton,
+                                  context: Context?,
+                                  backgroundColor: Int = ColorsUtils.elementColor(context)) {
+        fab.backgroundTintList = ColorStateList.valueOf(backgroundColor)
+        fab.rippleColor = ColorsUtils.calculateDarkColor(backgroundColor, context)
+    }
+}

--- a/src/main/java/com/nextcloud/ui/theming/ThemeFabUtils.kt
+++ b/src/main/java/com/nextcloud/ui/theming/ThemeFabUtils.kt
@@ -54,9 +54,11 @@ object ThemeFabUtils {
      */
     @JvmStatic
     @JvmOverloads
-    fun colorFloatingActionButton(fab: FloatingActionButton,
-                                  context: Context?,
-                                  backgroundColor: Int = ColorsUtils.elementColor(context)) {
+    fun colorFloatingActionButton(
+        fab: FloatingActionButton,
+        context: Context?,
+        backgroundColor: Int = ColorsUtils.elementColor(context)
+    ) {
         fab.backgroundTintList = ColorStateList.valueOf(backgroundColor)
         fab.rippleColor = ColorsUtils.calculateDarkColor(backgroundColor, context)
     }

--- a/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
+++ b/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
@@ -29,7 +29,8 @@ import com.owncloud.android.utils.ThemeUtils
  */
 object ThemePreferenceUtils {
     @JvmStatic
-    fun colorPreferenceCategory(context: Context?, preferenceCategory: PreferenceCategory?, @StringRes title: Int) {
+    fun colorPreferenceCategory(context: Context?, preferenceCategory: PreferenceCategory?, @StringRes
+    title: Int) {
         if (context != null && preferenceCategory != null) {
             preferenceCategory.title = ThemeUtils.getColoredTitle(
                 context.getString(title),

--- a/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
+++ b/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
@@ -29,11 +29,12 @@ import com.owncloud.android.utils.ThemeUtils
  */
 object ThemePreferenceUtils {
     @JvmStatic
-    fun colorPreferenceCategory(context: Context?, preferenceCategory: PreferenceCategory?,
-                                @StringRes title: Int) {
+    fun colorPreferenceCategory(context: Context?, preferenceCategory: PreferenceCategory?, @StringRes title: Int) {
         if (context != null && preferenceCategory != null) {
-            preferenceCategory.title = ThemeUtils.getColoredTitle(context.getString(title),
-                ThemeUtils.primaryAccentColor(context))
+            preferenceCategory.title = ThemeUtils.getColoredTitle(
+                context.getString(title),
+                ThemeUtils.primaryAccentColor(context)
+            )
         }
     }
 }

--- a/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
+++ b/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
@@ -29,8 +29,10 @@ import com.owncloud.android.utils.ThemeUtils
  */
 object ThemePreferenceUtils {
     @JvmStatic
-    fun colorPreferenceCategory(context: Context?, preferenceCategory: PreferenceCategory?, @StringRes
-    title: Int) {
+    fun colorPreferenceCategory(
+        context: Context?, preferenceCategory: PreferenceCategory?, @StringRes
+        title: Int
+    ) {
         if (context != null && preferenceCategory != null) {
             preferenceCategory.title = ThemeUtils.getColoredTitle(
                 context.getString(title),

--- a/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
+++ b/src/main/java/com/nextcloud/ui/theming/ThemePreferenceUtils.kt
@@ -1,0 +1,39 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Andy Scherzinger
+ * Copyright (C) 2020 Andy Scherzinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.ui.theming
+
+import android.content.Context
+import android.preference.PreferenceCategory
+import androidx.annotation.StringRes
+import com.owncloud.android.utils.ThemeUtils
+
+/**
+ * Utility class with methods for client side preference theming.
+ */
+object ThemePreferenceUtils {
+    @JvmStatic
+    fun colorPreferenceCategory(context: Context?, preferenceCategory: PreferenceCategory?,
+                                @StringRes title: Int) {
+        if (context != null && preferenceCategory != null) {
+            preferenceCategory.title = ThemeUtils.getColoredTitle(context.getString(title),
+                ThemeUtils.primaryAccentColor(context))
+        }
+    }
+}

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -88,6 +88,7 @@ import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.onboarding.FirstRunActivity;
 import com.nextcloud.client.onboarding.OnboardingService;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.ui.theming.ColorsUtils;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.AccountSetupBinding;
@@ -905,7 +906,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                         remoteOperationResult.getData().size() > 0) {
                         OCCapability capability = (OCCapability) remoteOperationResult.getData().get(0);
                         try {
-                            primaryColor = Color.parseColor(capability.getServerColor());
+                            primaryColor = ColorsUtils.elementColor(this);
                         } catch (Exception e) {
                             // falls back to primary color
                         }

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -2037,6 +2037,10 @@ public class FileDataStorageManager {
                           capability.getServerTextColor());
         contentValues.put(ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR,
                           capability.getServerElementColor());
+        contentValues.put(ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_BRIGHT,
+                          capability.getServerElementColorBright());
+        contentValues.put(ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_DARK,
+                          capability.getServerElementColorDark());
         contentValues.put(ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL,
                           capability.getServerBackground());
         contentValues.put(ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN,
@@ -2174,6 +2178,11 @@ public class FileDataStorageManager {
             capability.setServerColor(getString(cursor, ProviderTableMeta.CAPABILITIES_SERVER_COLOR));
             capability.setServerTextColor(getString(cursor, ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR));
             capability.setServerElementColor(getString(cursor, ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR));
+            capability.setServerElementColorBright(
+                getString(cursor,
+                          ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_BRIGHT));
+            capability.setServerElementColorDark(getString(cursor,
+                                                           ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_DARK));
             capability.setServerBackground(getString(cursor, ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL));
             capability.setServerSlogan(getString(cursor, ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN));
             capability.setEndToEndEncryption(getBoolean(cursor, ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION));

--- a/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -209,6 +209,8 @@ public class ProviderMeta {
         public static final String CAPABILITIES_SERVER_COLOR = "server_color";
         public static final String CAPABILITIES_SERVER_TEXT_COLOR = "server_text_color";
         public static final String CAPABILITIES_SERVER_ELEMENT_COLOR = "server_element_color";
+        public static final String CAPABILITIES_SERVER_ELEMENT_COLOR_BRIGHT = "server_element_color_bright";
+        public static final String CAPABILITIES_SERVER_ELEMENT_COLOR_DARK = "server_element_color_dark";
         public static final String CAPABILITIES_SERVER_BACKGROUND_URL = "background_url";
         public static final String CAPABILITIES_SERVER_SLOGAN = "server_slogan";
         public static final String CAPABILITIES_SERVER_BACKGROUND_DEFAULT = "background_default";

--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -782,6 +782,8 @@ public class FileContentProvider extends ContentProvider {
                        + ProviderTableMeta.CAPABILITIES_SERVER_COLOR + TEXT
                        + ProviderTableMeta.CAPABILITIES_SERVER_TEXT_COLOR + TEXT
                        + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR + TEXT
+                       + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_BRIGHT + TEXT
+                       + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_DARK + TEXT
                        + ProviderTableMeta.CAPABILITIES_SERVER_SLOGAN + TEXT
                        + ProviderTableMeta.CAPABILITIES_SERVER_BACKGROUND_URL + TEXT
                        + ProviderTableMeta.CAPABILITIES_END_TO_END_ENCRYPTION + INTEGER
@@ -2257,6 +2259,23 @@ public class FileContentProvider extends ContentProvider {
                 try {
                     db.execSQL(ALTER_TABLE + ProviderTableMeta.OCSHARES_TABLE_NAME +
                                    ADD_COLUMN + ProviderTableMeta.OCSHARES_SHARE_LABEL + " TEXT ");
+
+                    upgraded = true;
+                    db.setTransactionSuccessful();
+                } finally {
+                    db.endTransaction();
+                }
+            }
+
+            if (oldVersion < 60 && newVersion >= 60) {
+                Log_OC.i(SQL, "Entering in the #60 Adding element color bright/dark to capabilities");
+                db.beginTransaction();
+                try {
+                    db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                                   ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_BRIGHT + " TEXT ");
+
+                    db.execSQL(ALTER_TABLE + ProviderTableMeta.CAPABILITIES_TABLE_NAME +
+                                   ADD_COLUMN + ProviderTableMeta.CAPABILITIES_SERVER_ELEMENT_COLOR_DARK + " TEXT ");
 
                     upgraded = true;
                     db.setTransactionSuccessful();

--- a/src/main/java/com/owncloud/android/ui/ThemeableSwitchPreference.java
+++ b/src/main/java/com/owncloud/android/ui/ThemeableSwitchPreference.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Switch;
 
+import com.nextcloud.ui.theming.ColorsUtils;
 import com.owncloud.android.R;
 import com.owncloud.android.utils.ThemeUtils;
 
@@ -75,7 +76,7 @@ public class ThemeableSwitchPreference extends SwitchPreference {
 
                 if(thumbColorStateList == null && trackColorStateList == null) {
                     int thumbColor = ThemeUtils.primaryAccentColor(getContext());
-                    if (ThemeUtils.darkTheme(getContext()) &&
+                    if (ColorsUtils.darkColor(getContext()) &&
                         AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
                         thumbColor = Color.WHITE;
                     }

--- a/src/main/java/com/owncloud/android/ui/activity/CommunityActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/CommunityActivity.java
@@ -63,21 +63,21 @@ public class CommunityActivity extends DrawerActivity {
         contributeIrcView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeIrcView.setText(Html.fromHtml(getString(R.string.community_contribute_irc_text) + " " +
                                                     getString(R.string.community_contribute_irc_text_link,
-                        ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this, true)),
+                        ThemeUtils.primaryColorHexString(this),
                         getString(R.string.irc_weblink))));
 
         TextView contributeForumView = findViewById(R.id.community_contribute_forum_text);
         contributeForumView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeForumView.setText(Html.fromHtml(getString(R.string.community_contribute_forum_text) + " " +
                                                       getString(R.string.community_contribute_forum_text_link,
-                                                                ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this, true)),
+                                                                ThemeUtils.primaryColorHexString(this),
                                                                 getString(R.string.help_link), getString(R.string.community_contribute_forum_forum))));
 
         TextView contributeTranslationView = findViewById(R.id.community_contribute_translate_text);
         contributeTranslationView.setMovementMethod(LinkMovementMethod.getInstance());
         contributeTranslationView.setText(Html.fromHtml(
             getString(R.string.community_contribute_translate_link,
-                      ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this, true)),
+                      ThemeUtils.primaryColorHexString(this),
                       getString(R.string.translation_link),
                       getString(R.string.community_contribute_translate_translate)) + " " +
                 getString(R.string.community_contribute_translate_text)));
@@ -87,7 +87,7 @@ public class CommunityActivity extends DrawerActivity {
         contributeGithubView.setText(Html.fromHtml(
             getString(R.string.community_contribute_github_text,
                       getString(R.string.community_contribute_github_text_link,
-                                ThemeUtils.colorToHexString(ThemeUtils.primaryColor(this, true)),
+                                ThemeUtils.primaryColorHexString(this),
                                 getString(R.string.contributing_link)))));
 
         MaterialButton reportButton = findViewById(R.id.community_testing_report);

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -692,7 +692,7 @@ public abstract class DrawerActivity extends ToolbarActivity
             mCheckedMenuItem = menuItemId;
             MenuItem currentItem = mNavigationView.getMenu().findItem(menuItemId);
             int drawerColor = getResources().getColor(R.color.drawer_text_color);
-            int activeColor = ThemeUtils.primaryColor(null, true, true, this);
+            int activeColor = ThemeUtils.primaryColor(getAccount(), true, true, this);
 
             currentItem.setChecked(true);
 

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -685,7 +685,8 @@ public class SettingsActivity extends ThemedPreferenceActivity
 
     private void setupGeneralCategory() {
         PreferenceCategory preferenceCategoryGeneral = (PreferenceCategory) findPreference("general");
-        ThemePreferenceUtils.colorPreferenceCategory(this, preferenceCategoryGeneral, R.string.prefs_category_general);
+        ThemePreferenceUtils.colorPreferenceCategory(this, preferenceCategoryGeneral,
+                                                     R.string.prefs_category_general);
 
         prefStoragePath = (ListPreference) findPreference(AppPreferencesImpl.STORAGE_PATH);
         if (prefStoragePath != null) {

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -166,25 +166,25 @@ public class SettingsActivity extends ThemedPreferenceActivity
         setupBaseUri();
 
         // General
-        setupGeneralCategory(accentColor);
+        setupGeneralCategory();
 
         // Synced folders
-        setupAutoUploadCategory(accentColor, preferenceScreen);
+        setupAutoUploadCategory(preferenceScreen);
 
         // Details
-        setupDetailsCategory(accentColor, preferenceScreen);
+        setupDetailsCategory(preferenceScreen);
 
         // More
-        setupMoreCategory(accentColor);
+        setupMoreCategory();
 
         // About
-        setupAboutCategory(accentColor, appVersion);
+        setupAboutCategory(appVersion);
 
         // Dev
-        setupDevCategory(accentColor, preferenceScreen);
+        setupDevCategory(preferenceScreen);
     }
 
-    private void setupDevCategory(int accentColor, PreferenceScreen preferenceScreen) {
+    private void setupDevCategory(PreferenceScreen preferenceScreen) {
         // Dev category
         PreferenceCategory preferenceCategoryDev = (PreferenceCategory) findPreference("dev_category");
 
@@ -229,7 +229,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
         }
     }
 
-    private void setupAboutCategory(int accentColor, String appVersion) {
+    private void setupAboutCategory(String appVersion) {
         PreferenceCategory preferenceCategoryAbout = (PreferenceCategory) findPreference("about");
         ThemePreferenceUtils.colorPreferenceCategory(this, preferenceCategoryAbout, R.string.prefs_category_about);
 
@@ -314,7 +314,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
         }
     }
 
-    private void setupMoreCategory(int accentColor) {
+    private void setupMoreCategory() {
         PreferenceCategory preferenceCategoryMore = (PreferenceCategory) findPreference("more");
         ThemePreferenceUtils.colorPreferenceCategory(this,
                                                      preferenceCategoryMore,
@@ -513,7 +513,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
         }
     }
 
-    private void setupDetailsCategory(int accentColor, PreferenceScreen preferenceScreen) {
+    private void setupDetailsCategory(PreferenceScreen preferenceScreen) {
         PreferenceCategory preferenceCategoryDetails = (PreferenceCategory) findPreference("details");
         ThemePreferenceUtils.colorPreferenceCategory(this,
                                                      preferenceCategoryDetails,
@@ -609,7 +609,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
         }
     }
 
-    private void setupAutoUploadCategory(int accentColor, PreferenceScreen preferenceScreen) {
+    private void setupAutoUploadCategory(PreferenceScreen preferenceScreen) {
         PreferenceCategory preferenceCategorySyncedFolders =
                 (PreferenceCategory) findPreference("synced_folders_category");
         ThemePreferenceUtils.colorPreferenceCategory(this,
@@ -683,7 +683,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
         }
     }
 
-    private void setupGeneralCategory(int accentColor) {
+    private void setupGeneralCategory() {
         PreferenceCategory preferenceCategoryGeneral = (PreferenceCategory) findPreference("general");
         ThemePreferenceUtils.colorPreferenceCategory(this, preferenceCategoryGeneral, R.string.prefs_category_general);
 

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -58,6 +58,7 @@ import com.nextcloud.client.network.ClientFactory;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.nextcloud.client.preferences.DarkMode;
+import com.nextcloud.ui.theming.ThemePreferenceUtils;
 import com.owncloud.android.BuildConfig;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -187,9 +188,11 @@ public class SettingsActivity extends ThemedPreferenceActivity
         // Dev category
         PreferenceCategory preferenceCategoryDev = (PreferenceCategory) findPreference("dev_category");
 
+
         if (getResources().getBoolean(R.bool.is_beta)) {
-            preferenceCategoryDev.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_category_dev),
-                    accentColor));
+            ThemePreferenceUtils.colorPreferenceCategory(this,
+                                                         preferenceCategoryDev,
+                                                         R.string.prefs_category_dev);
 
             /* Link to dev apks */
             Preference pDevLink = findPreference("dev_link");
@@ -228,8 +231,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
 
     private void setupAboutCategory(int accentColor, String appVersion) {
         PreferenceCategory preferenceCategoryAbout = (PreferenceCategory) findPreference("about");
-        preferenceCategoryAbout.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_category_about),
-                accentColor));
+        ThemePreferenceUtils.colorPreferenceCategory(this, preferenceCategoryAbout, R.string.prefs_category_about);
 
         /* About App */
         Preference pAboutApp = findPreference("about_app");
@@ -314,8 +316,9 @@ public class SettingsActivity extends ThemedPreferenceActivity
 
     private void setupMoreCategory(int accentColor) {
         PreferenceCategory preferenceCategoryMore = (PreferenceCategory) findPreference("more");
-        preferenceCategoryMore.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_category_more),
-                accentColor));
+        ThemePreferenceUtils.colorPreferenceCategory(this,
+                                                     preferenceCategoryMore,
+                                                     R.string.prefs_category_more);
 
         setupAutoUploadPreference(preferenceCategoryMore);
 
@@ -512,8 +515,9 @@ public class SettingsActivity extends ThemedPreferenceActivity
 
     private void setupDetailsCategory(int accentColor, PreferenceScreen preferenceScreen) {
         PreferenceCategory preferenceCategoryDetails = (PreferenceCategory) findPreference("details");
-        preferenceCategoryDetails.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_category_details),
-                accentColor));
+        ThemePreferenceUtils.colorPreferenceCategory(this,
+                                                     preferenceCategoryDetails,
+                                                     R.string.prefs_category_details);
 
         boolean fPassCodeEnabled = getResources().getBoolean(R.bool.passcode_enabled);
         boolean fDeviceCredentialsEnabled = getResources().getBoolean(R.bool.device_credentials_enabled);
@@ -608,8 +612,9 @@ public class SettingsActivity extends ThemedPreferenceActivity
     private void setupAutoUploadCategory(int accentColor, PreferenceScreen preferenceScreen) {
         PreferenceCategory preferenceCategorySyncedFolders =
                 (PreferenceCategory) findPreference("synced_folders_category");
-        preferenceCategorySyncedFolders.setTitle(ThemeUtils.getColoredTitle(getString(R.string.drawer_synced_folders),
-                accentColor));
+        ThemePreferenceUtils.colorPreferenceCategory(this,
+                                                     preferenceCategorySyncedFolders,
+                                                     R.string.drawer_synced_folders);
 
         if (!getResources().getBoolean(R.bool.syncedFolder_light)) {
             preferenceScreen.removePreference(preferenceCategorySyncedFolders);
@@ -680,8 +685,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
 
     private void setupGeneralCategory(int accentColor) {
         PreferenceCategory preferenceCategoryGeneral = (PreferenceCategory) findPreference("general");
-        preferenceCategoryGeneral.setTitle(ThemeUtils.getColoredTitle(getString(R.string.prefs_category_general),
-                accentColor));
+        ThemePreferenceUtils.colorPreferenceCategory(this, preferenceCategoryGeneral, R.string.prefs_category_general);
 
         prefStoragePath = (ListPreference) findPreference(AppPreferencesImpl.STORAGE_PATH);
         if (prefStoragePath != null) {

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -54,6 +54,7 @@ import com.nextcloud.client.device.DeviceInfo;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.network.ClientFactory;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.ui.theming.ThemeFabUtils;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
@@ -291,7 +292,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         mFabMain = requireActivity().findViewById(R.id.fab_main);
 
         if (mFabMain != null) { // is not available in FolderPickerActivity
-            ThemeUtils.colorFloatingActionButton(mFabMain, R.drawable.ic_plus, requireContext());
+            ThemeFabUtils.colorFloatingActionButton(mFabMain, R.drawable.ic_plus, requireContext());
         }
 
         Log_OC.i(TAG, "onCreateView() end");
@@ -1810,7 +1811,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
             getActivity().runOnUiThread(() -> {
                 if (visible) {
                     mFabMain.show();
-                    ThemeUtils.colorFloatingActionButton(mFabMain, requireContext());
+                    ThemeFabUtils.colorFloatingActionButton(mFabMain, requireContext());
                 } else {
                     mFabMain.hide();
                 }
@@ -1860,10 +1861,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
             getActivity().runOnUiThread(() -> {
                 if (enabled) {
                     mFabMain.setEnabled(true);
-                    ThemeUtils.colorFloatingActionButton(mFabMain, requireContext());
+                    ThemeFabUtils.colorFloatingActionButton(mFabMain, requireContext());
                 } else {
                     mFabMain.setEnabled(false);
-                    ThemeUtils.colorFloatingActionButton(mFabMain, requireContext(), Color.GRAY);
+                    ThemeFabUtils.colorFloatingActionButton(mFabMain, requireContext(), Color.GRAY);
                 }
             });
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -433,7 +433,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         FileActivity activity = (FileActivity) getActivity();
 
         if (mFabMain != null) { // is not available in FolderPickerActivity
-            ThemeUtils.colorFloatingActionButton(mFabMain, R.drawable.ic_plus, requireContext());
+            ThemeFabUtils.colorFloatingActionButton(mFabMain, R.drawable.ic_plus, requireContext());
             mFabMain.setOnClickListener(v -> new OCFileListBottomSheetDialog(activity,
                                                                              this,
                                                                              deviceInfo,

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -36,12 +36,12 @@ import android.view.ViewGroup;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.lib.richWorkspace.RichWorkspaceDirectEditingRemoteOperation;
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.ui.theming.ThemeFabUtils;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.utils.DisplayUtils;
-import com.owncloud.android.utils.ThemeUtils;
 
 import javax.inject.Inject;
 

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -679,27 +679,6 @@ public final class ThemeUtils {
         return String.format("#%06X", 0xFFFFFF & color);
     }
 
-    public static void colorFloatingActionButton(FloatingActionButton button, @DrawableRes int drawable,
-                                                 Context context) {
-        int primaryColor = ThemeUtils.primaryColor(null, true, false, context);
-
-        colorFloatingActionButton(button, context, primaryColor);
-        button.setImageDrawable(ThemeUtils.tintDrawable(drawable, getColorForPrimary(primaryColor, context)));
-    }
-
-    public static void colorFloatingActionButton(FloatingActionButton button, Context context) {
-        colorFloatingActionButton(button, context, ThemeUtils.primaryColor(null, true, false, context));
-    }
-
-    public static void colorFloatingActionButton(FloatingActionButton button, Context context, int primaryColor) {
-        colorFloatingActionButton(button, primaryColor, calculateDarkColor(primaryColor, context));
-    }
-
-    public static void colorFloatingActionButton(FloatingActionButton button, int backgroundColor, int rippleColor) {
-        button.setBackgroundTintList(ColorStateList.valueOf(backgroundColor));
-        button.setRippleColor(rippleColor);
-    }
-
     public static void colorIconImageViewWithBackground(ImageView imageView, Context context) {
         int primaryColor = ThemeUtils.primaryColor(null, true, false, context);
 

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -164,7 +164,7 @@ public final class ThemeUtils {
         }
 
         try {
-            int color = Color.parseColor(getCapability(account, context).getServerColor());
+            int color = ColorsUtils.elementColor(account, context);
             if (replaceEdgeColors) {
                 if (isDarkModeActive(context)) {
                     if (Color.BLACK == color) {

--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -52,6 +52,7 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputLayout;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManagerImpl;
+import com.nextcloud.ui.theming.ColorsUtils;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -675,8 +676,8 @@ public final class ThemeUtils {
         item.setTitle(newItemTitle);
     }
 
-    public static String colorToHexString(int color) {
-        return String.format("#%06X", 0xFFFFFF & color);
+    public static String primaryColorHexString(Context context) {
+        return ColorsUtils.colorToHexString(primaryColor(context, true));
     }
 
     public static void colorIconImageViewWithBackground(ImageView imageView, Context context) {


### PR DESCRIPTION
**WiP**

The genral idea/motivation behind this PR is to cleanup and restructure the theming implementation to:
* generally separate/extract color manipulation and color access
* separate color calculations for the theme (primary/dark/accent) including fallbacks
* separate UI element theming implementations per UI element (like primary button, border-less button, preference category, editText, etc.)


Looping in @dan0xii @JorisBodin @Shagequi @sirambd so you are aware of this in-progress refactoring, also looping in @ezaquarii since it might involve moving from account to user while I'd probably postpone that to a later PR (while I tend to write the UI element theming using kotlin, so looking forward to your feedback when this is in a reviewable state)