### PR TITLE
GalleryFragment: restore title and fab on resume

### DIFF
--- a/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -27,12 +27,15 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.asynctasks.GallerySearchTask;
 import com.owncloud.android.ui.events.ChangeMenuEvent;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -107,6 +110,12 @@ public class GalleryFragment extends OCFileListFragment {
     public void onResume() {
         super.onResume();
         setLoading(photoSearchQueryRunning);
+        final FragmentActivity activity = getActivity();
+        if (activity instanceof FileDisplayActivity) {
+            FileDisplayActivity fileDisplayActivity = ((FileDisplayActivity) activity);
+            fileDisplayActivity.updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_item_gallery));
+            fileDisplayActivity.setMainFabVisible(false);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #8528

Note: This sort of logic seems to be necessary in most fragments. Idea for the future:

- Fragments used in FDA implement an interface that returns whether to show sort list, change titlebar, and/or show FAB.
- FDA reads those values from the fragment on `setLeftFragment` and `onResume` and changes view visibilities accordingly.

(a better way would be to have a shared ViewModel between the activity and fragment, but we may be a bit too far from that happening)

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed