### PR TITLE
Backport of  #10307

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.java
@@ -273,11 +273,13 @@ public class ChooseTemplateDialogFragment extends DialogFragment implements View
     }
 
     private void checkEnablingCreateButton() {
-        Template selectedTemplate = adapter.getSelectedTemplate();
-        String name = binding.filename.getText().toString();
+        if (positiveButton != null) {
+            Template selectedTemplate = adapter.getSelectedTemplate();
+            String name = binding.filename.getText().toString();
 
-        positiveButton.setEnabled(selectedTemplate != null && !name.isEmpty() &&
-                                      !name.equalsIgnoreCase(DOT + selectedTemplate.getExtension()));
+            positiveButton.setEnabled(selectedTemplate != null && !name.isEmpty() &&
+                                          !name.equalsIgnoreCase(DOT + selectedTemplate.getExtension()));
+        }
     }
 
     private static class CreateFileFromTemplateTask extends AsyncTask<Void, Void, String> {


### PR DESCRIPTION
⚠️ I only backported the real fix, not Kotlin migration, as this failed.

This method can be called before positiveButton is initialized

Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
