### PR TITLE
Initialize last displayed user to correct empty Optional in FileDisplayActivity

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -215,7 +215,7 @@ public class FileDisplayActivity extends FileActivity
 
     private SearchView searchView;
     private PlayerServiceConnection mPlayerConnection;
-    private Optional<User> lastDisplayedUser;
+    private Optional<User> lastDisplayedUser = Optional.empty();
     private int menuItemId = -1;
 
     @Inject


### PR DESCRIPTION
Fixes #8725

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
