### PR TITLE
Refresh on favorite/shared view does search again, not showing root folder content

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1541,6 +1541,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
                     if (remoteOperationResult.isSuccess() && remoteOperationResult.getResultData() != null
                         && !isCancelled() && searchFragment) {
+                        searchEvent = event;
+                        
                         if (remoteOperationResult.getResultData() == null || ((List) remoteOperationResult.getResultData()).isEmpty()) {
                             setEmptyView(event);
                         } else {
@@ -1549,7 +1551,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
                                              storageManager,
                                              mFile,
                                              true);
-                            searchEvent = event;
                         }
 
                         final ToolbarActivity fileDisplayActivity = (ToolbarActivity) getActivity();


### PR DESCRIPTION
Fix #9317 

Steps to Reproduce:
1. start the app
2. tap on burgermenu
3. select "favorites"/ "Recent Files"
4. empty view is shown
5. perform gesture pull to refresh


Actual Results:
after pull to refresh root folder is displayed instead of favorites/Recent Files


Expected Results:
"no files here" is still shown

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
