### PR TITLE
user search: when reusing temp file, we first need to delete it

### DIFF
--- a/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -406,6 +406,11 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
         // create a file to write bitmap data
         File f = new File(getContext().getCacheDir(), "test");
         try {
+            if (f.exists()) {
+                if (!f.delete()) {
+                    throw new IllegalStateException("Existing file could not be deleted!");
+                }
+            }
             if (!f.createNewFile()) {
                 throw new IllegalStateException("File could not be created!");
             }


### PR DESCRIPTION
Test:
- open file sharing
- search for user
- see many results with correct user status

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
