### PR TITLE
Use github_token also for auto_approve

### DIFF
--- a/.github/workflows/autoApproveDependabot.yml
+++ b/.github/workflows/autoApproveDependabot.yml
@@ -10,4 +10,4 @@ jobs:
             -   uses: hmarr/auto-approve-action@v2.0.0
                 if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
                 with:
-                    github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}"
+                    github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
According to https://github.com/hmarr/auto-approve-action we can also use github_token here.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
