### PR TITLE
Fix swipe up glitch

### DIFF
--- a/src/main/res/layout/empty_list.xml
+++ b/src/main/res/layout/empty_list.xml
@@ -26,7 +26,8 @@
     android:layout_margin="@dimen/standard_margin"
     android:gravity="center_vertical|center_horizontal"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/standard_double_margin">
+    android:paddingBottom="@dimen/standard_double_margin"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <ImageView
         android:id="@+id/empty_list_icon"

--- a/src/main/res/layout/list_fragment.xml
+++ b/src/main/res/layout/list_fragment.xml
@@ -33,7 +33,8 @@
         <com.owncloud.android.ui.EmptyRecyclerView
             android:id="@+id/list_root"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <include


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/9403

- allow swipe up on second folder hierarchy
- disallow swipe up on empty folder

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
