### PR TITLE
Rename Download into Transfer

### DIFF
--- a/src/androidTest/java/com/nextcloud/client/files/downloader/DownloaderConnectionTest.kt
+++ b/src/androidTest/java/com/nextcloud/client/files/downloader/DownloaderConnectionTest.kt
@@ -42,10 +42,10 @@ class DownloaderConnectionTest {
     lateinit var context: Context
 
     @MockK
-    lateinit var firstDownloadListener: (Download) -> Unit
+    lateinit var firstDownloadListener: (Transfer) -> Unit
 
     @MockK
-    lateinit var secondDownloadListener: (Download) -> Unit
+    lateinit var secondDownloadListener: (Transfer) -> Unit
 
     @MockK
     lateinit var firstStatusListener: (Downloader.Status) -> Unit
@@ -80,7 +80,7 @@ class DownloaderConnectionTest {
 
         // THEN
         //      all listeners are passed to the service
-        val listeners = mutableListOf<(Download) -> Unit>()
+        val listeners = mutableListOf<(Transfer) -> Unit>()
         verify { binder.registerDownloadListener(capture(listeners)) }
         assertEquals(listOf(firstDownloadListener, secondDownloadListener), listeners)
     }
@@ -130,11 +130,11 @@ class DownloaderConnectionTest {
 
         val request1 = Request(user, file)
         connection.download(request1)
-        val download1 = Download(request1.uuid, DownloadState.RUNNING, 50, request1.file, request1)
+        val download1 = Transfer(request1.uuid, TransferState.RUNNING, 50, request1.file, request1)
 
         val request2 = Request(user, file)
         connection.download(request2)
-        val download2 = Download(request2.uuid, DownloadState.RUNNING, 50, request2.file, request1)
+        val download2 = Transfer(request2.uuid, TransferState.RUNNING, 50, request2.file, request1)
 
         every { binder.getDownload(request1.uuid) } returns download1
         every { binder.getDownload(request2.uuid) } returns download2
@@ -145,11 +145,11 @@ class DownloaderConnectionTest {
 
         // THEN
         //      listeners receive current download state for pending downloads
-        val firstListenerNotifications = mutableListOf<Download>()
+        val firstListenerNotifications = mutableListOf<Transfer>()
         verify { firstDownloadListener(capture(firstListenerNotifications)) }
         assertEquals(listOf(download1, download2), firstListenerNotifications)
 
-        val secondListenerNotifications = mutableListOf<Download>()
+        val secondListenerNotifications = mutableListOf<Transfer>()
         verify { secondDownloadListener(capture(secondListenerNotifications)) }
         assertEquals(listOf(download1, download2), secondListenerNotifications)
     }
@@ -225,7 +225,7 @@ class DownloaderConnectionTest {
         //      some downloads requested without listener
         val request = Request(user, file)
         connection.download(request)
-        val download = Download(request.uuid, DownloadState.RUNNING, 50, request.file, request)
+        val download = Transfer(request.uuid, TransferState.RUNNING, 50, request.file, request)
         connection.registerDownloadListener(firstDownloadListener)
         every { binder.getDownload(request.uuid) } returns download
 

--- a/src/androidTest/java/com/nextcloud/client/files/downloader/DownloaderTest.kt
+++ b/src/androidTest/java/com/nextcloud/client/files/downloader/DownloaderTest.kt
@@ -42,7 +42,7 @@ import org.mockito.MockitoAnnotations
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
     DownloaderTest.Enqueue::class,
-    DownloaderTest.DownloadStatusUpdates::class
+    DownloaderTest.TransferStatusUpdates::class
 )
 class DownloaderTest {
 
@@ -125,7 +125,7 @@ class DownloaderTest {
             // THEN
             //      download is started immediately
             val download = downloader.getDownload(request.uuid)
-            assertEquals(DownloadState.RUNNING, download?.state)
+            assertEquals(TransferState.RUNNING, download?.state)
         }
 
         @Test
@@ -137,7 +137,7 @@ class DownloaderTest {
                 val request = Request(user, file)
                 downloader.download(request)
                 val runningDownload = downloader.getDownload(request.uuid)
-                assertEquals(runningDownload?.state, DownloadState.RUNNING)
+                assertEquals(runningDownload?.state, TransferState.RUNNING)
             }
 
             // WHEN
@@ -149,11 +149,11 @@ class DownloaderTest {
             // THEN
             //      download is pending
             val download = downloader.getDownload(request.uuid)
-            assertEquals(DownloadState.PENDING, download?.state)
+            assertEquals(TransferState.PENDING, download?.state)
         }
     }
 
-    class DownloadStatusUpdates : Base() {
+    class TransferStatusUpdates : Base() {
 
         @get:Rule
         val rule = InstantTaskExecutorRule()
@@ -165,7 +165,7 @@ class DownloaderTest {
             // GIVEN
             //      download is running
             //      download is being observed
-            val downloadUpdates = mutableListOf<Download>()
+            val downloadUpdates = mutableListOf<Transfer>()
             downloader.registerDownloadListener { downloadUpdates.add(it) }
             downloader.download(Request(user, file))
 
@@ -175,8 +175,8 @@ class DownloaderTest {
 
             // THEN
             //      listener is notified about status change
-            assertEquals(DownloadState.RUNNING, downloadUpdates[0].state)
-            assertEquals(DownloadState.COMPLETED, downloadUpdates[1].state)
+            assertEquals(TransferState.RUNNING, downloadUpdates[0].state)
+            assertEquals(TransferState.COMPLETED, downloadUpdates[1].state)
         }
 
         @Test
@@ -184,7 +184,7 @@ class DownloaderTest {
             // GIVEN
             //      download is running
             //      download is being observed
-            val downloadUpdates = mutableListOf<Download>()
+            val downloadUpdates = mutableListOf<Transfer>()
             downloader.registerDownloadListener { downloadUpdates.add(it) }
             downloader.download(Request(user, file))
 
@@ -195,15 +195,15 @@ class DownloaderTest {
 
             // THEN
             //      listener is notified about status change
-            assertEquals(DownloadState.RUNNING, downloadUpdates[0].state)
-            assertEquals(DownloadState.FAILED, downloadUpdates[1].state)
+            assertEquals(TransferState.RUNNING, downloadUpdates[0].state)
+            assertEquals(TransferState.FAILED, downloadUpdates[1].state)
         }
 
         @Test
         fun download_progress_is_updated() {
             // GIVEN
             //      download is running
-            val downloadUpdates = mutableListOf<Download>()
+            val downloadUpdates = mutableListOf<Transfer>()
             downloader.registerDownloadListener { downloadUpdates.add(it) }
             downloader.download(Request(user, file))
 
@@ -219,12 +219,12 @@ class DownloaderTest {
             //          completion
             assertEquals(6, downloadUpdates.size)
             if (downloadUpdates.size >= 6) {
-                assertEquals(DownloadState.RUNNING, downloadUpdates[0].state)
+                assertEquals(TransferState.RUNNING, downloadUpdates[0].state)
                 assertEquals(25, downloadUpdates[1].progress)
                 assertEquals(50, downloadUpdates[2].progress)
                 assertEquals(75, downloadUpdates[3].progress)
                 assertEquals(100, downloadUpdates[4].progress)
-                assertEquals(DownloadState.COMPLETED, downloadUpdates[5].state)
+                assertEquals(TransferState.COMPLETED, downloadUpdates[5].state)
             }
         }
 

--- a/src/main/java/com/nextcloud/client/etm/pages/EtmDownloaderFragment.kt
+++ b/src/main/java/com/nextcloud/client/etm/pages/EtmDownloaderFragment.kt
@@ -12,7 +12,8 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.nextcloud.client.etm.EtmBaseFragment
-import com.nextcloud.client.files.downloader.Download
+import com.nextcloud.client.files.downloader.Direction
+import com.nextcloud.client.files.downloader.Transfer
 import com.nextcloud.client.files.downloader.Downloader
 import com.nextcloud.client.files.downloader.Request
 import com.owncloud.android.R
@@ -48,7 +49,7 @@ class EtmDownloaderFragment : EtmBaseFragment() {
                 }
         }
 
-        private var downloads = listOf<Download>()
+        private var downloads = listOf<Transfer>()
 
         fun setStatus(status: Downloader.Status) {
             downloads = listOf(status.pending, status.running, status.completed).flatten().reversed()
@@ -123,7 +124,12 @@ class EtmDownloaderFragment : EtmBaseFragment() {
     }
 
     private fun scheduleTestDownload() {
-        val request = Request(user = vm.currentUser, file = OCFile(TEST_DOWNLOAD_DUMMY_PATH), test = true)
+        val request = Request(
+            vm.currentUser,
+            OCFile(TEST_DOWNLOAD_DUMMY_PATH),
+            Direction.DOWNLOAD,
+            true
+        )
         vm.downloaderConnection.download(request)
     }
 

--- a/src/main/java/com/nextcloud/client/files/downloader/Direction.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/Direction.kt
@@ -1,0 +1,25 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Chris Narkiewicz
+ * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.client.files.downloader
+
+enum class Direction {
+    DOWNLOAD,
+    UPLOAD
+}

--- a/src/main/java/com/nextcloud/client/files/downloader/Downloader.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/Downloader.kt
@@ -28,9 +28,9 @@ interface Downloader {
      * Snapshot of downloader status. All data is immutable and can be safely shared.
      */
     data class Status(
-        val pending: List<Download>,
-        val running: List<Download>,
-        val completed: List<Download>
+        val pending: List<Transfer>,
+        val running: List<Transfer>,
+        val completed: List<Transfer>
     ) {
         companion object {
             val EMPTY = Status(emptyList(), emptyList(), emptyList())
@@ -50,12 +50,12 @@ interface Downloader {
     /**
      * Register download progress listener. Registration is idempotent - listener can be registered only once.
      */
-    fun registerDownloadListener(listener: (Download) -> Unit)
+    fun registerDownloadListener(listener: (Transfer) -> Unit)
 
     /**
      * Removes registered listener if exists.
      */
-    fun removeDownloadListener(listener: (Download) -> Unit)
+    fun removeDownloadListener(listener: (Transfer) -> Unit)
 
     /**
      * Register downloader status listener. Registration is idempotent - listener can be registered only once.
@@ -80,7 +80,7 @@ interface Downloader {
      * @param uuid Download process uuid
      * @return download status or null if not found
      */
-    fun getDownload(uuid: UUID): Download?
+    fun getDownload(uuid: UUID): Transfer?
 
     /**
      * Query user's downloader for a download status. It performs linear search
@@ -94,5 +94,5 @@ interface Downloader {
      * @param file Downloaded file
      * @return download status or null, if download does not exist
      */
-    fun getDownload(file: OCFile): Download?
+    fun getDownload(file: OCFile): Transfer?
 }

--- a/src/main/java/com/nextcloud/client/files/downloader/DownloaderConnection.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/DownloaderConnection.kt
@@ -29,7 +29,7 @@ import java.util.UUID
 
 class DownloaderConnection(context: Context, val user: User) : LocalConnection<DownloaderService>(context), Downloader {
 
-    private var downloadListeners: MutableSet<(Download) -> Unit> = mutableSetOf()
+    private var downloadListeners: MutableSet<(Transfer) -> Unit> = mutableSetOf()
     private var statusListeners: MutableSet<(Downloader.Status) -> Unit> = mutableSetOf()
     private var binder: DownloaderService.Binder? = null
     private val downloadsRequiringStatusRedelivery: MutableSet<UUID> = mutableSetOf()
@@ -40,9 +40,9 @@ class DownloaderConnection(context: Context, val user: User) : LocalConnection<D
     override val status: Downloader.Status
         get() = binder?.status ?: Downloader.Status.EMPTY
 
-    override fun getDownload(uuid: UUID): Download? = binder?.getDownload(uuid)
+    override fun getDownload(uuid: UUID): Transfer? = binder?.getDownload(uuid)
 
-    override fun getDownload(file: OCFile): Download? = binder?.getDownload(file)
+    override fun getDownload(file: OCFile): Transfer? = binder?.getDownload(file)
 
     override fun download(request: Request) {
         val intent = DownloaderService.createDownloadIntent(context, request)
@@ -52,12 +52,12 @@ class DownloaderConnection(context: Context, val user: User) : LocalConnection<D
         }
     }
 
-    override fun registerDownloadListener(listener: (Download) -> Unit) {
+    override fun registerDownloadListener(listener: (Transfer) -> Unit) {
         downloadListeners.add(listener)
         binder?.registerDownloadListener(listener)
     }
 
-    override fun removeDownloadListener(listener: (Download) -> Unit) {
+    override fun removeDownloadListener(listener: (Transfer) -> Unit) {
         downloadListeners.remove(listener)
         binder?.removeDownloadListener(listener)
     }

--- a/src/main/java/com/nextcloud/client/files/downloader/DownloaderImpl.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/DownloaderImpl.kt
@@ -50,11 +50,11 @@ class DownloaderImpl(
     }
 
     private val registry = Registry(
-        onStartDownload = this::onStartDownload,
-        onDownloadChanged = this::onDownloadUpdate,
+        onStartTransfer = this::onStartDownload,
+        onTransferChanged = this::onDownloadUpdate,
         maxRunning = threads
     )
-    private val downloadListeners: MutableSet<(Download) -> Unit> = mutableSetOf()
+    private val downloadListeners: MutableSet<(Transfer) -> Unit> = mutableSetOf()
     private val statusListeners: MutableSet<(Downloader.Status) -> Unit> = mutableSetOf()
 
     override val isRunning: Boolean get() = registry.isRunning
@@ -66,11 +66,11 @@ class DownloaderImpl(
             completed = registry.completed
         )
 
-    override fun registerDownloadListener(listener: (Download) -> Unit) {
+    override fun registerDownloadListener(listener: (Transfer) -> Unit) {
         downloadListeners.add(listener)
     }
 
-    override fun removeDownloadListener(listener: (Download) -> Unit) {
+    override fun removeDownloadListener(listener: (Transfer) -> Unit) {
         downloadListeners.remove(listener)
     }
 
@@ -87,9 +87,9 @@ class DownloaderImpl(
         registry.startNext()
     }
 
-    override fun getDownload(uuid: UUID): Download? = registry.getDownload(uuid)
+    override fun getDownload(uuid: UUID): Transfer? = registry.getTransfer(uuid)
 
-    override fun getDownload(file: OCFile): Download? = registry.getDownload(file)
+    override fun getDownload(file: OCFile): Transfer? = registry.getTransfer(file)
 
     private fun onStartDownload(uuid: UUID, request: Request) {
         val downloadTask = createDownloadTask(request)
@@ -115,8 +115,8 @@ class DownloaderImpl(
         }
     }
 
-    private fun onDownloadUpdate(download: Download) {
-        downloadListeners.forEach { it.invoke(download) }
+    private fun onDownloadUpdate(transfer: Transfer) {
+        downloadListeners.forEach { it.invoke(transfer) }
         if (statusListeners.isNotEmpty()) {
             val status = this.status
             statusListeners.forEach { it.invoke(status) }

--- a/src/main/java/com/nextcloud/client/files/downloader/DownloaderService.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/DownloaderService.kt
@@ -115,7 +115,7 @@ class DownloaderService : Service() {
         }
     }
 
-    private fun onDownloadUpdate(download: Download) {
+    private fun onDownloadUpdate(transfer: Transfer) {
         if (!isRunning) {
             logger.d(TAG, "All downloads completed")
             notificationsManager.cancelDownloadProgress()
@@ -123,10 +123,10 @@ class DownloaderService : Service() {
             stopSelf()
         } else {
             notificationsManager.postDownloadProgress(
-                fileOwner = download.request.user,
-                file = download.request.file,
-                progress = download.progress,
-                allowPreview = !download.request.test
+                fileOwner = transfer.request.user,
+                file = transfer.request.file,
+                progress = transfer.progress,
+                allowPreview = !transfer.request.test
             )
         }
     }

--- a/src/main/java/com/nextcloud/client/files/downloader/Request.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/Request.kt
@@ -26,33 +26,44 @@ import com.owncloud.android.datamodel.OCFile
 import java.util.UUID
 
 /**
- * Download request. This class should collect all information
- * required to trigger download operation.
+ * Transfer request. This class should collect all information
+ * required to trigger transfer operation.
  *
  * Class is immutable by design, although [OCFile] or other
  * types might not be immutable. Clients should no modify
  * contents of this object.
  *
- * @property user Download will be triggered for a given user
- * @property file Remote file to download
- * @property uuid Unique request identifier; this identifier can be set in [Download]
- * @property dummy if true, this requests a dummy test download; no real file transfer will occur
+ * @property user Transfer will be triggered for a given user
+ * @property file File to transfer
+ * @property uuid Unique request identifier; this identifier can be set in [Transfer]
+ * @property dummy if true, this requests a dummy test transfer; no real file transfer will occur
  */
 class Request internal constructor(
     val user: User,
     val file: OCFile,
     val uuid: UUID,
+    val type: Direction = Direction.DOWNLOAD,
     val test: Boolean = false
 ) : Parcelable {
 
-    constructor(user: User, file: OCFile) : this(user, file, UUID.randomUUID())
+    constructor(
+        user: User,
+        file: OCFile,
+        type: Direction = Direction.DOWNLOAD
+    ) : this(user, file, UUID.randomUUID(), type)
 
-    constructor(user: User, file: OCFile, test: Boolean) : this(user, file, UUID.randomUUID(), test)
+    constructor(
+        user: User,
+        file: OCFile,
+        type: Direction,
+        test: Boolean
+    ) : this(user, file, UUID.randomUUID(), type, test)
 
     constructor(parcel: Parcel) : this(
         user = parcel.readParcelable<User>(User::class.java.classLoader) as User,
         file = parcel.readParcelable<OCFile>(OCFile::class.java.classLoader) as OCFile,
         uuid = parcel.readSerializable() as UUID,
+        type = parcel.readSerializable() as Direction,
         test = parcel.readInt() != 0
     )
 
@@ -60,6 +71,7 @@ class Request internal constructor(
         parcel.writeParcelable(user, flags)
         parcel.writeParcelable(file, flags)
         parcel.writeSerializable(uuid)
+        parcel.writeSerializable(type)
         parcel.writeInt(if (test) 1 else 0)
     }
 

--- a/src/main/java/com/nextcloud/client/files/downloader/Transfer.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/Transfer.kt
@@ -23,21 +23,21 @@ import com.owncloud.android.datamodel.OCFile
 import java.util.UUID
 
 /**
- * This class represents current download process state.
+ * This class represents current transfer (download or upload) process state.
  * This object is immutable by design.
  *
  * NOTE: Although [OCFile] object is mutable, it is caused by shortcomings
  * of legacy design; please behave like an adult and treat it as immutable value.
  *
- * @property uuid Unique download process id
- * @property state current download state
- * @property progress download progress, 0-100 percent
- * @property file downloaded file, if download is in progress or failed, it is remote; if finished successfully - local
- * @property request initial download request
+ * @property uuid Unique transfer id
+ * @property state current transfer state
+ * @property progress transfer progress, 0-100 percent
+ * @property file transferred file
+ * @property request initial transfer request
  */
-data class Download(
+data class Transfer(
     val uuid: UUID,
-    val state: DownloadState,
+    val state: TransferState,
     val progress: Int,
     val file: OCFile,
     val request: Request
@@ -45,5 +45,5 @@ data class Download(
     /**
      * True if download is no longer running, false if it is still being processed.
      */
-    val isFinished: Boolean get() = state == DownloadState.COMPLETED || state == DownloadState.FAILED
+    val isFinished: Boolean get() = state == TransferState.COMPLETED || state == TransferState.FAILED
 }

--- a/src/main/java/com/nextcloud/client/files/downloader/TransferState.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/TransferState.kt
@@ -19,7 +19,7 @@
  */
 package com.nextcloud.client.files.downloader
 
-enum class DownloadState {
+enum class TransferState {
     PENDING,
     RUNNING,
     COMPLETED,

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
@@ -57,14 +57,14 @@ import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
-import com.nextcloud.client.files.downloader.Download;
-import com.nextcloud.client.files.downloader.DownloadState;
+import com.nextcloud.client.files.downloader.Direction;
+import com.nextcloud.client.files.downloader.Transfer;
+import com.nextcloud.client.files.downloader.TransferState;
 import com.nextcloud.client.files.downloader.DownloaderConnection;
 import com.nextcloud.client.files.downloader.Request;
 import com.nextcloud.client.jobs.BackgroundJobManager;
 import com.nextcloud.client.network.ClientFactory;
 import com.owncloud.android.R;
-import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.TextDrawable;
@@ -217,7 +217,7 @@ public class ContactListFragment extends FileFragment implements Injectable {
         fileDownloader.registerDownloadListener(this::onDownloadUpdate);
         fileDownloader.bind();
         if (!ocFile.isDown()) {
-            Request request = new Request(user, ocFile);
+            Request request = new Request(user, ocFile, Direction.DOWNLOAD);
             fileDownloader.download(request);
         } else {
             loadContactsTask.execute();
@@ -503,9 +503,9 @@ public class ContactListFragment extends FileFragment implements Injectable {
         }
     }
 
-    private Unit onDownloadUpdate(Download download) {
+    private Unit onDownloadUpdate(Transfer download) {
         final Activity activity = getActivity();
-        if (download.getState() == DownloadState.COMPLETED && activity != null) {
+        if (download.getState() == TransferState.COMPLETED && activity != null) {
             ocFile = download.getFile();
             loadContactsTask.execute();
         }


### PR DESCRIPTION
Extending Download into more generic Transfer that
can support both downloads and uploads.

Upload functionality is not provided in this PR - it's
only a rename.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

### Testing 
- [x] Tests updated
