### PR TITLE
Use openjdk-11 in Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV ANDROID_HOME=/usr/lib/android-sdk
 
 RUN apt-get update -y
-RUN apt-get install -y unzip wget openjdk-8-jdk vim
+RUN apt-get install -y unzip wget openjdk-11-jdk vim
 
 RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O /tmp/commandlinetools.zip
 RUN cd /tmp && unzip commandlinetools.zip


### PR DESCRIPTION
Signed-off-by: Robin Windey <ro.windey@gmail.com>

- [x] Tests written, or not not needed

Closing https://github.com/nextcloud/android/issues/10541
