### PR TITLE
fix inplace scrollview in sharing fragment

### DIFF
--- a/src/main/res/layout/file_details_sharing_fragment.xml
+++ b/src/main/res/layout/file_details_sharing_fragment.xml
@@ -101,8 +101,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/publicShareList"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
+            android:layout_height="wrap_content"
             android:divider="@drawable/divider"
             android:dividerHeight="1dp" />
 
@@ -111,8 +110,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/shareUsersList"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
+            android:layout_height="wrap_content"
             android:divider="@drawable/divider"
             android:dividerHeight="1dp" />
 


### PR DESCRIPTION
This patch removes the embedded scrollview as well as the size constraint of the two unrelated views.

The embedded scrollview leads to the problem that further shares are (sometimes completely) hidden. The constraint between the two views creates empty space that is not necessary.

![Screenshot_1598971890](https://user-images.githubusercontent.com/898577/91872717-75836f00-ec78-11ea-8f11-2fd8bed4ba1b.png)
![Screenshot_1598971590](https://user-images.githubusercontent.com/898577/91872735-7c11e680-ec78-11ea-8186-c037f80b6a5b.png)
