### PR TITLE
FileDetailsSharingProcessFragment: avoid crashing when modifying existing shares

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -133,10 +133,13 @@ class FileDetailsSharingProcessFragment : Fragment(), ExpirationDatePickerDialog
         arguments?.let {
             file = it.getParcelable(ARG_OCFILE)
             shareeName = it.getString(ARG_SHAREE_NAME)
+            share = it.getParcelable(ARG_OCSHARE)
             if (it.containsKey(ARG_SHARE_TYPE)) {
                 shareType = it.getSerializable(ARG_SHARE_TYPE) as ShareType
+            } else if (share != null) {
+                shareType = share!!.shareType
             }
-            share = it.getParcelable(ARG_OCSHARE)
+
             shareProcessStep = it.getInt(ARG_SCREEN_TYPE, SCREEN_TYPE_PERMISSION)
             isReshareShown = it.getBoolean(ARG_RESHARE_SHOWN, true)
             isExpDateShown = it.getBoolean(ARG_EXP_DATE_SHOWN, true)


### PR DESCRIPTION
This can only happen on certain codepaths but should be avoided anyway.

Fixes #10480


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
