### PR TITLE
Fix dependabot.yml syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
             interval: daily
             time: "03:00"
             timezone: Europe/Paris
+        rebase-strategy: "disabled"
         open-pull-requests-limit: 10
         labels:
             - 2. to review

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,91 +1,16 @@
 version: 2
 updates:
     -   package-ecosystem: "github-actions"
-            directory: "/" # Location of package manifests
-            schedule:
-                interval: "weekly"
+        directory: "/"
+        schedule:
+            interval: "weekly"
     -   package-ecosystem: gradle
-            directory: "/"
-            schedule:
-                interval: daily
-                time: "03:00"
-                timezone: Europe/Paris
-            open-pull-requests-limit: 10
-            labels:
-                - 2. to review
-                - dependencies
-            ignore:
-                -   dependency-name: com.github.albfernandez:juniversalchardet
-                    versions:
-                        - "> 2.0.3"
-                -   dependency-name: com.github.albfernandez:juniversalchardet
-                    versions:
-                        - "< v2.2.0.999999"
-                        - ">= v2.2.0.a"
-                -   dependency-name: com.github.albfernandez:juniversalchardet
-                    versions:
-                        - "< v2.3.999999"
-                        - ">= v2.3.a"
-                -   dependency-name: com.github.bumptech.glide:glide
-                    versions:
-                        - ">= 4.9.a"
-                        - "< 4.10"
-                -   dependency-name: com.github.bumptech.glide:glide
-                    versions:
-                        - ">= 4.a"
-                        - "< 5"
-                -   dependency-name: com.github.nextcloud:android-library
-                    versions:
-                        - "< 2"
-                        - ">= 1.a"
-                -   dependency-name: gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin
-                    versions:
-                        - ">= 1.6.10.a"
-                        - "< 1.6.11"
-                -   dependency-name: gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin
-                    versions:
-                        - ">= 1.6.11.a"
-                        - "< 1.6.12"
-                -   dependency-name: gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin
-                    versions:
-                        - ">= 1.7.0.a"
-                        - "< 1.7.1"
-                -   dependency-name: gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin
-                    versions:
-                        - ">= 1.7.1.a"
-                        - "< 1.7.2"
-                -   dependency-name: org.apache.jackrabbit:jackrabbit-webdav
-                    versions:
-                        - ">= 2.16.a"
-                        - "< 2.17"
-                -   dependency-name: org.apache.jackrabbit:jackrabbit-webdav
-                    versions:
-                        - ">= 2.17.a"
-                        - "< 2.18"
-                -   dependency-name: org.apache.jackrabbit:jackrabbit-webdav
-                    versions:
-                        - ">= 2.18.a"
-                        - "< 2.19"
-                -   dependency-name: org.apache.jackrabbit:jackrabbit-webdav
-                    versions:
-                        - ">= 2.19.a"
-                        - "< 2.20"
-                -   dependency-name: org.apache.jackrabbit:jackrabbit-webdav
-                    versions:
-                        - ">= 2.20.a"
-                        - "< 2.21"
-                -   dependency-name: org.apache.jackrabbit:jackrabbit-webdav
-                    versions:
-                        - ">= 2.21.a"
-                        - "< 2.22"
-                -   dependency-name: org.objenesis:objenesis
-                    versions:
-                        - "> 2.6"
-                -   dependency-name: pl.droidsonroids.gif:android-gif-drawable
-                    versions:
-                        - "< 1.2.17"
-                        - ">= 1.2.16.a"
-                -   dependency-name: pl.droidsonroids.gif:android-gif-drawable
-                    versions:
-                        - ">= 1.2.17.a"
-                        - "< 1.2.18"
+        directory: "/"
+        schedule:
+            interval: daily
+            time: "03:00"
+            timezone: Europe/Paris
+        open-pull-requests-limit: 10
+        labels:
+            - 2. to review
+            - dependencies


### PR DESCRIPTION
This was broken since https://github.com/nextcloud/android/commit/7af55b2e773d5ca25029a66b02d633f3e09a3ce3

As a consequence dependabot wasn't really reading the config file (resulting for example in PRs at any hour rather than only 3:00 AM), and parts of the admin UI were broken too.

I've also **removed the dependency ignores**, as they weren't being read anyway and we can use dependabot commands for that.

Additionally I've **disabled autorebasing of dependabot PRs** as it doesn't make much sense for us and creates too much load on CI.

- [x] Tests written, or not not needed