### PR TITLE
code style: Disable autowrap while typing

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,7 +28,7 @@
       </value>
     </option>
     <option name="RIGHT_MARGIN" value="120" />
-    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
+    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="false" />
     <JavaCodeStyleSettings>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>


### PR DESCRIPTION
Our `.editorconfig` indiscriminately applies max length of 120 to every single file (except yaml).
When coupled with this setting (autowrap), this results in the editor inserting line ends in files _while I'm typing_, even when it breaks the syntax (such as bash scripts) or tools (such as strings.xml). This becomes really annoying really quickly.

This change keeps the margin indicator but disables auto-wrap while typing.


Another alternative is limiting `.editorconfig` that it only applies max length to Java and Kotlin files by default.


- [x] Tests written, or not not needed