### PR TITLE
Revert "Bump hwsecurity-fido from 4.1.0 to 4.4.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
     byteBuddyVersion = "1.11.15"
     espressoVersion = "3.4.0"
     workRuntime = "2.5.0"
-    fidoVersion = "4.4.0"
+    fidoVersion = "4.1.0"
 
     ciBuild = System.getenv("CI") == "true"
 


### PR DESCRIPTION
This reverts commit 0d7d40e1d3afae4bf1822a265667f85b2e182137.

This is a fix for crashes reported in #8585 and several related issues, all caused by an unregistered receiver when trying to pause Activities.

@dschuermann If you can, please look at why this might be happening,