### PR TITLE
Better approach for avoiding state loss in FileDetailFragment

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -743,7 +743,7 @@ public abstract class FileActivity extends DrawerActivity
 
         if (result.isSuccess()) {
             if (sharingFragment != null) {
-                sharingFragment.onUpdateShareInformation(result, getFile());
+                sharingFragment.onUpdateShareInformation(result);
             }
         } else {
             DisplayUtils.showSnackMessage(this, R.string.note_could_not_sent);
@@ -757,7 +757,7 @@ public abstract class FileActivity extends DrawerActivity
         if (result.isSuccess()) {
             updateFileFromDB();
             if (sharingFragment != null) {
-                sharingFragment.onUpdateShareInformation(result, getFile());
+                sharingFragment.onUpdateShareInformation(result);
             }
         } else if (sharingFragment != null && sharingFragment.getView() != null) {
             if (TextUtils.isEmpty(result.getMessage())) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1516,7 +1516,6 @@ public class FileDisplayActivity extends FileActivity
 
         resetScrolling();
 
-        setFile(file);
         Fragment detailFragment = FileDetailFragment.newInstance(file, currentUser, activeTab);
         setLeftFragment(detailFragment);
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -26,7 +26,6 @@
 package com.owncloud.android.ui.fragment;
 
 import android.accounts.AccountManager;
-import android.app.AlertDialog;
 import android.app.SearchManager;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
@@ -310,6 +309,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
 
     /**
      * show quick sharing permission dialog
+     *
      * @param share
      */
     @Override
@@ -322,10 +322,22 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
      *
      * @param result {@link RemoteOperationResult} of an update on the edited {@link OCFile} sharing information.
      * @param file   the edited {@link OCFile}
+     * @see #onUpdateShareInformation(RemoteOperationResult)
      */
     public void onUpdateShareInformation(RemoteOperationResult result, OCFile file) {
         this.file = file;
 
+        onUpdateShareInformation(result);
+    }
+
+    /**
+     * Updates the UI after the result of an update operation on the edited {@link OCFile}. Keeps the current {@link
+     * OCFile held by this fragment}.
+     *
+     * @param result {@link RemoteOperationResult} of an update on the edited {@link OCFile} sharing information.
+     * @see #onUpdateShareInformation(RemoteOperationResult, OCFile)
+     */
+    public void onUpdateShareInformation(RemoteOperationResult result) {
         if (result.isSuccess()) {
             refreshUiFromDB();
         } else {


### PR DESCRIPTION
Do not overwrite file when updating share information, instead of holding the file in FDA

Follow up to #9970 and #9930, should prevent both bugs at the same time

Signed-off-by: Álvaro Brey Vilas <alvaro.brey@nextcloud.com>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
