### PR TITLE
stale action: Add exempt label to mark issues that shouldn't be stale automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
                     days-before-close: 14
                     days-before-pr-close: -1
                     only-labels: 'bug,needs info/discussion'
+                    exempt-issue-labels: 'no-stale'
                     stale-issue-message: 'This bug report did not receive an update in the last 4 weeks.
                                         Please take a look again and update the issue with new details,
                                         otherwise the issue will be automatically closed in 2 weeks. Thank you!'


### PR DESCRIPTION
We've got some issues that are open since a long time ago but aren't resolved, and  there isn't some clear short term resolution to them (so the `needs discussion`label still makes sense)
As such these isues are kept open because they still affect users, but the users have to be "fighting" the stale bot, which
understandably generates confusion and frustration.

This PR adds a specific label we can add to those issues so that the stale action will ignore them.
