### PR TITLE
FileDataStorageManager: don't add files to media scan in android 11+

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1626,25 +1626,29 @@ public class FileDataStorageManager {
         if (path != null && !TextUtils.isEmpty(path)) {
             ContentValues values = new ContentValues();
             ContentResolver contentResolver = MainApp.getAppContext().getContentResolver();
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ) {
-                if (file != null) {
-                    values.put(MediaStore.Images.Media.MIME_TYPE, file.getMimeType());
-                    values.put(MediaStore.Images.Media.TITLE, file.getFileName());
-                    values.put(MediaStore.Images.Media.DISPLAY_NAME, file.getFileName());
-                }
-                values.put(MediaStore.Images.Media.DATE_ADDED, System.currentTimeMillis() / 1000);
-                values.put(MediaStore.Images.Media.RELATIVE_PATH, path);
-                values.put(MediaStore.Images.Media.IS_PENDING, 0);
-                try {
-                    contentResolver.insert(MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY),
-                                           values);
-                } catch (IllegalArgumentException e) {
-                    Log_OC.e("MediaScanner", "Adding image to media scanner failed: " + e);
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+                    if (file != null) {
+                        values.put(MediaStore.Images.Media.MIME_TYPE, file.getMimeType());
+                        values.put(MediaStore.Images.Media.TITLE, file.getFileName());
+                        values.put(MediaStore.Images.Media.DISPLAY_NAME, file.getFileName());
+                    }
+                    values.put(MediaStore.Images.Media.DATE_ADDED, System.currentTimeMillis() / 1000);
+                    values.put(MediaStore.Images.Media.RELATIVE_PATH, path);
+                    values.put(MediaStore.Images.Media.IS_PENDING, 0);
+                    try {
+                        contentResolver.insert(MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY),
+                                               values);
+                    } catch (IllegalArgumentException e) {
+                        Log_OC.e("MediaScanner", "Adding image to media scanner failed: " + e);
+                    }
+                } else {
+                    Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                    intent.setData(Uri.fromFile(new File(path)));
+                    MainApp.getAppContext().sendBroadcast(intent);
                 }
             } else {
-                Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                intent.setData(Uri.fromFile(new File(path)));
-                MainApp.getAppContext().sendBroadcast(intent);
+                Log_OC.d(TAG, "SDK > 29, skipping media scan");
             }
         }
     }


### PR DESCRIPTION
This avoids the `(invalid)` folder bug, but still does not solve the fact that files in our internal storage will no longer be visible to other apps/gallery.

For that, #9981 should be advanced further.

Fixes #9328

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed