### PR TITLE
Rename Downloader to TransferManager

### DIFF
--- a/src/main/java/com/nextcloud/client/etm/EtmViewModel.kt
+++ b/src/main/java/com/nextcloud/client/etm/EtmViewModel.kt
@@ -35,7 +35,7 @@ import com.nextcloud.client.etm.pages.EtmBackgroundJobsFragment
 import com.nextcloud.client.etm.pages.EtmDownloaderFragment
 import com.nextcloud.client.etm.pages.EtmMigrations
 import com.nextcloud.client.etm.pages.EtmPreferencesFragment
-import com.nextcloud.client.files.downloader.DownloaderConnection
+import com.nextcloud.client.files.downloader.TransferManagerConnection
 import com.nextcloud.client.jobs.BackgroundJobManager
 import com.nextcloud.client.jobs.JobInfo
 import com.nextcloud.client.migrations.MigrationInfo
@@ -109,7 +109,7 @@ class EtmViewModel @Inject constructor(
             pageClass = EtmDownloaderFragment::class
         )
     )
-    val downloaderConnection = DownloaderConnection(context, accountManager.user)
+    val downloaderConnection = TransferManagerConnection(context, accountManager.user)
 
     val preferences: Map<String, String> get() {
         return defaultPreferences.all

--- a/src/main/java/com/nextcloud/client/etm/pages/EtmDownloaderFragment.kt
+++ b/src/main/java/com/nextcloud/client/etm/pages/EtmDownloaderFragment.kt
@@ -14,7 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.nextcloud.client.etm.EtmBaseFragment
 import com.nextcloud.client.files.downloader.Direction
 import com.nextcloud.client.files.downloader.Transfer
-import com.nextcloud.client.files.downloader.Downloader
+import com.nextcloud.client.files.downloader.TransferManager
 import com.nextcloud.client.files.downloader.Request
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.OCFile
@@ -51,7 +51,7 @@ class EtmDownloaderFragment : EtmBaseFragment() {
 
         private var downloads = listOf<Transfer>()
 
-        fun setStatus(status: Downloader.Status) {
+        fun setStatus(status: TransferManager.Status) {
             downloads = listOf(status.pending, status.running, status.completed).flatten().reversed()
             notifyDataSetChanged()
         }
@@ -130,10 +130,10 @@ class EtmDownloaderFragment : EtmBaseFragment() {
             Direction.DOWNLOAD,
             true
         )
-        vm.downloaderConnection.download(request)
+        vm.downloaderConnection.enqueue(request)
     }
 
-    private fun onDownloaderStatusChanged(status: Downloader.Status) {
+    private fun onDownloaderStatusChanged(status: TransferManager.Status) {
         adapter.setStatus(status)
     }
 }

--- a/src/main/java/com/nextcloud/client/files/downloader/Registry.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/Registry.kt
@@ -20,8 +20,7 @@
 package com.nextcloud.client.files.downloader
 
 import com.owncloud.android.datamodel.OCFile
-import java.lang.IllegalStateException
-import java.util.TreeMap
+import java.util.LinkedHashMap
 import java.util.UUID
 import kotlin.math.max
 import kotlin.math.min
@@ -46,9 +45,9 @@ internal class Registry(
     private val onTransferChanged: (Transfer) -> Unit,
     private val maxRunning: Int = 2
 ) {
-    private val pendingQueue = TreeMap<UUID, Transfer>()
-    private val runningQueue = TreeMap<UUID, Transfer>()
-    private val completedQueue = TreeMap<UUID, Transfer>()
+    private val pendingQueue = LinkedHashMap<UUID, Transfer>()
+    private val runningQueue = LinkedHashMap<UUID, Transfer>()
+    private val completedQueue = LinkedHashMap<UUID, Transfer>()
 
     val isRunning: Boolean get() = pendingQueue.size > 0 || runningQueue.size > 0
 
@@ -80,7 +79,7 @@ internal class Registry(
     fun startNext() {
         val freeThreads = max(0, maxRunning - runningQueue.size)
         for (i in 0 until min(freeThreads, pendingQueue.size)) {
-            val key = pendingQueue.firstKey()
+            val key = pendingQueue.keys.first()
             val pendingTransfer = pendingQueue.remove(key) ?: throw IllegalStateException("Transfer $key not found")
             val runningTransfer = pendingTransfer.copy(state = TransferState.RUNNING)
             runningQueue[key] = runningTransfer

--- a/src/main/java/com/nextcloud/client/files/downloader/TransferManager.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/TransferManager.kt
@@ -22,10 +22,10 @@ package com.nextcloud.client.files.downloader
 import com.owncloud.android.datamodel.OCFile
 import java.util.UUID
 
-interface Downloader {
+interface TransferManager {
 
     /**
-     * Snapshot of downloader status. All data is immutable and can be safely shared.
+     * Snapshot of transfer manager status. All data is immutable and can be safely shared.
      */
     data class Status(
         val pending: List<Transfer>,
@@ -38,27 +38,27 @@ interface Downloader {
     }
 
     /**
-     * True if downloader has any pending or running downloads.
+     * True if transfer manager has any pending or running transfers.
      */
     val isRunning: Boolean
 
     /**
-     * Status snapshot of all downloads.
+     * Status snapshot of all transfers.
      */
     val status: Status
 
     /**
-     * Register download progress listener. Registration is idempotent - listener can be registered only once.
+     * Register transfer progress listener. Registration is idempotent - listener can be registered only once.
      */
-    fun registerDownloadListener(listener: (Transfer) -> Unit)
+    fun registerTransferListener(listener: (Transfer) -> Unit)
 
     /**
      * Removes registered listener if exists.
      */
-    fun removeDownloadListener(listener: (Transfer) -> Unit)
+    fun removeTransferListener(listener: (Transfer) -> Unit)
 
     /**
-     * Register downloader status listener. Registration is idempotent - listener can be registered only once.
+     * Register transfer manager status listener. Registration is idempotent - listener can be registered only once.
      */
     fun registerStatusListener(listener: (Status) -> Unit)
 
@@ -68,31 +68,31 @@ interface Downloader {
     fun removeStatusListener(listener: (Status) -> Unit)
 
     /**
-     * Adds download request to pending queue and returns immediately.
+     * Adds transfer request to pending queue and returns immediately.
      *
-     * @param request Download request
+     * @param request Transfer request
      */
-    fun download(request: Request)
+    fun enqueue(request: Request)
 
     /**
-     * Find download status by UUID.
+     * Find transfer status by UUID.
      *
      * @param uuid Download process uuid
-     * @return download status or null if not found
+     * @return transfer status or null if not found
      */
-    fun getDownload(uuid: UUID): Transfer?
+    fun getTransfer(uuid: UUID): Transfer?
 
     /**
-     * Query user's downloader for a download status. It performs linear search
-     * of all queues and returns first download matching [OCFile.remotePath].
+     * Query user's transfer manager for a transfer status. It performs linear search
+     * of all queues and returns first transfer matching [OCFile.remotePath].
      *
-     * Since there can be multiple downloads with identical file in downloader's queues,
+     * Since there can be multiple transfers with identical file in the queues,
      * order of search matters.
      *
-     * It looks for pending downloads first, then running and completed queue last.
+     * It looks for pending transfers first, then running and completed queue last.
      *
      * @param file Downloaded file
-     * @return download status or null, if download does not exist
+     * @return transfer status or null, if transfer does not exist
      */
-    fun getDownload(file: OCFile): Transfer?
+    fun getTransfer(file: OCFile): Transfer?
 }

--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/ContactListFragment.java
@@ -60,7 +60,7 @@ import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.files.downloader.Direction;
 import com.nextcloud.client.files.downloader.Transfer;
 import com.nextcloud.client.files.downloader.TransferState;
-import com.nextcloud.client.files.downloader.DownloaderConnection;
+import com.nextcloud.client.files.downloader.TransferManagerConnection;
 import com.nextcloud.client.files.downloader.Request;
 import com.nextcloud.client.jobs.BackgroundJobManager;
 import com.nextcloud.client.network.ClientFactory;
@@ -151,7 +151,7 @@ public class ContactListFragment extends FileFragment implements Injectable {
     @Inject UserAccountManager accountManager;
     @Inject ClientFactory clientFactory;
     @Inject BackgroundJobManager backgroundJobManager;
-    private DownloaderConnection fileDownloader;
+    private TransferManagerConnection fileDownloader;
 
     public static ContactListFragment newInstance(OCFile file, User user) {
         ContactListFragment frag = new ContactListFragment();
@@ -213,12 +213,12 @@ public class ContactListFragment extends FileFragment implements Injectable {
         ocFile = getArguments().getParcelable(FILE_NAME);
         setFile(ocFile);
         user = getArguments().getParcelable(USER);
-        fileDownloader = new DownloaderConnection(getActivity(), user);
-        fileDownloader.registerDownloadListener(this::onDownloadUpdate);
+        fileDownloader = new TransferManagerConnection(getActivity(), user);
+        fileDownloader.registerTransferListener(this::onDownloadUpdate);
         fileDownloader.bind();
         if (!ocFile.isDown()) {
             Request request = new Request(user, ocFile, Direction.DOWNLOAD);
-            fileDownloader.download(request);
+            fileDownloader.enqueue(request);
         } else {
             loadContactsTask.execute();
         }


### PR DESCRIPTION
As the Downloader architecture can support any type of
asynchronous operations so we can easily support file uploads.

Rename Downloader to TransferManager to reflect this.
This is just a rename, without upload implementation.
Upload feature shall follow in separate PRs.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] No functional change - existing tests should still pass
