### PR TITLE
qa: run on pull_request_target, to enable running on fork PRs

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,20 +1,18 @@
 name: "QA"
 
 on:
-    pull_request:
+    pull_request_target:
         branches: [ master, stable-* ]
 
 jobs:
     qa:
         runs-on: ubuntu-latest
         steps:
-            -   name: Check if secrets are available
-                run: echo "::set-output name=ok::${{ secrets.KS_PASS != '' }}"
-                id: check-secrets
             -   uses: actions/checkout@v3
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
+                with:
+                    repository: ${{ github.event.pull_request.head.repo.full_name }}
+                    ref: $GITHUB_HEAD_REF
             -   name: set up JDK 11
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 uses: actions/setup-java@v2
                 with:
                     distribution: "temurin"
@@ -24,7 +22,6 @@ jobs:
                     source ndk.env
                     /usr/local/lib/android/sdk/tools/bin/sdkmanager "ndk;${NDK_VERSION}" "cmake;${CMAKE_VERSION}"
             -   name: Build QA
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 env:
                     KS_PASS: ${{ secrets.KS_PASS }}
                     KEY_PASS: ${{ secrets.KEY_PASS }}


### PR DESCRIPTION
Note: `pull_request_target` always runs from the target branch workflow, so this won't do anything until it's merged.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed