### PR TITLE
fastlane: Restore version prompt for RC releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,7 @@ end
 desc "Release phase 2 for RC: checks, tag, upload gplay to playstore with values from build.gradle"
 lane :RC_releasePhase2 do |options|
     info = androidVersion
+    promptVersion(info)
     checkChangelog(info)
     checkLibrary_RC()
     checkIfScreenshotsExist()


### PR DESCRIPTION
Was lost in https://github.com/nextcloud/android/pull/9118, so now RC releases didn't pause for version check.

- [x] Tests written, or not not needed