### PR TITLE
Explicitly set background for fragments

### DIFF
--- a/src/main/res/layout/file_details_sharing_menu_bottom_sheet_fragment.xml
+++ b/src/main/res/layout/file_details_sharing_menu_bottom_sheet_fragment.xml
@@ -25,6 +25,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:background="@color/bg_default"
     android:paddingTop="@dimen/standard_padding">
 
     <LinearLayout

--- a/src/main/res/layout/send_share_fragment.xml
+++ b/src/main/res/layout/send_share_fragment.xml
@@ -22,7 +22,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/bg_default">
 
     <RelativeLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fix #9399

I do not understand, why this is needed, as we do not do it on other occurrences, but it helps.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
