### PR TITLE
Directly start foreground service

### DIFF
--- a/src/main/java/com/nextcloud/client/media/PlayerService.kt
+++ b/src/main/java/com/nextcloud/client/media/PlayerService.kt
@@ -35,7 +35,6 @@ import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.ThemeUtils
 import dagger.android.AndroidInjection
-import java.lang.IllegalArgumentException
 import javax.inject.Inject
 
 class PlayerService : Service() {

--- a/src/main/java/com/nextcloud/client/media/PlayerService.kt
+++ b/src/main/java/com/nextcloud/client/media/PlayerService.kt
@@ -35,6 +35,7 @@ import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.ThemeUtils
 import dagger.android.AndroidInjection
+import java.util.Locale
 import javax.inject.Inject
 
 class PlayerService : Service() {
@@ -46,6 +47,7 @@ class PlayerService : Service() {
         const val EXTRA_START_POSITION_MS = "START_POSITION_MS"
         const val ACTION_PLAY = "PLAY"
         const val ACTION_STOP = "STOP"
+        const val ACTION_TOGGLE = "TOGGLE"
         const val ACTION_STOP_FILE = "STOP_FILE"
     }
 
@@ -73,7 +75,7 @@ class PlayerService : Service() {
         }
 
         override fun onStop() {
-            stopForeground(true)
+            stopServiceAndRemoveNotification(null)
         }
 
         override fun onError(error: PlayerError) {
@@ -96,10 +98,20 @@ class PlayerService : Service() {
         player = Player(applicationContext, clientFactory, playerListener, audioManager)
         notificationBuilder = NotificationCompat.Builder(this)
         notificationBuilder.color = ThemeUtils.primaryColor(this)
+
         val stop = Intent(this, PlayerService::class.java)
         stop.action = ACTION_STOP
         val pendingStop = PendingIntent.getService(this, 0, stop, 0)
-        notificationBuilder.addAction(0, "STOP", pendingStop)
+        notificationBuilder.addAction(0, getString(R.string.player_stop).toUpperCase(Locale.getDefault()), pendingStop)
+
+        val toggle = Intent(this, PlayerService::class.java)
+        toggle.action = ACTION_TOGGLE
+        val pendingToggle = PendingIntent.getService(this, 0, toggle, 0)
+        notificationBuilder.addAction(
+            0,
+            getString(R.string.player_toggle).toUpperCase(Locale.getDefault()),
+            pendingToggle
+        )
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -111,8 +123,17 @@ class PlayerService : Service() {
             ACTION_PLAY -> onActionPlay(intent)
             ACTION_STOP -> onActionStop()
             ACTION_STOP_FILE -> onActionStopFile(intent.extras)
+            ACTION_TOGGLE -> onActionToggle()
         }
         return START_NOT_STICKY
+    }
+
+    private fun onActionToggle() {
+        if (player.isPlaying) {
+            player.pause()
+        } else {
+            player.start()
+        }
     }
 
     private fun onActionPlay(intent: Intent) {
@@ -125,12 +146,13 @@ class PlayerService : Service() {
     }
 
     private fun onActionStop() {
-        player.stop()
+        stopServiceAndRemoveNotification(null)
     }
 
     private fun onActionStopFile(args: Bundle?) {
         val file: OCFile = args?.getParcelable(EXTRA_FILE) ?: throw IllegalArgumentException("Missing file argument")
-        player.stop(file)
+
+        stopServiceAndRemoveNotification(file)
     }
 
     private fun startForeground(currentFile: OCFile) {
@@ -147,5 +169,16 @@ class PlayerService : Service() {
         }
 
         startForeground(R.string.media_notif_ticker, notificationBuilder.build())
+    }
+
+    private fun stopServiceAndRemoveNotification(file: OCFile?) {
+        if (file == null) {
+            player.stop()
+        } else {
+            player.stop(file)
+        }
+
+        stopSelf()
+        stopForeground(true)
     }
 }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -324,7 +324,9 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
                 mMultiListContainer.setVisibility(View.GONE);
                 mPreviewContainer.setVisibility(View.VISIBLE);
             } else if (MimeTypeUtil.isVideo(file)) {
-                stopAudio();
+                if (mMediaPlayerServiceConnection.isConnected() && mMediaPlayerServiceConnection.isPlaying()) {
+                    stopAudio();
+                }
                 playVideo();
             }
         }

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -317,14 +317,17 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
         Log_OC.v(TAG, "onStart");
         OCFile file = getFile();
         if (file != null) {
+            // bind to any existing player
+            mMediaPlayerServiceConnection.bind();
+
             if (MimeTypeUtil.isAudio(file)) {
                 mMediaController.setMediaPlayer(mMediaPlayerServiceConnection);
-                mMediaPlayerServiceConnection.bind();
                 mMediaPlayerServiceConnection.start(user, file, mAutoplay, mSavedPlaybackPosition);
                 mMultiListContainer.setVisibility(View.GONE);
                 mPreviewContainer.setVisibility(View.VISIBLE);
             } else if (MimeTypeUtil.isVideo(file)) {
-                if (mMediaPlayerServiceConnection.isConnected() && mMediaPlayerServiceConnection.isPlaying()) {
+                if (mMediaPlayerServiceConnection.isConnected()) {
+                    // always stop player
                     stopAudio();
                 }
                 playVideo();

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -945,4 +945,6 @@
     <string name="fourHours">4 hours</string>
     <string name="thisWeek">This week</string>
     <string name="drawer_item_gallery">Media</string>
+    <string name="player_stop">stop</string>
+    <string name="player_toggle">toggle</string>
 </resources>


### PR DESCRIPTION
Fix #2010 
Fix #6905

This is not done at all, but it prevents from crashing on my test device.
@ezaquarii for some reason the startForeground in PlayerService is not called, when starting a video.
Thus it get killed by Android after a specific time.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
