### PR TITLE
Ensure entire logcat is collected during CI connected tests

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/RetryTestRule.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/RetryTestRule.kt
@@ -49,7 +49,7 @@ class RetryTestRule(val retryCount: Int = defaultRetryValue) : TestRule {
         return object : Statement() {
 
             override fun evaluate() {
-                Log.e(TAG, "Evaluating ${description.methodName}")
+                Log.d(TAG, "Evaluating ${description.methodName}")
 
                 var caughtThrowable: Throwable? = null
 

--- a/scripts/runCombinedTest.sh
+++ b/scripts/runCombinedTest.sh
@@ -6,12 +6,13 @@ LOG_PASSWORD=$3
 DRONE_BUILD_NUMBER=$4
 
 function upload_logcat() {
-    log_filename="${DRONE_PULL_REQUEST}_logcat.txt.gz"
+    log_filename="${DRONE_PULL_REQUEST}_logcat.txt.xz"
     log_file="app/build/${log_filename}"
     upload_path="https://nextcloud.kaminsky.me/remote.php/webdav/android-logcat/$log_filename"
-    adb logcat -d | gzip > "$log_file"
+    xz logcat.txt
+    mv logcat.txt.xz "$log_file"
     curl -u "${LOG_USERNAME}:${LOG_PASSWORD}" -X PUT "$upload_path" --upload-file "$log_file"
-    echo >&2 "Uploaded logcat to https://kaminsky.me/nc-dev/android-logcat/$log_filename"
+    echo >&2 "Uploaded logcat to https://www.kaminsky.me/nc-dev/android-logcat/$log_filename"
 }
 
 scripts/deleteOldComments.sh "master" "IT" "$DRONE_PULL_REQUEST"
@@ -22,9 +23,15 @@ scripts/wait_for_emulator.sh
 
 ./gradlew installGplayDebugAndroidTest
 scripts/wait_for_server.sh "server"
+
+# clear logcat and start saving it to file
 adb logcat -c
+adb logcat > logcat.txt &
+LOGCAT_PID=$!
 ./gradlew createGplayDebugCoverageReport -Pcoverage -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.owncloud.android.utils.ScreenshotTest
 stat=$?
+# stop saving logcat
+kill $LOGCAT_PID
 
 if [ ! $stat -eq 0 ]; then
     upload_logcat


### PR DESCRIPTION
Start streaming logcat before tests instead of dumping it after. This avoids buffer overflow.

Additionally use xz instead of gzip, for greater compression
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
