### PR TITLE
Since newest Transifex update we have many translations with not need…

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -23,9 +23,7 @@
     </issue>
 
     <issue id="UnusedQuantity">
-        <ignore path="**/values-sk-rSK/strings.xml"/>
-        <ignore path="**/values-cs-rCZ/strings.xml"/>
-        <ignore path="**/values-lt-rLT/strings.xml"/>
+        <ignore path="**/values-**/strings.xml" />
     </issue>
 
     <issue id="ExtraTranslation">


### PR DESCRIPTION
…ed translations, e.g. "many" in spanish.

To not have lint warnings all the time, and as it does not harm Android, we can ignore it.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
