### PR TITLE
Fix NPE when navigating out of PreviewMediaFragment during video loading

### DIFF
--- a/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -507,7 +507,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
         protected void onPostExecute(Uri uri) {
             final PreviewMediaFragment previewMediaFragment = previewMediaFragmentWeakReference.get();
             final Context context = previewMediaFragment != null ? previewMediaFragment.getContext() : null;
-            if (previewMediaFragment != null && context != null) {
+            if (previewMediaFragment != null && previewMediaFragment.binding != null && context != null) {
                 if (uri != null) {
                     previewMediaFragment.videoUri = uri;
 


### PR DESCRIPTION
Fix #8620

Although original error has been fixed by migration to Exo player,
there is still a potential NPE when fragment went through
onDestroyView().


Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
