### PR TITLE
Add support for GitHub codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV ANDROID_HOME=/usr/lib/android-sdk
+
+RUN apt-get update -y
+RUN apt-get install -y unzip wget openjdk-8-jdk vim
+
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O /tmp/commandlinetools.zip
+RUN cd /tmp && unzip commandlinetools.zip
+RUN mkdir -p /usr/lib/android-sdk/cmdline-tools/
+RUN cd /tmp/ && mv cmdline-tools/ latest/ && mv latest/ /usr/lib/android-sdk/cmdline-tools/
+RUN mkdir /usr/lib/android-sdk/licenses/
+RUN chmod -R 755 /usr/lib/android-sdk/
+RUN mkdir -p $HOME/.gradle
+RUN echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,5 @@
+# Instructions
+
+1. Start a DevContainer either on GitHub Codespaces or locally in VSCode
+2. Accept all licenses by running `yes | /usr/lib/android-sdk/cmdline-tools/latest/bin/sdkmanager --licenses`
+3. You can now build the app using `./gradlew clean build`

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,0 +1,3 @@
+ANDROID_HOME=/usr/lib/android-sdk
+JAVA_OPTS="-Xmx8192M"
+GRADLE_OPTS="-Dorg.gradle.daemon=true"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "NextcloudAndroid",
+	"dockerFile": "Dockerfile",
+}


### PR DESCRIPTION
This change enables you to get an IDE that is able to compile the Android app with just a few clicks. Either by using GitHub codespaces in the cloud, or using VS Code Containers.

# GitHub
## Start the codespace
![Screenshot 2021-02-10 at 12 12 11](https://user-images.githubusercontent.com/878997/107505619-4533eb00-6b9d-11eb-9864-ff6978053eaa.png)


![Screenshot 2021-02-10 at 12 12 17](https://user-images.githubusercontent.com/878997/107505617-449b5480-6b9d-11eb-80ea-7758d1ab78f1.png)

## Have a IDE in the cloud
![Screenshot 2021-02-10 at 12 15 54](https://user-images.githubusercontent.com/878997/107505614-4402be00-6b9d-11eb-89c4-46a5ee3a4632.png)

Then just run the following commands from `README.md`:

```
yes | /usr/lib/android-sdk/cmdline-tools/latest/bin/sdkmanager --licenses
./gradlew clean build
```

And you will have a APK that you can throw into the device/emulator of your choice:

![image](https://user-images.githubusercontent.com/878997/107505756-73192f80-6b9d-11eb-9de0-d008f011deec.png)
