### PR TITLE
ChooseTemplateDialog: Fix crash on prefillFilenameIfEmpty

### DIFF
--- a/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
+++ b/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
@@ -248,10 +248,10 @@ public class ChooseTemplateDialogFragment extends DialogFragment implements View
         String name = binding.filename.getText().toString();
         if (name.isEmpty() || name.equalsIgnoreCase(DOT + template.getExtension())) {
             binding.filename.setText(String.format("%s.%s", template.title, template.extension));
+            name = binding.filename.getText().toString();
+            int dotPos = name.lastIndexOf('.');
+            binding.filename.setSelection((dotPos != -1) ? dotPos : name.length());
         }
-        name = binding.filename.getText().toString();
-        int dotPos = name.lastIndexOf('.');
-        binding.filename.setSelection((dotPos != -1) ? dotPos : name.length());
     }
 
     @Override


### PR DESCRIPTION
Don't do anything if the filename is not empty.

Fixes #9640

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed