### PR TITLE
Fix connected test crashes

### DIFF
--- a/src/androidTest/java/com/nextcloud/client/SettingsActivityIT.java
+++ b/src/androidTest/java/com/nextcloud/client/SettingsActivityIT.java
@@ -86,6 +86,7 @@ public class SettingsActivityIT extends AbstractIT {
         SettingsActivity sut = activityRule.launchActivity(null);
         sut.handleMnemonicRequest(intent);
 
+        Looper.myLooper().quitSafely();
         assertTrue(true); // if we reach this, everything is ok
     }
 }

--- a/src/androidTest/java/com/nextcloud/client/SyncedFoldersActivityIT.java
+++ b/src/androidTest/java/com/nextcloud/client/SyncedFoldersActivityIT.java
@@ -71,7 +71,7 @@ public class SyncedFoldersActivityIT extends AbstractIT {
                                                                    false,
                                                                    false,
                                                                    true,
-                                                                   "test@https://server.com",
+                                                                   "test@https://nextcloud.localhost",
                                                                    0,
                                                                    0,
                                                                    true,

--- a/src/androidTest/java/com/nextcloud/client/account/RegisteredUserTest.kt
+++ b/src/androidTest/java/com/nextcloud/client/account/RegisteredUserTest.kt
@@ -38,7 +38,7 @@ class RegisteredUserTest {
 
     private companion object {
         fun buildTestUser(accountName: String): RegisteredUser {
-            val uri = Uri.parse("https://nextcloud.localhost.localdomain")
+            val uri = Uri.parse("https://nextcloud.localhost")
             val credentials = OwnCloudBasicCredentials("user", "pass")
             val account = Account(accountName, "test-type")
             val ownCloudAccount = OwnCloudAccount(uri, credentials)
@@ -58,7 +58,7 @@ class RegisteredUserTest {
 
     @Before
     fun setUp() {
-        user = buildTestUser("test@nextcloud.localhost.localdomain")
+        user = buildTestUser("test@nextcloud.localhost")
     }
 
     @Test

--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -103,13 +103,13 @@ public abstract class AbstractIT {
                 }
             }
 
-            Account temp = new Account("test@https://server.com", MainApp.getAccountType(targetContext));
+            Account temp = new Account("test@https://nextcloud.localhost", MainApp.getAccountType(targetContext));
             platformAccountManager.addAccountExplicitly(temp, "password", null);
-            platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+            platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.localhost");
             platformAccountManager.setUserData(temp, KEY_USER_ID, "test");
 
             final UserAccountManager userAccountManager = UserAccountManagerImpl.fromContext(targetContext);
-            account = userAccountManager.getAccountByName("test@https://server.com");
+            account = userAccountManager.getAccountByName("test@https://nextcloud.localhost");
 
             if (account == null) {
                 throw new ActivityNotFoundException();

--- a/src/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
+++ b/src/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
@@ -58,7 +58,7 @@ public class OCFileUnitTest {
     private static final long LAST_SYNC_DATE_FOR_PROPERTIES = 5432109876L;
     private static final long LAST_SYNC_DATE_FOR_DATA = 4321098765L;
     private static final String ETAG = "adshfas98ferqw8f9yu2";
-    private static final String PUBLIC_LINK = "https://fake.url.net/owncloud/987427448712984sdas29";
+    private static final String PUBLIC_LINK = "https://nextcloud.localhost/owncloud/987427448712984sdas29";
     private static final String PERMISSIONS = "SRKNVD";
     private static final String REMOTE_ID = "jadñgiadf8203:9jrp98v2mn3er2089fh";
     private static final String ETAG_IN_CONFLICT = "2adshfas98ferqw8f9yu";

--- a/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
+++ b/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
@@ -79,7 +79,6 @@ public class DialogFragmentIT extends AbstractIT {
     public void quitLooperIfNeeded() {
         if (Looper.myLooper() != null) {
             Looper.myLooper().quitSafely();
-            shortSleep();
         }
     }
 

--- a/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
+++ b/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
@@ -44,6 +44,7 @@ import com.owncloud.android.lib.common.Creator;
 import com.owncloud.android.lib.common.DirectEditing;
 import com.owncloud.android.lib.common.Editor;
 import com.owncloud.android.lib.common.OwnCloudAccount;
+import com.owncloud.android.lib.common.accounts.AccountTypeUtils;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
@@ -56,6 +57,7 @@ import com.owncloud.android.ui.fragment.OCFileListBottomSheetDialog;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.ScreenshotTest;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -72,6 +74,14 @@ import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentat
 public class DialogFragmentIT extends AbstractIT {
     @Rule public IntentsTestRule<FileDisplayActivity> activityRule =
         new IntentsTestRule<>(FileDisplayActivity.class, true, false);
+
+    @After
+    public void quitLooperIfNeeded() {
+        if (Looper.myLooper() != null) {
+            Looper.myLooper().quitSafely();
+            shortSleep();
+        }
+    }
 
     @Test
     @ScreenshotTest
@@ -168,6 +178,7 @@ public class DialogFragmentIT extends AbstractIT {
         accountManager.addAccountExplicitly(newAccount, "password", null);
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_USER_ID, "test");
+        accountManager.setAuthToken(newAccount, AccountTypeUtils.getAuthTokenTypePass(newAccount.type), "password");
 
 
         Account newAccount2 = new Account("user1@server.com", MainApp.getAccountType(targetContext));
@@ -175,6 +186,8 @@ public class DialogFragmentIT extends AbstractIT {
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_USER_ID, "user1");
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_VERSION, "20.0.0");
+        accountManager.setAuthToken(newAccount2, AccountTypeUtils.getAuthTokenTypePass(newAccount.type), "password");
+
 
         FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(newAccount,
                                                                                    targetContext.getContentResolver());
@@ -236,6 +249,7 @@ public class DialogFragmentIT extends AbstractIT {
         accountManager.addAccountExplicitly(newAccount, "password", null);
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_USER_ID, "test");
+        accountManager.setAuthToken(newAccount, AccountTypeUtils.getAuthTokenTypePass(newAccount.type), "password");
 
         FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(newAccount,
                                                                                    targetContext.getContentResolver());

--- a/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
+++ b/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
@@ -72,6 +72,9 @@ import androidx.test.espresso.intent.rule.IntentsTestRule;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 public class DialogFragmentIT extends AbstractIT {
+
+    private final String SERVER_URL = "https://nextcloud.localhost";
+
     @Rule public IntentsTestRule<FileDisplayActivity> activityRule =
         new IntentsTestRule<>(FileDisplayActivity.class, true, false);
 
@@ -173,16 +176,16 @@ public class DialogFragmentIT extends AbstractIT {
             accountManager.removeAccountExplicitly(account);
         }
 
-        Account newAccount = new Account("test@https://server.com", MainApp.getAccountType(targetContext));
+        Account newAccount = new Account("test@https://nextcloud.localhost", MainApp.getAccountType(targetContext));
         accountManager.addAccountExplicitly(newAccount, "password", null);
-        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, SERVER_URL);
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_USER_ID, "test");
         accountManager.setAuthToken(newAccount, AccountTypeUtils.getAuthTokenTypePass(newAccount.type), "password");
 
 
-        Account newAccount2 = new Account("user1@server.com", MainApp.getAccountType(targetContext));
+        Account newAccount2 = new Account("user1@nextcloud.localhost", MainApp.getAccountType(targetContext));
         accountManager.addAccountExplicitly(newAccount2, "password", null);
-        accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+        accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_BASE_URL, SERVER_URL);
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_USER_ID, "user1");
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_VERSION, "20.0.0");
         accountManager.setAuthToken(newAccount2, AccountTypeUtils.getAuthTokenTypePass(newAccount.type), "password");
@@ -199,7 +202,7 @@ public class DialogFragmentIT extends AbstractIT {
         ChooseAccountDialogFragment sut =
             ChooseAccountDialogFragment.newInstance(new RegisteredUser(newAccount,
                                                                        new OwnCloudAccount(newAccount, targetContext),
-                                                                       new Server(URI.create("https://server.com"),
+                                                                       new Server(URI.create(SERVER_URL),
                                                                                   OwnCloudVersion.nextcloud_20)));
         FileDisplayActivity activity = showDialog(sut);
 
@@ -244,9 +247,9 @@ public class DialogFragmentIT extends AbstractIT {
             accountManager.removeAccountExplicitly(account);
         }
 
-        Account newAccount = new Account("test@https://server.com", MainApp.getAccountType(targetContext));
+        Account newAccount = new Account("test@https://nextcloud.localhost", MainApp.getAccountType(targetContext));
         accountManager.addAccountExplicitly(newAccount, "password", null);
-        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, SERVER_URL);
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_USER_ID, "test");
         accountManager.setAuthToken(newAccount, AccountTypeUtils.getAuthTokenTypePass(newAccount.type), "password");
 
@@ -261,7 +264,7 @@ public class DialogFragmentIT extends AbstractIT {
         ChooseAccountDialogFragment sut =
             ChooseAccountDialogFragment.newInstance(new RegisteredUser(newAccount,
                                                                        new OwnCloudAccount(newAccount, targetContext),
-                                                                       new Server(URI.create("https://server.com"),
+                                                                       new Server(URI.create(SERVER_URL),
                                                                                   OwnCloudVersion.nextcloud_20)));
         showDialog(sut);
     }

--- a/src/androidTest/java/com/owncloud/android/ui/fragment/AvatarIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/fragment/AvatarIT.kt
@@ -56,7 +56,7 @@ class AvatarIT : AbstractIT() {
             fragment.addAvatar("winston brent", avatarRadius, width, targetContext)
             fragment.addAvatar("Baker James Lorena", avatarRadius, width, targetContext)
             fragment.addAvatar("Baker  James   Lorena", avatarRadius, width, targetContext)
-            fragment.addAvatar("email@server.com", avatarRadius, width, targetContext)
+            fragment.addAvatar("email@nextcloud.localhost", avatarRadius, width, targetContext)
         }
 
         shortSleep()

--- a/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
@@ -110,7 +110,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         OCShare(file.decryptedRemotePath).apply {
             remoteId = 3
             shareType = ShareType.EMAIL
-            sharedWithDisplayName = "admin@nextcloud.server.com"
+            sharedWithDisplayName = "admin@nextcloud.localhost"
             userId = getUserId(user)
             activity.storageManager.saveShare(this)
         }
@@ -132,7 +132,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         OCShare(file.decryptedRemotePath).apply {
             remoteId = 6
             shareType = ShareType.FEDERATED
-            sharedWithDisplayName = "admin@nextcloud.remoteserver.com"
+            sharedWithDisplayName = "admin@nextcloud.localhost"
             permissions = OCShare.FEDERATED_PERMISSIONS_FOR_FILE
             userId = getUserId(user)
             activity.storageManager.saveShare(this)

--- a/src/androidTest/java/com/owncloud/android/ui/fragment/OCFileListFragmentStaticServerIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/fragment/OCFileListFragmentStaticServerIT.kt
@@ -104,7 +104,7 @@ class OCFileListFragmentStaticServerIT : AbstractIT() {
         val emailShare = OCFile("/sharedToEmail.jpg").apply {
             parentId = sut.storageManager.getFileByEncryptedRemotePath("/").fileId
             isSharedWithSharee = true
-            sharees = listOf(ShareeUser("admin@nextcloud.server.com", "admin@nextcloud.server.com", ShareType.EMAIL))
+            sharees = listOf(ShareeUser("admin@nextcloud.localhost", "admin@nextcloud.localhost", ShareType.EMAIL))
         }
         sut.storageManager.saveFile(emailShare)
 

--- a/src/androidTest/java/com/owncloud/android/ui/trashbin/TrashbinActivityIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/trashbin/TrashbinActivityIT.kt
@@ -123,15 +123,15 @@ class TrashbinActivityIT : AbstractIT() {
 
     @Test
     fun differentUser() {
-        val temp = Account("differentUser@https://server.com", MainApp.getAccountType(targetContext))
+        val temp = Account("differentUser@https://nextcloud.localhost", MainApp.getAccountType(targetContext))
 
         val platformAccountManager = AccountManager.get(targetContext)
         platformAccountManager.addAccountExplicitly(temp, "password", null)
-        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com")
+        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.localhost")
         platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_USER_ID, "differentUser")
 
         val intent = Intent()
-        intent.putExtra(Intent.EXTRA_USER, "differentUser@https://server.com")
+        intent.putExtra(Intent.EXTRA_USER, "differentUser@https://nextcloud.localhost")
         val sut: TrashbinActivity = activityRule.launchActivity(intent)
 
         val trashbinRepository = TrashbinLocalRepository(TestCase.EMPTY)

--- a/src/main/res/layout/account_item.xml
+++ b/src/main/res/layout/account_item.xml
@@ -117,7 +117,7 @@
                 android:maxLines="1"
                 android:text="@string/placeholder_sentence"
                 android:textColor="?android:attr/textColorSecondary"
-                tools:text="https://server.com/nextcloud" />
+                tools:text="https://nextcloud.localhost/nextcloud" />
 
         </LinearLayout>
 

--- a/src/test/java/com/nextcloud/client/network/ConnectivityServiceTest.kt
+++ b/src/test/java/com/nextcloud/client/network/ConnectivityServiceTest.kt
@@ -65,7 +65,7 @@ class ConnectivityServiceTest {
                 return networkInfo
             }
 
-            const val SERVER_BASE_URL = "https://test.server.com"
+            const val SERVER_BASE_URL = "https://test.nextcloud.localhost"
         }
 
         @Mock

--- a/src/test/java/com/owncloud/android/ui/TextDrawableTest.kt
+++ b/src/test/java/com/owncloud/android/ui/TextDrawableTest.kt
@@ -34,6 +34,6 @@ class TextDrawableTest {
         assertEquals("WB", TextDrawable.extractCharsFromDisplayName("winston brent"))
         assertEquals("BJ", TextDrawable.extractCharsFromDisplayName("Baker James Lorena"))
         assertEquals("BJ", TextDrawable.extractCharsFromDisplayName("Baker  James   Lorena"))
-        assertEquals("E", TextDrawable.extractCharsFromDisplayName("email@server.com"))
+        assertEquals("E", TextDrawable.extractCharsFromDisplayName("email@nextcloud.localhost"))
     }
 }


### PR DESCRIPTION
This is a fix for the "Process crashed" message that was crashing the `connectedTest`s in my device and emulator.
This should additionally fix crashes in Drone and in screenshot tests.

Summary of the changes:
- In tests where `Looper.prepare()` was used, made sure to quit the looper after the tests. Otherwise the thread would remain active indefinitely and the process would get killed as an ANR.
- In `DialogFragmentIT` tests, force set account tokens. This works around a race condition (I think) where the account token was peeked _before_ it was saved in the AccountManager cache.
- Changed `server.com` and `server` to `nextcloud.localhost` everywhere. `server.com` is a real domain with DNS records, which gives a timeout when trying to connect. This causes crashes and also dramatically slows down tests. An invalid domain such as `nextcloud.localhost` should fail to resolve immediately, preventing all of that. Note: `nextcloud.localhost` is just the first thing I thought of. Better suggestions welcome!

Related: https://github.com/nextcloud/android/pull/8032, https://github.com/nextcloud/android/pull/8059

- [X] Tests written, or not not needed
