### PR TITLE
Use invalid domain for server in integration tests

### DIFF
--- a/src/androidTest/java/com/nextcloud/client/SyncedFoldersActivityIT.java
+++ b/src/androidTest/java/com/nextcloud/client/SyncedFoldersActivityIT.java
@@ -71,7 +71,7 @@ public class SyncedFoldersActivityIT extends AbstractIT {
                                                                    false,
                                                                    false,
                                                                    true,
-                                                                   "test@https://server.com",
+                                                                   "test@https://nextcloud.nodomain",
                                                                    0,
                                                                    0,
                                                                    true,

--- a/src/androidTest/java/com/nextcloud/client/account/RegisteredUserTest.kt
+++ b/src/androidTest/java/com/nextcloud/client/account/RegisteredUserTest.kt
@@ -38,7 +38,7 @@ class RegisteredUserTest {
 
     private companion object {
         fun buildTestUser(accountName: String): RegisteredUser {
-            val uri = Uri.parse("https://nextcloud.localhost.localdomain")
+            val uri = Uri.parse("https://nextcloud.nodomain")
             val credentials = OwnCloudBasicCredentials("user", "pass")
             val account = Account(accountName, "test-type")
             val ownCloudAccount = OwnCloudAccount(uri, credentials)
@@ -58,7 +58,7 @@ class RegisteredUserTest {
 
     @Before
     fun setUp() {
-        user = buildTestUser("test@nextcloud.localhost.localdomain")
+        user = buildTestUser("test@nextcloud.nodomainn")
     }
 
     @Test

--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -103,13 +103,13 @@ public abstract class AbstractIT {
                 }
             }
 
-            Account temp = new Account("test@https://server.com", MainApp.getAccountType(targetContext));
+            Account temp = new Account("test@https://nextcloud.nodomain", MainApp.getAccountType(targetContext));
             platformAccountManager.addAccountExplicitly(temp, "password", null);
-            platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+            platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.nodomain");
             platformAccountManager.setUserData(temp, KEY_USER_ID, "test");
 
             final UserAccountManager userAccountManager = UserAccountManagerImpl.fromContext(targetContext);
-            account = userAccountManager.getAccountByName("test@https://server.com");
+            account = userAccountManager.getAccountByName("test@https://nextcloud.nodomain");
 
             if (account == null) {
                 throw new ActivityNotFoundException();

--- a/src/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
+++ b/src/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
@@ -58,7 +58,7 @@ public class OCFileUnitTest {
     private static final long LAST_SYNC_DATE_FOR_PROPERTIES = 5432109876L;
     private static final long LAST_SYNC_DATE_FOR_DATA = 4321098765L;
     private static final String ETAG = "adshfas98ferqw8f9yu2";
-    private static final String PUBLIC_LINK = "https://fake.url.net/owncloud/987427448712984sdas29";
+    private static final String PUBLIC_LINK = "https://nextcloud.nodomain/owncloud/987427448712984sdas29";
     private static final String PERMISSIONS = "SRKNVD";
     private static final String REMOTE_ID = "jadñgiadf8203:9jrp98v2mn3er2089fh";
     private static final String ETAG_IN_CONFLICT = "2adshfas98ferqw8f9yu";

--- a/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
+++ b/src/androidTest/java/com/owncloud/android/ui/dialog/DialogFragmentIT.java
@@ -164,15 +164,15 @@ public class DialogFragmentIT extends AbstractIT {
             accountManager.removeAccountExplicitly(account);
         }
 
-        Account newAccount = new Account("test@https://server.com", MainApp.getAccountType(targetContext));
+        Account newAccount = new Account("test@https://nextcloud.nodomain", MainApp.getAccountType(targetContext));
         accountManager.addAccountExplicitly(newAccount, "password", null);
-        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.nodomain");
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_USER_ID, "test");
 
 
-        Account newAccount2 = new Account("user1@server.com", MainApp.getAccountType(targetContext));
+        Account newAccount2 = new Account("user1@nextcloud.nodomain", MainApp.getAccountType(targetContext));
         accountManager.addAccountExplicitly(newAccount2, "password", null);
-        accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+        accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.nodomain");
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_USER_ID, "user1");
         accountManager.setUserData(newAccount2, AccountUtils.Constants.KEY_OC_VERSION, "20.0.0");
 
@@ -187,7 +187,7 @@ public class DialogFragmentIT extends AbstractIT {
         ChooseAccountDialogFragment sut =
             ChooseAccountDialogFragment.newInstance(new RegisteredUser(newAccount,
                                                                        new OwnCloudAccount(newAccount, targetContext),
-                                                                       new Server(URI.create("https://server.com"),
+                                                                       new Server(URI.create("https://nextcloud.nodomain"),
                                                                                   OwnCloudVersion.nextcloud_20)));
         FileDisplayActivity activity = showDialog(sut);
 
@@ -232,9 +232,9 @@ public class DialogFragmentIT extends AbstractIT {
             accountManager.removeAccountExplicitly(account);
         }
 
-        Account newAccount = new Account("test@https://server.com", MainApp.getAccountType(targetContext));
+        Account newAccount = new Account("test@https://nextcloud.nodomain", MainApp.getAccountType(targetContext));
         accountManager.addAccountExplicitly(newAccount, "password", null);
-        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com");
+        accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.nodomain");
         accountManager.setUserData(newAccount, AccountUtils.Constants.KEY_USER_ID, "test");
 
         FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(newAccount,
@@ -248,7 +248,7 @@ public class DialogFragmentIT extends AbstractIT {
         ChooseAccountDialogFragment sut =
             ChooseAccountDialogFragment.newInstance(new RegisteredUser(newAccount,
                                                                        new OwnCloudAccount(newAccount, targetContext),
-                                                                       new Server(URI.create("https://server.com"),
+                                                                       new Server(URI.create("https://nextcloud.nodomain"),
                                                                                   OwnCloudVersion.nextcloud_20)));
         showDialog(sut);
     }

--- a/src/androidTest/java/com/owncloud/android/ui/fragment/AvatarIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/fragment/AvatarIT.kt
@@ -56,7 +56,7 @@ class AvatarIT : AbstractIT() {
             fragment.addAvatar("winston brent", avatarRadius, width, targetContext)
             fragment.addAvatar("Baker James Lorena", avatarRadius, width, targetContext)
             fragment.addAvatar("Baker  James   Lorena", avatarRadius, width, targetContext)
-            fragment.addAvatar("email@server.com", avatarRadius, width, targetContext)
+            fragment.addAvatar("email@nextcloud.nodomain", avatarRadius, width, targetContext)
         }
 
         shortSleep()

--- a/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
@@ -110,7 +110,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         OCShare(file.decryptedRemotePath).apply {
             remoteId = 3
             shareType = ShareType.EMAIL
-            sharedWithDisplayName = "admin@nextcloud.server.com"
+            sharedWithDisplayName = "admin@nextcloud.nodomain"
             userId = getUserId(user)
             activity.storageManager.saveShare(this)
         }
@@ -132,7 +132,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         OCShare(file.decryptedRemotePath).apply {
             remoteId = 6
             shareType = ShareType.FEDERATED
-            sharedWithDisplayName = "admin@nextcloud.remoteserver.com"
+            sharedWithDisplayName = "admin@nextcloud.nodomain"
             permissions = OCShare.FEDERATED_PERMISSIONS_FOR_FILE
             userId = getUserId(user)
             activity.storageManager.saveShare(this)

--- a/src/androidTest/java/com/owncloud/android/ui/fragment/OCFileListFragmentStaticServerIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/fragment/OCFileListFragmentStaticServerIT.kt
@@ -104,7 +104,7 @@ class OCFileListFragmentStaticServerIT : AbstractIT() {
         val emailShare = OCFile("/sharedToEmail.jpg").apply {
             parentId = sut.storageManager.getFileByEncryptedRemotePath("/").fileId
             isSharedWithSharee = true
-            sharees = listOf(ShareeUser("admin@nextcloud.server.com", "admin@nextcloud.server.com", ShareType.EMAIL))
+            sharees = listOf(ShareeUser("admin@nextcloud.nodomain", "admin@nextcloud.nodomain", ShareType.EMAIL))
         }
         sut.storageManager.saveFile(emailShare)
 

--- a/src/androidTest/java/com/owncloud/android/ui/trashbin/TrashbinActivityIT.kt
+++ b/src/androidTest/java/com/owncloud/android/ui/trashbin/TrashbinActivityIT.kt
@@ -123,15 +123,15 @@ class TrashbinActivityIT : AbstractIT() {
 
     @Test
     fun differentUser() {
-        val temp = Account("differentUser@https://server.com", MainApp.getAccountType(targetContext))
+        val temp = Account("differentUser@https://nextcloud.nodomain", MainApp.getAccountType(targetContext))
 
         val platformAccountManager = AccountManager.get(targetContext)
         platformAccountManager.addAccountExplicitly(temp, "password", null)
-        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://server.com")
+        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.nodomain")
         platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_USER_ID, "differentUser")
 
         val intent = Intent()
-        intent.putExtra(Intent.EXTRA_USER, "differentUser@https://server.com")
+        intent.putExtra(Intent.EXTRA_USER, "differentUser@https://nextcloud.nodomain")
         val sut: TrashbinActivity = activityRule.launchActivity(intent)
 
         val trashbinRepository = TrashbinLocalRepository(TestCase.EMPTY)

--- a/src/main/res/layout/account_item.xml
+++ b/src/main/res/layout/account_item.xml
@@ -117,7 +117,7 @@
                 android:maxLines="1"
                 android:text="@string/placeholder_sentence"
                 android:textColor="?android:attr/textColorSecondary"
-                tools:text="https://server.com/nextcloud" />
+                tools:text="https://nextcloud.nodomain/nextcloud" />
 
         </LinearLayout>
 

--- a/src/test/java/com/nextcloud/client/network/ConnectivityServiceTest.kt
+++ b/src/test/java/com/nextcloud/client/network/ConnectivityServiceTest.kt
@@ -65,7 +65,7 @@ class ConnectivityServiceTest {
                 return networkInfo
             }
 
-            const val SERVER_BASE_URL = "https://test.server.com"
+            const val SERVER_BASE_URL = "https://test.nextcloud.nodomain"
         }
 
         @Mock

--- a/src/test/java/com/owncloud/android/ui/TextDrawableTest.kt
+++ b/src/test/java/com/owncloud/android/ui/TextDrawableTest.kt
@@ -34,6 +34,6 @@ class TextDrawableTest {
         assertEquals("WB", TextDrawable.extractCharsFromDisplayName("winston brent"))
         assertEquals("BJ", TextDrawable.extractCharsFromDisplayName("Baker James Lorena"))
         assertEquals("BJ", TextDrawable.extractCharsFromDisplayName("Baker  James   Lorena"))
-        assertEquals("E", TextDrawable.extractCharsFromDisplayName("email@server.com"))
+        assertEquals("E", TextDrawable.extractCharsFromDisplayName("email@nextcloud.nodomain"))
     }
 }


### PR DESCRIPTION
Changed it elsewhere (layout files, unit tests) for consistency too.

This speeds up integration tests significantly, as the domain resolution fails immediately, in contrast to the timeout for server.com, which can take a while.

In my machine and emulator, this takes almost 3 minutes off of the connected tests runtime (from ~9:30 to ~6:40).

As a bonus, we also avoid making actual network requests to server.com!

The domain I've chosen is just the first idea I had for a fake domain. Better suggestions are highly appreciated!

- [x] Tests written, or not not needed
