### PR TITLE
Remove jaxb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -271,14 +271,6 @@ dependencies {
     versionDevImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
     qaImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
 
-    kapt 'javax.xml.bind:jaxb-api:2.3.1'
-    kapt 'org.glassfish.jaxb:jaxb-core:3.0.1'
-    kapt 'org.glassfish.jaxb:jaxb-runtime:3.0.1'
-
-    annotationProcessor 'javax.xml.bind:jaxb-api:2.3.1'
-    annotationProcessor 'org.glassfish.jaxb:jaxb-core:3.0.1'
-    annotationProcessor 'org.glassfish.jaxb:jaxb-runtime:3.0.1'
-
     compileOnly 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2' // remove after entire switch to lib v2
     implementation "commons-httpclient:commons-httpclient:3.1@jar" // remove after entire switch to lib v2
     implementation 'org.apache.jackrabbit:jackrabbit-webdav:2.13.1' // remove after entire switch to lib v2


### PR DESCRIPTION
It was introduced for https://github.com/nextcloud/android/issues/6135, but I tested it now with JDK8/11 and it seems not to be needed.
Instead I cannot build anylonger with it enabled.

Who needs this?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
