### PR TITLE
DocumentsStorageProviderIT: testServerChangedFileContent fails

### DIFF
--- a/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
+++ b/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
@@ -202,6 +202,7 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
         putMethod.releaseConnection() // let the connection available for other methods
 
         // read back content bytes
-        assertReadEquals(content2, contentResolver.openInputStream(file1.uri))
+        val bytes = contentResolver.openInputStream(file1.uri)?.readBytes() ?: ByteArray(0)
+        assertEquals(String(content2), String(bytes))
     }
 }


### PR DESCRIPTION
@jmue @grote 

This test fails now with:
> ComparisonFailure: expected:<[new] content> but was:<[initial] content>

So it seems that we do not refresh doc storage after updating.
I am unsure when this changed and what the impact of this is?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
