### PR TITLE
Fix crash on missing user

### DIFF
--- a/src/main/java/com/nextcloud/client/account/UserAccountManager.java
+++ b/src/main/java/com/nextcloud/client/account/UserAccountManager.java
@@ -80,6 +80,9 @@ public interface UserAccountManager extends CurrentAccountProvider {
     @NonNull
     Optional<User> getUser(CharSequence accountName);
 
+
+    User getAnonymousUser();
+
     /**
      * Check if Nextcloud account is registered in {@link android.accounts.AccountManager}
      *

--- a/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -22,10 +22,10 @@ package com.nextcloud.client.account;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
-import android.app.Activity;
 import android.accounts.AccountManagerFuture;
 import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
@@ -243,8 +243,13 @@ public class UserAccountManagerImpl implements UserAccountManager {
     @NonNull
     public Optional<User> getUser(CharSequence accountName) {
         Account account = getAccountByName(accountName.toString());
-        User user =  createUserFromAccount(account);
+        User user = createUserFromAccount(account);
         return Optional.ofNullable(user);
+    }
+
+    @Override
+    public User getAnonymousUser() {
+        return AnonymousUser.fromContext(context);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -80,6 +80,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import dagger.android.AndroidInjection;
 
 public class OperationsService extends Service {
@@ -647,17 +648,19 @@ public class OperationsService extends Service {
                     case ACTION_SYNC_FILE:
                         remotePath = operationIntent.getStringExtra(EXTRA_REMOTE_PATH);
                         boolean syncFileContents = operationIntent.getBooleanExtra(EXTRA_SYNC_FILE_CONTENTS, true);
-                        operation = new SynchronizeFileOperation(remotePath, user, syncFileContents,
-                                getApplicationContext());
+                        operation = new SynchronizeFileOperation(remotePath,
+                                                                 user,
+                                                                 syncFileContents,
+                                                                 getApplicationContext());
                         break;
 
                     case ACTION_SYNC_FOLDER:
                         remotePath = operationIntent.getStringExtra(EXTRA_REMOTE_PATH);
                         operation = new SynchronizeFolderOperation(
-                                this,                       // TODO remove this dependency from construction time
-                                remotePath,
-                                user,
-                                System.currentTimeMillis()  // TODO remove this dependency from construction time
+                            this,                       // TODO remove this dependency from construction time
+                            remotePath,
+                            user,
+                            System.currentTimeMillis()  // TODO remove this dependency from construction time
                         );
                         break;
 
@@ -702,17 +705,20 @@ public class OperationsService extends Service {
     }
 
     /**
-     * This is a temporary compatibility helper to convert legacy {@link Account} instance
-     * to new {@link User} model.
+     * This is a temporary compatibility helper to convert legacy {@link Account} instance to new {@link User} model.
      *
      * @param account Account instance
      * @return User model that corresponds to Account
-     * @throws RuntimeException if account cannot be converted
      */
     @NonNull
-    private User toUser(Account account) {
-        Optional<User> optionalUser = accountManager.getUser(account.name);
-        return optionalUser.orElseThrow(RuntimeException::new); // if account is valid, this should never fail
+    private User toUser(@Nullable Account account) {
+        String accountName = account != null ? account.name : "";
+        Optional<User> optionalUser = accountManager.getUser(accountName);
+        if (optionalUser.isPresent()) {
+            return optionalUser.get();
+        } else {
+            return accountManager.getAnonymousUser();
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

@ezaquarii during login there is no account/user.
This is one possible fix.
The other is to extract ACTION_GET_SERVER_INFO method to AuthenticatorActivity so that OperationsService always needs account/user.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
