### PR TITLE
PreviewMediaFragment: prevent crash due to onStop called before exoplayer initialization

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -601,7 +601,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
         final OCFile file = getFile();
         if (MimeTypeUtil.isAudio(file) && !mediaPlayerServiceConnection.isPlaying()) {
             stopAudio();
-        } else if (MimeTypeUtil.isVideo(file) && exoPlayer.isPlaying()) {
+        } else if (MimeTypeUtil.isVideo(file) && exoPlayer != null && exoPlayer.isPlaying()) {
             savedPlaybackPosition = exoPlayer.getCurrentPosition();
             exoPlayer.pause();
         }


### PR DESCRIPTION
Fixes #10161

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed