### PR TITLE
[stable-3.20] build: Disable LeakCanary unless manually activated with a property

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -303,7 +303,7 @@ dependencies {
         }
     }
 
-    if (!ciBuild) {
+    if (project.hasProperty("leakCanary")) {
         debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
     }
 


### PR DESCRIPTION
Use `./gradlew installGplayDebug -P "leakCanary"`, for example, to activate it.

LeakCanary dramatically slows down normal development work due to app freezes for memory dumps.

This way we can avoid that, but still use it when we want to check for leaks. I don't think leaks should be a primary focus right now,
since we have other stuff to work on first.

Manual backport of #10129


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed