### PR TITLE
Fix unit test

### DIFF
--- a/src/test/java/com/owncloud/android/ui/adapter/ActivityListAdapterTest.java
+++ b/src/test/java/com/owncloud/android/ui/adapter/ActivityListAdapterTest.java
@@ -28,8 +28,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.internal.util.reflection.InstanceField;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 public final class ActivityListAdapterTest {
@@ -42,7 +43,9 @@ public final class ActivityListAdapterTest {
     public void setUp() throws NoSuchFieldException {
         MockitoAnnotations.initMocks(this);
         MockitoAnnotations.initMocks(activityListAdapter);
-        FieldSetter.setField(activityListAdapter, activityListAdapter.getClass().getDeclaredField("values"), new ArrayList<>());
+        Field field = activityListAdapter.getClass().getDeclaredField("values");
+        InstanceField instanceField = new InstanceField(field, activityListAdapter);
+        instanceField.set(new ArrayList<>());
     }
 
     @Test


### PR DESCRIPTION
`FieldSetter` was removed from mockito in 3.5.0.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
