### PR TITLE
highlight correct menu drawer icon

### DIFF
--- a/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -119,6 +119,13 @@ public class TrashbinActivity extends DrawerActivity implements
         setupContent();
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        setDrawerMenuItemChecked(R.id.nav_trashbin);
+    }
+
     private void setupContent() {
         EmptyRecyclerView recyclerView = binding.list;
         recyclerView.setEmptyView(binding.emptyList.emptyListView);


### PR DESCRIPTION
Actions Performed
1. Open the app
2. Open the hamburger menu
3. Tap deleted files
3. Open the hamburger menu
4. Tap settings
5. Tap the back button
6. Open the hamburger menu


Expected Result
The deleted files item is highlighted because the user has returned to the deleted files screen.


Actual Result
The settings item is still highlighted in the menu.


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
