### PR TITLE
Clean up notification channels

### DIFF
--- a/src/main/java/com/owncloud/android/MainApp.java
+++ b/src/main/java/com/owncloud/android/MainApp.java
@@ -500,9 +500,7 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
                               R.string.notification_channel_file_sync_name,
                               R.string.notification_channel_file_sync_description, context);
 
-                createChannel(notificationManager, NotificationUtils.NOTIFICATION_CHANNEL_FILE_OBSERVER,
-                              R.string.notification_channel_file_observer_name, R.string
-                                  .notification_channel_file_observer_description, context);
+                notificationManager.deleteNotificationChannel(NotificationUtils.NOTIFICATION_CHANNEL_FILE_OBSERVER);
 
                 createChannel(notificationManager, NotificationUtils.NOTIFICATION_CHANNEL_PUSH,
                               R.string.notification_channel_push_name, R.string

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -668,8 +668,6 @@
     <string name="notification_channel_media_description">Music player progress</string>
     <string name="notification_channel_file_sync_name">File sync</string>
     <string name="notification_channel_file_sync_description">Shows file sync progress and results</string>
-    <string name="notification_channel_file_observer_name">File observer</string>
-    <string name="notification_channel_file_observer_description">Monitors files for changes</string>
 
     <string name="account_not_found">Account not found!</string>
 


### PR DESCRIPTION
The commits mostly describe the work here, but the general idea is to make the notification channels more understandable. "Notification channel", for example, is both redundant (the user is already looking at the notification channels screen) and unnecessarily technical ("notification channels" is a developer term; the UI refers to this as "notification categories").

There is almost certainly something here that gets l10n wrong - it's unclear to me in the face of https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#translations whether strings should be deleted when they're no longer needed. In this case though it seems fine since it seems like this was never actually used?

### Testing 

It's unclear to me whether this kind of change should be tested? If it should be there will probably already be tests and CI should tell me I suppose. I _have_ manually tested this.

- [x] Tests written, or not not needed
