### PR TITLE
Do not set notification manager to null in uploader service

### DIFF
--- a/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -264,7 +264,6 @@ public class FileUploader extends Service
     /**
      * Service clean up
      */
-    @SuppressWarnings("PMD.NullAssignment")
     @Override
     public void onDestroy() {
         Log_OC.v(TAG, "Destroying service");
@@ -275,12 +274,9 @@ public class FileUploader extends Service
         if (mNotificationManager != null) {
             mNotificationManager.cancel(FOREGROUND_SERVICE_ID);
         }
-        mNotificationManager = null;
-
         // remove AccountsUpdatedListener
         AccountManager am = AccountManager.get(getApplicationContext());
         am.removeOnAccountsUpdatedListener(this);
-
         super.onDestroy();
     }
 
@@ -855,7 +851,6 @@ public class FileUploader extends Service
             if (!uploadResult.isSuccess()) {
                 mNotificationManager.notify((new SecureRandom()).nextInt(), mNotificationBuilder.build());
             }
-
         }
     }
 


### PR DESCRIPTION
NPE is most likely caused by a race condition, when
file upload update arrives after onDestroy().

Do not set notification manager to null - it does not
make any sense anyway, as it's a system service.

Fixes #9390

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>
