### PR TITLE
build: Clean up repository configuration 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,15 +54,6 @@ configurations.configureEach {
     }
 }
 
-repositories {
-    google()
-    maven { url "https://jitpack.io" }
-    mavenCentral()
-    maven {
-        url 'https://plugins.gradle.org/m2/'
-    }
-}
-
 // semantic versioning for version code
 def versionMajor = 3
 def versionMinor = 20

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -241,7 +241,7 @@ dependencies {
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.24'
     implementation 'com.github.tobiaskaminsky:qrcodescanner:0.1.2.4' // 'com.github.blikoon:QRCodeScanner:0.1.2'
-    implementation 'com.google.android:flexbox:2.0.1'
+    implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation('com.github.bumptech.glide:glide:3.8.0') {
         exclude group: "com.android.support"
     }
@@ -275,7 +275,7 @@ dependencies {
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     
     // Shimmer animation
-    implementation 'com.elyeproj.libraries:loaderviewlibrary:2.0.0'
+    implementation 'io.github.elye:loaderviewlibrary:3.0.0'
 
     // dependencies for markdown rendering
     implementation "io.noties.markwon:core:$markwonVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -26,17 +26,16 @@ buildscript {
 subprojects {
     buildscript {
         repositories {
+            gradlePluginPortal()
             google()
-            maven {
-                url 'https://plugins.gradle.org/m2/'
-            }
             mavenCentral()
         }
     }
     repositories {
         google()
-        maven { url "https://jitpack.io" }
         mavenCentral()
+        jcenter()
+        maven { url "https://jitpack.io" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
- Repo configuration was duplicated between root build.gradle and app build.gradle. Now it's all in the root build.gradle.
- Remove JCenter usage (which was mirrored through gradle plugin portal). This required updating 2 libraries with no breaking changes.
- Put jitpack at the bottom of the list of repos. This means that libraries that are both on jitpack and elsewhere will get fetched from other repos first. This should mitigate the sorts of random CI failures we get due to jitpack unavailability.

As part of this last point, this should fix our ktlint builds in CI which are currently broken. (see https://github.com/pinterest/ktlint/issues/1452)

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
