### PR TITLE
Fix bugs when removing accounts

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
@@ -58,7 +58,6 @@ import com.owncloud.android.utils.FileStorageUtils
 import com.owncloud.android.utils.PushUtils
 import org.greenrobot.eventbus.EventBus
 import java.io.File
-import java.util.ArrayList
 
 /**
  * Removes account and all local files
@@ -149,6 +148,9 @@ class AccountRemovalWork(
         if (optionNextcloudClient.isPresent) {
             deleteAppPasswordRemoteOperation.execute(optionNextcloudClient.get())
         }
+
+        // delete cached OwncloudClient
+        OwnCloudClientManagerFactory.getDefaultSingleton().removeClientFor(user.toOwnCloudAccount())
 
         if (userRemoved) {
             eventBus.post(AccountRemovedEvent())

--- a/app/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -45,6 +45,7 @@ import com.nextcloud.client.onboarding.FirstRunActivity;
 import com.nextcloud.java.util.Optional;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
+import com.owncloud.android.authentication.AuthenticatorActivity;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.files.services.FileDownloader;
@@ -180,11 +181,18 @@ public class ManageAccountsActivity extends FileActivity implements UserListAdap
     @Override
     public void onBackPressed() {
         Intent resultIntent = new Intent();
-        resultIntent.putExtra(KEY_ACCOUNT_LIST_CHANGED, hasAccountListChanged());
-        resultIntent.putExtra(KEY_CURRENT_ACCOUNT_CHANGED, hasCurrentAccountChanged());
-        setResult(RESULT_OK, resultIntent);
+        if (accountManager.getAllUsers().size() > 0) {
+            resultIntent.putExtra(KEY_ACCOUNT_LIST_CHANGED, hasAccountListChanged());
+            resultIntent.putExtra(KEY_CURRENT_ACCOUNT_CHANGED, hasCurrentAccountChanged());
+            setResult(RESULT_OK, resultIntent);
 
-        super.onBackPressed();
+            super.onBackPressed();
+        } else {
+            final Intent intent = new Intent(this, AuthenticatorActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(intent);
+            finish();
+        }
     }
 
     /**


### PR DESCRIPTION
- Fixed bug where old token would be used if logging into the same account right after logout
- Go directly to login activity after logout of the last account, instead of flashing file activity


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed