### PR TITLE
Avoid full folder refresh during onBrowseUp

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -666,7 +666,11 @@ public class ExtendedListFragment extends Fragment implements
     @Override
     public void onRefresh(boolean ignoreETag) {
         if (mOnRefreshListener != null) {
-            mOnRefreshListener.onRefresh();
+            if (mOnRefreshListener instanceof FileDisplayActivity) {
+                ((FileDisplayActivity) mOnRefreshListener).onRefresh(ignoreETag);
+            } else {
+                mOnRefreshListener.onRefresh();
+            }
         }
     }
 


### PR DESCRIPTION
I have noticed that during going up in the folder hierarchy the folder gets refreshed longer than expected.

It turns out that during execution of **com.owncloud.android.ui.fragment.OCFileListFragment.onBrowseUp**, a full refresh is requested (with **ignoreETag** set to **true**).

Is this the expected behaviour?

If not - this PR is an attempt to fix it, but I am not sure if this is a correct way (in current code value of **ignoreETag** is lost between **ExtendedListFragment.onRefresh** and **FileDisplayActivity.onRefresh**).

Thoughts?