### PR TITLE
Fix for too many thumbnails in autoupload settings

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/ContentResolverHelper.kt
+++ b/src/main/java/com/owncloud/android/datamodel/ContentResolverHelper.kt
@@ -58,7 +58,7 @@ object ContentResolverHelper {
             "Invalid sort direction"
         }
         return when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
                 val queryArgs = getQueryArgsBundle(selection, sortColumn, sortDirection, limit)
                 contentResolver.query(uri, projection, queryArgs, cancellationSignal)
             }
@@ -90,7 +90,7 @@ object ContentResolverHelper {
         return sortOrderBuilder.toString()
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.R)
     private fun
     getQueryArgsBundle(selection: String?, sortColumn: String?, sortDirection: String?, limit: Int?): Bundle {
         return Bundle().apply {

--- a/src/main/java/com/owncloud/android/datamodel/MediaProvider.java
+++ b/src/main/java/com/owncloud/android/datamodel/MediaProvider.java
@@ -123,8 +123,8 @@ public final class MediaProvider {
 
                 if (cursorImages != null) {
                     String filePath;
-
-                    while (cursorImages.moveToNext()) {
+                    int imageCount = 0;
+                    while (cursorImages.moveToNext() && imageCount < itemLimit) {
                         filePath = cursorImages.getString(cursorImages.getColumnIndexOrThrow(
                             MediaStore.MediaColumns.DATA));
 
@@ -133,6 +133,8 @@ public final class MediaProvider {
                             mediaFolder.filePaths.add(filePath);
                             mediaFolder.absolutePath = filePath.substring(0, filePath.lastIndexOf('/'));
                         }
+                        // ensure we don't go over the limit due to faulty android implementations
+                        imageCount++;
                     }
                     cursorImages.close();
 
@@ -241,7 +243,8 @@ public final class MediaProvider {
 
                 if (cursorVideos != null) {
                     String filePath;
-                    while (cursorVideos.moveToNext()) {
+                    int videoCount = 0;
+                    while (cursorVideos.moveToNext() && videoCount < itemLimit) {
                         filePath = cursorVideos.getString(cursorVideos.getColumnIndexOrThrow(
                             MediaStore.MediaColumns.DATA));
 
@@ -249,6 +252,8 @@ public final class MediaProvider {
                             mediaFolder.filePaths.add(filePath);
                             mediaFolder.absolutePath = filePath.substring(0, filePath.lastIndexOf('/'));
                         }
+                        // ensure we don't go over the limit due to faulty android implementations
+                        videoCount++;
                     }
                     cursorVideos.close();
 


### PR DESCRIPTION
This patch is twofold:
- Keep using SQL limit until android 11 (which is where it becomes mandatory to not use it). This should make the second step unnecessary in most cases.
- Force MediaProvider to stop querying images after limit has been reached, even if cursor contains more.
This handles the edge case of Android versions over 11 which don't properly implement the limit argument.

Fixes #9311

It maybe also does something for #8863, we'll see after release

Special thanks to @tleb for analysis and debugging.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed