### PR TITLE
Bugfix/fix email type

### DIFF
--- a/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -552,7 +552,6 @@ public final class MimeTypeUtil {
         MIMETYPE_TO_ICON_MAPPING.put("text/x-shellscript", R.drawable.file_code);
         MIMETYPE_TO_ICON_MAPPING.put("web", R.drawable.file_code);
         MIMETYPE_TO_ICON_MAPPING.put(MimeType.DIRECTORY, R.drawable.folder);
-        MIMETYPE_TO_ICON_MAPPING.put("message/rfc822", R.drawable.file_text);
     }
 
     /**


### PR DESCRIPTION

Added message/rfc822 for eml files.

As far as I have tested, opening eml files works with latest Gmail on Android 11. Nevertheless it strongly depends on the intent-filters of the installed apps. FairEmail for example registers an extra intent filter for message/rfc822 so this might help in some cases. I guess there is no silver bullet solution for this use case here.

