### PR TITLE
Upon select all in upload files activity, enable upload button

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -418,6 +418,8 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             selectAll.setIcon(
                 ThemeDrawableUtils.tintDrawable(R.drawable.ic_select_all, ThemeColorUtils.primaryColor(this)));
         }
+
+        uploadButton.setEnabled(checked);
     }
 
     @Override


### PR DESCRIPTION
1. Open the app
2. Tap on the + button
3. Tap upload files
4. Tap on the kebab menu > select all
5. Tap on upload


Expected Result
All selected files are uploaded.


Actual Result
Nothing happens when tapping the Hochladen button.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
