### PR TITLE
upload files activity: update select all button when selected files changed

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -546,6 +546,9 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     @Override
     public void onFileClick(File file) {
         uploadButton.setEnabled(mFileListFragment.getCheckedFilesCount() > 0);
+        
+        boolean selectAll = mFileListFragment.getCheckedFilesCount() == mFileListFragment.getFilesCount();
+        setSelectAllMenuItem(mOptionsMenu.findItem(R.id.action_select_all), selectAll);
     }
 
     /**

--- a/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -88,6 +88,10 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     public int getItemCount() {
         return mFiles.size() + 1;
     }
+    
+    public int getFilesCount() {
+        return mFiles.size();
+    }
 
     public boolean isCheckedFile(File file) {
         return checkedFiles.contains(file);

--- a/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -297,6 +297,10 @@ public class LocalFileListFragment extends ExtendedListFragment implements
     public int getCheckedFilesCount() {
         return mAdapter.checkedFilesCount();
     }
+    
+    public int getFilesCount() {
+        return mAdapter.getFilesCount();
+    }
 
     public void sortFiles(FileSortOrder sortOrder) {
         mSortButton.setText(DisplayUtils.getSortOrderStringId(sortOrder));


### PR DESCRIPTION
Actions Performed
1. Open the  app
2. Tap on the + button
3. Tap upload files
4. Tap on the kebab menu > select all
5. Unselect all files or one
6. Tap on the kebab menu


Expected Result
"select all" is no longer marked.


Actual Result
If all files are unselected, it is still marked "select all".

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
