### PR TITLE
workflows/qa: Skip NDK install if PR is not from this repo

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,6 +20,7 @@ jobs:
                     distribution: "temurin"
                     java-version: 11
             -   name: Install NDK and cmake
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 run: |
                     source ndk.env
                     /usr/local/lib/android/sdk/tools/bin/sdkmanager "ndk;${NDK_VERSION}" "cmake;${CMAKE_VERSION}"


### PR DESCRIPTION
We already do this for the rest of steps, I forgot to add it when I added the NDK install



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed