### PR TITLE
Fix #5755

### DIFF
--- a/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
+++ b/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
@@ -142,8 +142,7 @@ class BackgroundJobFactory @Inject constructor(
             uploadsStorageManager = uploadsStorageManager,
             connectivityService = connectivityService,
             powerManagementService = powerManagementService,
-            clock = clock,
-            backgroundJobManager = backgroundJobManager.get()
+            clock = clock
         )
     }
 

--- a/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -70,8 +70,7 @@ class FilesSyncWork(
     private val uploadsStorageManager: UploadsStorageManager,
     private val connectivityService: ConnectivityService,
     private val powerManagementService: PowerManagementService,
-    private val clock: Clock,
-    private val backgroundJobManager: BackgroundJobManager
+    private val clock: Clock
 ) : Worker(context, params) {
 
     companion object {
@@ -197,7 +196,7 @@ class FilesSyncWork(
                 UploadFileOperation.CREATED_AS_INSTANT_PICTURE,
                 needsWifi,
                 needsCharging,
-                FileUploader.NameCollisionPolicy.ASK_USER
+                syncedFolder.nameCollisionPolicy
             )
             filesystemDataProvider.updateFilesystemFileAsSentForUpload(
                 path,

--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
@@ -21,6 +21,8 @@
 
 package com.owncloud.android.datamodel;
 
+import com.owncloud.android.files.services.FileUploader;
+
 import java.io.Serializable;
 
 /**
@@ -178,8 +180,12 @@ public class SyncedFolder implements Serializable, Cloneable {
         return this.uploadAction;
     }
 
-    public int getNameCollisionPolicy() {
+    public int getNameCollisionPolicyInt() {
         return this.nameCollisionPolicy;
+    }
+
+    public FileUploader.NameCollisionPolicy getNameCollisionPolicy() {
+        return FileUploader.NameCollisionPolicy.deserialize(nameCollisionPolicy);
     }
 
     public boolean isEnabled() {

--- a/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -399,7 +399,7 @@ public class SyncedFolderProvider extends Observable {
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT, syncedFolder.getAccount());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_UPLOAD_ACTION, syncedFolder.getUploadAction());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_NAME_COLLISION_POLICY,
-               syncedFolder.getNameCollisionPolicy());
+               syncedFolder.getNameCollisionPolicyInt());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_TYPE, syncedFolder.getType().getId());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_HIDDEN, syncedFolder.isHidden());
 

--- a/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -903,7 +903,9 @@ public class UploadFileOperation extends SyncOperation {
     }
 
     @CheckResult
-    private RemoteOperationResult checkNameCollision(OwnCloudClient client, DecryptedFolderMetadata metadata, boolean encrypted)
+    private RemoteOperationResult checkNameCollision(OwnCloudClient client,
+                                                     DecryptedFolderMetadata metadata,
+                                                     boolean encrypted)
         throws OperationCancelledException {
         Log_OC.d(TAG, "Checking name collision in server");
 

--- a/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
@@ -403,23 +403,23 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
         List<String> filePaths = getDisplayFilePathList(files);
 
         return new SyncedFolderDisplayItem(
-                syncedFolder.getId(),
-                syncedFolder.getLocalPath(),
-                syncedFolder.getRemotePath(),
-                syncedFolder.isWifiOnly(),
-                syncedFolder.isChargingOnly(),
-                syncedFolder.isExisting(),
-                syncedFolder.isSubfolderByDate(),
-                syncedFolder.getAccount(),
-                syncedFolder.getUploadAction(),
-                syncedFolder.getNameCollisionPolicy(),
-                syncedFolder.isEnabled(),
-                clock.getCurrentTime(),
-                filePaths,
-                localFolder.getName(),
-                files.length,
-                syncedFolder.getType(),
-                syncedFolder.isHidden());
+            syncedFolder.getId(),
+            syncedFolder.getLocalPath(),
+            syncedFolder.getRemotePath(),
+            syncedFolder.isWifiOnly(),
+            syncedFolder.isChargingOnly(),
+            syncedFolder.isExisting(),
+            syncedFolder.isSubfolderByDate(),
+            syncedFolder.getAccount(),
+            syncedFolder.getUploadAction(),
+            syncedFolder.getNameCollisionPolicyInt(),
+            syncedFolder.isEnabled(),
+            clock.getCurrentTime(),
+            filePaths,
+            localFolder.getName(),
+            files.length,
+            syncedFolder.getType(),
+            syncedFolder.isHidden());
     }
 
     /**
@@ -432,23 +432,23 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
     @NonNull
     private SyncedFolderDisplayItem createSyncedFolder(@NonNull SyncedFolder syncedFolder, @NonNull MediaFolder mediaFolder) {
         return new SyncedFolderDisplayItem(
-                syncedFolder.getId(),
-                syncedFolder.getLocalPath(),
-                syncedFolder.getRemotePath(),
-                syncedFolder.isWifiOnly(),
-                syncedFolder.isChargingOnly(),
-                syncedFolder.isExisting(),
-                syncedFolder.isSubfolderByDate(),
-                syncedFolder.getAccount(),
-                syncedFolder.getUploadAction(),
-                syncedFolder.getNameCollisionPolicy(),
-                syncedFolder.isEnabled(),
-                clock.getCurrentTime(),
-                mediaFolder.filePaths,
-                mediaFolder.folderName,
-                mediaFolder.numberOfFiles,
-                mediaFolder.type,
-                syncedFolder.isHidden());
+            syncedFolder.getId(),
+            syncedFolder.getLocalPath(),
+            syncedFolder.getRemotePath(),
+            syncedFolder.isWifiOnly(),
+            syncedFolder.isChargingOnly(),
+            syncedFolder.isExisting(),
+            syncedFolder.isSubfolderByDate(),
+            syncedFolder.getAccount(),
+            syncedFolder.getUploadAction(),
+            syncedFolder.getNameCollisionPolicyInt(),
+            syncedFolder.isEnabled(),
+            clock.getCurrentTime(),
+            mediaFolder.filePaths,
+            mediaFolder.folderName,
+            mediaFolder.numberOfFiles,
+            mediaFolder.type,
+            syncedFolder.isHidden());
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
@@ -61,7 +61,7 @@ public class SyncedFolderParcelable implements Parcelable {
         account = syncedFolderDisplayItem.getAccount();
         uploadAction = syncedFolderDisplayItem.getUploadAction();
         nameCollisionPolicy = FileUploader.NameCollisionPolicy.deserialize(
-            syncedFolderDisplayItem.getNameCollisionPolicy());
+            syncedFolderDisplayItem.getNameCollisionPolicyInt());
         this.section = section;
         hidden = syncedFolderDisplayItem.isHidden();
     }


### PR DESCRIPTION
- use correct name collision info by synced folder
- syncedFolder.getNameCollisionPolicyInt -> returns int
- syncedFolder.getNameColllisionPolicy -> returns enum
- remove not needed backgroundJobManager from FilesSyncWork.kt

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
