### PR TITLE
Fix contents cut off when scrolling is locked

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1545,14 +1545,10 @@ public class FileDisplayActivity extends FileActivity
      */
     @VisibleForTesting
     public void lockScrolling() {
-        final CoordinatorLayout.LayoutParams coordinatorParams = (CoordinatorLayout.LayoutParams) binding.rootLayout.getLayoutParams();
-        coordinatorParams.setBehavior(null);
-        binding.rootLayout.setLayoutParams(coordinatorParams);
-        binding.rootLayout.setNestedScrollingEnabled(false);
+        binding.appbar.appbar.setExpanded(true, false);
         final AppBarLayout.LayoutParams appbarParams = (AppBarLayout.LayoutParams) binding.appbar.toolbarFrame.getLayoutParams();
         appbarParams.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_NO_SCROLL);
         binding.appbar.toolbarFrame.setLayoutParams(appbarParams);
-        binding.appbar.appbar.setExpanded(true, false);
     }
 
     /**
@@ -1560,9 +1556,6 @@ public class FileDisplayActivity extends FileActivity
      */
     @VisibleForTesting
     public void resetScrolling() {
-        final CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) binding.rootLayout.getLayoutParams();
-        params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
-        binding.rootLayout.setLayoutParams(params);
         AppBarLayout.LayoutParams appbarParams = (AppBarLayout.LayoutParams) binding.appbar.toolbarFrame.getLayoutParams();
         appbarParams.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
         binding.appbar.toolbarFrame.setLayoutParams(appbarParams);

--- a/app/src/main/res/layout/fragment_preview_media.xml
+++ b/app/src/main/res/layout/fragment_preview_media.xml
@@ -26,7 +26,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
-    android:layout_marginTop="?attr/actionBarSize"
     tools:context=".ui.preview.PreviewMediaFragment">
 
     <ImageView


### PR DESCRIPTION
Don't need to touch the coordinator params, just set appbar scroll flags properly

Follow up to #10009 

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
