### PR TITLE
Bump targetSdkVersion to 31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         buildConfigField 'boolean', 'CI', ciBuild.toString()
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
     <application
         android:name=".MainApp"
         android:fullBackupContent="@xml/backup_config"
+        android:dataExtractionRules="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:installLocation="internalOnly"
         android:label="@string/app_name"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~ Nextcloud Android client application
+  ~
+  ~ @author Tobias Kaminsky
+  ~ Copyright (C) 2022 Tobias Kaminsky
+  ~ Copyright (C) 2022 Nextcloud GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <exclude
+            domain="sharedpref"
+            path="evernote_jobs.xml" />
+        <exclude
+            domain="database"
+            path="evernote_jobs.db" />
+        <exclude
+            domain="file"
+            path="." />
+    </cloud-backup>
+</data-extraction-rules>


### PR DESCRIPTION
Ref:
https://github.com/nextcloud/android/issues/9997

I tested it and beside deep link everything works so far.

- Toast length, due to translations cannot be checked, also as sometimes the text is provide by server. When we experience problems, we need to tackle it
- Notification still look fine: 
![image](https://user-images.githubusercontent.com/5836855/180144789-a533d270-d084-4384-bd67-cf5432ae970a.png)
- music playing (foreground service) also works. Limitation seems to be only when starting it in background.


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
