### PR TITLE
Removed Account dependency from preview fragments

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -116,6 +116,7 @@ public abstract class FileActivity extends DrawerActivity
 
     public static final String EXTRA_FILE = "com.owncloud.android.ui.activity.FILE";
     public static final String EXTRA_ACCOUNT = "com.owncloud.android.ui.activity.ACCOUNT";
+    public static final String EXTRA_USER = "com.owncloud.android.ui.activity.USER";
     public static final String EXTRA_FROM_NOTIFICATION = "com.owncloud.android.ui.activity.FROM_NOTIFICATION";
     public static final String APP_OPENED_COUNT = "APP_OPENED_COUNT";
     public static final String EXTRA_SEARCH = "com.owncloud.android.ui.activity.SEARCH";

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2191,7 +2191,6 @@ public class FileDisplayActivity extends FileActivity
 
             Fragment mediaFragment = PreviewMediaFragment.newInstance(file, user.get(), startPlaybackPosition, autoplay);
             setLeftFragment(mediaFragment);
-            //updateFragmentsVisibility(true);
             updateActionBarTitleAndHomeButton(file);
             setFile(file);
         } else {
@@ -2207,21 +2206,21 @@ public class FileDisplayActivity extends FileActivity
     }
 
     /**
-     * Stars the preview of a text file {@link OCFile}.
+     * Starts the preview of a text file {@link OCFile}.
      *
      * @param file Text {@link OCFile} to preview.
      */
     public void startTextPreview(OCFile file, boolean showPreview) {
+        Optional<User> optUser = getUser();
+        if (!optUser.isPresent()) {
+            // remnants of old unsafe system; do not crash, silently stop
+            return;
+        }
+        User user = optUser.get();
         if (showPreview) {
             showSortListGroup(false);
-            Bundle args = new Bundle();
-            args.putParcelable(EXTRA_FILE, file);
-            args.putParcelable(EXTRA_ACCOUNT, getAccount());
-            args.putBoolean(EXTRA_SEARCH, searchOpen);
-            args.putString(EXTRA_SEARCH_QUERY, searchQuery);
-            Fragment textPreviewFragment = Fragment.instantiate(getApplicationContext(),
-                                                                PreviewTextFileFragment.class.getName(), args);
-            setLeftFragment(textPreviewFragment);
+            PreviewTextFileFragment fragment = PreviewTextFileFragment.create(user, file, searchOpen, searchQuery);
+            setLeftFragment(fragment);
             binding.rightFragmentContainer.setVisibility(View.GONE);
             super.updateActionBarTitleAndHomeButton(file);
         } else {

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -21,7 +21,6 @@
  */
 package com.owncloud.android.ui.preview;
 
-import android.accounts.Account;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -159,7 +158,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
      * MUST BE KEPT: the system uses it when tries to re-instantiate a fragment automatically
      * (for instance, when the device is turned a aside).
      *
-     * DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful
+     * DO NOT CALL IT: an {@link OCFile} and {@link User} must be provided for a successful
      * construction
      */
     public PreviewImageFragment() {

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -22,7 +22,6 @@
  */
 package com.owncloud.android.ui.preview;
 
-import android.accounts.Account;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -79,7 +78,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 /**
  * This fragment shows a preview of a downloaded media file (audio or video).
  * <p>
- * Trying to get an instance with NULL {@link OCFile} or ownCloud {@link Account} values will produce an {@link
+ * Trying to get an instance with NULL {@link OCFile} or ownCloud {@link User} values will produce an {@link
  * IllegalStateException}.
  * <p>
  * By now, if the {@link OCFile} passed is not downloaded, an {@link IllegalStateException} is generated on
@@ -147,7 +146,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
      * MUST BE KEPT: the system uses it when tries to reinstantiate a fragment automatically (for instance, when the
      * device is turned a aside).
      * <p/>
-     * DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful construction
+     * DO NOT CALL IT: an {@link OCFile} and {@link User} must be provided for a successful construction
      */
     public PreviewMediaFragment() {
         super();

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
@@ -22,7 +22,6 @@
 
 package com.owncloud.android.ui.preview;
 
-import android.accounts.Account;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
@@ -39,7 +38,6 @@ import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.lib.common.utils.Log_OC;
-import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.utils.DisplayUtils;
@@ -65,13 +63,27 @@ import androidx.core.view.MenuItemCompat;
 
 public class PreviewTextFileFragment extends PreviewTextFragment {
     private static final String EXTRA_FILE = "FILE";
-    private static final String EXTRA_ACCOUNT = "ACCOUNT";
+    private static final String EXTRA_USER = "USER";
+    private static final String EXTRA_OPEN_SEARCH = "SEARCH";
+    private static final String EXTRA_SEARCH_QUERY = "SEARCH_QUERY";
+
     private static final String TAG = PreviewTextFileFragment.class.getSimpleName();
 
     private TextLoadAsyncTask textLoadAsyncTask;
-    private Account account;
+    private User user;
 
     @Inject UserAccountManager accountManager;
+
+    public static PreviewTextFileFragment create(User user, OCFile file, boolean openSearch, String searchQuery) {
+        Bundle args = new Bundle();
+        args.putParcelable(EXTRA_FILE, file);
+        args.putParcelable(EXTRA_USER, user);
+        args.putBoolean(EXTRA_OPEN_SEARCH, openSearch);
+        args.putString(EXTRA_SEARCH_QUERY, searchQuery);
+        PreviewTextFileFragment fragment = new PreviewTextFileFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
 
     /**
      * Creates an empty fragment for previews.
@@ -79,11 +91,11 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
      * MUST BE KEPT: the system uses it when tries to re-instantiate a fragment automatically (for instance, when the
      * device is turned a aside).
      * <p>
-     * DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful construction
+     * DO NOT CALL IT: an {@link OCFile} and {@link User} must be provided for a successful construction
      */
     public PreviewTextFileFragment() {
         super();
-        account = null;
+        user = null;
     }
 
     /**
@@ -99,28 +111,28 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
         Bundle args = getArguments();
 
         if (file == null) {
-            file = args.getParcelable(FileDisplayActivity.EXTRA_FILE);
+            file = args.getParcelable(EXTRA_FILE);
         }
 
-        if (account == null) {
-            account = args.getParcelable(FileDisplayActivity.EXTRA_ACCOUNT);
+        if (user == null) {
+            user = args.getParcelable(EXTRA_USER);
         }
 
-        if (args.containsKey(FileDisplayActivity.EXTRA_SEARCH_QUERY)) {
-            searchQuery = args.getString(FileDisplayActivity.EXTRA_SEARCH_QUERY);
+        if (args.containsKey(EXTRA_SEARCH_QUERY)) {
+            searchQuery = args.getString(EXTRA_SEARCH_QUERY);
         }
-        searchOpen = args.getBoolean(FileDisplayActivity.EXTRA_SEARCH, false);
+        searchOpen = args.getBoolean(EXTRA_OPEN_SEARCH, false);
 
         if (savedInstanceState == null) {
             if (file == null) {
                 throw new IllegalStateException("Instanced with a NULL OCFile");
             }
-            if (account == null) {
+            if (user == null) {
                 throw new IllegalStateException("Instanced with a NULL ownCloud Account");
             }
         } else {
             file = savedInstanceState.getParcelable(EXTRA_FILE);
-            account = savedInstanceState.getParcelable(EXTRA_ACCOUNT);
+            user = savedInstanceState.getParcelable(EXTRA_USER);
         }
 
         handler = new Handler();
@@ -133,8 +145,7 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putParcelable(PreviewTextFileFragment.EXTRA_FILE, getFile());
-        outState.putParcelable(PreviewTextFileFragment.EXTRA_ACCOUNT, account);
-
+        outState.putParcelable(PreviewTextFileFragment.EXTRA_USER, user);
         super.onSaveInstanceState(outState);
     }
 

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -22,7 +22,6 @@
 
 package com.owncloud.android.ui.preview;
 
-import android.accounts.Account;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.LayoutInflater;
@@ -36,7 +35,6 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.lib.richWorkspace.RichWorkspaceDirectEditingRemoteOperation;
 import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.R;
-import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.utils.DisplayUtils;
@@ -55,11 +53,6 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
 
     /**
      * Creates an empty fragment for previews.
-     * <p>
-     * MUST BE KEPT: the system uses it when tries to re-instantiate a fragment automatically (for instance, when the
-     * device is turned a aside).
-     * <p>
-     * DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful construction
      */
     public PreviewTextStringFragment() {
         super();

--- a/src/main/java/com/owncloud/android/ui/preview/PreviewVideoActivity.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewVideoActivity.java
@@ -20,7 +20,6 @@
 
 package com.owncloud.android.ui.preview;
 
-import android.accounts.Account;
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
@@ -68,16 +67,6 @@ public class PreviewVideoActivity extends FileActivity implements OnCompletionLi
     private ExoPlayer exoPlayer;             // view to play the file; both performs and show the playback
     private Uri mStreamUri;
 
-    /**
-     *  Called when the activity is first created.
-     *
-     *  Searches for an {@link OCFile} and ownCloud {@link Account} holding it in the starting {@link Intent}.
-     *
-     *  The {@link Account} is unnecessary if the file is downloaded; else, the {@link Account} is used to
-     *  try to stream the remote file - TODO get the streaming works
-     *
-     *  {@inheritDoc}
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -217,6 +206,4 @@ public class PreviewVideoActivity extends FileActivity implements OnCompletionLi
             finish();
         }
    }
-
-
 }


### PR DESCRIPTION
Remove Account dependency in text preview fragment.
Remove Account dependency from outdated JavaDoc in
image and video preview fragments.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
