### PR TITLE
Harden notification empty screenshot test

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/NotificationsActivity.java
@@ -202,6 +202,7 @@ public class NotificationsActivity extends DrawerActivity implements Notificatio
 
     @VisibleForTesting
     public void populateList(List<Notification> notifications) {
+        initializeAdapter();
         adapter.setNotificationItems(notifications);
         binding.loadingContent.setVisibility(View.GONE);
 
@@ -220,19 +221,7 @@ public class NotificationsActivity extends DrawerActivity implements Notificatio
 
     private void fetchAndSetData() {
         Thread t = new Thread(() -> {
-            if (client == null && optionalUser.isPresent()) {
-                try {
-                    User user = optionalUser.get();
-                    client = clientFactory.create(user);
-                } catch (ClientFactory.CreationException e) {
-                    Log_OC.e(TAG, "Error initializing client", e);
-                }
-            }
-
-            if (adapter == null) {
-                adapter = new NotificationListAdapter(client, this);
-                binding.list.setAdapter(adapter);
-            }
+            initializeAdapter();
 
             RemoteOperation getRemoteNotificationOperation = new GetNotificationsRemoteOperation();
             final RemoteOperationResult result = getRemoteNotificationOperation.execute(client);
@@ -251,6 +240,25 @@ public class NotificationsActivity extends DrawerActivity implements Notificatio
         });
 
         t.start();
+    }
+
+    private void initializeClient() {
+        if (client == null && optionalUser.isPresent()) {
+            try {
+                User user = optionalUser.get();
+                client = clientFactory.create(user);
+            } catch (ClientFactory.CreationException e) {
+                Log_OC.e(TAG, "Error initializing client", e);
+            }
+        }
+    }
+
+    private void initializeAdapter() {
+        initializeClient();
+        if (adapter == null) {
+            adapter = new NotificationListAdapter(client, this);
+            binding.list.setAdapter(adapter);
+        }
     }
 
     private void hideRefreshLayoutLoader() {


### PR DESCRIPTION
Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>

Fixes the following scenario:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.owncloud.android.ui.adapter.NotificationListAdapter.setNotificationItems(java.util.List)' on a null object reference
at com.owncloud.android.ui.activity.NotificationsActivity.populateList(NotificationsActivity.java:205)
at com.owncloud.android.ui.activity.NotificationsActivityIT$empty$1.run(NotificationsActivityIT.kt:53)
at android.os.Handler.handleCallback(Handler.java:790)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:164)
at android.app.ActivityThread.main(ActivityThread.java:6494)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
