### PR TITLE
CI:skip QA build if keystore pass is not available

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,12 +8,18 @@ jobs:
     qa:
         runs-on: ubuntu-latest
         steps:
+            -   name: Check if secrets are available
+                run: echo "::set-output name=ok::${{ secrets.KS_PASS != '' }}"
+                id: check-secrets
             -   uses: actions/checkout@v2
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
             -   name: set up JDK 1.8
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 uses: actions/setup-java@v1
                 with:
                     java-version: 1.8
             -   name: Build QA
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 env:
                     KS_PASS: ${{ secrets.KS_PASS }}
                     KEY_PASS: ${{ secrets.KEY_PASS }}


### PR DESCRIPTION
This is just another step towards green checks on PRs :)

There is currently no way to skip the whole workflow depending on whether it is PR from a fork or not. The only workaround is to check whether secrets are present or not.

So, I've added a step to check if KS_PASS is empty, and set an output depending on that.  If it is empty, we just skip the rest of the steps.

To avoid the `if` repetition, a separate job can be used and then the whole `qa` job can depend on its outputs. But that would add another "check" in the github UI.

Inspired by https://github.com/nextcloud/android/pull/8791#issuecomment-890524333

Signed-off-by: Álvaro Brey <alvaro.brv@gmail.com>

- [x] Tests written, or not not needed
