### PR TITLE
Fix sharing from media view

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -877,10 +877,11 @@ public abstract class FileActivity extends DrawerActivity
 
     /**
      * open the new sharing process fragment to create the share
+     *
      * @param shareeName
      * @param shareType
      */
-    private void doShareWith(String shareeName, ShareType shareType) {
+    protected void doShareWith(String shareeName, ShareType shareType) {
         FileDetailFragment fragment = getFileDetailFragment();
         if (fragment != null) {
             fragment.initiateSharingProcess(shareeName, shareType);

--- a/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -37,8 +37,10 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation;
 import com.owncloud.android.lib.resources.files.model.RemoteFile;
+import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.operations.GetSharesForFileOperation;
 import com.owncloud.android.ui.fragment.FileDetailSharingFragment;
+import com.owncloud.android.ui.fragment.FileDetailsSharingProcessFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.theme.ThemeColorUtils;
@@ -133,9 +135,19 @@ public class ShareActivity extends FileActivity {
         refreshSharesFromStorageManager();
     }
 
+    @Override
+    protected void doShareWith(String shareeName, ShareType shareType) {
+        getSupportFragmentManager().beginTransaction().replace(R.id.share_fragment_container,
+                                                               FileDetailsSharingProcessFragment.newInstance(getFile(),
+                                                                                                             shareeName,
+                                                                                                             shareType),
+                                                               FileDetailsSharingProcessFragment.TAG)
+            .commit();
+    }
+
     /**
-     * Updates the view associated to the activity after the finish of some operation over files
-     * in the current account.
+     * Updates the view associated to the activity after the finish of some operation over files in the current
+     * account.
      *
      * @param operation Removal operation performed.
      * @param result    Result of the removal.
@@ -174,5 +186,10 @@ public class ShareActivity extends FileActivity {
      */
     private FileDetailSharingFragment getShareFileFragment() {
         return (FileDetailSharingFragment) getSupportFragmentManager().findFragmentByTag(TAG_SHARE_FRAGMENT);
+    }
+
+    @Override
+    public void onShareProcessClosed() {
+        finish();
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -162,6 +162,7 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
 
     private fun showShareProcessFirst() {
         binding.shareProcessGroupOne.visibility = View.VISIBLE
+        binding.shareProcessEditShareLink.visibility = View.VISIBLE
         binding.shareProcessGroupTwo.visibility = View.GONE
 
         // set up UI for modifying share

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -309,6 +309,7 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
      */
     private fun showShareProcessSecond() {
         binding.shareProcessGroupOne.visibility = View.GONE
+        binding.shareProcessEditShareLink.visibility = View.GONE
         binding.shareProcessGroupTwo.visibility = View.VISIBLE
         if (share != null) {
             binding.shareProcessBtnNext.text = requireContext().resources.getString(R.string.set_note)

--- a/app/src/main/res/layout/file_details_sharing_process_fragment.xml
+++ b/app/src/main/res/layout/file_details_sharing_process_fragment.xml
@@ -24,12 +24,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:minHeight="400dp"
     android:focusable="true"
     android:focusableInTouchMode="true">
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        android:minHeight="400dp"
         android:padding="@dimen/standard_padding"
         app:layout_constraintBottom_toTopOf="@+id/share_process_btn_cancel"
         app:layout_constraintEnd_toEndOf="parent"
@@ -213,7 +215,7 @@
                 android:textColor="@color/secondary_text_color"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/share_process_edit_share_link"/>
+                app:layout_constraintTop_toBottomOf="@+id/share_process_edit_share_link" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/note_container"

--- a/app/src/main/res/layout/file_details_sharing_process_fragment.xml
+++ b/app/src/main/res/layout/file_details_sharing_process_fragment.xml
@@ -30,8 +30,7 @@
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="400dp"
+        android:layout_height="0dp"
         android:padding="@dimen/standard_padding"
         app:layout_constraintBottom_toTopOf="@+id/share_process_btn_cancel"
         app:layout_constraintEnd_toEndOf="parent"
@@ -40,7 +39,8 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:minHeight="400dp">
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/share_process_edit_share_link"

--- a/app/src/main/res/layout/share_activity.xml
+++ b/app/src/main/res/layout/share_activity.xml
@@ -74,6 +74,6 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/share_fragment_container"></FrameLayout>
+        android:id="@+id/share_fragment_container" />
 
 </LinearLayout>


### PR DESCRIPTION
- open media view
- select an image
- select send/share
- share to an user

This now works, but it is too small, and I have no clue where this size is set:
![image](https://user-images.githubusercontent.com/5836855/157815839-0c0f02da-469e-4e7c-9a6b-29505b459fca.png)
@AlvaroBrey do you have an idea?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
