### PR TITLE
Added copyright comment to the header of a file

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -6,6 +6,7 @@
  *   @author David A. Velasco
  *   Copyright (C) 2011 Bartek Przybylski
  *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2020 Kwon Yuna <yunaghgh@naver.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,


### PR DESCRIPTION
Signed-off-by: Kuuuna98 <yunaghgh@naver.com>

I am Kuuuna98 who implemented the passcode back button event code 2 weeks ago.
https://github.com/nextcloud/android/pull/7372 

I didn't add copyright comment while implementing code at that time. I want to add copyright comment in 'PassCodeActivity.java' 

Thank you for reading it. 😊

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
