### PR TITLE
Change naming in conflicts to location instead of date

### DIFF
--- a/src/main/res/layout/conflict_resolve_dialog.xml
+++ b/src/main/res/layout/conflict_resolve_dialog.xml
@@ -64,7 +64,7 @@
                 android:id="@+id/new_checkbox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/conflict_new_file" />
+                android:text="@string/conflict_local_file" />
 
             <ImageView
                 android:id="@+id/new_thumbnail"
@@ -98,7 +98,7 @@
                 android:id="@+id/existing_checkbox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/conflict_already_existing_file" />
+                android:text="@string/conflict_server_file" />
 
             <ImageView
                 android:id="@+id/existing_thumbnail"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -910,8 +910,8 @@
     <string name="sync_not_enough_space_dialog_title">Not enough space</string>
     <string name="conflict_file_headline">Conflicting file %1$s</string>
     <string name="conflict_message_description">If you select both versions, the local file will have a number appended to its name.</string>
-    <string name="conflict_new_file">New file</string>
-    <string name="conflict_already_existing_file">Already existing file</string>
+    <string name="conflict_local_file">Local file</string>
+    <string name="conflict_server_file">Server file</string>
     <string name="thumbnail_for_new_file_desc">Thumbnail for new file</string>
     <string name="thumbnail_for_existing_file_description">Thumbnail for existing file</string>
     <string name="invalid_url">Invalid URL</string>


### PR DESCRIPTION
- [x] Tests not not needed

Hi, I had following experience and wanted to make it better: I downloaded/synchronized a file to my android phone. I edited the file on my mobile via an offline editor (markor). Later I made some changes to the file in the cloud. When I tried to sync the files from the android app, the conflicts dialog popped up with `New File` and `Already existing file`. I was stuck as I had no clue which file was which: I didn't create a new file and my changes to the local file were made before the changes to the cloud file. That's why I propose to describe these files with `Local file` and `File in cloud`. 

Other options I can think of are:
* `New file (local)`
* `Cloud file`
* `File already in cloud`
* `Already existing file (cloud)`

I am a total newbie to contributing to FLOSS and appreciate any hints about how to fit in your processes.