### PR TITLE
Use correct eTag to check if something has changed on server

### DIFF
--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -370,11 +370,9 @@ public class RefreshFolderOperation extends RemoteOperation {
                 // check if remote and local folder are different
                 String remoteFolderETag = remoteFolder.getEtag();
                 if (remoteFolderETag != null) {
-                    mRemoteFolderChanged =
-                            !(remoteFolderETag.equalsIgnoreCase(mLocalFolder.getEtag()));
+                    mRemoteFolderChanged = !(remoteFolderETag.equalsIgnoreCase(mLocalFolder.getEtagOnServer()));
                 } else {
-                    Log_OC.e(TAG, "Checked " + mAccount.name + remotePath + " : " +
-                            "No ETag received from server");
+                    Log_OC.e(TAG, "Checked " + mAccount.name + remotePath + ": No ETag received from server");
                 }
             }
 


### PR DESCRIPTION
To test old:
- go into a subfolder
- see mRemoteFolderChanged is true
- go up, go into same subfolder
- see mRemoteFolderChanged is still true

New:
- go into a subfolder
- see mRemoteFolderChanged is true
- go up, go into same subfolder
- see mRemoteFolderChanged is false

- go into a subfolder
- see mRemoteFolderChanged is false
- change something on server
- go up, go into same subfolder
- see mRemoteFolderChanged is true

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
