### PR TITLE
Update DocumentsProvider roots when enabling/disabling app lock feature

### DIFF
--- a/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
@@ -25,8 +25,6 @@ package com.nextcloud.client.jobs
 
 import android.accounts.Account
 import android.content.Context
-import android.os.Build
-import android.provider.DocumentsContract
 import android.text.TextUtils
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -48,6 +46,7 @@ import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.lib.resources.users.RemoteWipeSuccessRemoteOperation
+import com.owncloud.android.providers.DocumentsStorageProvider
 import com.owncloud.android.ui.activity.ContactsPreferenceActivity
 import com.owncloud.android.ui.activity.ManageAccountsActivity
 import com.owncloud.android.ui.events.AccountRemovedEvent
@@ -127,11 +126,7 @@ class AccountRemovalWork(
             }
         }
         // notify Document Provider
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            val authority = context.resources.getString(R.string.document_provider_authority)
-            val rootsUri = DocumentsContract.buildRootsUri(authority)
-            context.contentResolver.notifyChange(rootsUri, null)
-        }
+        DocumentsStorageProvider.notifyRootsChanged(context)
         return Result.success()
     }
 

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -61,7 +61,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
-import android.provider.DocumentsContract;
 import android.text.TextUtils;
 import android.util.AndroidRuntimeException;
 import android.view.KeyEvent;
@@ -114,6 +113,7 @@ import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.lib.resources.users.GetUserInfoRemoteOperation;
 import com.owncloud.android.operations.DetectAuthenticationMethodOperation.AuthenticationMethod;
 import com.owncloud.android.operations.GetServerInfoOperation;
+import com.owncloud.android.providers.DocumentsStorageProvider;
 import com.owncloud.android.services.OperationsService;
 import com.owncloud.android.services.OperationsService.OperationsServiceBinder;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
@@ -1287,11 +1287,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             setResult(RESULT_OK, intent);
 
             // notify Document Provider
-            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                String authority = getResources().getString(R.string.document_provider_authority);
-                Uri rootsUri = DocumentsContract.buildRootsUri(authority);
-                getContentResolver().notifyChange(rootsUri, null);
-            }
+            DocumentsStorageProvider.notifyRootsChanged(this);
 
             return true;
         }

--- a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -135,6 +135,14 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         return result;
     }
 
+    public static void notifyRootsChanged(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            String authority = context.getString(R.string.document_provider_authority);
+            Uri rootsUri = DocumentsContract.buildRootsUri(authority);
+            context.getContentResolver().notifyChange(rootsUri, null);
+        }
+    }
+
     @Override
     public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
         Log.d(TAG, "queryDocument(), id=" + documentId);

--- a/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -70,6 +70,7 @@ import com.owncloud.android.datastorage.StoragePoint;
 import com.owncloud.android.lib.common.ExternalLink;
 import com.owncloud.android.lib.common.ExternalLinkType;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.providers.DocumentsStorageProvider;
 import com.owncloud.android.ui.asynctasks.LoadingVersionNumberTask;
 import com.owncloud.android.utils.DeviceCredentialUtils;
 import com.owncloud.android.utils.DisplayUtils;
@@ -641,10 +642,15 @@ public class SettingsActivity extends ThemedPreferenceActivity
                 DisplayUtils.showSnackMessage(this, R.string.prefs_lock_device_credentials_not_setup);
             } else {
                 DisplayUtils.showSnackMessage(this, R.string.prefs_lock_device_credentials_enabled);
-                this.lock.setValue(LOCK_DEVICE_CREDENTIALS);
-                this.lock.setSummary(this.lock.getEntry());
+                changeLockSetting(LOCK_DEVICE_CREDENTIALS);
             }
         }
+    }
+
+    private void changeLockSetting(String value) {
+        lock.setValue(value);
+        lock.setSummary(lock.getEntry());
+        DocumentsStorageProvider.notifyRootsChanged(this);
     }
 
     private void disableLock(String lock) {
@@ -819,14 +825,12 @@ public class SettingsActivity extends ThemedPreferenceActivity
                     appPrefs.putString(PassCodeActivity.PREFERENCE_PASSCODE_D + i, passcode.substring(i - 1, i));
                 }
                 appPrefs.apply();
-                lock.setValue(LOCK_PASSCODE);
-                lock.setSummary(lock.getEntry());
+                changeLockSetting(LOCK_PASSCODE);
                 DisplayUtils.showSnackMessage(this, R.string.pass_code_stored);
             }
         } else if (requestCode == ACTION_CONFIRM_PASSCODE && resultCode == RESULT_OK) {
             if (data.getBooleanExtra(PassCodeActivity.KEY_CHECK_RESULT, false)) {
-                lock.setValue(LOCK_NONE);
-                lock.setSummary(lock.getEntry());
+                changeLockSetting(LOCK_NONE);
 
                 DisplayUtils.showSnackMessage(this, R.string.pass_code_removed);
                 if (!LOCK_NONE.equals(pendingLock)) {
@@ -840,8 +844,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
                 data.getIntExtra(RequestCredentialsActivity.KEY_CHECK_RESULT,
                         RequestCredentialsActivity.KEY_CHECK_RESULT_FALSE) ==
                         RequestCredentialsActivity.KEY_CHECK_RESULT_TRUE) {
-            lock.setValue(LOCK_NONE);
-            lock.setSummary(lock.getEntry());
+            changeLockSetting(LOCK_NONE);
             DisplayUtils.showSnackMessage(this, R.string.credentials_disabled);
             if (!LOCK_NONE.equals(pendingLock)) {
                 enableLock(pendingLock);


### PR DESCRIPTION
Note that this doesn't attempt to re-enable the roots when the passcode was entered. As the timeout is only 5 seconds that would not be very useful. Also, you would need extra infrastructure to disable the roots again from the background after 5 seconds which might not be reliable (if the OS kills you before). So keeping the roots off when the passcode feature is active is probably the sanest approach.

Fixes #6882 