### PR TITLE
Upon move update folder size

### DIFF
--- a/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -468,6 +468,9 @@ public class RefreshFolderOperation extends RemoteOperation {
         // update eTag
         mLocalFolder.setEtag(remoteFolder.getEtag());
 
+        // update size
+        mLocalFolder.setFileLength(remoteFolder.getFileLength());
+
         DecryptedFolderMetadata metadata = getDecryptedFolderMetadata(encryptedAncestor,
                                                                       mLocalFolder,
                                                                       getClient(),


### PR DESCRIPTION
Actions Performed
Precondition user is logged in

1. Open the app
2. Tap on the three dots beside any photo.
3. Tap on move
4. Choose an empty folder
5. Tap on the folder you just added the photo in it
6. Tap on the three dots beside the photo
7. Tap on move
8. Choose all files and complete the operation


Expected Result
The folder shows "No Files here" again as before adding the photo


Actual Result
"Loading" is shown even after refreshing the vie

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
