### PR TITLE
Show correct empty screen if gallery search returns empty

### DIFF
--- a/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
+++ b/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
@@ -103,6 +103,7 @@ public class GallerySearchTask extends AsyncTask<Void, Void, RemoteOperationResu
             if (result.isSuccess() && result.getData() != null && !isCancelled()) {
                 if (result.getData() == null || result.getData().size() == 0) {
                     photoFragment.setSearchDidNotFindNewPhotos(true);
+                    photoFragment.setEmptyListMessage(ExtendedListFragment.SearchType.GALLERY_SEARCH);
                 } else {
                     OCFileListAdapter adapter = photoFragment.getAdapter();
 

--- a/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -685,6 +685,10 @@ public class ExtendedListFragment extends Fragment implements
                     setMessageForEmptyList(R.string.file_list_empty_shared_headline,
                                            R.string.file_list_empty_shared,
                                            R.drawable.ic_list_empty_shared);
+                } else if (searchType == SearchType.GALLERY_SEARCH) {
+                    setMessageForEmptyList(R.string.file_list_empty_headline_server_search,
+                                           R.string.file_list_empty_gallery,
+                                           R.drawable.file_image);
                 }
             }
         });

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1005,4 +1005,5 @@
     <string name="load_more_results">Load more results</string>
     <string name="file_management_permission">Permissions needed</string>
     <string name="file_management_permission_text">%1$s needs file management permissions to work properly. Please enable it in the following screen to continue.</string>
+    <string name="file_list_empty_gallery">Found no images or videos</string>
 </resources>


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/9375

Steps to test
- have no images/videos
- go to "media"
- see now a correct info
- previously it still showed "loading…"

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
