### PR TITLE
meta: Don't put the testing explanation in the rendered PR text

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,11 @@
-### Testing 
+<!--
+TESTING
+
 Writing tests is very important. Please try to write some tests for your PR. 
 If you need help, please do not hesitate to ask in this PR for help.
 
-[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
-[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
-[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)
-
+Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
+Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
+UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
+ -->
 - [ ] Tests written, or not not needed


### PR DESCRIPTION
By adding it as a comment, the user writing the PR will still see it but it won't be present in the rendered text, which will be less noisy.

<!--
### Testing 
Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

[unit tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests)
[instrumented tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests)
[UI tests](https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests)
-->

- [x] Tests written, or not not needed
