### PR TITLE
Migrations: add migration to remove (invalid) media folder created by incorrect scan

### DIFF
--- a/app/src/main/java/com/nextcloud/client/migrations/Migrations.kt
+++ b/app/src/main/java/com/nextcloud/client/migrations/Migrations.kt
@@ -22,7 +22,6 @@ package com.nextcloud.client.migrations
 import android.content.Context
 import android.os.Build
 import android.os.Environment
-import android.provider.MediaStore
 import androidx.work.WorkManager
 import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.jobs.BackgroundJobManager
@@ -30,11 +29,10 @@ import com.nextcloud.client.logger.Logger
 import com.owncloud.android.datamodel.ArbitraryDataProvider
 import com.owncloud.android.ui.activity.ContactsPreferenceActivity
 import com.owncloud.android.utils.PermissionUtil
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.filefilter.TrueFileFilter
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.Paths
 import javax.inject.Inject
-import kotlin.streams.toList
 
 /**
  * This class collects all migration steps and provides API to supply those
@@ -158,7 +156,9 @@ class Migrations @Inject constructor(
         return if (folder.exists()) {
             folder.deleteRecursively()
             logger.i(TAG, "$s: Removed (invalid) nextcloud subdir")
-            val otherChildren = Files.walk(Paths.get(invalidFolderPath)).filter(Files::isRegularFile).toList()
+            val otherChildren = FileUtils
+                .listFiles(File(invalidFolderPath), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE)
+                .filter { it.isFile }
             if (otherChildren.isEmpty()) {
                 val invalidFolder = File(invalidFolderPath)
                 invalidFolder.deleteRecursively()


### PR DESCRIPTION
This folder was created in version 3.18.1  - 3.20.2 (inclusive) when moving media files to private storage.

This is caused by MediaScanner not being able to access the private storage, and instead of crashing it creates
the (invalid) folder, with folders named the same as the original pictures.

Note: this will only work if the app has been granted storage permission, and the fake images won't disappear from
gallery apps / mediaStore until next reboot or media scan.

More info: #9328
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
