### PR TITLE
AndroidManifest: allow querying for davdroid app.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -467,6 +467,7 @@
         <package android:name="it.niedermann.nextcloud.deck" />
         <package android:name="it.niedermann.nextcloud.deck.play" />
         <package android:name="it.niedermann.nextcloud.deck.dev" />
+        <package android:name="at.bitfire.davdroid"/>
 
         <intent>
             <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Fixes #9339

- [x] Tests written, or not not needed