### PR TITLE
Allow to upload whole folders.

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -82,6 +82,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
 
     private static final String KEY_ALL_SELECTED = UploadFilesActivity.class.getCanonicalName() + ".KEY_ALL_SELECTED";
     public final static String KEY_LOCAL_FOLDER_PICKER_MODE = UploadFilesActivity.class.getCanonicalName() + ".LOCAL_FOLDER_PICKER_MODE";
+    public static final String LOCAL_BASE_PATH = UploadFilesActivity.class.getCanonicalName() + ".LOCAL_BASE_PATH";
     public static final String EXTRA_CHOSEN_FILES = UploadFilesActivity.class.getCanonicalName() + ".EXTRA_CHOSEN_FILES";
     public static final String KEY_DIRECTORY_PATH = UploadFilesActivity.class.getCanonicalName() + ".KEY_DIRECTORY_PATH";
 
@@ -454,6 +455,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
                 preferences.setUploaderBehaviour(FileUploader.LOCAL_BEHAVIOUR_DELETE);
             } else {
                 data.putExtra(EXTRA_CHOSEN_FILES, mFileListFragment.getCheckedFilePaths());
+                data.putExtra(LOCAL_BASE_PATH, mCurrentDir.getAbsolutePath());
 
                 // set result code
                 switch (mBehaviourSpinner.getSelectedItemPosition()) {

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -44,6 +44,7 @@ import com.owncloud.android.utils.theme.ThemeDrawableUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -101,14 +102,7 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public void addAllFilesToCheckedFiles() {
-        for (File file : mFiles) {
-
-            // only select files
-            if (file.isFile()) {
-                checkedFiles.add(file);
-            }
-
-        }
+        checkedFiles.addAll(mFiles);
     }
 
     public void removeAllFilesFromCheckedFiles() {
@@ -120,15 +114,25 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public String[] getCheckedFilesPath() {
-        List<String> result = new ArrayList<>();
-
-        for (File file : checkedFiles) {
-            result.add(file.getAbsolutePath());
-        }
+        List<String> result = listFilesRecursive(checkedFiles);
 
         Log_OC.d(TAG, "Returning " + result.size() + " selected files");
 
         return result.toArray(new String[0]);
+    }
+
+    public List<String> listFilesRecursive(Collection<File> files) {
+        List<String> result = new ArrayList<>();
+
+        for (File file : files) {
+            if (file.isDirectory()) {
+                result.addAll(listFilesRecursive(getFiles(file)));
+            } else {
+                result.add(file.getAbsolutePath());
+            }
+        }
+
+        return result;
     }
 
     @Override
@@ -164,15 +168,13 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
                 gridViewHolder.thumbnail.setTag(file.hashCode());
                 setThumbnail(file, gridViewHolder.thumbnail, mContext);
 
-                if (file.isDirectory()) {
-                    gridViewHolder.checkbox.setVisibility(View.GONE);
-                } else {
-                    gridViewHolder.checkbox.setVisibility(View.VISIBLE);
-                }
+                gridViewHolder.checkbox.setVisibility(View.VISIBLE);
 
                 File finalFile = file;
                 gridViewHolder.itemLayout.setOnClickListener(v -> localFileListFragmentInterface
                         .onItemClicked(finalFile));
+                gridViewHolder.checkbox.setOnClickListener(v -> localFileListFragmentInterface
+                        .onItemCheckboxClicked(finalFile));
 
 
                 if (holder instanceof LocalFileListItemViewHolder) {

--- a/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -164,7 +164,8 @@ public class LocalFileListFragment extends ExtendedListFragment implements
     }
 
     /**
-     * Checks the file clicked over. Browses inside if it is a directory.
+     * Checks the file clicked over. Browses inside if it is a directory. Otherwise behaves like the checkbox was
+     * clicked.
      * Notifies the container activity in any case.
      */
     @Override
@@ -180,21 +181,30 @@ public class LocalFileListFragment extends ExtendedListFragment implements
                 // save index and top position
                 saveIndexAndTopPosition(mAdapter.getItemPosition(file));
 
-            } else {    /// Click on a file
-                if (mAdapter.isCheckedFile(file)) {
-                    // uncheck
-                    mAdapter.removeCheckedFile(file);
-                } else {
-                    // check
-                    mAdapter.addCheckedFile(file);
-                }
-
-                mAdapter.notifyItemChanged(mAdapter.getItemPosition(file));
-
-                // notify the change to the container Activity
-                mContainerActivity.onFileClick(file);
+            } else {    /// Click on a file, behave like checkbox was clicked
+                onItemCheckboxClicked(file);
             }
 
+        } else {
+            Log_OC.w(TAG, "Null object in ListAdapter!!");
+        }
+    }
+
+    @Override
+    public void onItemCheckboxClicked(File file) {
+        if (file != null) {
+            if (mAdapter.isCheckedFile(file)) {
+                // uncheck
+                mAdapter.removeCheckedFile(file);
+            } else {
+                // check
+                mAdapter.addCheckedFile(file);
+            }
+
+            mAdapter.notifyItemChanged(mAdapter.getItemPosition(file));
+
+            // notify the change to the container Activity
+            mContainerActivity.onFileClick(file);
         } else {
             Log_OC.w(TAG, "Null object in ListAdapter!!");
         }

--- a/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -190,6 +190,9 @@ public class LocalFileListFragment extends ExtendedListFragment implements
         }
     }
 
+    /**
+     * Toggle selection of checked/unchecked file and notify adapter.
+     */
     @Override
     public void onItemCheckboxClicked(File file) {
         if (file != null) {

--- a/src/main/java/com/owncloud/android/ui/interfaces/LocalFileListFragmentInterface.java
+++ b/src/main/java/com/owncloud/android/ui/interfaces/LocalFileListFragmentInterface.java
@@ -31,4 +31,5 @@ import java.io.File;
 public interface LocalFileListFragmentInterface {
     int getColumnsCount();
     void onItemClicked(File file);
+    void onItemCheckboxClicked(File file);
 }

--- a/src/main/java/com/owncloud/android/utils/StringUtils.java
+++ b/src/main/java/com/owncloud/android/utils/StringUtils.java
@@ -68,4 +68,13 @@ public final class StringUtils {
             return "";
         }
     }
+
+    public static
+    @NonNull String removePrefix(@NonNull String s, @NonNull String prefix)
+    {
+        if (s.startsWith(prefix)){
+            return s.substring(prefix.length());
+        }
+        return s;
+    }
 }

--- a/src/test/java/com/owncloud/android/utils/StringUtilsTest.java
+++ b/src/test/java/com/owncloud/android/utils/StringUtilsTest.java
@@ -91,4 +91,44 @@ public class StringUtilsTest {
         assertEquals("returned parsed text value was incorrect",
                      expectedReturn, StringUtils.searchAndColor(text, searchText, dummyColorInt));
     }
+
+    @Test
+    public void prefixBothEmpty() {
+        String text = "";
+        String prefix = "";
+        String expectedReturn = "";
+
+        assertEquals("returned text without prefix was incorrect",
+                     expectedReturn, StringUtils.removePrefix(text, prefix));
+    }
+
+    @Test
+    public void noPrefix() {
+        String text = "/this/is/some/path";
+        String prefix = "/that/is/another/path";
+        String expectedReturn = "/this/is/some/path";
+
+        assertEquals("returned text without prefix was incorrect",
+                     expectedReturn, StringUtils.removePrefix(text, prefix));
+    }
+
+    @Test
+    public void simplePrefix() {
+        String text = "/path/and/subpath";
+        String prefix = "/path";
+        String expectedReturn = "/and/subpath";
+
+        assertEquals("returned text without prefix was incorrect",
+                     expectedReturn, StringUtils.removePrefix(text, prefix));
+    }
+
+    @Test
+    public void prefixEqual() {
+        String text = "/path/and/subpath";
+        String prefix = "/path/and/subpath";
+        String expectedReturn = "";
+
+        assertEquals("returned text without prefix was incorrect",
+                     expectedReturn, StringUtils.removePrefix(text, prefix));
+    }
 }


### PR DESCRIPTION
This PR aims to implement the long and often requested feature to upload whole folders: #184

A few notes on the implementation:
- Also show checkboxes beside folders
- Edited the LocalFileListFragmentInterface, which now has an additional onItemCheckboxClicked, beside the already existing onItemClicked:
    - onItemCheckboxClicked: Selects the respective file or folder (as the old onItemClicked implementation for files)
    - onItemClicked:
        - For Files: Calls onItemCheckboxClicked for the respective file to select it
        - For Folders: Opens the directory as in the old onItemClicked implementation
- getCheckedFilesPath() in LocalFileListAdapter returns all selected files and all files in the selected directories recursively.
- UploadFilesActivity onFinish addtionally puts the local path within which files were selected to the Intent. This is needed to calculate the correct subdirectories on upload.
- Changed requestUploadOfFilesFromFileSystem in FileDisplayActivity to calculate remotePath based on the difference between the localBasePath and the selected files.
- Changed the FileUploader settings in requestUploadOfFilesFromFileSystem to create missing directories. This is needed to create the subdirectories recursviely.

### Testing 
- [x] Tests written, or not not needed

Added Unit test for the added StringUtils.
For everything else there did not seem to exist similar tests yet which would require edits, extensions or enhancements.