### PR TITLE
Fix old screenshot test comments deletion

### DIFF
--- a/.github/workflows/screenShotTest.yml
+++ b/.github/workflows/screenShotTest.yml
@@ -23,6 +23,8 @@ jobs:
                     mkdir -p $HOME/.gradle
                     echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties
                     ./gradlew assembleGplayDebug
+            -   name: Delete old comments
+                run: scripts/deleteOldComments.sh "${{ matrix.color }}-${{ matrix.scheme }}" "Screenshot" ${{github.event.number}} ${{ secrets.GITHUB_TOKEN }}
             -   name: run tests
                 uses: reactivecircus/android-emulator-runner@v2
                 with:

--- a/scripts/deleteOldComments.sh
+++ b/scripts/deleteOldComments.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#1: LOG_USERNAME
+#2: LOG_PASSWORD
+#3: DRONE_BUILD_NUMBER
+#4: BRANCH (stable or master)
+#5: TYPE (IT or Unit)
+#6: DRONE_PULL_REQUEST
+#7: GITHUB_TOKEN
+
+BRANCH=$1
+TYPE=$2
+PR=$3
+GITHUB_USER=$4
+GITHUB_PASSWORD=$5
+BRANCH_TYPE=$BRANCH-$TYPE
+
+ # delete all old comments, matching this type
+echo "Deleting old comments for $BRANCH_TYPE"
+oldComments=$(curl 2>/dev/null --header "authorization: Bearer $GITHUB_TOKEN" -X GET https://api.github.com/repos/nextcloud/android/issues/$PR/comments | jq --arg TYPE $BRANCH_TYPE '.[] | (.id |tostring) + "|" + (.user.login | test("nextcloud-android-bot") | tostring) + "|" + (.body | test([$TYPE]) | tostring)'| grep "true|true" | tr -d "\"" | cut -f1 -d"|")
+count=$(echo $oldComments | grep true | wc -l)
+echo "Found $count old comments"
+
+echo $oldComments | while read comment ; do
+echo "Deleting comment: $comment"
+curl 2>/dev/null --header "authorization: Bearer $GITHUB_TOKEN" -X DELETE https://api.github.com/repos/nextcloud/android/issues/comments/$comment
+done
+
+exit 0

--- a/scripts/deleteOldComments.sh
+++ b/scripts/deleteOldComments.sh
@@ -10,8 +10,8 @@
 BRANCH=$1
 TYPE=$2
 PR=$3
-GITHUB_USER=$4
-GITHUB_PASSWORD=$5
+GITHUB_TOKEN=$4
+
 BRANCH_TYPE=$BRANCH-$TYPE
 
  # delete all old comments, matching this type

--- a/scripts/deleteOldComments.sh
+++ b/scripts/deleteOldComments.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-#1: LOG_USERNAME
-#2: LOG_PASSWORD
-#3: DRONE_BUILD_NUMBER
-#4: BRANCH (stable or master)
-#5: TYPE (IT or Unit)
-#6: DRONE_PULL_REQUEST
-#7: GITHUB_TOKEN
+#1: BRANCH
+#2: TYPE
+#3: PR
+#4: GITHUB_TOKEN
 
 BRANCH=$1
 TYPE=$2
@@ -16,13 +13,15 @@ BRANCH_TYPE=$BRANCH-$TYPE
 
  # delete all old comments, matching this type
 echo "Deleting old comments for $BRANCH_TYPE"
-oldComments=$(curl 2>/dev/null --header "authorization: Bearer $GITHUB_TOKEN" -X GET https://api.github.com/repos/nextcloud/android/issues/$PR/comments | jq --arg TYPE $BRANCH_TYPE '.[] | (.id |tostring) + "|" + (.user.login | test("nextcloud-android-bot") | tostring) + "|" + (.body | test([$TYPE]) | tostring)'| grep "true|true" | tr -d "\"" | cut -f1 -d"|")
-count=$(echo $oldComments | grep true | wc -l)
+oldComments=$(curl 2>/dev/null --header "authorization: Bearer $GITHUB_TOKEN" -X GET https://api.github.com/repos/nextcloud/android/issues/$PR/comments | jq --arg TYPE $BRANCH_TYPE '.[] | (.id |tostring) + "|" + (.user.login | test("(nextcloud-android-bot|github-actions)") | tostring) + "|" + (.body | test([$TYPE]) | tostring)'| grep "true|true" | tr -d "\"" | cut -f1 -d"|")
+count=$(echo -n "$oldComments" | grep -c '^')
 echo "Found $count old comments"
 
-echo $oldComments | while read comment ; do
-echo "Deleting comment: $comment"
-curl 2>/dev/null --header "authorization: Bearer $GITHUB_TOKEN" -X DELETE https://api.github.com/repos/nextcloud/android/issues/comments/$comment
-done
+if [ "$count" -gt 0 ]; then
+  echo "$oldComments" | while read comment ; do
+    echo "Deleting comment: $comment"
+    curl 2>/dev/null --header "authorization: Bearer $GITHUB_TOKEN" -X DELETE https://api.github.com/repos/nextcloud/android/issues/comments/$comment
+  done
+fi
 
 exit 0


### PR DESCRIPTION
Different attempt at https://github.com/nextcloud/android/pull/8961 , this one should not delete comments unrelated to screenshots.

This restores a script that I deleted in a previous commit that was supposed to delete screenshot test comments, and also contains a small fix for said script.

- [x] Tests written, or not not needed