### PR TITLE
Moved libraries from nextcloud to nextcloud-deps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -237,10 +237,10 @@ dependencies {
     implementation 'org.lukhnos:nnio:0.2'
     implementation 'org.bouncycastle:bcpkix-jdk15to18:1.70'
     implementation 'com.google.code.gson:gson:2.9.1'
-    implementation 'com.github.nextcloud:sectioned-recyclerview:0.6.1'
+    implementation 'com.github.nextcloud-deps:sectioned-recyclerview:0.6.1'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.24'
-    implementation 'com.github.nextcloud:qrcodescanner:0.1.2.4' // 'com.github.blikoon:QRCodeScanner:0.1.2'
+    implementation 'com.github.nextcloud-deps:qrcodescanner:0.1.2.4' // 'com.github.blikoon:QRCodeScanner:0.1.2'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation('com.github.bumptech.glide:glide:3.8.0') {
         exclude group: "com.android.support"


### PR DESCRIPTION
As links still work, this is not really needed, but still good to point to new location.
Thus no backport is needed.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
