### PR TITLE
Media search improvement

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
@@ -152,7 +152,7 @@ class GalleryAdapter(
     }
 
     @SuppressLint("NotifyDataSetChanged")
-    fun showAllGalleryItems(storageManager: FileDataStorageManager) {
+    fun showAllGalleryItems() {
         val items = storageManager.allGalleryItems
 
         files = items

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
@@ -43,6 +43,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import androidx.lifecycle.Lifecycle;
+
 public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.Result> {
 
     private final User user;
@@ -100,7 +102,11 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
                 boolean emptySearch = parseMedia(startDate, endDate, result.getData());
                 long lastTimeStamp = findLastTimestamp(result.getData());
 
-                photoFragment.showAllGalleryItems();
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
 
                 return new Result(result.isSuccess(), emptySearch, lastTimeStamp);
             } else {
@@ -117,7 +123,9 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
             photoFragment.setLoading(false);
             photoFragment.searchCompleted(result.emptySearch, result.lastTimestamp);
 
-            if (!result.success) {
+            if (result.success && photoFragment.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) {
+                photoFragment.showAllGalleryItems();
+            } else {
                 photoFragment.setEmptyListMessage(SearchType.GALLERY_SEARCH);
             }
         }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -165,7 +165,7 @@ public class GalleryFragment extends OCFileListFragment {
         setEmptyListLoadingMessage();
 
         // always show first stored items
-        mAdapter.showAllGalleryItems(mContainerActivity.getStorageManager());
+        mAdapter.showAllGalleryItems();
 
         setFabVisible(false);
 
@@ -272,6 +272,6 @@ public class GalleryFragment extends OCFileListFragment {
     }
 
     public void showAllGalleryItems() {
-        mAdapter.showAllGalleryItems(mContainerActivity.getStorageManager());
+        mAdapter.showAllGalleryItems();
     }
 }


### PR DESCRIPTION
Fix #10176

- start showAllGalleryItems() only if Fragment is still visible
- use existing storageManager, no need to pass a new one

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
