### PR TITLE
[stable-3.20] SyncedFoldersActivity: don't refresh entire adapter when toggling a folder from dialog

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -659,8 +659,7 @@ class SyncedFoldersActivity :
             )
             saveOrUpdateSyncedFolder(item)
 
-            // TODO test if notifyItemChanged is sufficient (should improve performance)
-            adapter.notifyDataSetChanged()
+            adapter.notifyItemChanged(adapter.getSectionHeaderIndex(syncedFolder.section))
         }
         syncedFolderPreferencesDialogFragment = null
         if (syncedFolder.isEnabled) {


### PR DESCRIPTION
Manual backport of #10355
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
