### PR TITLE
Avoid checking for walled connection until necessary

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -57,7 +57,7 @@ class OfflineSyncWork constructor(
 
     override fun doWork(): Result {
         val wakeLock: WakeLock? = null
-        if (!powerManagementService.isPowerSavingEnabled && !connectivityService.isInternetWalled) {
+        if (!powerManagementService.isPowerSavingEnabled) {
             val users = userAccountManager.allUsers
             for (user in users) {
                 val storageManager = FileDataStorageManager(user, contentResolver)
@@ -102,7 +102,13 @@ class OfflineSyncWork constructor(
                 return
             }
             ResultCode.ETAG_CHANGED -> Log_OC.d(TAG, "$folderName: eTag changed")
-            else -> Log_OC.d(TAG, "$folderName: eTag changed")
+            else -> {
+                if (connectivityService.isInternetWalled) {
+                    Log_OC.d(TAG, "No connectivity, skipping sync")
+                    return
+                }
+                Log_OC.d(TAG, "$folderName: eTag changed")
+            }
         }
         // iterate over downloaded files
         val files = folder.listFiles { obj: File -> obj.isFile }

--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -23,7 +23,6 @@ package com.nextcloud.client.jobs
 
 import android.content.ContentResolver
 import android.content.Context
-import android.os.PowerManager.WakeLock
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.nextcloud.client.account.User
@@ -51,12 +50,9 @@ class OfflineSyncWork constructor(
 
     companion object {
         const val TAG = "OfflineSyncJob"
-        private const val WAKELOCK_TAG_SEPARATION = ":"
-        private const val WAKELOCK_ACQUISITION_TIMEOUT_MS = 10L * 60L * 1000L
     }
 
     override fun doWork(): Result {
-        val wakeLock: WakeLock? = null
         if (!powerManagementService.isPowerSavingEnabled) {
             val users = userAccountManager.allUsers
             for (user in users) {
@@ -67,7 +63,6 @@ class OfflineSyncWork constructor(
                 }
                 recursive(File(ocRoot.storagePath), storageManager, user)
             }
-            wakeLock?.release()
         }
         return Result.success()
     }

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -675,7 +675,7 @@ public class FileUploader extends Service
     /**
      * Convert current account to user. This is a temporary workaround until
      * service is migrated to new user model.
-     * 
+     *
      * @return Optional {@link User}
      */
     private Optional<User> getCurrentUser() {
@@ -1075,7 +1075,7 @@ public class FileUploader extends Service
         }
 
         final Connectivity connectivity = connectivityService.getConnectivity();
-        final boolean gotNetwork = connectivity.isConnected() && !connectivityService.isInternetWalled();
+        final boolean gotNetwork = connectivity.isConnected();
         final boolean gotWifi = connectivity.isWifi();
         final BatteryStatus batteryStatus = powerManagementService.getBattery();
         final boolean charging = batteryStatus.isCharging() || batteryStatus.isFull();
@@ -1094,7 +1094,8 @@ public class FileUploader extends Service
                     failedUpload.setLastResult(UploadResult.FILE_NOT_FOUND);
                     uploadsStorageManager.updateUpload(failedUpload);
                 }
-            } else if (!isPowerSaving && gotNetwork && canUploadBeRetried(failedUpload, gotWifi, charging)) {
+            } else if (!isPowerSaving && gotNetwork &&
+                canUploadBeRetried(failedUpload, gotWifi, charging) && !connectivityService.isInternetWalled()) {
                 // 2B. for existing local files, try restarting it if possible
                 retryUpload(context, uploadUser.get(), failedUpload);
             }

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -236,7 +236,7 @@ public final class FilesSyncHelper {
         }
 
         new Thread(() -> {
-            if (connectivityService.getConnectivity().isConnected() && !connectivityService.isInternetWalled()) {
+            if (connectivityService.getConnectivity().isConnected()) {
                 FileUploader.retryFailedUploads(
                     context,
                     uploadsStorageManager,


### PR DESCRIPTION
Both when syncing offline files and when retrying failed uploads, don't check for walled internet until the moment it's needed, thus avoiding network calls in cases where it's not needed (missing files, or other conditions not met)

This should reduce load on server, data consumption, and battery drain in such cases.

This is a successor to #10087 with a slightly different approach, thanks @obel1x for your findings and ideas.

In the future we might consider removing this check completely as it is a source of problems, and just handle the errors when trying to do operations in a walled network.
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
