### PR TITLE
Manifest: allow app to query for apps that can resolve VIEW or SEND intents

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -467,5 +467,14 @@
         <package android:name="it.niedermann.nextcloud.deck" />
         <package android:name="it.niedermann.nextcloud.deck.play" />
         <package android:name="it.niedermann.nextcloud.deck.dev" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND_MULTIPLE" />
+        </intent>
     </queries>
 </manifest>


### PR DESCRIPTION
This is otherwise limited by default in sdk 30 and above, which results in users not being able to share or open files through other installed apps.

Fixes https://github.com/nextcloud/android/issues/9227
Fixes https://github.com/nextcloud/android/issues/9214
Fixes https://github.com/nextcloud/android/issues/9213

- [x] Tests written, or not not needed