### PR TITLE
Only perform deep connection test on an unmeted connection

### DIFF
--- a/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
+++ b/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
@@ -61,7 +61,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
     @Override
     public boolean isInternetWalled() {
         Connectivity c = getConnectivity();
-        if (c.isConnected() && c.isWifi()) {
+        if (c.isConnected() && c.isWifi() & !c.isMetered()) {
 
             Server server = accountManager.getUser().getServer();
             String baseServerAddress = server.getUri().toString();


### PR DESCRIPTION
Using the isMetered property of the Connection object allows us to avoid performing the deep connection check on metered WIFI connections.

Depending on the rationale of the initial implementation of the deep check, the condition could be simplified to c.isConnected() and !c.isMetered().

- [X] Tests written, or not not needed
