### PR TITLE
Fix crash in SetStatusDialogFragment.clearTopStatus

### DIFF
--- a/src/main/java/com/nextcloud/ui/SetStatusDialogFragment.kt
+++ b/src/main/java/com/nextcloud/ui/SetStatusDialogFragment.kt
@@ -344,12 +344,13 @@ class SetStatusDialogFragment :
     }
 
     private fun clearTopStatus() {
-        val grey = resources.getColor(R.color.grey_200)
-
-        onlineStatus.setBackgroundColor(grey)
-        awayStatus.setBackgroundColor(grey)
-        dndStatus.setBackgroundColor(grey)
-        invisibleStatus.setBackgroundColor(grey)
+        context?.let {
+            val grey = it.resources.getColor(R.color.grey_200)
+            onlineStatus.setBackgroundColor(grey)
+            awayStatus.setBackgroundColor(grey)
+            dndStatus.setBackgroundColor(grey)
+            invisibleStatus.setBackgroundColor(grey)
+        }
     }
 
     private fun setStatusMessage() {


### PR DESCRIPTION
Fix #7741

Speculative test as it's a classic race condition between UI and background tasks.
When scheduled task finishes after the dialog has been dismissed, it crashes accessing detached context.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] Tests written, or not not needed
