### PR TITLE
ChooseRichDocumentsTemplate: avoid IOOBE if there is no dot in field

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -249,7 +249,11 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
         if (name.isEmpty() || name.equalsIgnoreCase(DOT + template.getExtension())) {
             binding.filename.setText(String.format("%s.%s", template.getName(), template.getExtension()));
         }
-        binding.filename.setSelection(binding.filename.getText().toString().lastIndexOf('.'));
+
+        final int dotIndex = binding.filename.getText().toString().lastIndexOf('.');
+        if (dotIndex >= 0) {
+            binding.filename.setSelection(dotIndex);
+        }
     }
 
     private void checkEnablingCreateButton() {


### PR DESCRIPTION
Fixes #9277
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
