### PR TITLE
PassCodeActivity: enable cancel button when re-created in confirmation step

### DIFF
--- a/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -141,8 +141,8 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                 binding.header.setText(R.string.pass_code_configure_your_pass_code);
 
                 binding.explanation.setVisibility(View.VISIBLE);
-                setCancelButtonEnabled(true);
             }
+            setCancelButtonEnabled(true);
 
         } else if (ACTION_CHECK_WITH_RESULT.equals(getIntent().getAction())) {
             // pass code preference has just been disabled in SettingsActivity;


### PR DESCRIPTION
Prevents a bug where the cancel button would stop working if the device was rotated



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed