### PR TITLE
Codecov: wait for CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,6 @@ codecov:
   branch: master
   ci:
     - drone.nextcloud.com
-  require_ci_to_pass: false
 
 coverage:
   precision: 2


### PR DESCRIPTION
Now that we don't have a permanently broken CI setup, this makes sense again, so we don't get coverage results based on partial tests



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed