### PR TITLE
Fix #10405 Context check for ImagePreviewFragment

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -718,7 +718,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
                                    PreviewImageActivity activity = (PreviewImageActivity) getActivity();
                                    if (activity != null) {
                                        activity.requestForDownload(getFile());
-                                   } else {
+                                   } else if (getContext() != null) {
                                        Snackbar.make(binding.emptyListView,
                                                      getResources().getString(R.string.could_not_download_image),
                                                      Snackbar.LENGTH_INDEFINITE).show();


### PR DESCRIPTION
Show only error snackbar if context is available

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
