### PR TITLE
Ensure that upload notification gets cancelled

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -751,6 +751,8 @@ public class FileUploader extends Service
             mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         }
 
+        mNotificationManager.cancel(FOREGROUND_SERVICE_ID);
+
         // Only notify if the upload fails
         if (!uploadResult.isCancelled() &&
             !uploadResult.isSuccess() &&


### PR DESCRIPTION
This is a follow up to #6997.

Normally, the notification gets cancelled when the service is destroyed. But that does not always happen in practice, so we also cancel it after every result.