### PR TITLE
Fix insert image file picker only opens once

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.java
@@ -144,7 +144,10 @@ public class RichDocumentsEditorWebView extends EditorWebView {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (RESULT_OK != resultCode) {
-            // TODO
+            if (requestCode == REQUEST_LOCAL_FILE) {
+                this.uploadMessage.onReceiveValue(null);
+                this.uploadMessage = null;
+            }
             return;
         }
 


### PR DESCRIPTION
When no image is selected from the intent we should set onReceiveValue to null and uploadMessage to null otherwise it does not open after closing it without selecting an image.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
