### PR TITLE
Fix: boxed primitive for compare

### DIFF
--- a/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderByDate.java
@@ -60,8 +60,7 @@ public class FileSortOrderByDate extends FileSortOrder {
         final int multiplier = isAscending ? 1 : -1;
 
         Collections.sort(files, (o1, o2) -> {
-            Long obj1 = o1.getDeletionTimestamp();
-            return multiplier * obj1.compareTo(o2.getDeletionTimestamp());
+            return multiplier * Long.compare(o1.getDeletionTimestamp(),o2.getDeletionTimestamp());
         });
 
         return super.sortTrashbinFiles(files);

--- a/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
+++ b/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.java
@@ -55,8 +55,7 @@ public class FileSortOrderBySize extends FileSortOrder {
             } else if (o2.isFolder()) {
                 return 1;
             } else {
-                Long obj1 = o1.getFileLength();
-                return multiplier * obj1.compareTo(o2.getFileLength());
+                return multiplier * Long.compare(o1.getFileLength(),o2.getFileLength());
             }
         });
 
@@ -82,8 +81,7 @@ public class FileSortOrderBySize extends FileSortOrder {
             } else if (o2.isFolder()) {
                 return 1;
             } else {
-                Long obj1 = o1.getFileLength();
-                return multiplier * obj1.compareTo(o2.getFileLength());
+                return multiplier * Long.compare(o1.getFileLength(),o2.getFileLength());
             }
         });
 
@@ -108,8 +106,7 @@ public class FileSortOrderBySize extends FileSortOrder {
             } else if (o2.isDirectory()) {
                 return 1;
             } else {
-                Long obj1 = o1.length();
-                return multiplier * obj1.compareTo(o2.length());
+                return multiplier * Long.compare(o1.length(),o2.length());
             }
         });
 

--- a/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -262,9 +262,7 @@ public final class FileStorageUtils {
     public static List<OCFile> sortOcFolderDescDateModifiedWithoutFavoritesFirst(List<OCFile> files) {
         final int multiplier = -1;
         Collections.sort(files, (o1, o2) -> {
-            @SuppressFBWarnings(value = "Bx", justification = "Would require stepping up API level")
-            Long obj1 = o1.getModificationTimestamp();
-            return multiplier * obj1.compareTo(o2.getModificationTimestamp());
+            return multiplier * Long.compare(o1.getModificationTimestamp(),o2.getModificationTimestamp());
         });
 
         return files;


### PR DESCRIPTION
[Broken Window Theory] As per current SpotBugs report, replace all usages
of boxed Long.compareTo(Long) with Long.compare(long, long)

- [X] Tests written, or not not needed

Note: the justification for the SuppressFBWarning annotation in FileStorage appears to be obsolete (has no current application) and, so, I removed the annotation.