### PR TITLE
Fixed Misdisplaying view in landscape mode.

### DIFF
--- a/src/main/res/layout/files.xml
+++ b/src/main/res/layout/files.xml
@@ -43,7 +43,7 @@
 
             <FrameLayout
                 android:id="@+id/left_fragment_container"
-                android:layout_width="@dimen/zero"
+                android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior" />


### PR DESCRIPTION
According to issue " Misdisplaying view in landscape mode (starting from landscape) #8076",  I changed  the value of the field "android:layout_width" in files.xml, from @dimen/zero" to "match_parent".
Now it works correctly in either landscape or portrait mode.


