### PR TITLE
Avoid leaking AccountManagerService via InputStreamBinder

### DIFF
--- a/src/main/java/com/owncloud/android/services/AccountManagerService.java
+++ b/src/main/java/com/owncloud/android/services/AccountManagerService.java
@@ -44,7 +44,7 @@ public class AccountManagerService extends Service {
     @Override
     public IBinder onBind(Intent intent) {
         if(mBinder == null) {
-            mBinder = new InputStreamBinder(this, accountManager);
+            mBinder = new InputStreamBinder(getApplicationContext(), accountManager);
         }
         return mBinder;
     }


### PR DESCRIPTION
Leak trace detected by LeakCanary before this PR:
```┬───
│ GC Root: Global variable in native code
│
├─ com.nextcloud.android.sso.InputStreamBinder instance
│    Leaking: UNKNOWN
│    Retaining 1,9 kB in 22 objects
│    context instance of com.owncloud.android.services.AccountManagerService
│    ↓ InputStreamBinder.context
│                        ~~~~~~~
╰→ com.owncloud.android.services.AccountManagerService instance
​     Leaking: YES (ObjectWatcher was watching this because com.owncloud.
​     android.services.AccountManagerService received Service#onDestroy()
​     callback)
​     Retaining 1,4 kB in 20 objects
​     key = 0675a6aa-3a5c-42ec-aa07-1b05835697ff
​     watchDurationMillis = 10562
​     retainedDurationMillis = 5560
​     mApplication instance of com.owncloud.android.MainApp
​     mBase instance of android.app.ContextImpl
```

Switched to application context because InputStreamBinder outlives AccountManagerService.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
