### PR TITLE
Allow 3rd party apps to open the trashbin for a specific account

### DIFF
--- a/src/androidTest/java/com/owncloud/android/ui/trashbin/TrashbinActivityIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/trashbin/TrashbinActivityIT.kt
@@ -21,8 +21,13 @@
  */
 package com.owncloud.android.ui.trashbin
 
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Intent
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import com.owncloud.android.AbstractIT
+import com.owncloud.android.MainApp
+import com.owncloud.android.lib.common.accounts.AccountUtils
 import com.owncloud.android.utils.ScreenshotTest
 import org.junit.Rule
 import org.junit.Test
@@ -95,6 +100,45 @@ class TrashbinActivityIT : AbstractIT() {
         sut.trashbinPresenter = TrashbinPresenter(trashbinRepository, sut)
 
         sut.runOnUiThread { sut.showInitialLoading() }
+
+        shortSleep()
+
+        screenshot(sut)
+    }
+
+    @Test
+    fun normalUser() {
+        val sut: TrashbinActivity = activityRule.launchActivity(null)
+
+        val trashbinRepository = TrashbinLocalRepository(TestCase.EMPTY)
+
+        sut.trashbinPresenter = TrashbinPresenter(trashbinRepository, sut)
+
+        sut.runOnUiThread { sut.showUser() }
+
+        shortSleep()
+
+        screenshot(sut)
+    }
+
+    @Test
+    fun differentUser() {
+        val temp = Account("differentUser@https://server.com", MainApp.getAccountType(targetContext))
+
+        val platformAccountManager = AccountManager.get(targetContext)
+        platformAccountManager.addAccountExplicitly(temp, "password", null)
+        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com")
+        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_USER_ID, "differentUser")
+
+        val intent = Intent()
+        intent.putExtra(Intent.EXTRA_USER, "differentUser@https://server.com")
+        val sut: TrashbinActivity = activityRule.launchActivity(intent)
+
+        val trashbinRepository = TrashbinLocalRepository(TestCase.EMPTY)
+
+        sut.trashbinPresenter = TrashbinPresenter(trashbinRepository, sut)
+
+        sut.runOnUiThread { sut.showUser() }
 
         shortSleep()
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -346,6 +346,7 @@
         <activity android:name=".ui.activity.UploadListActivity" />
         <activity
             android:name=".ui.trashbin.TrashbinActivity"
+            android:exported="true"
             android:configChanges="orientation|screenSize|keyboardHidden"/>
         <activity android:name="com.nextcloud.client.onboarding.WhatsNewActivity"
                   android:theme="@style/Theme.ownCloud.noActionBar.Login" />

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -285,6 +285,17 @@ public class TrashbinActivity extends DrawerActivity implements
         binding.list.setVisibility(View.GONE);
     }
 
+    @VisibleForTesting
+    public void showUser() {
+        binding.loadingContent.setVisibility(View.GONE);
+        binding.list.setVisibility(View.VISIBLE);
+        binding.swipeContainingList.setRefreshing(false);
+
+        binding.emptyList.emptyListViewText.setText(getUser().get().getAccountName());
+        binding.emptyList.emptyListViewText.setVisibility(View.VISIBLE);
+        binding.emptyList.emptyListView.setVisibility(View.VISIBLE);
+    }
+
     @Override
     public void showError(int message) {
         if (active) {

--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -23,6 +23,7 @@
  */
 package com.owncloud.android.ui.trashbin;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -69,8 +70,6 @@ public class TrashbinActivity extends DrawerActivity implements
     TrashbinContract.View,
     Injectable {
 
-    private static final String ARG_TARGET_ACCOUNT_NAME = "TARGET_ACCOUNT_NAME";
-
     public static final int EMPTY_LIST_COUNT = 1;
     @Inject AppPreferences preferences;
     @Inject CurrentAccountProvider accountProvider;
@@ -87,7 +86,7 @@ public class TrashbinActivity extends DrawerActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         final User currentUser = getUser().orElse(accountProvider.getUser());
-        final String targetAccount = getIntent().getStringExtra(ARG_TARGET_ACCOUNT_NAME);
+        final String targetAccount = getIntent().getStringExtra(Intent.EXTRA_USER);
         if (targetAccount != null && !currentUser.nameEquals(targetAccount)) {
             final Optional<User> targetUser = getUserAccountManager().getUser(targetAccount);
             if (targetUser.isPresent()) {


### PR DESCRIPTION
# General

This PR allows any third party Android apps to launch the `TrashbinActivity`. The `TrashbinActivity` also allows to choose a target account (because it might be different to the currently selected account) via an Intent argument named `Intent.EXTRA_USER`.

# Specific

The [Notes Android app](https://github.com/stefan-niedermann/nextcloud-notes/) has a menu item called "Trashbin". This currently opens Nextcloud in a web browser to allow restoring of deleted notes. It is not planned to implement a complete trashbin for the Notes app. For a better integration [it shall launch the Android apps trashbin in the future](https://github.com/stefan-niedermann/nextcloud-notes/pull/1217) if possible and use the web browser only as a fallback.

I need some guidance for tests: Are they necessary for this change? (Might make sense to ensure that the argument names aren't changed by accident ...?) How can one test an activity? I don't have experience with testing UIs on Android.

cc: @tobiasKaminsky and @AndyScherzinger as proposed in the community chat.

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
