### PR TITLE
Codecov: don't require CI to pass

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,7 @@ codecov:
   branch: master
   ci:
     - drone.nextcloud.com
+  require_ci_to_pass: false
 
 coverage:
   precision: 2
@@ -18,4 +19,4 @@ comment:
 
 ignore:
   - "src/main/res/values*/*"
-  
+


### PR DESCRIPTION
We have 3 independent builds in drone and we still want to see codecov if one of the other builds fails

- [x] Tests written, or not not needed