### PR TITLE
Fix ConnectivityService.isInternetWalled() check when content length is -1

### DIFF
--- a/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
@@ -74,7 +74,8 @@ class ConnectivityServiceImpl implements ConnectivityService {
 
             int status = get.execute(client);
 
-            boolean result = !(status == HttpStatus.SC_NO_CONTENT && get.getResponseContentLength() == 0);
+            // Content-Length is not available when using chunked transfer encoding, so check for -1 as well
+            boolean result = !(status == HttpStatus.SC_NO_CONTENT && get.getResponseContentLength() <= 0);
 
             get.releaseConnection();
 

--- a/src/test/java/com/nextcloud/client/network/ConnectivityServiceTest.kt
+++ b/src/test/java/com/nextcloud/client/network/ConnectivityServiceTest.kt
@@ -277,6 +277,12 @@ class ConnectivityServiceTest {
         }
 
         @Test
+        fun `status 204 and no content length means internet is not walled`() {
+            mockResponse(contentLength = -1, status = HttpStatus.SC_NO_CONTENT)
+            assertFalse(connectivityService.isInternetWalled)
+        }
+
+        @Test
         fun `other status than 204 means internet is walled`() {
             mockResponse(contentLength = 0, status = HttpStatus.SC_GONE)
             assertTrue(connectivityService.isInternetWalled)


### PR DESCRIPTION
When server returns no Content-Length, the check was failing due to
expectation of 0. Change the condition to account for no content-length
situation and updated test.

Fixes #8384