### PR TITLE
Remember selected files in upload files activity upon screen rotation

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -147,6 +147,7 @@
 
         <activity
             android:name=".ui.activity.UploadFilesActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="false" />
         <activity
             android:name=".ui.activity.ExternalSiteWebView"


### PR DESCRIPTION
Actions Performed
1. Open the app
2. Tap on the + button
3. Tap Upload files
4. Select any file
5. Rotate the screen


Expected Result
The file is still selected.


Actual Result
The file is unselected.



Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
