### PR TITLE
object.getId() can also be a string if RichObjects refers to an user

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -266,7 +266,13 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         imageView.setLayoutParams(params);
 
         for (RichObject object : richObjectList) {
-            if (Integer.parseInt(object.getId()) == previewObject.getFileId()) {
+            int objectId = -1;
+            try {
+                objectId = Integer.parseInt(object.getId());
+            } catch (NumberFormatException e) {
+                // object.getId() can also be a string if RichObjects refers to an user
+            }
+            if (objectId == previewObject.getFileId()) {
                 imageView.setOnClickListener(v -> activityListInterface.onActivityClicked(object));
                 break;
             }


### PR DESCRIPTION
Fix #6643 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
