### PR TITLE
Prevent duplicate Settings activity on back stack

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.java
@@ -301,8 +301,11 @@ public class BackupFragment extends FileFragment implements DatePickerDialog.OnD
                     } else {
                         contactsPreferenceActivity.openDrawer();
                     }
+                } else if (getActivity() != null) {
+                    getActivity().finish();
                 } else {
                     Intent settingsIntent = new Intent(getContext(), SettingsActivity.class);
+                    settingsIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     startActivity(settingsIntent);
                 }
                 retval = true;


### PR DESCRIPTION
Currently, when you open "Contacts & calendar backup" in Nextlcoud app settings and go back by pressing the Back button in the toolbar, it opens a new settings activity. If you click back in the newly opened Settings screen, it shows the previous Settings screen (i.e. there are multiple copies of it on the back stack).

Solution: Instead of spawning a new SettingsActivity, go back to the existing activity via `finish()`. 

### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)

- [ ] Tests written, or not not needed
