### PR TITLE
[stable-3.20] Correct scan permission handling

### DIFF
--- a/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -143,6 +143,8 @@ import de.cotech.hw.fido2.WebViewWebauthnBridge;
 import de.cotech.hw.fido2.ui.WebauthnDialogOptions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import static com.owncloud.android.utils.PermissionUtil.PERMISSIONS_CAMERA;
+
 /**
  * This Activity is used to add an ownCloud account to the App
  */
@@ -1298,7 +1300,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         if (PermissionUtil.checkSelfPermission(this, Manifest.permission.CAMERA)) {
             startQRScanner();
         } else {
-            PermissionUtil.requestCameraPermission(this);
+            PermissionUtil.requestCameraPermission(this, PERMISSIONS_CAMERA);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -394,6 +394,15 @@ public class FileDisplayActivity extends FileActivity
                     // toggle on is save since this is the only scenario this code gets accessed
                 }
                 break;
+            case PermissionUtil.PERMISSIONS_SCAN_DOCUMENT:
+                // If request is cancelled, result arrays are empty.
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    // permission was granted
+                    getFileOperationsHelper().scanFromCamera(
+                        this,
+                        FileDisplayActivity.REQUEST_CODE__UPLOAD_SCAN_DOC_FROM_CAMERA);
+                }
+                break;
             case PermissionUtil.PERMISSIONS_CAMERA:
                 // If request is cancelled, result arrays are empty.
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -1068,7 +1068,7 @@ public class FileOperationsHelper {
             if (PermissionUtil.checkSelfPermission(activity, Manifest.permission.CAMERA)) {
                 activity.startActivityForResult(pictureIntent, requestCode);
             } else {
-                PermissionUtil.requestCameraPermission(activity);
+                PermissionUtil.requestCameraPermission(activity, PermissionUtil.PERMISSIONS_CAMERA);
             }
         } else {
             DisplayUtils.showSnackMessage(activity, "No Camera found");
@@ -1084,7 +1084,7 @@ public class FileOperationsHelper {
         if (PermissionUtil.checkSelfPermission(activity, Manifest.permission.CAMERA)) {
             activity.startActivityForResult(scanIntent, requestCode);
         } else {
-            PermissionUtil.requestCameraPermission(activity);
+            PermissionUtil.requestCameraPermission(activity, PermissionUtil.PERMISSIONS_SCAN_DOCUMENT);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -51,6 +51,7 @@ object PermissionUtil {
     const val PERMISSIONS_CAMERA = 5
     const val PERMISSIONS_READ_CALENDAR_AUTOMATIC = 6
     const val PERMISSIONS_WRITE_CALENDAR = 7
+    const val PERMISSIONS_SCAN_DOCUMENT = 6
 
     const val REQUEST_CODE_MANAGE_ALL_FILES = 19203
 
@@ -226,10 +227,10 @@ object PermissionUtil {
      * @param activity The target activity.
      */
     @JvmStatic
-    fun requestCameraPermission(activity: Activity) {
+    fun requestCameraPermission(activity: Activity, requestCode: Int) {
         ActivityCompat.requestPermissions(
             activity, arrayOf(Manifest.permission.CAMERA),
-            PERMISSIONS_CAMERA
+            requestCode
         )
     }
 }


### PR DESCRIPTION
Manual backport of #10042

- scan document
- approve permission
- see scan document activity, previously it was wrong upload image activity



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed