### PR TITLE
FileDisplayActivity: Preserve title bar after resume

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1168,7 +1168,11 @@ public class FileDisplayActivity extends FileActivity
             localBroadcastManager.registerReceiver(mSyncBroadcastReceiver, syncIntentFilter);
         }
 
+
         if (!(leftFragment instanceof OCFileListFragment)) {
+            if (leftFragment instanceof FileFragment) {
+                super.updateActionBarTitleAndHomeButton(((FileFragment) leftFragment).getFile());
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes title bar reverting to searchbar even if the resumed fragment is the preview or the details fragments



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed