### PR TITLE
GalleryFastScrollViewHelper: fix index out of bounds in getScrollOffset

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/util/GalleryFastScrollViewHelper.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/util/GalleryFastScrollViewHelper.kt
@@ -41,6 +41,7 @@ import me.zhanghai.android.fastscroll.FastScroller
 import me.zhanghai.android.fastscroll.PopupTextProvider
 import me.zhanghai.android.fastscroll.Predicate
 import kotlin.math.ceil
+import kotlin.math.min
 
 /**
  * Custom ViewHelper to get fast scroll working on gallery, which has a gridview and variable height (due to headers)
@@ -138,7 +139,7 @@ class GalleryFastScrollViewHelper(
         val isHeader = itemCoord.relativePos() == -1
 
         val seenRowsInPreviousSections = adapter.files
-            .subList(0, itemCoord.section())
+            .subList(0, min(itemCoord.section(), adapter.files.size))
             .sumOf { itemCountToRowCount(it.files.size) }
         val seenRowsInThisSection = if (isHeader) 0 else itemCountToRowCount(itemCoord.relativePos())
         val totalSeenRows = seenRowsInPreviousSections + seenRowsInThisSection


### PR DESCRIPTION
Fixes #10350

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed