### PR TITLE
Make SAF root IDs stable through server version updates

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
@@ -38,7 +38,7 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
     private val authority = context.getString(R.string.document_provider_authority)
 
     private val rootFileId = storageManager.getFileByEncryptedRemotePath(ROOT_PATH).fileId
-    private val documentId = "${user.hashCode()}${DOCUMENTID_SEPARATOR}$rootFileId"
+    private val documentId = "${DocumentsStorageProvider.rootIdForUser(user)}${DOCUMENTID_SEPARATOR}$rootFileId"
     private val uri = DocumentsContract.buildTreeDocumentUri(authority, documentId)
     private val rootDir get() = DocumentFile.fromTreeUri(context, uri)!!
 

--- a/app/src/main/java/com/nextcloud/client/account/Server.kt
+++ b/app/src/main/java/com/nextcloud/client/account/Server.kt
@@ -24,7 +24,6 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.owncloud.android.lib.resources.status.OwnCloudVersion
 import java.net.URI
-import java.util.Objects
 
 /**
  * This object provides all information necessary to interact
@@ -43,10 +42,6 @@ data class Server(val uri: URI, val version: OwnCloudVersion) : Parcelable {
         writeSerializable(uri)
         writeParcelable(version, 0)
     }
-    
-    override fun hashCode() = 
-        // a server is identified by its uri, the version is an attribute of this one server
-        Objects.hash(uri)
 
     companion object {
         @JvmField

--- a/app/src/main/java/com/nextcloud/client/account/Server.kt
+++ b/app/src/main/java/com/nextcloud/client/account/Server.kt
@@ -24,6 +24,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.owncloud.android.lib.resources.status.OwnCloudVersion
 import java.net.URI
+import java.util.Objects
 
 /**
  * This object provides all information necessary to interact
@@ -42,6 +43,10 @@ data class Server(val uri: URI, val version: OwnCloudVersion) : Parcelable {
         writeSerializable(uri)
         writeParcelable(version, 0)
     }
+    
+    override fun hashCode() = 
+        // a server is identified by its uri, the version is an attribute of this one server
+        Objects.hash(uri)
 
     companion object {
         @JvmField

--- a/app/src/main/java/com/nextcloud/client/utils/HashUtil.kt
+++ b/app/src/main/java/com/nextcloud/client/utils/HashUtil.kt
@@ -1,0 +1,42 @@
+/*
+ *  Nextcloud Android Library is available under MIT license
+ *
+ *  @author Álvaro Brey Vilas
+ *  Copyright (C) 2022 Álvaro Brey Vilas
+ *  Copyright (C) 2022 Nextcloud GmbH
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.nextcloud.client.utils
+
+import org.apache.commons.codec.binary.Hex
+import java.security.MessageDigest
+
+object HashUtil {
+    private const val ALGORITHM_MD5 = "MD5"
+
+    @JvmStatic
+    fun md5Hash(input: String): String {
+        val digest = MessageDigest.getInstance(ALGORITHM_MD5)
+            .digest(input.toByteArray())
+        return String(Hex.encodeHex(digest))
+    }
+}

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -730,7 +730,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             throw new FileNotFoundException("Invalid documentID " + documentId + "!");
         }
 
-        FileDataStorageManager storageManager = rootIdToStorageManager.get(Integer.parseInt(separated[0]));
+        FileDataStorageManager storageManager = rootIdToStorageManager.get(separated[0]);
         if (storageManager == null) {
             throw new FileNotFoundException("No storage manager associated for " + documentId + "!");
         }

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -40,7 +40,6 @@ import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.DocumentsProvider;
 import android.util.Log;
-import android.util.SparseArray;
 import android.widget.Toast;
 
 import com.nextcloud.client.account.User;
@@ -86,6 +85,7 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -683,7 +683,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         return rootIdToStorageManager.get(rootId);
     }
 
-    private String rootIdForUser(User user) {
+    @VisibleForTesting
+    public static String rootIdForUser(User user) {
         return HashUtil.md5Hash(user.getAccountName());
     }
 

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -47,6 +47,7 @@ import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.files.downloader.DownloadTask;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
+import com.nextcloud.client.utils.HashUtil;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -80,8 +81,6 @@ import org.nextcloud.providers.cursors.RootCursor;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -685,12 +684,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     }
 
     private String rootIdForUser(User user) {
-        try {
-            return URLEncoder.encode(user.getAccountName(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // this is a theoretical exception as UTF-8 is a standard required encoding
-            throw new IllegalStateException("UTF-8 encoding unavailable in this environment", e);
-        }
+        return HashUtil.md5Hash(user.getAccountName());
     }
 
     private void initiateStorageMap() {

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -116,7 +116,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @VisibleForTesting
     static final String DOCUMENTID_SEPARATOR = "/";
     private static final int DOCUMENTID_PARTS = 2;
-    private final HashMap<String, FileDataStorageManager> rootIdToStorageManager = new HashMap<>();
+    private final Map<String, FileDataStorageManager> rootIdToStorageManager = new HashMap<>();
 
     private final Executor executor = Executors.newCachedThreadPool();
 

--- a/app/src/test/java/com/nextcloud/client/utils/HashUtilTest.kt
+++ b/app/src/test/java/com/nextcloud/client/utils/HashUtilTest.kt
@@ -1,0 +1,53 @@
+/*
+ *  Nextcloud Android Library is available under MIT license
+ *
+ *  @author Álvaro Brey Vilas
+ *  Copyright (C) 2022 Álvaro Brey Vilas
+ *  Copyright (C) 2022 Nextcloud GmbH
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.nextcloud.client.utils
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class HashUtilTest(private val input: String, private val expected: String) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun params(): List<Array<Any>> = listOf(
+            arrayOf("", "d41d8cd98f00b204e9800998ecf8427e"),
+            arrayOf("test", "098f6bcd4621d373cade4e832627b4f6"),
+            arrayOf("test@nextcloud.localhost", "12aa338095d171f307c3e3f724702ab1"),
+            arrayOf("tost@nextcloud.localhost", "e01e5301f90c123a65e872d68e84c4b2")
+        )
+    }
+
+    @Test
+    fun testMd5Hash() {
+        val hash = HashUtil.md5Hash(input)
+        Assert.assertEquals("Wrong hash for input", expected, hash)
+    }
+}


### PR DESCRIPTION
Bug #9906 seems to be triggered by a version change of the nextcloud server the client is connected to. It appears the most logical solution to make nextcloud object IDs stable against server version changes. These object IDs are derived from the User object using account/anonymous, and the referenced Server object. Providing a hashCode function in Server that ignores the server's version therefore provides stability of object IDs. This seems safe to do, as an URI is already designed to be an identificator.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
