### PR TITLE
Do not ping the Server for checking the Connection

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -57,17 +57,19 @@ class OfflineSyncWork constructor(
 
     override fun doWork(): Result {
         val wakeLock: WakeLock? = null
-        if (!powerManagementService.isPowerSavingEnabled && !connectivityService.isInternetWalled) {
-            val users = userAccountManager.allUsers
-            for (user in users) {
-                val storageManager = FileDataStorageManager(user, contentResolver)
-                val ocRoot = storageManager.getFileByPath(OCFile.ROOT_PATH)
-                if (ocRoot.storagePath == null) {
-                    break
+        if (!powerManagementService.isPowerSavingEnabled) {
+            if (!connectivityService.isInternetWalled) { // Put in a new CodeBlock to minimise impact while powersaving
+                val users = userAccountManager.allUsers
+                for (user in users) {
+                    val storageManager = FileDataStorageManager(user, contentResolver)
+                    val ocRoot = storageManager.getFileByPath(OCFile.ROOT_PATH)
+                    if (ocRoot.storagePath == null) {
+                        break
+                    }
+                    recursive(File(ocRoot.storagePath), storageManager, user)
                 }
-                recursive(File(ocRoot.storagePath), storageManager, user)
+                wakeLock?.release()
             }
-            wakeLock?.release()
         }
         return Result.success()
     }

--- a/app/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
+++ b/app/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
@@ -68,23 +68,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
     public boolean isInternetWalled() {
         Connectivity c = getConnectivity();
         if (c.isConnected() && c.isWifi() && !c.isMetered()) {
-
-            Server server = accountManager.getUser().getServer();
-            String baseServerAddress = server.getUri().toString();
-            if (baseServerAddress.isEmpty()) {
-                return true;
-            }
-
-            GetMethod get = requestBuilder.invoke(baseServerAddress + "/index.php/204");
-            PlainClient client = clientFactory.createPlainClient();
-
-            int status = get.execute(client);
-
-            // Content-Length is not available when using chunked transfer encoding, so check for -1 as well
-            boolean result = !(status == HttpStatus.SC_NO_CONTENT && get.getResponseContentLength() <= 0);
-            get.releaseConnection();
-
-            return result;
+            return false;
         } else {
             return !c.isConnected();
         }

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1079,7 +1079,6 @@ public class FileUploader extends Service
         }
 
         final Connectivity connectivity = connectivityService.getConnectivity();
-        final boolean gotNetwork = connectivity.isConnected() && !connectivityService.isInternetWalled();
         final boolean gotWifi = connectivity.isWifi();
         final BatteryStatus batteryStatus = powerManagementService.getBattery();
         final boolean charging = batteryStatus.isCharging() || batteryStatus.isFull();
@@ -1098,9 +1097,11 @@ public class FileUploader extends Service
                     failedUpload.setLastResult(UploadResult.FILE_NOT_FOUND);
                     uploadsStorageManager.updateUpload(failedUpload);
                 }
-            } else if (!isPowerSaving && gotNetwork && canUploadBeRetried(failedUpload, gotWifi, charging)) {
-                // 2B. for existing local files, try restarting it if possible
-                retryUpload(context, uploadUser.get(), failedUpload);
+            } else if (!isPowerSaving && canUploadBeRetried(failedUpload, gotWifi, charging)) {
+                if (!connectivityService.isInternetWalled()) { // Put to a new line to make powersaving effective
+                    // 2B. for existing local files, try restarting it if possible
+                    retryUpload(context, uploadUser.get(), failedUpload);
+                }
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -236,7 +236,7 @@ public final class FilesSyncHelper {
         }
 
         new Thread(() -> {
-            if (connectivityService.getConnectivity().isConnected() && !connectivityService.isInternetWalled()) {
+            if (!connectivityService.isInternetWalled()) {
                 FileUploader.retryFailedUploads(
                     context,
                     uploadsStorageManager,


### PR DESCRIPTION
- [ ] Tests written, or not not needed

This is for fixing the Issue #9598, which leads to high battery drainage and unneccessary communication. The method which pinged, is called multiple times in a row by the source, which causes many pings to the server even if in powersave-mode. I removed the pings completely, as i did not see any reason to ping the server at all and fixed powersaving- handling.