### PR TITLE
FileActivity: fix crash when creating share link from FileDetailsFragment

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -782,7 +782,7 @@ public abstract class FileActivity extends DrawerActivity
     private void onCreateShareViaLinkOperationFinish(CreateShareViaLinkOperation operation,
                                                      RemoteOperationResult result) {
         FileDetailSharingFragment sharingFragment = getShareFileFragment();
-        OCFileListFragment fileListFragment = (OCFileListFragment) getSupportFragmentManager().findFragmentByTag(FileDisplayActivity.TAG_LIST_OF_FILES);
+        final Fragment fileListFragment = getSupportFragmentManager().findFragmentByTag(FileDisplayActivity.TAG_LIST_OF_FILES);
 
         if (result.isSuccess()) {
             updateFileFromDB();
@@ -806,8 +806,8 @@ public abstract class FileActivity extends DrawerActivity
                 sharingFragment.onUpdateShareInformation(result, file);
             }
 
-            if (fileListFragment != null && file != null) {
-                fileListFragment.updateOCFile(file);
+            if (fileListFragment instanceof OCFileListFragment && file != null) {
+                ((OCFileListFragment) fileListFragment).updateOCFile(file);
             }
         } else {
             // Detect Failure (403) --> maybe needs password


### PR DESCRIPTION

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
