### PR TITLE
FileContentProvider: fix crash on certain upgrades

### DIFF
--- a/src/main/java/com/owncloud/android/providers/FileContentProvider.java
+++ b/src/main/java/com/owncloud/android/providers/FileContentProvider.java
@@ -722,7 +722,7 @@ public class FileContentProvider extends ContentProvider {
 
     private boolean checkIfColumnExists(SQLiteDatabase database, String table, String column) {
         Cursor cursor = database.rawQuery("SELECT * FROM " + table + " LIMIT 0", null);
-        boolean exists = cursor.getColumnIndexOrThrow(column) != -1;
+        boolean exists = cursor.getColumnIndex(column) != -1;
         cursor.close();
 
         return exists;


### PR DESCRIPTION
`checkIfColumnExists` should not use `getColumnIndexOrThrow`, as it's supposed to check if the index doesn't exist

Found the crash in GPlay reports

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed