### PR TITLE
Handle back button in richdocuments

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.java
@@ -251,6 +251,17 @@ public class RichDocumentsEditorWebView extends EditorWebView {
         startActivity(intent);
     }
 
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (event.getAction() == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_BACK) {
+            if (webview.canGoBackOrForward(-2)) {
+                webview.goBack();
+                return true;
+            }
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+
     private class RichDocumentsMobileInterface extends MobileInterface {
         @JavascriptInterface
         public void insertGraphic() {


### PR DESCRIPTION
This patch allows to go back in menus using back button in Collabora Online instead of closing the file (only when menu is opened).