### PR TITLE
pre-push hook: Exclude merges from signoff check

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -15,7 +15,7 @@ while read local_ref local_sha remote_ref remote_sha; do
         fi
 
         # Check for commits without sign-off
-        commit=$(git rev-list --grep 'Signed-off-by' --invert-grep "$range")
+        commit=$(git rev-list --no-merges --grep 'Signed-off-by' --invert-grep "$range")
         if [ -n "$commit" ]; then
             echo >&2 "Found commits without sign-off in $local_ref. Aborting push. Offending commits:"
             echo >&2 "$commit"


### PR DESCRIPTION
Note: to update, just run `./gradlew installGitHooks` again.
- [x] Tests written, or not not needed