### PR TITLE
Revert "Bump exoplayer from 2.16.1 to 2.17.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ dependencies {
     ktlint "com.pinterest:ktlint:0.44.0"
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.17.0'
+    implementation 'com.google.android.exoplayer:exoplayer:2.16.1'
 
     // Shimmer animation
     implementation 'com.elyeproj.libraries:loaderviewlibrary:2.0.0'


### PR DESCRIPTION
Breaks instrumented test dependencies for some reason

This reverts commit b089ca76a497c95d7f38786895ea5a11b252b563.


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed