### PR TITLE
dependabot: Pin facebook screenshot version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,3 +89,6 @@ updates:
                     versions:
                         - ">= 1.2.17.a"
                         - "< 1.2.18"
+                -   dependency-name: com.facebook.testing.screenshot:core
+                    versions:
+                        - "< 0.14.0"


### PR DESCRIPTION
As outlined in https://github.com/nextcloud/android/pull/8934, upgrading this dependency
breaks screenshot tests (0 tests are detected by Shot), so let's pin it back for now

The actual "final" fix should be having Shot take the screenshots directly, rather than
manually taking them with the facebook lib

- [x] Tests written, or not not needed