### PR TITLE
Remove unfavorited file from favorited search

### DIFF
--- a/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -209,10 +209,15 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return position;
     }
 
-    public void setFavoriteAttributeForItemID(String fileId, boolean favorite) {
+    public void setFavoriteAttributeForItemID(String fileId, boolean favorite, boolean removeFromList) {
         for (OCFile file : mFiles) {
             if (file.getRemoteId().equals(fileId)) {
                 file.setFavorite(favorite);
+
+                if (removeFromList) {
+                    mFiles.remove(file);
+                }
+                
                 break;
             }
         }
@@ -220,9 +225,15 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         for (OCFile file : mFilesAll) {
             if (file.getRemoteId().equals(fileId)) {
                 file.setFavorite(favorite);
+                
+                if (removeFromList) {
+                    mFiles.remove(file);
+                }
+                
                 break;
             }
         }
+        
 
         FileSortOrder sortOrder = preferences.getSortOrderByFolder(currentDirectory);
         mFiles = sortOrder.sortCloudFiles(mFiles);

--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1480,7 +1480,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
             RemoteOperationResult remoteOperationResult = toggleFavoriteOperation.execute(client);
 
             if (remoteOperationResult.isSuccess()) {
-                mAdapter.setFavoriteAttributeForItemID(event.remoteId, event.shouldFavorite);
+                boolean removeFromList = currentSearchType == SearchType.FAVORITE_SEARCH && !event.shouldFavorite;
+                mAdapter.setFavoriteAttributeForItemID(event.remoteId, event.shouldFavorite, removeFromList);
             }
 
         } catch (ClientFactory.CreationException e) {


### PR DESCRIPTION
Precondition: User has files on the Favorites screen.
1. Open the app
2. Tap on the hamburger menu
3. Tap Favorites
4. Open the context menu of any file
6. Remove from favourites

Expected Result
The file is no longer marked with a star and does not appear on the Favorites screen.

Actual Result
The file is not marked with a star, but it still appears on the favorites screen.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
