### PR TITLE
Lock: ensure underlying activity isn't shown while waiting for lock screen to render

### DIFF
--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -346,7 +346,7 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
             @Override
             public void onActivityResumed(@NonNull Activity activity) {
                 Log_OC.d(activity.getClass().getSimpleName(), "onResume() starting");
-                passCodeManager.onActivityStarted(activity);
+                passCodeManager.onActivityResumed(activity);
             }
 
             @Override

--- a/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -657,7 +657,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         onlyAdd = intent.getBooleanExtra(KEY_ONLY_ADD, false) || checkIfViaSSO(intent);
 
         // Passcode
-        passCodeManager.onActivityStarted(this);
+        passCodeManager.onActivityResumed(this);
 
         Uri data = intent.getData();
 

--- a/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
+++ b/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
@@ -23,6 +23,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.PowerManager
+import android.view.View
 import android.view.WindowManager
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.preferences.AppPreferences
@@ -55,18 +56,25 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
         return exemptOfPasscodeActivities.contains(activity.javaClass)
     }
 
-    fun onActivityStarted(activity: Activity): Boolean {
+    fun onActivityResumed(activity: Activity): Boolean {
         var askedForPin = false
         val timestamp = preferences.lockTimestamp
         setSecureFlag(activity)
 
         if (!isExemptActivity(activity)) {
-            if (passCodeShouldBeRequested(timestamp)) {
+            val passcodeRequested = passCodeShouldBeRequested(timestamp)
+            val credentialsRequested = deviceCredentialsShouldBeRequested(timestamp, activity)
+            if (passcodeRequested || credentialsRequested) {
+                getActivityRootView(activity)?.visibility = View.GONE
+            } else {
+                getActivityRootView(activity)?.visibility = View.VISIBLE
+            }
+            if (passcodeRequested) {
                 askedForPin = true
                 preferences.lockTimestamp = 0
                 requestPasscode(activity)
             }
-            if (deviceCredentialsShouldBeRequested(timestamp, activity)) {
+            if (credentialsRequested) {
                 askedForPin = true
                 preferences.lockTimestamp = 0
                 requestCredentials(activity)
@@ -80,6 +88,7 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
         if (!isExemptActivity(activity)) {
             visibleActivitiesCounter++ // keep it AFTER passCodeShouldBeRequested was checked
         }
+
         return askedForPin
     }
 
@@ -141,5 +150,10 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
     private fun deviceCredentialsAreEnabled(activity: Activity): Boolean {
         return SettingsActivity.LOCK_DEVICE_CREDENTIALS == preferences.lockPreference ||
             (preferences.isFingerprintUnlockEnabled && DeviceCredentialUtils.areCredentialsAvailable(activity))
+    }
+
+    private fun getActivityRootView(activity: Activity): View? {
+        return activity.window.findViewById(android.R.id.content)
+            ?: activity.window.decorView.findViewById(android.R.id.content)
     }
 }


### PR DESCRIPTION
As lock screen is shown with `startActivityForResult`, which is asynchronous, the activity
can continue rendering while waiting for the lock screen, which leaks details and potentially allows interaction.

To counteract this, immediately hide the root view of the activity while the lock screen is launched.


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
