### PR TITLE
URI permissions

### DIFF
--- a/src/main/java/com/nextcloud/client/utils/IntentUtil.kt
+++ b/src/main/java/com/nextcloud/client/utils/IntentUtil.kt
@@ -1,0 +1,56 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Álvaro Brey Vilas
+ * Copyright (C) 2021 Álvaro Brey Vilas
+ * Copyright (C) 2021 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.client.utils
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.owncloud.android.datamodel.OCFile
+
+object IntentUtil {
+
+    @JvmStatic
+    public fun createSendIntent(context: Context, file: OCFile): Intent =
+        createBaseSendFileIntent().apply {
+            type = file.mimeType
+            putExtra(Intent.EXTRA_STREAM, file.getExposedFileUri(context))
+        }
+
+    @JvmStatic
+    public fun createSendIntent(context: Context, files: Array<OCFile>): Intent =
+        createBaseSendFileIntent().apply {
+            type = getUniqueMimetype(files)
+            putExtra(Intent.EXTRA_STREAM, getExposedFileUris(context, files))
+        }
+
+    private fun createBaseSendFileIntent(): Intent =
+        Intent(Intent.ACTION_SEND).apply {
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
+    private fun getUniqueMimetype(files: Array<OCFile>): String? = when {
+        files.distinctBy { it.mimeType }.size > 1 -> null
+        else -> files[0].mimeType
+    }
+
+    private fun getExposedFileUris(context: Context, files: Array<OCFile>): Array<Uri> =
+        files.map { it.getExposedFileUri(context) }.toTypedArray()
+}

--- a/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -58,6 +58,7 @@ import com.nextcloud.client.files.DeepLinkHandler;
 import com.nextcloud.client.media.PlayerServiceConnection;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.client.utils.IntentUtil;
 import com.nextcloud.java.util.Optional;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -2098,11 +2099,8 @@ public class FileDisplayActivity extends FileActivity
 
     private void sendDownloadedFile(String packageName, String activityName) {
         if (mWaitingToSend != null) {
-            Intent sendIntent = new Intent(Intent.ACTION_SEND);
-            sendIntent.setType(mWaitingToSend.getMimeType());
-            sendIntent.putExtra(Intent.EXTRA_STREAM, mWaitingToSend.getExposedFileUri(this));
-            sendIntent.putExtra(Intent.ACTION_SEND, true);
 
+            Intent sendIntent = IntentUtil.createSendIntent(this, mWaitingToSend);
             sendIntent.setComponent(new ComponentName(packageName, activityName));
 
             // Show dialog

--- a/src/main/java/com/owncloud/android/ui/dialog/SendFilesDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SendFilesDialog.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+import com.nextcloud.client.utils.IntentUtil;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.ui.adapter.SendButtonAdapter;
@@ -80,7 +81,7 @@ public class SendFilesDialog extends BottomSheetDialogFragment {
         View view = inflater.inflate(R.layout.send_files_fragment, container, false);
 
         // populate send apps
-        Intent sendIntent = createSendIntent();
+        Intent sendIntent = IntentUtil.createSendIntent(requireContext(), files);
 
         List<SendButtonData> sendButtonDataList = setupSendButtonData(sendIntent);
 
@@ -123,37 +124,5 @@ public class SendFilesDialog extends BottomSheetDialogFragment {
             sendButtonDataList.add(sendButtonData);
         }
         return sendButtonDataList;
-    }
-
-    @NonNull
-    private Intent createSendIntent() {
-        Intent sendIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
-        sendIntent.setType(getUniqueMimetype());
-        sendIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, getExposedFileUris());
-        sendIntent.putExtra(Intent.ACTION_SEND, true);
-        return sendIntent;
-    }
-
-    @Nullable
-    private String getUniqueMimetype() {
-        String mimetype = files[0].getMimeType();
-
-        for (OCFile file : files) {
-            if (!mimetype.equals(file.getMimeType())) {
-                return null;
-            }
-        }
-
-        return mimetype;
-    }
-
-    private ArrayList<Uri> getExposedFileUris() {
-        ArrayList<Uri> uris = new ArrayList<>();
-
-        for (OCFile file : files) {
-            uris.add(file.getExposedFileUri(requireContext()));
-        }
-
-        return uris;
     }
 }

--- a/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.client.utils.IntentUtil;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -155,7 +156,7 @@ public class SendShareDialog extends BottomSheetDialogFragment {
         }
 
         // populate send apps
-        Intent sendIntent = createSendIntent();
+        Intent sendIntent = IntentUtil.createSendIntent(requireContext(), file);
 
         List<SendButtonData> sendButtonDataList = setupSendButtonData(sendIntent);
 
@@ -264,15 +265,6 @@ public class SendShareDialog extends BottomSheetDialogFragment {
             sendButtonDataList.add(sendButtonData);
         }
         return sendButtonDataList;
-    }
-
-    @NonNull
-    private Intent createSendIntent() {
-        Intent sendIntent = new Intent(Intent.ACTION_SEND);
-        sendIntent.setType(file.getMimeType());
-        sendIntent.putExtra(Intent.EXTRA_STREAM, file.getExposedFileUri(getActivity()));
-        sendIntent.putExtra(Intent.ACTION_SEND, true);
-        return sendIntent;
     }
 
     private void shareFile(OCFile file) {

--- a/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -405,7 +405,6 @@ public class FileOperationsHelper {
             String guessedMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt);
             if (guessedMimeType != null) {
                 openFileWithIntent = new Intent(Intent.ACTION_VIEW);
-                openFileWithIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
                 openFileWithIntent.setDataAndType(
                         fileUri,
                         guessedMimeType


### PR DESCRIPTION
Fixes #8845

* For `FileProvider`: centralize intent creation and explicitly grant `READ_URI` permision when sharing files.

`DocumentStorageProvider` is already using uri permissions explicitly.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed