### PR TITLE
Reduce extend of FileActivity, use DrawerActivity instead

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activities/ActivitiesActivity.java
@@ -38,7 +38,7 @@ import com.owncloud.android.lib.resources.activities.model.RichObject;
 import com.owncloud.android.lib.resources.files.FileUtils;
 import com.owncloud.android.ui.activities.data.activities.ActivitiesRepository;
 import com.owncloud.android.ui.activities.data.files.FilesRepository;
-import com.owncloud.android.ui.activity.FileActivity;
+import com.owncloud.android.ui.activity.DrawerActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.adapter.ActivityListAdapter;
 import com.owncloud.android.ui.interfaces.ActivityListInterface;
@@ -60,7 +60,10 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 
-public class ActivitiesActivity extends FileActivity implements ActivityListInterface, ActivitiesContract.View {
+import static com.owncloud.android.ui.activity.FileActivity.EXTRA_ACCOUNT;
+import static com.owncloud.android.ui.activity.FileActivity.EXTRA_FILE;
+
+public class ActivitiesActivity extends DrawerActivity implements ActivityListInterface, ActivitiesContract.View {
     private static final String TAG = ActivitiesActivity.class.getSimpleName();
     private static final int UNDEFINED = -1;
 
@@ -139,14 +142,6 @@ public class ActivitiesActivity extends FileActivity implements ActivityListInte
     public void onDestroy() {
         super.onDestroy();
         unbinder.unbind();
-    }
-
-    @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent i = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(i);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/activity/CommunityActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/CommunityActivity.java
@@ -21,7 +21,6 @@
  */
 package com.owncloud.android.ui.activity;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
@@ -37,7 +36,7 @@ import com.owncloud.android.utils.ThemeUtils;
 /**
  * Activity providing information about ways to participate in the app's development.
  */
-public class CommunityActivity extends FileActivity {
+public class CommunityActivity extends DrawerActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -130,15 +129,6 @@ public class CommunityActivity extends FileActivity {
                 break;
         }
         return retval;
-    }
-
-    @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent fileDisplayActivity = new Intent(getApplicationContext(),
-                FileDisplayActivity.class);
-        fileDisplayActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(fileDisplayActivity);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ContactsPreferenceActivity.java
@@ -118,14 +118,6 @@ public class ContactsPreferenceActivity extends FileActivity implements FileFrag
     }
 
     @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent fileDisplayActivity = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        fileDisplayActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(fileDisplayActivity);
-    }
-
-    @Override
     public void showDetails(OCFile file) {
         // not needed
     }

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -473,14 +473,6 @@ public abstract class DrawerActivity extends ToolbarActivity
     }
 
     /**
-     * show the file list to the user.
-     *
-     * @param onDeviceOnly flag to decide if all files or only the ones on the device should be shown
-     */
-    public abstract void showFiles(boolean onDeviceOnly);
-
-
-    /**
      * sets the new/current account and restarts. In case the given account equals the actual/current account the call
      * will be ignored.
      *
@@ -947,7 +939,26 @@ public abstract class DrawerActivity extends ToolbarActivity
     /**
      * restart helper method which is called after a changing the current account.
      */
-    protected abstract void restart();
+    private void restart() {
+        Intent i = new Intent(this, FileDisplayActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.setAction(FileDisplayActivity.RESTART);
+        startActivity(i);
+
+        fetchExternalLinks(false);
+    }
+
+    /**
+     * show the file list to the user.
+     *
+     * @param onDeviceOnly flag to decide if all files or only the ones on the device should be shown
+     */
+    public void showFiles(boolean onDeviceOnly) {
+        MainApp.showOnlyFilesOnDevice(onDeviceOnly);
+        Intent fileDisplayActivity = new Intent(getApplicationContext(), FileDisplayActivity.class);
+        fileDisplayActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(fileDisplayActivity);
+    }
 
     @Override
     public void avatarGenerated(Drawable avatarDrawable, Object callContext) {

--- a/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
@@ -22,7 +22,6 @@
 package com.owncloud.android.ui.activity;
 
 import android.annotation.SuppressLint;
-import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.os.Build;
 import android.os.Bundle;
@@ -218,14 +217,6 @@ public class ExternalSiteWebView extends FileActivity {
                 break;
         }
         return retval;
-    }
-
-    @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent fileDisplayActivity = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        fileDisplayActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(fileDisplayActivity);
     }
 
     @Override

--- a/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -608,16 +608,6 @@ public abstract class FileActivity extends DrawerActivity
         return mUploaderBinder;
     }
 
-    @Override
-    public void restart() {
-        Intent i = new Intent(this, FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        i.setAction(FileDisplayActivity.RESTART);
-        startActivity(i);
-
-        fetchExternalLinks(false);
-    }
-
     public OCFile getCurrentDir() {
         OCFile file = getFile();
         if (file != null) {

--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -24,7 +24,6 @@
 
 package com.owncloud.android.ui.activity;
 
-import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.view.Menu;
@@ -72,7 +71,7 @@ import butterknife.Unbinder;
 /**
  * Activity displaying all server side stored notification items.
  */
-public class NotificationsActivity extends FileActivity implements NotificationsContract.View {
+public class NotificationsActivity extends DrawerActivity implements NotificationsContract.View {
 
     private static final String TAG = NotificationsActivity.class.getSimpleName();
 
@@ -224,14 +223,6 @@ public class NotificationsActivity extends FileActivity implements Notifications
     public void onDestroy() {
         super.onDestroy();
         unbinder.unbind();
-    }
-
-    @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent i = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(i);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.java
@@ -602,21 +602,6 @@ public class SyncedFoldersActivity extends FileActivity implements SyncedFolderA
     }
 
     @Override
-    public void restart() {
-        Intent i = new Intent(this, FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(i);
-    }
-
-    @Override
-    public void showFiles(boolean onDeviceOnly) {
-        MainApp.showOnlyFilesOnDevice(onDeviceOnly);
-        Intent fileDisplayActivity = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        fileDisplayActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(fileDisplayActivity);
-    }
-
-    @Override
     public void onSyncStatusToggleClick(int section, SyncedFolderDisplayItem syncedFolderDisplayItem) {
         if (syncedFolderDisplayItem.getId() > UNPERSISTED_ID) {
             syncedFolderProvider.updateSyncedFolderEnabled(syncedFolderDisplayItem.getId(),

--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -67,10 +67,12 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import static com.owncloud.android.ui.activity.FileActivity.EXTRA_ACCOUNT;
+
 /**
  * Displays local files and let the user choose what of them wants to upload to the current ownCloud account.
  */
-public class UploadFilesActivity extends FileActivity implements LocalFileListFragment.ContainerActivity,
+public class UploadFilesActivity extends DrawerActivity implements LocalFileListFragment.ContainerActivity,
     OnClickListener, ConfirmationDialogFragmentListener, SortingOrderDialogFragment.OnSortingOrderListener,
     CheckAvailableSpaceTask.CheckAvailableSpaceListener, StoragePathAdapter.StoragePathAdapterListener, Injectable {
 

--- a/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -109,14 +109,6 @@ public class UploadListActivity extends FileActivity {
     }
 
     @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent i = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(i);
-    }
-
-    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 

--- a/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -90,7 +90,7 @@ import butterknife.Unbinder;
 /**
  * This Activity presents the user information.
  */
-public class UserInfoActivity extends FileActivity implements Injectable {
+public class UserInfoActivity extends DrawerActivity implements Injectable {
     public static final String KEY_ACCOUNT = "ACCOUNT";
 
     private static final String TAG = UserInfoActivity.class.getSimpleName();

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -23,7 +23,6 @@
  */
 package com.owncloud.android.ui.trashbin;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -41,8 +40,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.databinding.TrashbinActivityBinding;
 import com.owncloud.android.lib.resources.trashbin.model.TrashbinFile;
 import com.owncloud.android.ui.EmptyRecyclerView;
-import com.owncloud.android.ui.activity.FileActivity;
-import com.owncloud.android.ui.activity.FileDisplayActivity;
+import com.owncloud.android.ui.activity.DrawerActivity;
 import com.owncloud.android.ui.adapter.TrashbinListAdapter;
 import com.owncloud.android.ui.dialog.SortingOrderDialogFragment;
 import com.owncloud.android.ui.interfaces.TrashbinActivityInterface;
@@ -63,7 +61,7 @@ import static com.owncloud.android.utils.DisplayUtils.openSortingOrderDialogFrag
 /**
  * Presenting trashbin data, received from presenter
  */
-public class TrashbinActivity extends FileActivity implements
+public class TrashbinActivity extends DrawerActivity implements
     TrashbinActivityInterface,
     SortingOrderDialogFragment.OnSortingOrderListener,
     TrashbinContract.View,
@@ -142,14 +140,6 @@ public class TrashbinActivity extends FileActivity implements
     protected void loadFolder() {
         binding.swipeContainingList.setRefreshing(true);
         trashbinPresenter.loadFolder();
-    }
-
-    @Override
-    public void showFiles(boolean onDeviceOnly) {
-        super.showFiles(onDeviceOnly);
-        Intent i = new Intent(getApplicationContext(), FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(i);
     }
 
     @Override


### PR DESCRIPTION
This cleans up unused dependencies, which might help us for later refactoring.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
