### PR TITLE
Server support bumps for 3.16

### DIFF
--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -120,7 +120,7 @@ import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFER
  */
 public class MainApp extends MultiDexApplication implements HasAndroidInjector {
 
-    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = OwnCloudVersion.nextcloud_17;
+    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = OwnCloudVersion.nextcloud_18;
     public static final OwnCloudVersion MINIMUM_SUPPORTED_SERVER_VERSION = OwnCloudVersion.nextcloud_16;
 
     private static final String TAG = MainApp.class.getSimpleName();

--- a/src/main/java/com/owncloud/android/ui/TextDrawable.java
+++ b/src/main/java/com/owncloud/android/ui/TextDrawable.java
@@ -100,7 +100,6 @@ public class TextDrawable extends Drawable {
      * @return the avatar as a TextDrawable
      */
     @NonNull
-    @NextcloudServer(max = 12)
     public static TextDrawable createAvatar(Account account, float radiusInDp) {
         String username = UserAccountManager.getDisplayName(account);
         return createNamedAvatar(username, radiusInDp);
@@ -115,7 +114,6 @@ public class TextDrawable extends Drawable {
      * @return the avatar as a TextDrawable
      */
     @NonNull
-    @NextcloudServer(max = 12)
     public static TextDrawable createAvatarByUserId(String userId, float radiusInDp) {
         return createNamedAvatar(userId, radiusInDp);
     }


### PR DESCRIPTION
- ```OUTDATED_SERVER_VERSION``` according https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule (e.g. NC12)
- ```MINIMUM_SUPPORTED_SERVER_VERSION```: latest end of life + 1 year (e.g. NC13 end of life 2019-02-28 + 1 year = 2020-02-28)

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not needed
