### PR TITLE
parseColor("") throws IndexOutOfBounds, so catch all Exceptions is better

### DIFF
--- a/src/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityIT.kt
+++ b/src/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityIT.kt
@@ -1,0 +1,77 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.authentication
+
+import android.graphics.Color
+import org.junit.Assert
+import org.junit.Test
+
+class AuthenticatorActivityIT {
+    @Test(expected = IndexOutOfBoundsException::class)
+    fun testException() {
+        Color.parseColor("")
+    }
+
+    @Test
+    fun tryCatch() {
+        val color = try {
+            Color.parseColor("1")
+        } catch (e: Exception) {
+            Color.BLACK
+        }
+
+        Assert.assertNotNull(color)
+    }
+
+    @Test
+    fun tryCatch2() {
+        val color = try {
+            Color.parseColor("")
+        } catch (e: Exception) {
+            Color.BLACK
+        }
+
+        Assert.assertNotNull(color)
+    }
+
+    @Test
+    fun tryCatch3() {
+        val color = try {
+            Color.parseColor(null)
+        } catch (e: Exception) {
+            Color.BLACK
+        }
+
+        Assert.assertNotNull(color)
+    }
+
+    @Test
+    fun tryCatch4() {
+        val color = try {
+            Color.parseColor("abc")
+        } catch (e: Exception) {
+            Color.BLACK
+        }
+
+        Assert.assertNotNull(color)
+    }
+}

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -906,7 +906,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                         OCCapability capability = (OCCapability) remoteOperationResult.getData().get(0);
                         try {
                             primaryColor = Color.parseColor(capability.getServerColor());
-                        } catch (IllegalArgumentException e) {
+                        } catch (Exception e) {
                             // falls back to primary color
                         }
                     }


### PR DESCRIPTION
Found via Google console

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
