### PR TITLE
Correct etag check/store when it has changed

### DIFF
--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -243,6 +243,8 @@ public class RefreshFolderOperation extends RemoteOperation {
             if (result.isSuccess()) {
                 // request for the synchronization of KEPT-IN-SYNC file contents
                 startContentSynchronizations(mFilesToSyncContents);
+            } else {
+                mLocalFolder.setEtag("");
             }
 
             mLocalFolder.setLastSyncDateForData(System.currentTimeMillis());
@@ -370,7 +372,7 @@ public class RefreshFolderOperation extends RemoteOperation {
                 // check if remote and local folder are different
                 String remoteFolderETag = remoteFolder.getEtag();
                 if (remoteFolderETag != null) {
-                    mRemoteFolderChanged = !(remoteFolderETag.equalsIgnoreCase(mLocalFolder.getEtagOnServer()));
+                    mRemoteFolderChanged = !(remoteFolderETag.equalsIgnoreCase(mLocalFolder.getEtag()));
                 } else {
                     Log_OC.e(TAG, "Checked " + mAccount.name + remotePath + ": No ETag received from server");
                 }
@@ -463,6 +465,9 @@ public class RefreshFolderOperation extends RemoteOperation {
 
         // update richWorkspace
         mLocalFolder.setRichWorkspace(remoteFolder.getRichWorkspace());
+
+        // update eTag
+        mLocalFolder.setEtag(remoteFolder.getEtag());
 
         DecryptedFolderMetadata metadata = getDecryptedFolderMetadata(encryptedAncestor,
                                                                       mLocalFolder,


### PR DESCRIPTION
Correct fix instead of #8359 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [x] Tests written, or not not needed
