### PR TITLE
if no shared files are on server, show correct empty message

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1442,6 +1442,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 case RECENTLY_MODIFIED_SEARCH:
                     setEmptyListMessage(SearchType.RECENTLY_MODIFIED_SEARCH);
                     break;
+                    
+                case SHARED_FILTER:
+                    setEmptyListMessage(SearchType.SHARED_FILTER);
+                    break;
 
                 default:
                     setEmptyListMessage(SearchType.NO_SEARCH);


### PR DESCRIPTION
TODO:
~- [ ] upon first showing shared files, for a short "empty list is" shown, but instead "loading…" should be shown~ Fixed by #9972 

Actions Performed
1. Open the  app
2. Open the hamburger menu
3. Tap on Shared


Expected Result
The files are displayed immediately or a file load icon/message is displayed.


Actual Result
The message that there are no files here is displayed for a few seconds, then the files are displayed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
