### PR TITLE
Codecov: don't annotate diffs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,6 +16,9 @@ comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default
 
+github_checks:
+    annotations: false
+
 ignore:
   - "src/main/res/values*/*"
 


### PR DESCRIPTION
It makes it really annoying to read diffs when our coverage isn't that good yet.



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed