### PR TITLE
Fix upload by sharing link with defensive check during mtime read

### DIFF
--- a/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -152,9 +152,11 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                                                                  null,
                                                                  null)) {
                     if (cursor != null && cursor.moveToFirst()) {
-                        lastModified = cursor.getLong(
-                            cursor.getColumnIndexOrThrow(
-                                DocumentsContract.Document.COLUMN_LAST_MODIFIED));
+                        // this check prevents a crash when last modification time is not available on certain phones
+                        int columnIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
+                        if (columnIndex >= 0) {
+                            lastModified = cursor.getLong(columnIndex);
+                        }
                     }
                 }
 
@@ -173,7 +175,7 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                 while ((count = inputStream.read(buffer)) > 0) {
                     outputStream.write(buffer, 0, count);
                 }
- 
+
                 if (lastModified != 0) {
                     try {
                         if (!cacheFile.setLastModified(lastModified)) {


### PR DESCRIPTION
Since mtime is used to update cache and is not on critical path,
we can make it optional. If it's not available, cache behaviour
will suffer, but sharing should not fail.

Fixes #7587
Fixes #7617 

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
