### PR TITLE
move service dismissal to handler to prevent race-condition

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileDownloader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileDownloader.java
@@ -182,7 +182,6 @@ public class FileDownloader extends Service
         // remove AccountsUpdatedListener
         AccountManager am = AccountManager.get(getApplicationContext());
         am.removeOnAccountsUpdatedListener(this);
-
         super.onDestroy();
     }
 
@@ -423,18 +422,16 @@ public class FileDownloader extends Service
                 }
             }
             mService.mStartedDownload=false;
-            (new Handler()).postDelayed(new Runnable(){
-                public void run() {
-                    if(!mService.mStartedDownload){
-                        mService.mNotificationManager.cancel(R.string.downloader_download_in_progress_ticker);
-                    }
-                }}, 2000);
 
-
-            Log_OC.d(TAG, "Stopping after command with id " + msg.arg1);
-            mService.mNotificationManager.cancel(FOREGROUND_SERVICE_ID);
-            mService.stopForeground(true);
-            mService.stopSelf(msg.arg1);
+            (new Handler()).postDelayed(() -> {
+                if(!mService.mStartedDownload){
+                    mService.mNotificationManager.cancel(R.string.downloader_download_in_progress_ticker);
+                }
+                Log_OC.d(TAG, "Stopping after command with id " + msg.arg1);
+                mService.mNotificationManager.cancel(FOREGROUND_SERVICE_ID);
+                mService.stopForeground(true);
+                mService.stopSelf(msg.arg1);
+            }, 2000);
         }
     }
 


### PR DESCRIPTION
### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

- [x] Tests written, or not not needed


This should fix #8308. The issue seems to be a race condition when the app is in the background for prolonged times. When the app is in foreground, the handler executes even when the service is stopped, but in background it gets killed with the service. Since it is quite hard to debug apps in background, i can only report that running this code has not created stuck notifications and works as intended. I'm open for suggestions on how to test this more thoroughly.

Fixes #8651 