### PR TITLE
Fix upload button not active unless select all is clicked

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -296,10 +296,10 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
                 onBackPressed();
             }
         } else if (itemId == R.id.action_select_all) {
-            item.setChecked(!item.isChecked());
-            mSelectAll = item.isChecked();
+            mSelectAll = !item.isChecked();
+            item.setChecked(mSelectAll);
+            mFileListFragment.selectAllFiles(mSelectAll);
             setSelectAllMenuItem(item, mSelectAll);
-            mFileListFragment.selectAllFiles(item.isChecked());
         } else if (itemId == R.id.action_choose_storage_path) {
             showLocalStoragePathPickerDialog();
         } else {
@@ -410,6 +410,11 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
         return !mDirectories.isEmpty();
     }
 
+    private void updateUploadButtonActive() {
+        final boolean anySelected = mFileListFragment.getCheckedFilesCount() > 0;
+        uploadButton.setEnabled(anySelected);
+    }
+
     private void setSelectAllMenuItem(MenuItem selectAll, boolean checked) {
         selectAll.setChecked(checked);
         if (checked) {
@@ -418,8 +423,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             selectAll.setIcon(
                 ThemeDrawableUtils.tintDrawable(R.drawable.ic_select_all, ThemeColorUtils.primaryColor(this)));
         }
-
-        uploadButton.setEnabled(checked);
+        updateUploadButtonActive();
     }
 
     @Override
@@ -548,7 +552,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     @Override
     public void onFileClick(File file) {
         uploadButton.setEnabled(mFileListFragment.getCheckedFilesCount() > 0);
-        
+
         boolean selectAll = mFileListFragment.getCheckedFilesCount() == mFileListFragment.getFilesCount();
         setSelectAllMenuItem(mOptionsMenu.findItem(R.id.action_select_all), selectAll);
     }


### PR DESCRIPTION
Follow up to #9444, which accidentally broke the button behaviour unless Select All was clicked.

This was because the selectAllMenuItem is called elsewhere, and sometimes it's called with a `false` value even though there 
are some files selected.

Found this while testing other stuff.
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed