### PR TITLE
Avoid redundant call to getConnectivity()

### DIFF
--- a/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
@@ -81,7 +81,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
 
             return result;
         } else {
-            return !getConnectivity().isConnected();
+            return !c.isConnected();
         }
     }
 


### PR DESCRIPTION
[Broken Windows Theory] avoid calling getConnectivity() a second time, since the object is still fresh in the else branch of the check for WiFi.

- [X] Tests written, or not not needed
