### PR TITLE
Deprecate FileDataStorageManager constructors depending on legacy Account

### DIFF
--- a/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -88,7 +88,7 @@ public abstract class AbstractIT {
     protected Activity currentActivity;
 
     protected FileDataStorageManager fileDataStorageManager =
-        new FileDataStorageManager(account, targetContext.getContentResolver());
+        new FileDataStorageManager(user, targetContext.getContentResolver());
 
     @BeforeClass
     public static void beforeAll() {

--- a/src/androidTest/java/com/owncloud/android/datamodel/FileDataStorageManagerContentResolverIT.java
+++ b/src/androidTest/java/com/owncloud/android/datamodel/FileDataStorageManagerContentResolverIT.java
@@ -25,7 +25,7 @@ package com.owncloud.android.datamodel;
 public class FileDataStorageManagerContentResolverIT extends FileDataStorageManagerIT {
     @Override
     public void before() {
-        sut = new FileDataStorageManager(account, targetContext.getContentResolver());
+        sut = new FileDataStorageManager(user, targetContext.getContentResolver());
 
         super.before();
     }

--- a/src/androidTest/java/com/owncloud/android/datamodel/OCCapabilityIT.kt
+++ b/src/androidTest/java/com/owncloud/android/datamodel/OCCapabilityIT.kt
@@ -31,7 +31,7 @@ import org.junit.Test
 class OCCapabilityIT : AbstractIT() {
     @Test
     fun saveCapability() {
-        val fileDataStorageManager = FileDataStorageManager(account, targetContext.contentResolver)
+        val fileDataStorageManager = FileDataStorageManager(user, targetContext.contentResolver)
 
         val capability = OCCapability()
         capability.etag = "123"
@@ -40,7 +40,7 @@ class OCCapabilityIT : AbstractIT() {
 
         fileDataStorageManager.saveCapabilities(capability)
 
-        val newCapability = fileDataStorageManager.getCapability(account.name)
+        val newCapability = fileDataStorageManager.getCapability(user.accountName)
 
         assertEquals(capability.etag, newCapability.etag)
         assertEquals(capability.userStatus, newCapability.userStatus)

--- a/src/androidTest/java/com/owncloud/android/util/ErrorMessageAdapterIT.java
+++ b/src/androidTest/java/com/owncloud/android/util/ErrorMessageAdapterIT.java
@@ -25,6 +25,8 @@ import android.accounts.Account;
 import android.content.Context;
 import android.content.res.Resources;
 
+import com.nextcloud.client.account.MockUser;
+import com.nextcloud.client.account.User;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
@@ -49,17 +51,17 @@ public class ErrorMessageAdapterIT {
     @Test
     public void getErrorCauseMessageForForbiddenRemoval() {
         Resources resources = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources();
-        Account account = new Account("name", ACCOUNT_TYPE);
+        User user = new MockUser("name", ACCOUNT_TYPE);
         Context context = MainApp.getAppContext();
 
         String errorMessage = ErrorMessageAdapter.getErrorCauseMessage(
             new RemoteOperationResult(RemoteOperationResult.ResultCode.FORBIDDEN),
             new RemoveFileOperation(new OCFile(PATH_TO_DELETE),
                                     false,
-                                    account,
+                                    user.toPlatformAccount(),
                                     false,
                                     context,
-                                    new FileDataStorageManager(account, context.getContentResolver())),
+                                    new FileDataStorageManager(user, context.getContentResolver())),
             resources
                                                                       );
 

--- a/src/debug/java/com/nextcloud/client/TestActivity.kt
+++ b/src/debug/java/com/nextcloud/client/TestActivity.kt
@@ -101,7 +101,7 @@ class TestActivity :
 
     override fun getStorageManager(): FileDataStorageManager {
         if (!this::storage.isInitialized) {
-            storage = FileDataStorageManager(account, contentResolver)
+            storage = FileDataStorageManager(user.get(), contentResolver)
 
             if (!storage.capabilityExistsForAccount(account.name)) {
                 val ocCapability = OCCapability()

--- a/src/main/java/com/nextcloud/client/files/downloader/DownloadTask.kt
+++ b/src/main/java/com/nextcloud/client/files/downloader/DownloadTask.kt
@@ -68,7 +68,7 @@ class DownloadTask(
         val result = op.execute(client)
         if (result.isSuccess) {
             val storageManager = FileDataStorageManager(
-                request.user.toPlatformAccount(),
+                request.user,
                 contentResolver
             )
             val file = saveDownloadedFile(op, storageManager)

--- a/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
@@ -94,7 +94,7 @@ class AccountRemovalWork(
         val user = optionalUser.get()
         backgroundJobManager.cancelPeriodicContactsBackup(user)
         val userRemoved = userAccountManager.removeUser(user)
-        val storageManager = FileDataStorageManager(user.toPlatformAccount(), context.contentResolver)
+        val storageManager = FileDataStorageManager(user, context.contentResolver)
 
         // disable daily backup
         arbitraryDataProvider.storeOrUpdateKeyValue(

--- a/src/main/java/com/nextcloud/client/jobs/ContactsBackupWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/ContactsBackupWork.kt
@@ -179,7 +179,7 @@ class ContactsBackupWork(
     private fun expireFiles(daysToExpire: Int, backupFolderString: String, user: User) { // -1 disables expiration
         if (daysToExpire > -1) {
             val storageManager = FileDataStorageManager(
-                user.toPlatformAccount(),
+                user,
                 applicationContext.getContentResolver()
             )
             val backupFolder: OCFile = storageManager.getFileByPath(backupFolderString)

--- a/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -60,7 +60,7 @@ class OfflineSyncWork constructor(
         if (!powerManagementService.isPowerSavingEnabled && !connectivityService.isInternetWalled) {
             val users = userAccountManager.allUsers
             for (user in users) {
-                val storageManager = FileDataStorageManager(user.toPlatformAccount(), contentResolver)
+                val storageManager = FileDataStorageManager(user, contentResolver)
                 val ocRoot = storageManager.getFileByPath(OCFile.ROOT_PATH)
                 if (ocRoot.storagePath == null) {
                     break

--- a/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -599,7 +599,7 @@ public final class AppPreferencesImpl implements AppPreferences {
         }
 
         ArbitraryDataProvider dataProvider = new ArbitraryDataProvider(context.getContentResolver());
-        FileDataStorageManager storageManager = new FileDataStorageManager(user.toPlatformAccount(), context.getContentResolver());
+        FileDataStorageManager storageManager = new FileDataStorageManager(user, context.getContentResolver());
 
         String value = dataProvider.getValue(user.getAccountName(), getKeyFromFolder(preferenceName, folder));
         OCFile prefFolder = folder;

--- a/src/main/java/com/nextcloud/ui/ChooseAccountDialogFragment.kt
+++ b/src/main/java/com/nextcloud/ui/ChooseAccountDialogFragment.kt
@@ -148,7 +148,7 @@ class ChooseAccountDialogFragment :
                 dismiss()
             }
 
-            val capability = FileDataStorageManager(user.toPlatformAccount(), context?.contentResolver)
+            val capability = FileDataStorageManager(user, context?.contentResolver)
                 .getCapability(user)
 
             if (capability.userStatus.isTrue) {

--- a/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -87,18 +87,27 @@ public class FileDataStorageManager {
     private ContentProviderClient contentProviderClient;
     private Account account;
 
+    @Deprecated
     public FileDataStorageManager(Account account, ContentResolver contentResolver) {
         this.contentProviderClient = null;
         this.contentResolver = contentResolver;
         this.account = account;
     }
 
+    public FileDataStorageManager(User user, ContentResolver contentResolver) {
+        this(user.toPlatformAccount(), contentResolver);
+    }
+
+    @Deprecated
     public FileDataStorageManager(Account account, ContentProviderClient contentProviderClient) {
         this.contentProviderClient = contentProviderClient;
         this.contentResolver = null;
         this.account = account;
     }
 
+    public FileDataStorageManager(User user, ContentProviderClient contentProviderClient) {
+        this(user.toPlatformAccount(), contentProviderClient);
+    }
 
     /**
      * Use getFileByEncryptedRemotePath() or getFileByDecryptedRemotePath()
@@ -2402,9 +2411,5 @@ public class FileDataStorageManager {
 
     public Account getAccount() {
         return this.account;
-    }
-
-    public void setAccount(Account account) {
-        this.account = account;
     }
 }

--- a/src/main/java/com/owncloud/android/providers/DiskLruImageCacheFileProvider.java
+++ b/src/main/java/com/owncloud/android/providers/DiskLruImageCacheFileProvider.java
@@ -62,7 +62,7 @@ public class DiskLruImageCacheFileProvider extends ContentProvider {
 
     private OCFile getFile(Uri uri) {
         User user = accountManager.getUser();
-        FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(user.toPlatformAccount(),
+        FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(user,
                 MainApp.getAppContext().getContentResolver());
 
         return fileDataStorageManager.getFileByPath(uri.getPath());

--- a/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -234,7 +234,7 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
             Uri emailBaseUri = new Uri.Builder().scheme(CONTENT).authority(DATA_EMAIL).build();
             Uri circleBaseUri = new Uri.Builder().scheme(CONTENT).authority(DATA_CIRCLE).build();
 
-            FileDataStorageManager manager = new FileDataStorageManager(user.toPlatformAccount(),
+            FileDataStorageManager manager = new FileDataStorageManager(user,
                                                                         getContext().getContentResolver());
             boolean federatedShareAllowed = manager.getCapability(user.getAccountName())
                 .getFilesSharingFederationOutgoing()

--- a/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -507,7 +507,7 @@ public class OperationsService extends Service {
                 String newParentPath;
                 long shareId;
 
-                FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(account,
+                FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(user,
                                                                                            getContentResolver());
 
                 switch (action) {

--- a/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -390,7 +390,7 @@ public abstract class DrawerActivity extends ToolbarActivity
     }
 
     private void filterDrawerMenu(final Menu menu, @NonNull final User user) {
-        FileDataStorageManager storageManager = new FileDataStorageManager(user.toPlatformAccount(),
+        FileDataStorageManager storageManager = new FileDataStorageManager(user,
                                                                            getContentResolver());
         OCCapability capability = storageManager.getCapability(user.getAccountName());
 

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2503,7 +2503,7 @@ public class FileDisplayActivity extends FileActivity
         FileDataStorageManager storageManager = getStorageManager();
 
         if (storageManager == null) {
-            storageManager = new FileDataStorageManager(user.toPlatformAccount(), getContentResolver());
+            storageManager = new FileDataStorageManager(user, getContentResolver());
         }
 
         FetchRemoteFileTask fetchRemoteFileTask = new FetchRemoteFileTask(user,

--- a/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
+++ b/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
@@ -436,7 +436,8 @@ public class StorageMigration {
         }
 
         private void updateIndex(Context context) throws MigrationException {
-            FileDataStorageManager manager = new FileDataStorageManager(null, context.getContentResolver());
+            final Account nullAccount = null;
+            FileDataStorageManager manager = new FileDataStorageManager(nullAccount, context.getContentResolver());
 
             try {
                 manager.migrateStoredFiles(mStorageSource, mStorageTarget);

--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -857,7 +857,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (mStorageManager == null) {
-            mStorageManager = new FileDataStorageManager(user.toPlatformAccount(), activity.getContentResolver());
+            mStorageManager = new FileDataStorageManager(user, activity.getContentResolver());
         }
 
         if (clear) {

--- a/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -287,7 +287,7 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
 
                     if (chooseTemplateDialogFragmentWeakReference.get() != null) {
                         FileDataStorageManager storageManager = new FileDataStorageManager(
-                            user.toPlatformAccount(),
+                            user,
                             chooseTemplateDialogFragmentWeakReference.get().requireContext().getContentResolver());
                         storageManager.saveFile(temp);
                         file = storageManager.getFileByPath(path);

--- a/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
@@ -332,7 +332,7 @@ public class ChooseTemplateDialogFragment extends DialogFragment implements View
                     return "";
                 }
 
-                FileDataStorageManager storageManager = new FileDataStorageManager(user.toPlatformAccount(),
+                FileDataStorageManager storageManager = new FileDataStorageManager(user,
                                                                                    context.getContentResolver());
 
                 OCFile temp = FileStorageUtils.fillOCFile((RemoteFile) newFileResult.getData().get(0));

--- a/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
@@ -200,7 +200,7 @@ public class ConflictsResolveDialog extends DialogFragment {
         OCFileListAdapter.setThumbnail(existingFile,
                                        binding.existingThumbnail,
                                        user,
-                                       new FileDataStorageManager(user.toPlatformAccount(),
+                                       new FileDataStorageManager(user,
                                                                   requireContext().getContentResolver()),
                                        asyncTasks,
                                        false,

--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -222,7 +222,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
     }
 
     private void setupView() {
-        FileDataStorageManager storageManager = new FileDataStorageManager(user.toPlatformAccount(),
+        FileDataStorageManager storageManager = new FileDataStorageManager(user,
                                                                            contentResolver);
         operationsHelper = ((ComponentsGetter) requireActivity()).getFileOperationsHelper();
 

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -201,7 +201,7 @@ public class FileOperationsHelper {
     public void startSyncForFileAndIntent(OCFile file, Intent intent) {
         new Thread(() -> {
             User user = fileActivity.getUser().orElseThrow(RuntimeException::new);
-            FileDataStorageManager storageManager = new FileDataStorageManager(fileActivity.getAccount(),
+            FileDataStorageManager storageManager = new FileDataStorageManager(user,
                                                                                fileActivity.getContentResolver());
 
             // check if file is in conflict (this is known due to latest folder refresh)
@@ -314,7 +314,7 @@ public class FileOperationsHelper {
                 public void run() {
                     User user = currentAccount.getUser();
                     FileDataStorageManager storageManager =
-                        new FileDataStorageManager(user.toPlatformAccount(), fileActivity.getContentResolver());
+                        new FileDataStorageManager(user, fileActivity.getContentResolver());
                     // a fresh object is needed; many things could have occurred to the file
                     // since it was registered to observe again, assuming that local files
                     // are linked to a remote file AT MOST, SOMETHING TO BE DONE;


### PR DESCRIPTION
This commit deprecates constructors using legacy platform `Account` type
and wraps them using new API accepting `User` model.

All calls to `FileDataStorageManager` constructors that were trivially
portable without are updated as well. Places where passing new type
requires more risky work were left out for now.

`FileDataStorageManager` still uses `Account` internally - modifying this
requires getting rid of all legacy constructors first.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
