### PR TITLE
Empty list is not centered and in landscape cut off

### DIFF
--- a/src/main/res/layout/empty_list.xml
+++ b/src/main/res/layout/empty_list.xml
@@ -19,14 +19,15 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/empty_list_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
     android:layout_margin="@dimen/standard_margin"
-    android:gravity="center_vertical|center_horizontal"
+    android:gravity="center_horizontal"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/standard_double_margin">
+    android:paddingTop="@dimen/standard_double_margin">
 
     <ImageView
         android:id="@+id/empty_list_icon"
@@ -34,7 +35,8 @@
         android:layout_height="@dimen/empty_list_icon_layout_height"
         android:contentDescription="@string/file_list_folder"
         android:src="@drawable/ic_list_empty_folder"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/empty_list_view_headline"
@@ -59,7 +61,8 @@
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingBottom="@dimen/standard_half_padding"
         android:text="@string/file_list_empty"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/empty_list_view_action"
@@ -68,5 +71,6 @@
         android:layout_marginTop="@dimen/standard_half_margin"
         android:theme="@style/Button.Primary"
         android:visibility="gone"
-        app:cornerRadius="@dimen/button_corner_radius" />
+        app:cornerRadius="@dimen/button_corner_radius"
+        tools:visibility="visible" />
 </LinearLayout>


### PR DESCRIPTION
Therefore as a quick win, moved all up, so that user does not think it should be centered.
This also then works in landscape.

Real solution is to compute height of toolbar and then programmatically (depending on orientation) center it.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
