### PR TITLE
Brander: white primary color

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -22,7 +22,7 @@
     <color name="list_item_lastmod_and_filesize_text">@color/secondary_text_color</color>
     <color name="black">#000000</color>
     <color name="white">#ffffff</color>
-    <color name="white_helper_text">#B3FFFFFF</color>
+    <color name="white_helper_text">#000</color>
     <color name="text_color">#333333</color>
     <color name="drawer_text_color">@color/secondary_text_color</color>
     <color name="text_color_inverse">#ffffff</color>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -22,7 +22,7 @@
 
     <!-- URLs and flags related -->
     <bool name="show_server_url_input">true</bool>
-    <bool name="show_provider_or_own_installation">true</bool>
+    <bool name="show_provider_or_own_installation">false</bool>
     <string name="provider_registration_server">https://www.nextcloud.com/register</string>
 
     <!-- Flags to enable/disable some features -->
@@ -43,11 +43,11 @@
     <array name="whatsnew_urls"></array>
 
     <!-- Colors -->
-    <color name="primary">#0082c9</color>
-    <color name="primary_dark">#006AA3</color>
-    <color name="color_accent">#007cc2</color>
-    <color name="login_text_color">#ffffff</color>
-    <color name="login_text_hint_color">#7fC0E3</color>
+    <color name="primary">#FFFFFF</color>
+    <color name="primary_dark">#cccccc</color>
+    <color name="color_accent">#FFFFFF</color>
+    <color name="login_text_color">#000</color>
+    <color name="login_text_hint_color">#000</color>
 
     <!-- Multiaccount support -->
     <bool name="multiaccount_support">true</bool>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -349,8 +349,8 @@
     </style>
 
     <style name="ThemeOverlay.App.Login.TextInputLayout" parent="">
-        <item name="colorPrimary">@color/white</item>
-        <item name="colorOnSurface">@color/white</item>
+        <item name="colorPrimary">@color/black</item>
+        <item name="colorOnSurface">@color/black</item>
         <item name="colorError">@color/hwSecurityRed</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.MaterialComponents.Subtitle1</item>
         <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>


### PR DESCRIPTION
As you know we allow any color during branding.
I now tested white without enforced domain and to make server-url input screen reasonable nice, I had to change it like this.

My "problem" is now, that I had to change two other files, instead of simply relying on setup.xml.
Do you have any idea how to do this better?

We might need to have a better differentiation between
- primary color as background, can be any color
- primary color used as background, but text is written onto it (e.g. primary button, login screen)

In later case white can still be primary color, but then the text color must be based on primary color.

Whatever we come up with, we then shall test it with 
- NC blue
- white
- black
- random color
(logic how current colors are computed are on brander: https://github.com/nextcloud-gmbh/brander/blob/19824f733dc6d1534d521ae228ae12650eba21f9/src/Brander/Worker/AndroidJobHandler.php#L445)

🤷 @AlvaroBrey @AndyScherzinger 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
