### PR TITLE
DocumentsStorageProviderIT: add timeout to testServerChangedFileContent()

### DIFF
--- a/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
+++ b/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
@@ -176,7 +176,8 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
         assertExistsOnServer(client, ocFile1.remotePath, false)
     }
 
-    @Test
+    @Suppress("MagicNumber")
+    @Test(timeout = 5 * 60 * 1000)
     fun testServerChangedFileContent() {
         // create random file
         val file1 = rootDir.createFile("text/plain", RandomString.make())!!


### PR DESCRIPTION
This test sometimes hangs forever, resulting in (for example) CI builds being killed.
This way, only this test fails and the rest of the suite continues.



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed