### PR TITLE
FileDisplayActivity: wait until OCFileListFragment is initialized to trigger browseToRoot()

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -513,6 +513,7 @@ public class FileDisplayActivity extends FileActivity
                 Log_OC.d(this, "Switch to oc file fragment");
 
                 setLeftFragment(new OCFileListFragment());
+                getSupportFragmentManager().executePendingTransactions();
                 browseToRoot();
             }
     }


### PR DESCRIPTION
This solves a bug which caused a "Directory does not exist" popup when coming back from Gallery,
as it tried to call browseToRoot on GalleryFragment due it being executed before the fragment transaction.

The bug can be seen in https://github.com/nextcloud/android/pull/10135


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed