### PR TITLE
Prevent NPE: Ensure that mNotificationManager is not null

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -715,6 +715,9 @@ public class FileUploader extends Service
             String fileName = filePath.substring(filePath.lastIndexOf(FileUtils.PATH_SEPARATOR) + 1);
             String text = String.format(getString(R.string.uploader_upload_in_progress_content), percent, fileName);
             mNotificationBuilder.setContentText(text);
+            if (mNotificationManager == null) {
+                mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            }
             mNotificationManager.notify(R.string.uploader_upload_in_progress_ticker, mNotificationBuilder.build());
         }
         mLastPercent = percent;


### PR DESCRIPTION
This PR ensures that `mNotificationManager` is not `null` when updating transfer progress in `FileUploader`.

This might happen, if the `FileUploader` service is being destroyed, so `mNotificationManager` is set to null.

The applied fix has been used in a couple of other places in this file as well, so it is at least consistent.

### Testing 

I skipped the unit tests, as you might want to apply a better fix (like not nulling the notificationManager at all) eventually.

Fixes #6719