### PR TITLE
when re-logging in too fast, we stored an empty auth token

### DIFF
--- a/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1279,6 +1279,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
             mAccount = newAccount;
             mAccountMgr.addAccountExplicitly(mAccount, webViewPassword, null);
+            mAccountMgr.notifyAccountAuthenticated(mAccount);
 
             // add the new account as default in preferences, if there is none already
             User defaultAccount = accountManager.getUser();


### PR DESCRIPTION
Steps
- remove account
- sign up with same user/password
- see that you got a 401 (or you would have to wait >1min)
- now it works

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
