### PR TITLE
favorite/unfavorite in details view

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -44,6 +44,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
+import com.nextcloud.client.network.ClientFactory;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.MainApp;
@@ -55,8 +56,11 @@ import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;
+import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.network.OnDatatransferProgressListener;
+import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.files.ToggleFavoriteRemoteOperation;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
@@ -64,11 +68,16 @@ import com.owncloud.android.ui.activity.ToolbarActivity;
 import com.owncloud.android.ui.adapter.FileDetailTabAdapter;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.ui.dialog.RenameFileDialogFragment;
+import com.owncloud.android.ui.events.FavoriteEvent;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.theme.ThemeBarUtils;
 import com.owncloud.android.utils.theme.ThemeColorUtils;
 import com.owncloud.android.utils.theme.ThemeLayoutUtils;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 
 import java.lang.ref.WeakReference;
 
@@ -101,15 +110,17 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     @Inject AppPreferences preferences;
     @Inject ConnectivityService connectivityService;
     @Inject UserAccountManager accountManager;
+    @Inject ClientFactory clientFactory;
+    @Inject FileDataStorageManager storageManager;
 
     /**
      * Public factory method to create new FileDetailFragment instances.
-     *
+     * <p>
      * When 'fileToDetail' or 'ocAccount' are null, creates a dummy layout (to use when a file wasn't tapped before).
      *
-     * @param fileToDetail      An {@link OCFile} to show in the fragment
-     * @param user              Currently active user
-     * @return                  New fragment with arguments set
+     * @param fileToDetail An {@link OCFile} to show in the fragment
+     * @param user         Currently active user
+     * @return New fragment with arguments set
      */
     public static FileDetailFragment newInstance(OCFile fileToDetail, User user) {
         FileDetailFragment frag = new FileDetailFragment();
@@ -286,6 +297,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     public void onStart() {
         super.onStart();
         listenForTransferProgress();
+        EventBus.getDefault().register(this);
     }
 
     @Override
@@ -315,6 +327,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             toolbarActivity.hidePreviewImage();
         }
 
+        EventBus.getDefault().unregister(this);
         super.onStop();
     }
 
@@ -717,6 +730,28 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                                                                              FileDetailsSharingProcessFragment.TAG)
             .commit();
         showHideFragmentView(true);
+    }
+
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    public void onMessageEvent(FavoriteEvent event) {
+        try {
+            User user = accountManager.getUser();
+            OwnCloudClient client = clientFactory.create(user);
+
+            ToggleFavoriteRemoteOperation toggleFavoriteOperation = new ToggleFavoriteRemoteOperation(
+                event.shouldFavorite, event.remotePath);
+            RemoteOperationResult remoteOperationResult = toggleFavoriteOperation.execute(client);
+
+            if (remoteOperationResult.isSuccess()) {
+                getFile().setFavorite(event.shouldFavorite);
+                OCFile file = storageManager.getFileByEncryptedRemotePath(event.remotePath);
+                file.setFavorite(event.shouldFavorite);
+                storageManager.saveFile(file);
+            }
+
+        } catch (ClientFactory.CreationException e) {
+            Log_OC.e(TAG, "Error processing event", e);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/9035

This is rather a quick solution, as in long term we should get rid of this event bus and then decouple the remote operation to not have the logic twice.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

- [x] Tests written, or not not needed
