### PR TITLE
Improve performance of DocumentsProvider#isChildDocument()

### DIFF
--- a/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
@@ -171,7 +171,7 @@ public class DownloadFileOperation extends RemoteOperation {
             modificationTimestamp = downloadOperation.getModificationTimestamp();
             etag = downloadOperation.getEtag();
             newFile = new File(getSavePath());
-            if (!newFile.getParentFile().mkdirs()) {
+            if (!newFile.getParentFile().exists() && !newFile.getParentFile().mkdirs()) {
                 Log_OC.e(TAG, "Unable to create parent folder " + newFile.getParentFile().getAbsolutePath());
             }
 


### PR DESCRIPTION
The old solution iterates through all parents of the child until it finds the given parent or the storage root. This has been show to be very expensive in empirical tests.

Therefore, this commit introduces a more efficient solution that simply compares the file paths of child and given parent. It also ensures that parent and child belong to the same account.

Reviewers need to take extra care that this change does not introduce security issues by claiming a document is a child of a parent when it is really not. Maybe also check if the correct path is compared as there seem to be many: local/remote/encrypted/decrypted

### Testing 

I'd be happy to provide instrumentation tests against the `DocumentsProvider` implementation. However, it seems that there's no framework for that in place, yet. So this would need to be discussed before.

The code change is rather small and it should be evident, that if the accounts match, the following is true:

* `/a/b/c` is a child of `/a/b` and `/a`
* `/a/b/c` is *not* a child `/a/x`
