### PR TITLE
DocumentsStorageProvider: prevent opening stale file contents

### DIFF
--- a/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
+++ b/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
@@ -183,23 +183,23 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
         val file1 = rootDir.createFile("text/plain", RandomString.make())!!
         file1.assertRegularFile(size = 0L)
 
-        val content1 = "initial content".toByteArray();
+        val content1 = "initial content".toByteArray()
 
         // write content bytes to file
         contentResolver.openOutputStream(file1.uri, "wt").use {
             it!!.write(content1)
         }
 
-        val remotePath = file1.getOCFile(storageManager)!!.remotePath;
+        val remotePath = file1.getOCFile(storageManager)!!.remotePath
 
-        val content2 = "new content".toByteArray();
+        val content2 = "new content".toByteArray()
 
         // modify content on server side
-        val putMethod = PutMethod(client.webdavUri.toString() + WebdavUtils.encodePath(remotePath));
-        putMethod.setRequestEntity(ByteArrayRequestEntity(content2));
-        assertEquals(HttpStatus.SC_NO_CONTENT, client.executeMethod(putMethod));
-        client.exhaustResponse(putMethod.responseBodyAsStream);
-        putMethod.releaseConnection(); // let the connection available for other methods
+        val putMethod = PutMethod(client.webdavUri.toString() + WebdavUtils.encodePath(remotePath))
+        putMethod.setRequestEntity(ByteArrayRequestEntity(content2))
+        assertEquals(HttpStatus.SC_NO_CONTENT, client.executeMethod(putMethod))
+        client.exhaustResponse(putMethod.responseBodyAsStream)
+        putMethod.releaseConnection() // let the connection available for other methods
 
         // read back content bytes
         assertReadEquals(content2, contentResolver.openInputStream(file1.uri))

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -201,7 +201,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         int accessMode = ParcelFileDescriptor.parseMode(mode);
 
-        boolean needsDownload = (accessMode != ParcelFileDescriptor.MODE_WRITE_ONLY);
+        boolean needsDownload = accessMode != ParcelFileDescriptor.MODE_WRITE_ONLY;
         if (needsDownload && ocFile.isDown()) {
             RemoteOperationResult result = new ReadFileRemoteOperation(ocFile.getRemotePath())
                 .execute(document.getClient());


### PR DESCRIPTION
Replace SynchronizeFileOperation by ReadFileRemoteOperation to prevent opening stale file contents
fix #6883

Signed-off-by: Jens Mueller <tschenser@gmx.de>
