### PR TITLE
Modify passcode setting layout alignment

### DIFF
--- a/src/main/res/layout/passcodelock.xml
+++ b/src/main/res/layout/passcodelock.xml
@@ -34,6 +34,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
+            android:layout_gravity="center_horizontal"
             android:text="@string/pass_code_enter_pass_code"
             android:textColor="@color/text_color"
             android:textSize="@dimen/two_line_primary_text_size" />
@@ -42,6 +43,7 @@
             android:id="@+id/explanation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
             android:gravity="center_horizontal"
             android:text="@string/pass_code_configure_your_pass_code_explanation"
             android:textAppearance="@android:style/TextAppearance.Small"
@@ -94,6 +96,7 @@
             android:id="@+id/cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
             android:text="@string/common_cancel"
             android:theme="@style/Button.Primary"
             app:cornerRadius="@dimen/button_corner_radius" />


### PR DESCRIPTION
Signed-off-by: Kuuuna98 <yunaghgh@naver.com>

### Testing 
1. Click Settings on the menu.
2. Set the passcode in the APP passcode.
3. A screen will appear to set passcode.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

As I changed the passcode entry error message, the central alignment seems to have changed to left alignment.
Is it intended that the title message and cancel button changed to the left alignment when setting the passcode?
If not intended, change back to central alignment and PR!

- [x] Tests written, or not not needed
