### PR TITLE
Replace edge colors for primary color highlighting of tabs

### DIFF
--- a/src/main/java/com/owncloud/android/utils/ThemeUtils.java
+++ b/src/main/java/com/owncloud/android/utils/ThemeUtils.java
@@ -516,7 +516,7 @@ public final class ThemeUtils {
     }
 
     public static void colorTabLayout(Context context, TabLayout tabLayout) {
-        int primaryColor = primaryColor(context);
+        int primaryColor = primaryColor(context, true);
         int textColor = context.getResources().getColor(R.color.text_color);
         tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
         tabLayout.setSelectedTabIndicatorColor(primaryColor);


### PR DESCRIPTION
Follow-Up to #8001 and https://github.com/nextcloud/android/pull/8001/commits/99e5694eced3eba067360e5171b101ace2c85ac9

--> replace edge colors for primary color detection (else it is white/light and black/dark combinations), e.g.
![com owncloud android ui fragment FileDetailFragmentStaticServerIT_showDetailsActivitiesNone_light_white](https://user-images.githubusercontent.com/1315170/108677664-45f84580-74ea-11eb-8e9f-c38394a9cc8e.png)


Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
