### PR TITLE
Prevent firebase crashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,6 @@ configurations {
     ktlint
 
     all {
-        exclude group: 'com.google.firebase', module: 'firebase-core'
-        exclude group: 'com.google.firebase', module: 'firebase-analytics'
-        exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'
         exclude group: 'org.jetbrains', module: 'annotations-java5' // via prism4j, already using annotations explicitly
 
         // check for updates every build

--- a/gplay.gradle
+++ b/gplay.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation "com.google.firebase:firebase-messaging:20.1.3"
+    implementation "com.google.firebase:firebase-messaging:20.2.4"
 }

--- a/lint.xml
+++ b/lint.xml
@@ -62,5 +62,6 @@
         <ignore path="**/jetified-butterknife-runtime-10.**/**/lint.jar" />
         <ignore path="**/jetified-dagger-lint-aar-2.29.**/**/lint.jar" />
         <ignore path="**/jetified-annotation-experimental-1.**/**/lint.jar" />
+        <ignore path="**/jetified-firebase-installations**/**/lint.jar" />
     </issue>
 </lint>

--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -30,10 +30,13 @@
 
         <meta-data
             android:name="firebase_analytics_collection_deactivated"
-            android:value="true"/>
+            android:value="true" />
         <meta-data
             android:name="google_analytics_adid_collection_enabled"
-            android:value="false"/>
+            android:value="false" />
+        <meta-data
+            android:name="google_analytics_ssaid_collection_enabled"
+            android:value="false" />
 
         <activity
             android:name=".authentication.ModifiedAuthenticatorActivity"


### PR DESCRIPTION
Fix #4675 

"Downside" is that it included a bit more Firebase, but all is disabled:
https://github.com/nextcloud/android/blob/master/src/gplay/AndroidManifest.xml#L31-L36

According to https://firebase.google.com/docs/analytics/configure-data-collection?platform=android#temporarily_disable_collection_1

However Exodus will still show it as available tracker, as it is technically still part of our code.


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
