### PR TITLE
DatePickerDialog: fix theme

### DIFF
--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -76,17 +76,16 @@
         <item name="colorError">@color/primary</item>
     </style>
 
-    <style name="FallbackDatePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
+    <style name="FallbackDatePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog">
         <item name="colorPrimary">@color/bg_default</item>
+        <item name="colorAccent">@color/bg_fallback_highlight</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:windowBackground">@color/bg_default</item>
         <item name="android:textColor">@color/fg_inverse</item>
         <item name="android:datePickerStyle">@style/DatePickerStyle</item>
-        <item name="colorControlHighlight">@color/bg_fallback_highlight</item>
-        <item name="colorControlActivated">@color/bg_fallback_highlight</item>
     </style>
 
-    <style name="DatePickerStyle" parent="">
+    <style name="DatePickerStyle">
         <item name="android:headerBackground">@color/bg_fallback_highlight</item>
         <item name="android:datePickerMode">calendar</item>
     </style>


### PR DESCRIPTION
Extend from Dialog, not Dialog.Alert.

Fixes #9377

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed