### PR TITLE
Fix expiration date picker layout when rotating screen

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ExpirationDatePickerDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ExpirationDatePickerDialogFragment.java
@@ -76,6 +76,19 @@ public class ExpirationDatePickerDialogFragment
         this.onExpiryDateListener = onExpiryDateListener;
     }
 
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        final Dialog currentDialog = getDialog();
+        if (currentDialog != null) {
+            final DatePickerDialog dialog = (DatePickerDialog) currentDialog;
+            dialog.getButton(DatePickerDialog.BUTTON_NEUTRAL).setTextColor(themeColorUtils.primaryColor(getContext(), true));
+            dialog.getButton(DatePickerDialog.BUTTON_NEGATIVE).setTextColor(themeColorUtils.primaryColor(getContext(), true));
+            dialog.getButton(DatePickerDialog.BUTTON_POSITIVE).setTextColor(themeColorUtils.primaryColor(getContext(), true));
+        }
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -112,11 +125,6 @@ public class ExpirationDatePickerDialogFragment
                     }
                 });
         }
-
-        dialog.show();
-        dialog.getButton(DatePickerDialog.BUTTON_NEUTRAL).setTextColor(themeColorUtils.primaryColor(getContext(), true));
-        dialog.getButton(DatePickerDialog.BUTTON_NEGATIVE).setTextColor(themeColorUtils.primaryColor(getContext(), true));
-        dialog.getButton(DatePickerDialog.BUTTON_POSITIVE).setTextColor(themeColorUtils.primaryColor(getContext(), true));
 
         // Prevent days in the past may be chosen
         DatePicker picker = dialog.getDatePicker();

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ExpirationDatePickerDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ExpirationDatePickerDialogFragment.java
@@ -138,6 +138,16 @@ public class ExpirationDatePickerDialogFragment
         return dialog;
     }
 
+    public long getCurrentSelectionMillis() {
+        final Dialog dialog = getDialog();
+        if (dialog != null) {
+            final DatePickerDialog datePickerDialog = (DatePickerDialog) dialog;
+            final DatePicker picker = datePickerDialog.getDatePicker();
+            return yearMonthDayToMillis(picker.getYear(), picker.getMonth(), picker.getDayOfMonth());
+        }
+        return 0;
+    }
+
     /**
      * Called when the user chooses an expiration date.
      *
@@ -149,15 +159,19 @@ public class ExpirationDatePickerDialogFragment
     @Override
     public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
 
-        Calendar chosenDate = Calendar.getInstance();
-        chosenDate.set(Calendar.YEAR, year);
-        chosenDate.set(Calendar.MONTH, monthOfYear);
-        chosenDate.set(Calendar.DAY_OF_MONTH, dayOfMonth);
-        long chosenDateInMillis = chosenDate.getTimeInMillis();
+        long chosenDateInMillis = yearMonthDayToMillis(year, monthOfYear, dayOfMonth);
 
         if (onExpiryDateListener != null) {
             onExpiryDateListener.onDateSet(year, monthOfYear, dayOfMonth, chosenDateInMillis);
         }
+    }
+
+    private long yearMonthDayToMillis(int year, int monthOfYear, int dayOfMonth) {
+        Calendar date = Calendar.getInstance();
+        date.set(Calendar.YEAR, year);
+        date.set(Calendar.MONTH, monthOfYear);
+        date.set(Calendar.DAY_OF_MONTH, dayOfMonth);
+        return date.getTimeInMillis();
     }
 
     public interface OnExpiryDateListener {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -28,7 +28,6 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.owncloud.android.R
 import com.owncloud.android.databinding.FileDetailsSharingProcessFragmentBinding
@@ -118,7 +117,7 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
     private var isReshareShown: Boolean = true // show or hide reshare option
     private var isExpDateShown: Boolean = true // show or hide expiry date option
 
-    private var datePickerFragment: DialogFragment? = null
+    private var expirationDatePickerFragment: ExpirationDatePickerDialogFragment? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -169,10 +168,11 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
         // Force recreation of dialog fragment when screen rotates
         // This is needed because the calendar layout should be different in portrait and landscape,
         // but as FDA persists through config changes, the dialog is not recreated automatically
-        val datePicker = datePickerFragment
+        val datePicker = expirationDatePickerFragment
         if (datePicker?.dialog?.isShowing == true) {
+            val currentSelectionMillis = datePicker.currentSelectionMillis
             datePicker.dismiss()
-            showExpirationDateDialog()
+            showExpirationDateDialog(currentSelectionMillis)
         }
     }
 
@@ -363,10 +363,10 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
         }
     }
 
-    private fun showExpirationDateDialog() {
-        val dialog = ExpirationDatePickerDialogFragment.newInstance(chosenExpDateInMills)
+    private fun showExpirationDateDialog(chosenDateInMillis: Long = chosenExpDateInMills) {
+        val dialog = ExpirationDatePickerDialogFragment.newInstance(chosenDateInMillis)
         dialog.setOnExpiryDateListener(this)
-        datePickerFragment = dialog
+        expirationDatePickerFragment = dialog
         fileActivity?.let {
             dialog.show(
                 it.supportFragmentManager,

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -22,11 +22,13 @@
 package com.owncloud.android.ui.fragment
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.owncloud.android.R
 import com.owncloud.android.databinding.FileDetailsSharingProcessFragmentBinding
@@ -116,6 +118,8 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
     private var isReshareShown: Boolean = true // show or hide reshare option
     private var isExpDateShown: Boolean = true // show or hide expiry date option
 
+    private var datePickerFragment: DialogFragment? = null
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         try {
@@ -158,6 +162,18 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
             showShareProcessSecond()
         }
         implementClickEvents()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // Force recreation of dialog fragment when screen rotates
+        // This is needed because the calendar layout should be different in portrait and landscape,
+        // but as FDA persists through config changes, the dialog is not recreated automatically
+        val datePicker = datePickerFragment
+        if (datePicker?.dialog?.isShowing == true) {
+            datePicker.dismiss()
+            showExpirationDateDialog()
+        }
     }
 
     private fun showShareProcessFirst() {
@@ -350,9 +366,10 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
     private fun showExpirationDateDialog() {
         val dialog = ExpirationDatePickerDialogFragment.newInstance(chosenExpDateInMills)
         dialog.setOnExpiryDateListener(this)
-        fileActivity?.let { it1 ->
+        datePickerFragment = dialog
+        fileActivity?.let {
             dialog.show(
-                it1.supportFragmentManager,
+                it.supportFragmentManager,
                 ExpirationDatePickerDialogFragment.DATE_PICKER_DIALOG
             )
         }


### PR DESCRIPTION
Due to FDA persisting to config changes, this dialog wasn't recreated, so the layout didn't change for portrait/landscape.

This resulted in the layout being too small in landscape, and squished in portrait.

To work around this, I've added a listener for config changes in FileDetailsSharingProcessFragment, to force the recreation of the dialog.

Follow up to https://github.com/nextcloud/android/pull/9494, actually fixes #9377 
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
