### PR TITLE
Player: don't try to pause a non-running media player

### DIFF
--- a/src/main/java/com/nextcloud/client/media/Player.kt
+++ b/src/main/java/com/nextcloud/client/media/Player.kt
@@ -152,8 +152,10 @@ internal class Player(
 
         override fun onPausePlayback() {
             trace("onPausePlayback()")
-            mediaPlayer?.pause()
-            listener?.onPause()
+            if (mediaPlayer?.isPlaying == true) {
+                mediaPlayer?.pause()
+                listener?.onPause()
+            }
         }
 
         override fun onRequestFocus() {


### PR DESCRIPTION
Fixes an issue triggered by pausing, and then minimizing and coming back to the app.

Right now state is still lost (file returns to the beginning) but as a stopgap it's OK.
In the future, the state machine and how it interacts with the fragment should be reworked.



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed