### PR TITLE
PreviewImageFragment: prevent crash when redrawing menu after file deletion

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -367,18 +367,21 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
 
         if (containerActivity.getStorageManager() != null && getFile() != null) {
             // Update the file
-            setFile(containerActivity.getStorageManager().getFileById(getFile().getFileId()));
+            final OCFile updatedFile = containerActivity.getStorageManager().getFileById(getFile().getFileId());
+            setFile(updatedFile);
 
-            User currentUser = accountManager.getUser();
-            FileMenuFilter mf = new FileMenuFilter(
-                getFile(),
-                containerActivity,
-                getActivity(),
-                false,
-                currentUser
-            );
+            if (getFile() != null) {
+                User currentUser = accountManager.getUser();
+                FileMenuFilter mf = new FileMenuFilter(
+                    getFile(),
+                    containerActivity,
+                    getActivity(),
+                    false,
+                    currentUser
+                );
 
-            mf.filter(menu, true);
+                mf.filter(menu, true);
+            }
         }
 
         // additional restriction for this fragment
@@ -394,7 +397,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
                 menu.findItem(R.id.action_unset_favorite)
         );
 
-        if (getFile().isSharedWithMe() && !getFile().canReshare()) {
+        if (getFile() != null && getFile().isSharedWithMe() && !getFile().canReshare()) {
             FileMenuFilter.hideMenuItem(menu.findItem(R.id.action_send_share_file));
         }
     }


### PR DESCRIPTION
For some reason this is called again after deleting the file (probably a fragment-ktx update or something).
However at this point getFileById will return null and crash the rest of the method.

This adds some checks to prevent that.

Fixes #10580 and all its duplicates

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
