### PR TITLE
SetStatusDialogFragment: fix nullability of itemSelected parameter

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/SetStatusDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/ui/SetStatusDialogFragment.kt
@@ -196,7 +196,7 @@ class SetStatusDialogFragment :
         binding.clearStatusAfterSpinner.apply {
             this.adapter = adapter
             onItemSelectedListener = object : OnItemSelectedListener {
-                override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
+                override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
                     setClearStatusAfterValue(position)
                 }
 


### PR DESCRIPTION
Prevents crash when fragment is recreated (like when dark mode is switched)

Rel #10488
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
