### PR TITLE
Proposal to change max line length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,9 @@ max_line_length=120
 indent_style=space
 indent_size=4
 
+[*.yml]
+max_line_length=150
+
 charset=utf-8
 
 # Trimming is good for consistency

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,8 @@ tests/proguard-project.txt
 
 # Android Studio and Gradle specific entries
 .gradle
-.idea
+.idea/*
+!.idea/codeStyles/
 build
 /gradle.properties
 .attach_pid*


### PR DESCRIPTION
When I edit files, IDE change automatic to wrong line break, eg

![image](https://user-images.githubusercontent.com/3314607/108977136-87265c00-7688-11eb-8170-8820d0cce33d.png)

**This cause errors** and wasn't the first time, eg https://github.com/nextcloud/android/pull/8034#discussion_r581230044

Btw, code format setting was already checked-in, but ignored, so any changes were not commited