### PR TITLE
build: Exclude xpp3 dependency from library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,10 +268,9 @@ dependencies {
     // dependencies for app building
     implementation 'androidx.multidex:multidex:2.0.1'
 //    implementation project('nextcloud-android-library')
-    genericImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
-    gplayImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
-    versionDevImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
-    qaImplementation "com.github.nextcloud:android-library:$androidLibraryVersion"
+    implementation ("com.github.nextcloud:android-library:$androidLibraryVersion") {
+        exclude group: 'org.ogce', module: 'xpp3' // unused in Android and brings wrong Junit version
+    }
 
     compileOnly 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2' // remove after entire switch to lib v2
     implementation "commons-httpclient:commons-httpclient:3.1@jar" // remove after entire switch to lib v2


### PR DESCRIPTION
Although this dep is excluded in the library itself, Gradle still includes it because it doesn't respect exclusions for transitive 
dependencies. (see https://github.com/gradle/gradle/issues/1473)

This would be okay if it wasn't for the fact that xpp3 forces an old Junit version that breaks the integration tests.

Signed-off-by: Álvaro Brey Vilas <alvaro.brey@nextcloud.com>

- [x] Tests written, or not not needed
