### PR TITLE
SessionMixin: set currentAccount to null when no accounts are available

### DIFF
--- a/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
+++ b/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
@@ -91,6 +91,7 @@ class SessionMixin constructor(
         val newAccount = accountManager.currentAccount
         if (newAccount == null) {
             // no account available: force account creation
+            currentAccount = null
             startAccountCreation()
         } else {
             currentAccount = newAccount


### PR DESCRIPTION
Prevents a crash when removing the last account


Fixes #9695
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed