### PR TITLE
Add shimmer to preview image fragment

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -285,12 +285,6 @@ public final class ThumbnailsCacheManager {
             file = (OCFile) params[0];
 
             try {
-                Thread.sleep(8000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-
-            try {
                 if (account != null) {
                     OwnCloudAccount ocAccount = new OwnCloudAccount(account, MainApp.getAppContext());
                     mClient = OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount,

--- a/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -258,6 +258,7 @@ public final class ThumbnailsCacheManager {
         private WeakReference<FrameLayout> frameLayoutReference;
         private OCFile file;
         private ConnectivityService connectivityService;
+        private int backgroundColor;
 
 
         public ResizedImageGenerationTask(FileFragment fileFragment,
@@ -265,7 +266,8 @@ public final class ThumbnailsCacheManager {
                                           FrameLayout emptyListProgress,
                                           FileDataStorageManager storageManager,
                                           ConnectivityService connectivityService,
-                                          Account account)
+                                          Account account,
+                                          int backgroundColor)
                 throws IllegalArgumentException {
             this.fileFragment = fileFragment;
             imageViewReference = new WeakReference<>(imageView);
@@ -273,6 +275,7 @@ public final class ThumbnailsCacheManager {
             this.storageManager = storageManager;
             this.connectivityService = connectivityService;
             this.account = account;
+            this.backgroundColor = backgroundColor;
         }
 
         @Override
@@ -397,6 +400,7 @@ public final class ThumbnailsCacheManager {
                         if (String.valueOf(imageView.getTag()).equals(tagId)) {
                             imageView.setVisibility(View.VISIBLE);
                             imageView.setImageBitmap(bitmap);
+                            imageView.setBackgroundColor(backgroundColor);
 
                             if (frameLayout != null) {
                                 frameLayout.setVisibility(View.GONE);

--- a/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -270,4 +270,8 @@ public abstract class ToolbarActivity extends BaseActivity {
     public ImageView getPreviewImageView() {
         return mPreviewImage;
     }
+
+    public FrameLayout getPreviewImageContainer() {
+        return mPreviewImageContainer;
+    }
 }

--- a/src/main/java/com/owncloud/android/ui/adapter/DiskLruImageCache.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/DiskLruImageCache.java
@@ -128,7 +128,11 @@ public class DiskLruImageCache {
                 options.inMutable = false;
                 options.inJustDecodeBounds = true;
 
-                bitmap = BitmapFactory.decodeStream(buffIn, null, options);
+                BitmapFactory.decodeStream(buffIn, null, options);
+
+                snapshot = mDiskCache.get(validKey);
+                inputStream = snapshot.getInputStream(0);
+                buffIn = new BufferedInputStream(inputStream, IO_BUFFER_SIZE);
 
                 // Calculate inSampleSize
                 options.inSampleSize = BitmapUtils.calculateSampleFactor(options, width, height);

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -579,12 +579,14 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                 if (ThumbnailsCacheManager.cancelPotentialThumbnailWork(getFile(), toolbarActivity.getPreviewImageView()) &&
                         containerActivity.getStorageManager() != null) {
                     final ThumbnailsCacheManager.ResizedImageGenerationTask task =
-                            new ThumbnailsCacheManager.ResizedImageGenerationTask(this,
-                                                                                  toolbarActivity.getPreviewImageView(),
-                                                                                  toolbarActivity.getPreviewImageContainer(),
-                                                                                  containerActivity.getStorageManager(),
-                                                                                  connectivityService,
-                                                                                  containerActivity.getStorageManager().getAccount());
+                        new ThumbnailsCacheManager.ResizedImageGenerationTask(this,
+                                                                              toolbarActivity.getPreviewImageView(),
+                                                                              toolbarActivity.getPreviewImageContainer(),
+                                                                              containerActivity.getStorageManager(),
+                                                                              connectivityService,
+                                                                              containerActivity.getStorageManager().getAccount(),
+                                                                              getResources().getColor(R.color.background_color_inverse)
+                        );
 
                     if (resizedImage == null) {
                         resizedImage = thumbnail;

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -581,6 +581,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                     final ThumbnailsCacheManager.ResizedImageGenerationTask task =
                             new ThumbnailsCacheManager.ResizedImageGenerationTask(this,
                                                                                   toolbarActivity.getPreviewImageView(),
+                                                                                  toolbarActivity.getPreviewImageContainer(),
                                                                                   containerActivity.getStorageManager(),
                                                                                   connectivityService,
                                                                                   containerActivity.getStorageManager().getAccount());

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -512,12 +512,6 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
                 return null;
             }
 
-            try {
-                Thread.sleep(8000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-
             Bitmap bitmapResult = null;
             Drawable drawableResult = null;
             OCFile ocFile = params[0];

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -239,6 +239,20 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
             int width = screenSize.x;
             int height = screenSize.y;
 
+            // show thumbnail while loading image
+            binding.image.setVisibility(View.GONE);
+            binding.emptyListProgress.setVisibility(View.VISIBLE);
+
+            Bitmap thumbnail = getThumbnailBitmap(getFile());
+            if (thumbnail != null) {
+                binding.shimmer.setVisibility(View.VISIBLE);
+                binding.shimmerThumbnail.setImageBitmap(thumbnail);
+                binding.image.setVisibility(View.GONE);
+                bitmap = thumbnail;
+            } else {
+                thumbnail = ThumbnailsCacheManager.mDefaultImg;
+            }
+
             if (showResizedImage) {
                 Bitmap resizedImage = getResizedBitmap(getFile(), width, height);
 
@@ -251,21 +265,6 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
 
                     bitmap = resizedImage;
                 } else {
-                    binding.emptyListProgress.setVisibility(View.VISIBLE);
-                    binding.image.setVisibility(View.GONE);
-
-                    // show thumbnail while loading resized image
-                    Bitmap thumbnail = getThumbnailBitmap(getFile());
-
-                    if (thumbnail != null) {
-                        binding.shimmer.setVisibility(View.VISIBLE);
-                        binding.shimmerThumbnail.setImageBitmap(thumbnail);
-                        binding.image.setVisibility(View.GONE);
-                        bitmap = thumbnail;
-                    } else {
-                        thumbnail = ThumbnailsCacheManager.mDefaultImg;
-                    }
-
                     // generate new resized image
                     if (ThumbnailsCacheManager.cancelPotentialThumbnailWork(getFile(), binding.image) &&
                         containerActivity.getStorageManager() != null) {
@@ -275,7 +274,9 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
                                                                                   binding.emptyListProgress,
                                                                                   containerActivity.getStorageManager(),
                                                                                   connectivityService,
-                                                                                  containerActivity.getStorageManager().getAccount());
+                                                                                  containerActivity.getStorageManager().getAccount(),
+                                                                                  getResources().getColor(R.color.background_color_inverse)
+                            );
                         if (resizedImage == null) {
                             resizedImage = thumbnail;
                         }

--- a/src/main/res/layout/preview_image_fragment.xml
+++ b/src/main/res/layout/preview_image_fragment.xml
@@ -89,19 +89,20 @@
         android:layout_height="match_parent">
 
         <com.elyeproj.loaderviewlibrary.LoaderImageView
-            android:layout_width="@dimen/empty_list_icon_layout_width"
-            android:layout_height="@dimen/empty_list_icon_layout_width"
+            android:id="@+id/shimmer"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
             android:layout_gravity="center"
             android:contentDescription="@null"
             app:corners="24" />
 
         <ImageView
+            android:id="@+id/shimmerThumbnail"
             android:layout_width="@dimen/empty_list_icon_layout_width"
             android:layout_height="@dimen/empty_list_icon_layout_height"
             android:layout_gravity="center"
             android:contentDescription="@null"
-            android:src="@drawable/ic_image_outline"
-            app:tint="@color/bg_default" />
+            android:src="@drawable/ic_image_outline" />
 
     </FrameLayout>
 </FrameLayout>

--- a/src/main/res/layout/toolbar_standard.xml
+++ b/src/main/res/layout/toolbar_standard.xml
@@ -91,6 +91,8 @@
                 android:layout_height="@dimen/nav_drawer_header_height"
                 android:visibility="gone">
 
+                <!--                TODO add shimmer -->
+
                 <ImageView
                     android:id="@+id/preview_image"
                     android:layout_width="match_parent"


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/7330

@AndyScherzinger can you test QA build?
It has a delay of 8s for showing local files and generating resized images, so that you can see shimmer.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
