### PR TITLE
Remove snapshot repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ buildscript {
         google()
         jcenter()
         maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-        maven {
             url 'https://plugins.gradle.org/m2/'
         }
         mavenCentral()
@@ -77,7 +74,6 @@ repositories {
     google()
     jcenter()
     maven { url "https://jitpack.io" }
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 
     flatDir {
         dirs 'libs'


### PR DESCRIPTION
Using snapshots caused https://github.com/nextcloud/android/issues/7699.

Snapshots were introduced for evernote:android-job https://github.com/nextcloud/android/commit/140f2d9b7bbad3a60910daf2faf83acd35fe2a32#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7 which is no longer a dep.

Fixes #7699 

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
