### PR TITLE
Fix/disable flaky tests

### DIFF
--- a/src/androidTest/java/com/owncloud/android/datamodel/FileDataStorageManagerContentProviderClientIT.java
+++ b/src/androidTest/java/com/owncloud/android/datamodel/FileDataStorageManagerContentProviderClientIT.java
@@ -24,7 +24,7 @@ package com.owncloud.android.datamodel;
 
 import com.owncloud.android.db.ProviderMeta;
 
-public class FileDataStorageManagerContentProviderClientTest extends FileDataStorageManagerTest {
+public class FileDataStorageManagerContentProviderClientIT extends FileDataStorageManagerIT {
 
     @Override
     public void before() {

--- a/src/androidTest/java/com/owncloud/android/datamodel/FileDataStorageManagerContentResolverIT.java
+++ b/src/androidTest/java/com/owncloud/android/datamodel/FileDataStorageManagerContentResolverIT.java
@@ -22,7 +22,7 @@
 
 package com.owncloud.android.datamodel;
 
-public class FileDataStorageManagerContentResolverTest extends FileDataStorageManagerTest {
+public class FileDataStorageManagerContentResolverIT extends FileDataStorageManagerIT {
     @Override
     public void before() {
         sut = new FileDataStorageManager(account, targetContext.getContentResolver());

--- a/src/androidTest/java/com/owncloud/android/files/services/FileUploaderIT.kt
+++ b/src/androidTest/java/com/owncloud/android/files/services/FileUploaderIT.kt
@@ -71,60 +71,61 @@ class FileUploaderIT : AbstractOnServerIT() {
     /**
      * uploads a file, overwrites it with an empty one, check if overwritten
      */
-    @Test
-    fun testKeepLocalAndOverwriteRemote() {
-        val file = getDummyFile("/chunkedFile.txt")
-        val ocUpload = OCUpload(file.absolutePath, "/testFile.txt", account.name)
-
-        assertTrue(
-            UploadFileOperation(
-                uploadsStorageManager,
-                connectivityServiceMock,
-                powerManagementServiceMock,
-                user,
-                null,
-                ocUpload,
-                FileUploader.NameCollisionPolicy.DEFAULT,
-                FileUploader.LOCAL_BEHAVIOUR_COPY,
-                targetContext,
-                false,
-                false
-            )
-                .setRemoteFolderToBeCreated()
-                .execute(client, storageManager)
-                .isSuccess
-        )
-
-        val result = ReadFileRemoteOperation("/testFile.txt").execute(client)
-        assertTrue(result.isSuccess)
-
-        assertEquals(file.length(), (result.data[0] as RemoteFile).length)
-
-        val ocUpload2 = OCUpload(getDummyFile("/empty.txt").absolutePath, "/testFile.txt", account.name)
-
-        assertTrue(
-            UploadFileOperation(
-                uploadsStorageManager,
-                connectivityServiceMock,
-                powerManagementServiceMock,
-                user,
-                null,
-                ocUpload2,
-                FileUploader.NameCollisionPolicy.OVERWRITE,
-                FileUploader.LOCAL_BEHAVIOUR_COPY,
-                targetContext,
-                false,
-                false
-            )
-                .execute(client, storageManager)
-                .isSuccess
-        )
-
-        val result2 = ReadFileRemoteOperation("/testFile.txt").execute(client)
-        assertTrue(result2.isSuccess)
-
-        assertEquals(0, (result2.data[0] as RemoteFile).length)
-    }
+    // disabled, flaky test
+    // @Test
+    // fun testKeepLocalAndOverwriteRemote() {
+    //     val file = getDummyFile("/chunkedFile.txt")
+    //     val ocUpload = OCUpload(file.absolutePath, "/testFile.txt", account.name)
+    //
+    //     assertTrue(
+    //         UploadFileOperation(
+    //             uploadsStorageManager,
+    //             connectivityServiceMock,
+    //             powerManagementServiceMock,
+    //             user,
+    //             null,
+    //             ocUpload,
+    //             FileUploader.NameCollisionPolicy.DEFAULT,
+    //             FileUploader.LOCAL_BEHAVIOUR_COPY,
+    //             targetContext,
+    //             false,
+    //             false
+    //         )
+    //             .setRemoteFolderToBeCreated()
+    //             .execute(client, storageManager)
+    //             .isSuccess
+    //     )
+    //
+    //     val result = ReadFileRemoteOperation("/testFile.txt").execute(client)
+    //     assertTrue(result.isSuccess)
+    //
+    //     assertEquals(file.length(), (result.data[0] as RemoteFile).length)
+    //
+    //     val ocUpload2 = OCUpload(getDummyFile("/empty.txt").absolutePath, "/testFile.txt", account.name)
+    //
+    //     assertTrue(
+    //         UploadFileOperation(
+    //             uploadsStorageManager,
+    //             connectivityServiceMock,
+    //             powerManagementServiceMock,
+    //             user,
+    //             null,
+    //             ocUpload2,
+    //             FileUploader.NameCollisionPolicy.OVERWRITE,
+    //             FileUploader.LOCAL_BEHAVIOUR_COPY,
+    //             targetContext,
+    //             false,
+    //             false
+    //         )
+    //             .execute(client, storageManager)
+    //             .isSuccess
+    //     )
+    //
+    //     val result2 = ReadFileRemoteOperation("/testFile.txt").execute(client)
+    //     assertTrue(result2.isSuccess)
+    //
+    //     assertEquals(0, (result2.data[0] as RemoteFile).length)
+    // }
 
     /**
      * uploads a file, overwrites it with an empty one, check if overwritten

--- a/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
+++ b/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
@@ -6,7 +6,6 @@ import androidx.documentfile.provider.DocumentFile
 import com.owncloud.android.AbstractOnServerIT
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.OCFile.ROOT_PATH
-import com.owncloud.android.lib.common.network.WebdavUtils
 import com.owncloud.android.providers.DocumentsProviderUtils.assertExistsOnServer
 import com.owncloud.android.providers.DocumentsProviderUtils.assertListFilesEquals
 import com.owncloud.android.providers.DocumentsProviderUtils.assertReadEquals
@@ -19,9 +18,6 @@ import com.owncloud.android.providers.DocumentsProviderUtils.listFilesBlocking
 import com.owncloud.android.providers.DocumentsStorageProvider.DOCUMENTID_SEPARATOR
 import kotlinx.coroutines.runBlocking
 import net.bytebuddy.utility.RandomString
-import org.apache.commons.httpclient.HttpStatus
-import org.apache.commons.httpclient.methods.ByteArrayRequestEntity
-import org.apache.commons.httpclient.methods.PutMethod
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -177,31 +173,32 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
         assertExistsOnServer(client, ocFile1.remotePath, false)
     }
 
-    @Test
-    fun testServerChangedFileContent() {
-        // create random file
-        val file1 = rootDir.createFile("text/plain", RandomString.make())!!
-        file1.assertRegularFile(size = 0L)
-
-        val content1 = "initial content".toByteArray()
-
-        // write content bytes to file
-        contentResolver.openOutputStream(file1.uri, "wt").use {
-            it!!.write(content1)
-        }
-
-        val remotePath = file1.getOCFile(storageManager)!!.remotePath
-
-        val content2 = "new content".toByteArray()
-
-        // modify content on server side
-        val putMethod = PutMethod(client.webdavUri.toString() + WebdavUtils.encodePath(remotePath))
-        putMethod.setRequestEntity(ByteArrayRequestEntity(content2))
-        assertEquals(HttpStatus.SC_NO_CONTENT, client.executeMethod(putMethod))
-        client.exhaustResponse(putMethod.responseBodyAsStream)
-        putMethod.releaseConnection() // let the connection available for other methods
-
-        // read back content bytes
-        assertReadEquals(content2, contentResolver.openInputStream(file1.uri))
-    }
+    // disabled as flaky test
+    // @Test
+    // fun testServerChangedFileContent() {
+    //     // create random file
+    //     val file1 = rootDir.createFile("text/plain", RandomString.make())!!
+    //     file1.assertRegularFile(size = 0L)
+    //
+    //     val content1 = "initial content".toByteArray()
+    //
+    //     // write content bytes to file
+    //     contentResolver.openOutputStream(file1.uri, "wt").use {
+    //         it!!.write(content1)
+    //     }
+    //
+    //     val remotePath = file1.getOCFile(storageManager)!!.remotePath
+    //
+    //     val content2 = "new content".toByteArray()
+    //
+    //     // modify content on server side
+    //     val putMethod = PutMethod(client.webdavUri.toString() + WebdavUtils.encodePath(remotePath))
+    //     putMethod.setRequestEntity(ByteArrayRequestEntity(content2))
+    //     assertEquals(HttpStatus.SC_NO_CONTENT, client.executeMethod(putMethod))
+    //     client.exhaustResponse(putMethod.responseBodyAsStream)
+    //     putMethod.releaseConnection() // let the connection available for other methods
+    //
+    //     // read back content bytes
+    //     assertReadEquals(content2, contentResolver.openInputStream(file1.uri))
+    // }
 }


### PR DESCRIPTION
- fix testGallerySearch test

Run 1: https://drone.nextcloud.com/nextcloud/android/16793 :heavy_check_mark: 
Run 2: https://drone.nextcloud.com/nextcloud/android/16796 :x: 
Run 3: https://drone.nextcloud.com/nextcloud/android/16799 :x: 
Run 4: https://drone.nextcloud.com/nextcloud/android/16801 :x: 
Run 5: https://drone.nextcloud.com/nextcloud/android/16803 :x: 

Failing ones are:
DocumentsStorageProviderIT | testServerChangedFileContent
FileUploaderIT | testKeepLocalAndOverwriteRemote
EndToEndRandomIT | pseudoRandom

--> investigating :mag: 
--> disabled them

Next 5 runs:
Run 1:  https://drone.nextcloud.com/nextcloud/android/16824 :heavy_check_mark: 
Run 2:  https://drone.nextcloud.com/nextcloud/android/16831 :heavy_check_mark: 
Run 3:  https://drone.nextcloud.com/nextcloud/android/16835 :x: --> pseudoRandom
Run 4:  https://drone.nextcloud.com/nextcloud/android/16836 :heavy_check_mark: 
Run 5:  https://drone.nextcloud.com/nextcloud/android/16839 :heavy_check_mark: 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
