### PR TITLE
Fix crashes during scheme normalization on login

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -756,7 +756,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
     private void checkOcServer() {
         String uri;
-        if (accountSetupBinding != null && accountSetupBinding.hostUrlInput.getText()!= null &&
+        if (accountSetupBinding != null && accountSetupBinding.hostUrlInput.getText() != null &&
             !accountSetupBinding.hostUrlInput.getText().toString().isEmpty()) {
             uri = accountSetupBinding.hostUrlInput.getText().toString().trim();
         } else {
@@ -771,7 +771,12 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 accountSetupBinding.hostUrlInput.setText(uri);
             }
 
-            uri = AuthenticatorUrlUtils.normalizeScheme(uri);
+            try {
+                uri = AuthenticatorUrlUtils.normalizeScheme(uri);
+            } catch (IllegalArgumentException ex) {
+                // Let Owncloud library check the error of the malformed URI
+                Log_OC.e(TAG, "Invalid URL", ex);
+            }
 
             // Handle internationalized domain names
             try {
@@ -954,11 +959,11 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             case OK:
                 if (accountSetupBinding.hostUrlInput.getText() != null &&
                     accountSetupBinding.hostUrlInput
-                    .getText()
-                    .toString()
-                    .trim()
-                    .toLowerCase(Locale.ROOT)
-                    .startsWith(HTTP_PROTOCOL)) {
+                        .getText()
+                        .toString()
+                        .trim()
+                        .toLowerCase(Locale.ROOT)
+                        .startsWith(HTTP_PROTOCOL)) {
                     mServerStatusText = getResources().getString(R.string.auth_connection_established);
                     mServerStatusIcon = R.drawable.ic_ok;
                 } else {
@@ -1017,7 +1022,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                     mServerStatusText = getResources().getString(
                         R.string.auth_unknown_error_exception_title,
                         result.getException().getMessage()
-                    );
+                                                                );
                 } else {
                     mServerStatusText = getResources().getString(R.string.auth_unknown_error_title);
                 }
@@ -1058,11 +1063,11 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 if (showWebViewLoginUrl) {
                     if (accountSetupBinding.hostUrlInput.getText() != null &&
                         accountSetupBinding.hostUrlInput
-                        .getText()
-                        .toString()
-                        .trim()
-                        .toLowerCase(Locale.ROOT)
-                        .startsWith(HTTP_PROTOCOL)) {
+                            .getText()
+                            .toString()
+                            .trim()
+                            .toLowerCase(Locale.ROOT)
+                            .startsWith(HTTP_PROTOCOL)) {
                         mAuthStatusText = getResources().getString(R.string.auth_connection_established);
                         mAuthStatusIcon = R.drawable.ic_ok;
                     } else {
@@ -1447,7 +1452,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         public void onServiceConnected(ComponentName component, IBinder service) {
             if (component.equals(
                 new ComponentName(AuthenticatorActivity.this, OperationsService.class)
-            )) {
+                                )) {
                 mOperationsServiceBinder = (OperationsServiceBinder) service;
 
                 Uri data = getIntent().getData();
@@ -1476,7 +1481,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         public void onServiceDisconnected(ComponentName component) {
             if (component.equals(
                 new ComponentName(AuthenticatorActivity.this, OperationsService.class)
-            )) {
+                                )) {
                 Log_OC.e(TAG, "Operations service crashed");
                 mOperationsServiceBinder = null;
             }

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -774,7 +774,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             try {
                 uri = AuthenticatorUrlUtils.normalizeScheme(uri);
             } catch (IllegalArgumentException ex) {
-                // Let Owncloud library check the error of the malformed URI
+                // Let the Nextcloud library check the error of the malformed URI
                 Log_OC.e(TAG, "Invalid URL", ex);
             }
 
@@ -782,7 +782,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             try {
                 uri = DisplayUtils.convertIdn(uri, true);
             } catch (IllegalArgumentException ex) {
-                // Let Owncloud library check the error of the malformed URI
+                // Let the Nextcloud library check the error of the malformed URI
                 Log_OC.e(TAG, "Error converting internationalized domain name " + uri, ex);
             }
 

--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorUrlUtils.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorUrlUtils.java
@@ -53,7 +53,7 @@ public final class AuthenticatorUrlUtils {
             normalizedUrl = normalizedUrl.trim();
 
             if (!normalizedUrl.toLowerCase(Locale.ROOT).startsWith(HTTP_PROTOCOL) &&
-                    !normalizedUrl.toLowerCase(Locale.ROOT).startsWith(HTTPS_PROTOCOL)) {
+                !normalizedUrl.toLowerCase(Locale.ROOT).startsWith(HTTPS_PROTOCOL)) {
                 if (sslWhenUnprefixed) {
                     normalizedUrl = HTTPS_PROTOCOL + normalizedUrl;
                 } else {
@@ -100,8 +100,8 @@ public final class AuthenticatorUrlUtils {
     }
 
     public static String normalizeScheme(String url) {
-        URI uri = URI.create(url);
-        if (uri.getScheme() != null) {
+        if (url.matches("[a-zA-Z][a-zA-Z0-9+.-]+://.+")) {
+            URI uri = URI.create(url);
             String lcScheme = uri.getScheme().toLowerCase(Locale.ROOT);
             return String.format("%s:%s", lcScheme, uri.getRawSchemeSpecificPart());
         } else {

--- a/src/test/java/com/owncloud/android/authentication/AuthenticatorUrlUtilsTest.java
+++ b/src/test/java/com/owncloud/android/authentication/AuthenticatorUrlUtilsTest.java
@@ -93,5 +93,54 @@ public class AuthenticatorUrlUtilsTest {
             //      output is empty
             Assert.assertEquals("", normalized);
         }
+
+
+        @Test
+        public void ipAddress() {
+            // GIVEN
+            //      input URL is an IP address
+            String url = "127.0.0.1";
+
+            // WHEN
+            //      scheme is normalized
+            String normalized = AuthenticatorUrlUtils.normalizeScheme(url);
+
+            // THEN
+            //      output is equal
+            Assert.assertEquals(url, normalized);
+        }
+
+
+        @Test
+        public void withPort() {
+            // GIVEN
+            //      input URL has a port
+            String url = "host.net:8080/index.php/apps/ABC/def/?";
+
+            // WHEN
+            //      scheme is normalized
+            String normalized = AuthenticatorUrlUtils.normalizeScheme(url);
+
+            // THEN
+            //      output is equal
+            Assert.assertEquals(url, normalized);
+        }
+
+
+        @Test
+        public void ipAddressWithPort() {
+            // GIVEN
+            //      input URL is an IP address
+            //      input URL has a port
+            String url = "127.0.0.1:8080/index.php/apps/ABC/def/?";
+
+            // WHEN
+            //      scheme is normalized
+            String normalized = AuthenticatorUrlUtils.normalizeScheme(url);
+
+            // THEN
+            //      output is equal
+            Assert.assertEquals(url, normalized);
+        }
     }
 }


### PR DESCRIPTION
We can't check this with `URI` because `URI.create` will crash with an `IllegalArgumentException` if there is a host and port but no scheme (for example: `127.0.0.1:8080`).
The workaround is to manually check for scheme and just skip URI creation if not present.

Fixes #9338
Fixes #9365
Follow up to #8535

- [x] Tests written, or not not needed