### PR TITLE
Check account in onResume fixing #7887

### DIFF
--- a/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
+++ b/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
@@ -133,4 +133,11 @@ class SessionMixin constructor(
         val account = accountManager.currentAccount
         setAccount(account)
     }
+
+    override fun onResume() {
+        super.onResume()
+        if (currentAccount == null) {
+            swapToDefaultAccount()
+        }
+    }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -89,7 +89,9 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     @Override
     protected void onResume() {
         super.onResume();
-        mixinRegistry.onResume();
+        if (enableAccountHandling) {
+            mixinRegistry.onResume();
+        }
         paused = false;
 
         if (themeChangePending) {

--- a/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
+++ b/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
@@ -23,10 +23,12 @@ package com.nextcloud.client.mixins
 import android.app.Activity
 import android.content.ContentResolver
 import com.nextcloud.client.account.UserAccountManager
+import junit.framework.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.same
+import org.mockito.Mockito.spy
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.verify
 
@@ -46,11 +48,11 @@ class SessionMixinTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        session = SessionMixin(
+        session = spy(SessionMixin(
             activity,
             contentResolver,
             userAccountManager
-        )
+        ))
     }
 
     @Test
@@ -63,5 +65,16 @@ class SessionMixinTest {
         //      start is delegated to account manager
         //      account manager receives parent activity
         verify(userAccountManager).startAccountCreation(same(activity))
+    }
+
+    @Test
+    fun `trigger accountCreation on resume when currentAccount is null`() {
+        // WHEN
+        //      start onResume and currentAccount is null
+        assertNull(session.currentAccount)
+        session.onResume()
+        // THEN
+        //      accountCreation flow is started
+        verify(session).startAccountCreation()
     }
 }

--- a/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
+++ b/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
@@ -48,11 +48,13 @@ class SessionMixinTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        session = spy(SessionMixin(
-            activity,
-            contentResolver,
-            userAccountManager
-        ))
+        session = spy(
+            SessionMixin(
+                activity,
+                contentResolver,
+                userAccountManager
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
Hi all,

I was able reproduce bug #7887.
I implemented a check in the onResume function to restart the accountCreation, smiliar to the onRestart. Since onResume is more frequently called than onRestart, I simplified the check to just check the currentAccount variable. Also, I do not see how the Account should get deleted between pause and resume, opposing to between restarts...

I'm not sure about the test cases, I was able to test the case when currentAccount is null. But I was not able to test the other case without mocking the mixin itself, and I feel like it somehow defeats the purpose if I mock the class I want to test.

PS:  this is my first contribution to an oss project, hope I'm doing this the right way 😅 I just browsed through the approved bugs for something small, I could try myself on.

- [x] Tests written, or not not needed