### PR TITLE
Drone: force-enable apps on master server

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -102,11 +102,11 @@ services:
       - su www-data -c "php /var/www/html/occ group:adduser users user1"
       - su www-data -c "php /var/www/html/occ group:adduser users user2"
       - su www-data -c "git clone -b master https://github.com/nextcloud/activity.git /var/www/html/apps/activity/"
-      - su www-data -c "php /var/www/html/occ app:enable activity"
+      - su www-data -c "php /var/www/html/occ app:enable -f activity"
       - su www-data -c "git clone -b master https://github.com/nextcloud/text.git /var/www/html/apps/text/"
-      - su www-data -c "php /var/www/html/occ app:enable text"
+      - su www-data -c "php /var/www/html/occ app:enable -f text"
       - su www-data -c "git clone -b master https://github.com/nextcloud/end_to_end_encryption/  /var/www/html/apps/end_to_end_encryption/"
-      - su www-data -c "php /var/www/html/occ app:enable end_to_end_encryption"
+      - su www-data -c "php /var/www/html/occ app:enable -f end_to_end_encryption"
       - /usr/local/bin/run.sh
 
 trigger:


### PR DESCRIPTION
When server master version has been updated, but `appinfo.xml` on apps has not been updated yet, the apps can't be installed so our CI with master server fails always.

Better solution: build our CI test images separately, instead of configuring the server for every build. This way we would have working master images (even if slightly older) for our CI, until we can build newer images.

Signed-off-by: Álvaro Brey Vilas <alvaro.brey@nextcloud.com>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
