### PR TITLE
Before uploading failed reports check if secrets are set

### DIFF
--- a/scripts/uploadReport.sh
+++ b/scripts/uploadReport.sh
@@ -52,6 +52,11 @@ BRANCH_TYPE=$BRANCH-$TYPE
 
 set -e
 
+if [ -z $USER ] || [ -z $PASS ]; then
+    echo "USER or PASS is empty!"
+    exit 1
+fi
+
 if [ $TYPE = "IT" ]; then
     FOLDER=build/reports/androidTests/connected/flavors/GPLAY
 elif [ $TYPE = "Unit" ]; then


### PR DESCRIPTION
In forked Repos all test will run via Github Action, but have no secrets to upload to my server
--> bruteforce on my server.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
