### PR TITLE
Migrate Account to User in some APIs

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -121,7 +121,7 @@ public abstract class AbstractIT {
             user = optionalUser.orElseThrow(IllegalAccessError::new);
 
             client = OwnCloudClientFactory.createOwnCloudClient(account, targetContext);
-            nextcloudClient = OwnCloudClientFactory.createNextcloudClient(account, targetContext);
+            nextcloudClient = OwnCloudClientFactory.createNextcloudClient(user, targetContext);
         } catch (OperationCanceledException e) {
             e.printStackTrace();
         } catch (AuthenticatorException e) {

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManager.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManager.java
@@ -147,21 +147,17 @@ public interface UserAccountManager extends CurrentAccountProvider {
      * <p>
      * Full account name is in form of "username@nextcloud.domain".
      *
-     * @param account Account instance
+     * @param user user instance
      * @return User name (without domain) or null, if name cannot be extracted.
      */
-    static @Nullable
-    String getUsername(Account account) {
-        if (account != null && account.name != null) {
-            return account.name.substring(0, account.name.lastIndexOf('@'));
-        } else {
-            return null;
-        }
+    static String getUsername(User user) {
+        final String name = user.getAccountName();
+        return name.substring(0, name.lastIndexOf('@'));
     }
 
-    static @Nullable
-    String getDisplayName(Account account) {
-        return AccountManager.get(MainApp.getAppContext()).getUserData(account,
+    @Nullable
+    static String getDisplayName(User user) {
+        return AccountManager.get(MainApp.getAppContext()).getUserData(user.toPlatformAccount(),
                                                                        AccountUtils.Constants.KEY_DISPLAY_NAME);
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/AccountRemovalWork.kt
@@ -23,7 +23,6 @@
 */
 package com.nextcloud.client.jobs
 
-import android.accounts.Account
 import android.content.Context
 import android.text.TextUtils
 import androidx.work.Worker
@@ -110,7 +109,7 @@ class AccountRemovalWork(
         arbitraryDataProvider.deleteKeyForAccount(user.accountName, ManageAccountsActivity.PENDING_FOR_REMOVAL)
 
         // remove synced folders set for account
-        removeSyncedFolders(context, user.toPlatformAccount(), clock)
+        removeSyncedFolders(context, user, clock)
 
         // delete all uploads for account
         uploadsStorageManager.removeUserUploads(user)
@@ -182,7 +181,7 @@ class AccountRemovalWork(
         }
     }
 
-    private fun removeSyncedFolders(context: Context, account: Account, clock: Clock) {
+    private fun removeSyncedFolders(context: Context, user: User, clock: Clock) {
         val syncedFolderProvider = SyncedFolderProvider(
             context.contentResolver,
             AppPreferencesImpl.fromContext(context),
@@ -191,11 +190,11 @@ class AccountRemovalWork(
         val syncedFolders = syncedFolderProvider.syncedFolders
         val syncedFolderIds: MutableList<Long> = ArrayList()
         for (syncedFolder in syncedFolders) {
-            if (syncedFolder.account == account.name) {
+            if (syncedFolder.account == user.accountName) {
                 syncedFolderIds.add(syncedFolder.id)
             }
         }
-        syncedFolderProvider.deleteSyncFoldersForAccount(account)
+        syncedFolderProvider.deleteSyncFoldersForAccount(user)
         val filesystemDataProvider = FilesystemDataProvider(context.contentResolver)
         for (syncedFolderId in syncedFolderIds) {
             filesystemDataProvider.deleteAllEntriesForSyncedFolder(syncedFolderId.toString())

--- a/app/src/main/java/com/nextcloud/client/jobs/MediaFoldersDetectionWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/MediaFoldersDetectionWork.kt
@@ -149,7 +149,7 @@ class MediaFoldersDetectionWork constructor(
                         for (imageMediaFolder in imageMediaFolderPaths) {
                             val folder = syncedFolderProvider.findByLocalPathAndAccount(
                                 imageMediaFolder,
-                                user.toPlatformAccount()
+                                user
                             )
                             if (folder == null &&
                                 SyncedFolderUtils.isQualifyingMediaFolder(imageMediaFolder, MediaFolderType.IMAGE)
@@ -170,7 +170,7 @@ class MediaFoldersDetectionWork constructor(
                         for (videoMediaFolder in videoMediaFolderPaths) {
                             val folder = syncedFolderProvider.findByLocalPathAndAccount(
                                 videoMediaFolder,
-                                user.toPlatformAccount()
+                                user
                             )
                             if (folder == null) {
                                 val contentTitle = String.format(

--- a/app/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
+++ b/app/src/main/java/com/nextcloud/client/network/ClientFactoryImpl.java
@@ -59,7 +59,7 @@ class ClientFactoryImpl implements ClientFactory {
     @Override
     public NextcloudClient createNextcloudClient(User user) throws CreationException {
         try {
-            return OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(), context);
+            return OwnCloudClientFactory.createNextcloudClient(user, context);
         } catch (AccountUtils.AccountNotFoundException e) {
             throw new CreationException(e);
         }

--- a/app/src/main/java/com/nextcloud/ui/SetPredefinedCustomStatusTask.kt
+++ b/app/src/main/java/com/nextcloud/ui/SetPredefinedCustomStatusTask.kt
@@ -29,7 +29,7 @@ import com.owncloud.android.lib.common.accounts.AccountUtils
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.lib.resources.users.SetPredefinedCustomStatusMessageRemoteOperation
 
-public class SetPredefinedCustomStatusTask(
+class SetPredefinedCustomStatusTask(
     val messageId: String,
     val clearAt: Long?,
     val account: Account?,

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -20,13 +20,13 @@
  */
 package com.owncloud.android.datamodel;
 
-import android.accounts.Account;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 
+import com.nextcloud.client.account.User;
 import com.nextcloud.client.core.Clock;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
@@ -187,14 +187,14 @@ public class SyncedFolderProvider extends Observable {
         return result;
     }
 
-    public SyncedFolder findByLocalPathAndAccount(String localPath, Account account) {
+    public SyncedFolder findByLocalPathAndAccount(String localPath, User user) {
         SyncedFolder result = null;
         Cursor cursor = mContentResolver.query(
             ProviderMeta.ProviderTableMeta.CONTENT_URI_SYNCED_FOLDERS,
             null,
             ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH + " LIKE ? AND " +
                 ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + " =? ",
-            new String[]{localPath + "%", account.name},
+            new String[]{localPath + "%", user.getAccountName()},
             null
         );
 
@@ -220,13 +220,13 @@ public class SyncedFolderProvider extends Observable {
     /**
      *  Delete all synced folders for an account
      *
-     *  @param account whose synced folders should be deleted
+     *  @param user whose synced folders should be deleted
      */
-    public int deleteSyncFoldersForAccount(Account account) {
+    public int deleteSyncFoldersForAccount(User user) {
         return mContentResolver.delete(
                 ProviderMeta.ProviderTableMeta.CONTENT_URI_SYNCED_FOLDERS,
                 ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + " = ?",
-                new String[]{String.valueOf(account.name)}
+                new String[]{String.valueOf(user.getAccountName())}
         );
     }
 

--- a/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -273,7 +273,7 @@ public class RefreshFolderOperation extends RemoteOperation {
     }
 
     private void updateOCVersion(OwnCloudClient client) {
-        UpdateOCVersionOperation update = new UpdateOCVersionOperation(user.toPlatformAccount(), mContext);
+        UpdateOCVersionOperation update = new UpdateOCVersionOperation(user, mContext);
         RemoteOperationResult result = update.execute(client);
         if (result.isSuccess()) {
             // Update Capabilities for this account
@@ -283,7 +283,7 @@ public class RefreshFolderOperation extends RemoteOperation {
 
     private void updateUserProfile() {
         try {
-            NextcloudClient nextcloudClient = OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(), mContext);
+            NextcloudClient nextcloudClient = OwnCloudClientFactory.createNextcloudClient(user, mContext);
 
             RemoteOperationResult<UserInfo> result = new GetUserProfileOperation(mStorageManager).execute(nextcloudClient);
             if (!result.isSuccess()) {
@@ -336,7 +336,7 @@ public class RefreshFolderOperation extends RemoteOperation {
         NextcloudClient client;
 
         try {
-            client = OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(), mContext);
+            client = OwnCloudClientFactory.createNextcloudClient(user, mContext);
         } catch (AccountUtils.AccountNotFoundException | NullPointerException e) {
             Log_OC.e(this, "Update of predefined status not possible!");
             return;

--- a/app/src/main/java/com/owncloud/android/operations/UpdateOCVersionOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UpdateOCVersionOperation.java
@@ -24,6 +24,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.Context;
 
+import com.nextcloud.client.account.User;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.accounts.AccountUtils.Constants;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
@@ -47,13 +48,12 @@ public class UpdateOCVersionOperation extends RemoteOperation {
 
     private static final String STATUS_PATH = "/status.php";
 
-    private Account mAccount;
+    private final User user;
     private Context mContext;
     private OwnCloudVersion mOwnCloudVersion;
-    
-    
-    public UpdateOCVersionOperation(Account account, Context context) {
-        mAccount = account;
+
+    public UpdateOCVersionOperation(User user, Context context) {
+        this.user = user;
         mContext = context;
         mOwnCloudVersion = null;
     }
@@ -62,7 +62,7 @@ public class UpdateOCVersionOperation extends RemoteOperation {
     @Override
     protected RemoteOperationResult run(OwnCloudClient client) {
         AccountManager accountMngr = AccountManager.get(mContext); 
-        String statUrl = accountMngr.getUserData(mAccount, Constants.KEY_OC_BASE_URL);
+        String statUrl = accountMngr.getUserData(user.toPlatformAccount(), Constants.KEY_OC_BASE_URL);
         statUrl += STATUS_PATH;
         RemoteOperationResult result = null;
         GetMethod getMethod = null;
@@ -85,7 +85,7 @@ public class UpdateOCVersionOperation extends RemoteOperation {
                         String version = json.getString("version");
                         mOwnCloudVersion = new OwnCloudVersion(version);
                         if (mOwnCloudVersion.isVersionValid()) {
-                            accountMngr.setUserData(mAccount, Constants.KEY_OC_VERSION, mOwnCloudVersion.getVersion());
+                            accountMngr.setUserData(user.toPlatformAccount(), Constants.KEY_OC_VERSION, mOwnCloudVersion.getVersion());
                             Log_OC.d(TAG, "Got new OC version " + mOwnCloudVersion);
 
                             result = new RemoteOperationResult(ResultCode.OK);

--- a/app/src/main/java/com/owncloud/android/operations/common/SyncOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/common/SyncOperation.java
@@ -61,7 +61,7 @@ public abstract class SyncOperation extends RemoteOperation {
             throw new IllegalArgumentException("Trying to execute a sync operation with a " +
                                                    "storage manager for an anonymous account");
         }
-        return super.execute(this.storageManager.getUser().toPlatformAccount(), context);
+        return super.execute(this.storageManager.getUser(), context);
     }
 
     public RemoteOperationResult execute(@NonNull NextcloudClient client) {

--- a/app/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -207,7 +207,7 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
         // request to the OC server about users and groups matching userQuery
         GetShareesRemoteOperation searchRequest = new GetShareesRemoteOperation(userQuery, REQUESTED_PAGE,
                                                                                 RESULTS_PER_PAGE);
-        RemoteOperationResult result = searchRequest.execute(user.toPlatformAccount(), getContext());
+        RemoteOperationResult result = searchRequest.execute(user, getContext());
         List<JSONObject> names = new ArrayList<>();
 
         if (result.isSuccess()) {

--- a/app/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/app/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -249,7 +249,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
      * Updates the locally stored version value of the ownCloud server
      */
     private void updateOCVersion() {
-        UpdateOCVersionOperation update = new UpdateOCVersionOperation(getAccount(), getContext());
+        UpdateOCVersionOperation update = new UpdateOCVersionOperation(getUser(), getContext());
         RemoteOperationResult result = update.execute(getClient());
         if (!result.isSuccess()) {
             mLastFailedResult = result;

--- a/app/src/main/java/com/owncloud/android/ui/TextDrawable.java
+++ b/app/src/main/java/com/owncloud/android/ui/TextDrawable.java
@@ -101,7 +101,7 @@ public class TextDrawable extends Drawable {
      */
     @NonNull
     public static TextDrawable createAvatar(User user, float radiusInDp) {
-        String username = UserAccountManager.getDisplayName(user.toPlatformAccount());
+        String username = UserAccountManager.getDisplayName(user);
         return createNamedAvatar(username, radiusInDp);
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -785,7 +785,7 @@ public class SettingsActivity extends ThemedPreferenceActivity
                 davDroidLoginIntent.setData(Uri.parse(serverBaseUri.toString() + AuthenticatorActivity.WEB_LOGIN));
                 davDroidLoginIntent.putExtra("davPath", DAV_PATH);
             }
-            davDroidLoginIntent.putExtra("username", UserAccountManager.getUsername(user.toPlatformAccount()));
+            davDroidLoginIntent.putExtra("username", UserAccountManager.getUsername(user));
 
             startActivityForResult(davDroidLoginIntent, ACTION_REQUEST_CODE_DAVDROID_SETUP);
         } else {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -316,7 +316,7 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
             NextcloudClient nextcloudClient;
 
             try {
-                nextcloudClient = OwnCloudClientFactory.createNextcloudClient(user.toPlatformAccount(),
+                nextcloudClient = OwnCloudClientFactory.createNextcloudClient(user,
                                                                               this);
             } catch (AccountUtils.AccountNotFoundException e) {
                 Log_OC.e(this, "Error retrieving user info", e);

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -367,9 +367,9 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             final UploadResult uploadResult = item.getLastResult();
             itemViewHolder.binding.uploadListItemLayout.setOnClickListener(v -> {
                 if (uploadResult == UploadResult.CREDENTIAL_ERROR) {
-                    final Optional<User> user = accountManager.getUser(item.getAccountName());
-                    final Account account = user.orElseThrow(RuntimeException::new).toPlatformAccount();
-                    parentActivity.getFileOperationsHelper().checkCurrentCredentials(account);
+                    final Optional<User> optUser = accountManager.getUser(item.getAccountName());
+                    final User user = optUser.orElseThrow(RuntimeException::new);
+                    parentActivity.getFileOperationsHelper().checkCurrentCredentials(user);
                     return;
                 } else if (uploadResult == UploadResult.SYNC_CONFLICT && optionalUser.isPresent()) {
                     User user = optionalUser.get();

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UserListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UserListAdapter.java
@@ -303,7 +303,7 @@ public class UserListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 binding.userName.setText(oca.getDisplayName());
             } catch (Exception e) {
                 Log_OC.w(TAG, "Account not found right after being read; using account name instead");
-                binding.userName.setText(UserAccountManager.getUsername(user.toPlatformAccount()));
+                binding.userName.setText(UserAccountManager.getUsername(user));
             }
             binding.userName.setTag(user.getAccountName());
         }

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/RichDocumentsLoadUrlTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/RichDocumentsLoadUrlTask.java
@@ -34,12 +34,12 @@ import java.lang.ref.WeakReference;
 
 public class RichDocumentsLoadUrlTask extends AsyncTask<Void, Void, String> {
 
-    private Account account;
+    private final User user;
     private WeakReference<EditorWebView> editorWebViewWeakReference;
     private OCFile file;
 
     public RichDocumentsLoadUrlTask(EditorWebView editorWebView, User user, OCFile file) {
-        this.account = user.toPlatformAccount();
+        this.user = user;
         this.editorWebViewWeakReference = new WeakReference<>(editorWebView);
         this.file = file;
     }
@@ -52,7 +52,7 @@ public class RichDocumentsLoadUrlTask extends AsyncTask<Void, Void, String> {
             return "";
         }
 
-        RemoteOperationResult result = new RichDocumentsUrlOperation(file.getLocalId()).execute(account, editorWebView);
+        RemoteOperationResult result = new RichDocumentsUrlOperation(file.getLocalId()).execute(user, editorWebView);
 
         if (!result.isSuccess()) {
             return "";

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/TextEditorLoadUrlTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/TextEditorLoadUrlTask.java
@@ -35,14 +35,12 @@ import java.lang.ref.WeakReference;
 
 public class TextEditorLoadUrlTask extends AsyncTask<Void, Void, String> {
 
-    private Account account;
     private WeakReference<EditorWebView> editorWebViewWeakReference;
     private OCFile file;
     private User user;
 
     public TextEditorLoadUrlTask(EditorWebView editorWebView, User user, OCFile file) {
         this.user = user;
-        this.account = user.toPlatformAccount();
         this.editorWebViewWeakReference = new WeakReference<>(editorWebView);
         this.file = file;
     }
@@ -62,7 +60,7 @@ public class TextEditorLoadUrlTask extends AsyncTask<Void, Void, String> {
         }
 
         RemoteOperationResult result = new DirectEditingOpenFileRemoteOperation(file.getRemotePath(), editor.getId())
-            .execute(account, editorWebViewWeakReference.get());
+            .execute(user, editorWebViewWeakReference.get());
 
 
         if (!result.isSuccess()) {

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SetupEncryptionDialogFragment.java
@@ -283,7 +283,7 @@ public class SetupEncryptionDialogFragment extends DialogFragment implements Inj
             //  - decrypt private key, store unencrypted private key in database
 
             GetPublicKeyOperation publicKeyOperation = new GetPublicKeyOperation();
-            RemoteOperationResult publicKeyResult = publicKeyOperation.execute(user.toPlatformAccount(), getContext());
+            RemoteOperationResult publicKeyResult = publicKeyOperation.execute(user, getContext());
 
             if (publicKeyResult.isSuccess()) {
                 Log_OC.d(TAG, "public key successful downloaded for " + user.getAccountName());

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -1049,12 +1049,12 @@ public class FileOperationsHelper {
     /**
      * Starts a check of the currently stored credentials for the given account.
      *
-     * @param account OC account which credentials will be checked.
+     * @param user user which credentials will be checked.
      */
-    public void checkCurrentCredentials(Account account) {
+    public void checkCurrentCredentials(User user) {
         Intent service = new Intent(fileActivity, OperationsService.class);
         service.setAction(OperationsService.ACTION_CHECK_CURRENT_CREDENTIALS);
-        service.putExtra(OperationsService.EXTRA_ACCOUNT, account);
+        service.putExtra(OperationsService.EXTRA_ACCOUNT, user.toPlatformAccount());
         mWaitingForOpId = fileActivity.getOperationsServiceBinder().queueNewOperation(service);
 
         fileActivity.showLoadingDialog(fileActivity.getString(R.string.wait_checking_credentials));


### PR DESCRIPTION
Migrate remaining Account uses to User model when it was
possible without wider refactoring.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>

- [x] Smoke tests only
