### PR TITLE
OCFile: fix NPE in getLocalId when remoteID is null

### DIFF
--- a/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -41,6 +41,7 @@ import java.io.File;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.FileProvider;
 import third_parties.daveKoeller.AlphanumComparator;
@@ -547,8 +548,13 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
      *
      * @return file fileId, unique within the instance
      */
+    @Nullable
     public String getLocalId() {
-        return getRemoteId().substring(0, 8).replaceAll("^0*", "");
+        if (getRemoteId() != null) {
+            return getRemoteId().substring(0, 8).replaceAll("^0*", "");
+        } else {
+            return null;
+        }
     }
 
     public boolean isInConflict() {


### PR DESCRIPTION
Follow up to #9893

getLocalId() directly depends on getRemoteId() and throws a NPE if remoteId is not set.

Instead, let's just return `null` if remoteId() is not set. This crash was detected in screenshot tests

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed