### PR TITLE
[stable-3.19] build.gradle: Restore juniversalchardet to 2.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ dependencies {
     implementation "androidx.work:work-runtime:$workRuntime"
     implementation "androidx.work:work-runtime-ktx:$workRuntime"
     implementation "androidx.fragment:fragment-ktx:1.4.0"
-    implementation 'com.github.albfernandez:juniversalchardet:2.3.2' // need this version for Android <7
+    implementation 'com.github.albfernandez:juniversalchardet:2.0.3' // need this version for Android <7
     compileOnly 'com.google.code.findbugs:annotations:3.0.1u2'
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.greenrobot:eventbus:3.3.1'


### PR DESCRIPTION
Newer versions cause crashes in android < 7. This was mistakenly bumped in dependabot

Manual backport of #9940


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->