### PR TITLE
Fix unresponsive preview player controls

### DIFF
--- a/src/main/res/layout/file_preview.xml
+++ b/src/main/res/layout/file_preview.xml
@@ -68,13 +68,10 @@
             android:layout_margin="@dimen/standard_margin" />
     </RelativeLayout>
 
-
-    <ScrollView
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
         <include layout="@layout/empty_list" />
-    </ScrollView>
-
+    </FrameLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
Media controls view were covered by a ScrollView
stealing all touch events. By changing it to FrameLayout,
touch events can reach media controls.

Content embedded inside ScrollView should not
exceed screen boundaries. If so - content must
be changed.

This fixes immediate problem with unresponsive media controls
reported in #6796 and #6782.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

### Testing 

Manual test:

1. open folder with music
2. start playing music
3. touch pause to stop it
