### PR TITLE
Allow using `Downloads` as a storage location

### DIFF
--- a/app/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java
@@ -24,10 +24,9 @@ package com.owncloud.android.datastorage;
 import android.os.Environment;
 
 import com.owncloud.android.MainApp;
+import com.owncloud.android.utils.PermissionUtil;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author Bartosz Przybylski
@@ -48,10 +47,9 @@ public class DataStorageProvider {
             return mCachedStoragePoints.toArray(new StoragePoint[0]);
         }
 
-        List<String> paths = new ArrayList<>();
         StoragePoint storagePoint;
         for (File f : MainApp.getAppContext().getExternalMediaDirs()) {
-            if (f != null && !paths.contains(f.getAbsolutePath())) {
+            if (f != null) {
                 storagePoint = new StoragePoint();
                 storagePoint.setPath(f.getAbsolutePath());
                 storagePoint.setDescription(f.getAbsolutePath());
@@ -75,9 +73,7 @@ public class DataStorageProvider {
         storagePoint.setPath(MainApp.getAppContext().getFilesDir().getAbsolutePath());
         storagePoint.setPrivacyType(StoragePoint.PrivacyType.PRIVATE);
         storagePoint.setStorageType(StoragePoint.StorageType.INTERNAL);
-        if (!paths.contains(MainApp.getAppContext().getFilesDir().getAbsolutePath())) {
             mCachedStoragePoints.add(storagePoint);
-        }
 
         // Add external storage directory if available.
         if (isExternalStorageWritable()) {
@@ -91,11 +87,21 @@ public class DataStorageProvider {
                 storagePoint.setDescription(externalFilesDirPath);
                 storagePoint.setPrivacyType(StoragePoint.PrivacyType.PRIVATE);
                 storagePoint.setStorageType(StoragePoint.StorageType.EXTERNAL);
-                if (!paths.contains(externalFilesDirPath)) {
-                    mCachedStoragePoints.add(storagePoint);
-                }
+                mCachedStoragePoints.add(storagePoint);
             }
         }
+
+        // Add Downloads subfolder, if the app has permission for external storage
+        if (PermissionUtil.checkExternalStoragePermission(MainApp.getAppContext(), true)) {
+            File downloadsFolder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            storagePoint = new StoragePoint();
+            storagePoint.setPath(downloadsFolder.getAbsolutePath());
+            storagePoint.setDescription(downloadsFolder.getAbsolutePath());
+            storagePoint.setPrivacyType(StoragePoint.PrivacyType.PUBLIC);
+            storagePoint.setStorageType(StoragePoint.StorageType.EXTERNAL);
+            mCachedStoragePoints.add(storagePoint);
+        }
+
 
         return mCachedStoragePoints.toArray(new StoragePoint[0]);
     }

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -91,14 +91,16 @@ object PermissionUtil {
      *
      * Under sdk 30 we use WRITE_EXTERNAL_STORAGE
      *
+     * @param writeRequired whether we need write permission for storage, or just read. Defaults to `false`
+     *
      * @return `true` if app has the permission, or `false` if not.
      */
     @JvmStatic
-    fun checkExternalStoragePermission(context: Context): Boolean = when {
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> Environment.isExternalStorageManager() || checkSelfPermission(
-            context,
-            Manifest.permission.READ_EXTERNAL_STORAGE
-        )
+    @JvmOverloads
+    fun checkExternalStoragePermission(context: Context, writeRequired: Boolean = false): Boolean = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> Environment.isExternalStorageManager() || (
+            !writeRequired && checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE)
+            )
         else -> checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
     }
 


### PR DESCRIPTION
On Android >=  10, MediaScanner won't index (either manually or automatically) files in our app's private folder. That means that other apps can't access files downloaded in Nextcloud.

To solve this, we intend to allow setting `Downloads` as a storage directory, which would be public.

- [x] Add option to set storage directory to Downloads. 
     - Requires `WRITE_EXTERNAL_STORAGE` or `MANAGE_EXTERNAL_STORAGE` as we use the File API. Could be done without it using the MediaStore API directly but this is an unknown amount of work.
     - [x] Test what happens if files are removed externally
     - [ ] Should we make this the default?
     - [ ] Test with android 9, 10, 11 & 12
     - [ ] Add all files to MediaScanner if in Downloads
           - [ ]  Media files may need to be added twice? (once to the Downloads collection and another to media) 
           - [ ]  Ensure files are deleted from MediaScanner when deleted

Fixes #6150
Fixes #10038


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed