### PR TITLE
When copy/move a file and creating a new folder we now go directly into this freshly created folder

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -449,7 +449,10 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     ) {
 
         if (result.isSuccess()) {
-            refreshListOfFilesFragment(false);
+            OCFileListFragment fileListFragment = getListOfFilesFragment();
+            if (fileListFragment != null) {
+                fileListFragment.onItemClicked(getStorageManager().getFileByPath(operation.getRemotePath()));
+            }
         } else {
             try {
                 DisplayUtils.showSnackMessage(


### PR DESCRIPTION
- create a text file
- select copy/move on this file
- create in select folder screen a new folder
- see that you are now directly in this new folder, same behavior as in normal file view)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
