### PR TITLE
UploadFilesActivity: don't attempt to check selectAll if selectAll is not visible in menu

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -462,14 +462,16 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     }
 
     private void setSelectAllMenuItem(MenuItem selectAll, boolean checked) {
-        selectAll.setChecked(checked);
-        if (checked) {
-            selectAll.setIcon(R.drawable.ic_select_none);
-        } else {
-            selectAll.setIcon(
-                ThemeDrawableUtils.tintDrawable(R.drawable.ic_select_all, ThemeColorUtils.primaryColor(this)));
+        if (selectAll != null) {
+            selectAll.setChecked(checked);
+            if (checked) {
+                selectAll.setIcon(R.drawable.ic_select_none);
+            } else {
+                selectAll.setIcon(
+                    ThemeDrawableUtils.tintDrawable(R.drawable.ic_select_all, ThemeColorUtils.primaryColor(this)));
+            }
+            updateUploadButtonActive();
         }
-        updateUploadButtonActive();
     }
 
     @Override


### PR DESCRIPTION
This was crashing autoupload settings.



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed