### PR TITLE
Reset last sync date of files written via DocumentsProvider

### DIFF
--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -244,7 +244,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                             showToast();
                         }
                     }
-                } catch (Exception exception) {
+                } catch (Exception e) {
+                    Log_OC.e(TAG, "Error syncing file", e);
                     showToast();
                 }
             });
@@ -253,7 +254,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             try {
                 syncThread.join();
             } catch (InterruptedException e) {
-                Log.e(TAG, "Failed to wait for thread to finish");
+                Log.e(TAG, "Failed to wait for thread to finish", e);
             }
         }
 
@@ -266,6 +267,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         if (isWrite) {
             try {
+                // reset last sync date to ensure we will be syncing this write to the server
+                ocFile.setLastSyncDateForData(0);
                 Handler handler = new Handler(context.getMainLooper());
                 return ParcelFileDescriptor.open(file, accessMode, handler, l -> {
                     RemoteOperationResult result = new SynchronizeFileOperation(newFile, oldFile, user, true,


### PR DESCRIPTION
The sync operation detects changes by comparing timestamps in milliseconds. However, the local modification time only has a precision of seconds (even though given in milliseconds).
When the DocumentsProvider is used programmatically, operations such as a create and a subsequent write can happen within the same second causing the sync operation to not detect the change and therefore failing to upload a file **causing data loss**.

This MR also moves the file close listener to the thread used by the DocumentsStorageProvider as this is more appropriate than the UI thread.

Fixes #6726 (I can create other tickets about the side-issues identified there)