### PR TITLE
Minor improvements to git hooks

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,6 +1,14 @@
 #!/bin/bash
 # Pre-commit hook: don't allow commits if detekt or ktlint fail. Skip with "git commit --no-verify".
-set -euo pipefail
+echo "Running pre-commit checks."
 
-./gradlew --daemon --quiet detekt
-./gradlew --daemon --quiet ktlint
+if ! ./gradlew --daemon ktlint &>/dev/null; then
+    echo >&2 "Lint failed! See report at file://$(pwd)/build/ktlint.txt"
+    echo >&2 "Hint: fix most lint errors with ./gradlew ktlintFormat"
+    exit 1
+fi
+
+if ! ./gradlew --daemon detekt &>/dev/null; then
+    echo >&2 "Detekt failed! See report at file://$(pwd)/build/reports/detekt/detekt.html"
+    exit 1
+fi

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -4,28 +4,24 @@ set -euo pipefail
 
 z40=0000000000000000000000000000000000000000 # magic deleted ref
 
-while read local_ref local_sha remote_ref remote_sha
-do
-	if [ "$local_sha" != $z40 ]
-	then
-		if [ "$remote_sha" = $z40 ]
-		then
-			# New branch, examine all commits
-			range="$(git merge-base master $local_sha)..$local_sha"
-		else
-			# Update to existing branch, examine new commits
-			range="$remote_sha..$local_sha"
-		fi
+while read local_ref local_sha remote_ref remote_sha; do
+    if [ "$local_sha" != $z40 ]; then
+        if [ "$remote_sha" = $z40 ]; then
+            # New branch, examine all commits
+            range="$(git merge-base master $local_sha)..$local_sha"
+        else
+            # Update to existing branch, examine new commits
+            range="$remote_sha..$local_sha"
+        fi
 
-		# Check for WIP commit
-		commit=$(git rev-list --grep 'Signed-off-by' --invert-grep "$range")
-		if [ -n "$commit" ]
-		then
-			echo >&2 "Found commits without signoff in $local_ref. Aborting push. Offending commits:"
-			echo >&2 "$commit"
-			exit 1
-		fi
-	fi
+        # Check for commits without sign-off
+        commit=$(git rev-list --grep 'Signed-off-by' --invert-grep "$range")
+        if [ -n "$commit" ]; then
+            echo >&2 "Found commits without sign-off in $local_ref. Aborting push. Offending commits:"
+            echo >&2 "$commit"
+            exit 1
+        fi
+    fi
 done
 
 exit 0


### PR DESCRIPTION
- pre-commit: Suppress all output and show reduced results.
   This is more concise and avoids unreadable errors when committing from an IDE
 - pre-push: Format with shell formatter, fix typo

To update git hooks, just run `./gradlew installGitHooks` again.