### PR TITLE
When going into subfolder or show details: show header even if it was scrolled away

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -44,6 +44,7 @@ import android.view.ViewGroup;
 import android.widget.AbsListView;
 import android.widget.PopupMenu;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
@@ -902,11 +903,13 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 int position = mAdapter.getItemPosition(file);
 
                 if (file.isFolder()) {
+                    resetHeaderScrollingState();
+
                     if (file.isEncrypted()) {
                         // check if API >= 19
                         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
                             Snackbar.make(getRecyclerView(), R.string.end_to_end_encryption_not_supported,
-                                Snackbar.LENGTH_LONG).show();
+                                          Snackbar.LENGTH_LONG).show();
                             return;
                         }
 
@@ -1115,6 +1118,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     if (mActiveActionMode != null) {
                         mActiveActionMode.finish();
                     }
+
+                    resetHeaderScrollingState();
+
                     mContainerActivity.showDetails(singleFile);
                     setFabVisible(false);
                     mContainerActivity.showSortListGroup(false);
@@ -1849,6 +1855,14 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     ThemeUtils.colorFloatingActionButton(mFabMain, requireContext(), Color.GRAY);
                 }
             });
+        }
+    }
+
+    private void resetHeaderScrollingState() {
+        AppBarLayout appBarLayout = ((FileDisplayActivity) requireActivity()).findViewById(R.id.appbar);
+
+        if (appBarLayout != null) {
+            appBarLayout.setExpanded(true);
         }
     }
 }


### PR DESCRIPTION
For https://github.com/nextcloud/android/issues/6360

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
