### PR TITLE
[WIP] Fix OOM bug in automatic upload queue

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -146,11 +146,11 @@ class FilesSyncWork(
         } else {
             null
         }
-        val maxUploadAmount = 250
+        val MAX_UPLOAD_AMOUNT = 250
         val paths = filesystemDataProvider.getFilesForUpload(
             syncedFolder.localPath,
             java.lang.Long.toString(syncedFolder.id),
-            maxUploadAmout
+            MAX_UPLOAD_AMOUNT
         )
         for (path in paths) {
             file = File(path)

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -146,9 +146,11 @@ class FilesSyncWork(
         } else {
             null
         }
+        val maxUploadAmount = 250
         val paths = filesystemDataProvider.getFilesForUpload(
             syncedFolder.localPath,
-            java.lang.Long.toString(syncedFolder.id)
+            java.lang.Long.toString(syncedFolder.id),
+            maxUploadAmout
         )
         for (path in paths) {
             file = File(path)

--- a/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
@@ -74,7 +74,7 @@ public class FilesystemDataProvider {
         );
     }
 
-    public Set<String> getFilesForUpload(String localPath, String syncedFolderId) {
+    public Set<String> getFilesForUpload(String localPath, String syncedFolderId, int maxUploadAmount) {
         Set<String> localPathsToUpload = new HashSet<>();
 
         String likeParam = localPath + "%";
@@ -105,6 +105,14 @@ public class FilesystemDataProvider {
                         } else if (!SyncedFolderUtils.isFileNameQualifiedForAutoUpload(file.getName())) {
                             Log_OC.d(TAG, "Ignoring file for upload (unqualified file): " + value);
                         } else {
+                            // This puts a limit to the amount of paths that can be uploaded
+                            // at the same time. In case the content resolver returns thousands
+                            // of files, this ensures that they are not all added to the
+                            // upload queue at the same time, but in batches of at most
+                            // maxUploadAmount in size.
+                            if (localPathsToUpload.size() >= maxUploadAmount) {
+                              break;
+                            }
                             localPathsToUpload.add(value);
                         }
                     }


### PR DESCRIPTION
## Background 
I recently setup a new Nextcloud instance and wanted to synchronize the contents of my Android phone with it. It contains tens of thousands of photos and videos. When I configured the app to automatically upload these photos and videos to Nextcloud, the app became unresponsive and crashed soon after. Disabling the automatic upload feature for that particular folder also became impossible, as the app became unresponsive as soon as it had started up. Reinstalling the app was the only way to use it again, as that would reset the automatic upload settings.

## Fix

```java
Exception in thread "Thread-3" java.lang.OutOfMemoryError: Failed to allocate a 48 byte allocation with 1003528 free bytes and 980KB until OOM, target footprint 268435456, growth limit 268435456; giving up on allocation because <1% of heap free after GC.
    at java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:68)
    at java.lang.StringBuilder.<init>(StringBuilder.java:90)
    at sun.security.x509.AVA.toRFC2253CanonicalString(AVA.java:957)
    at sun.security.x509.RDN.toRFC2253StringInternal(RDN.java:444)
    at sun.security.x509.RDN.toRFC2253String(RDN.java:424)
    at sun.security.x509.X500Name.getRFC2253CanonicalName(X500Name.java:730)
    at sun.security.x509.X500Name.hashCode(X500Name.java:383)
    at javax.security.auth.x500.X500Principal.hashCode(X500Principal.java:487)
    at java.util.HashMap.hash(HashMap.java:338)
    at java.util.LinkedHashMap.get(LinkedHashMap.java:464)
    at okhttp3.internal.tls.BasicTrustRootIndex.<init>(BasicTrustRootIndex.kt:57)
    at okhttp3.internal.platform.Platform.buildTrustRootIndex(Platform.kt:163)
    at okhttp3.internal.platform.Platform.buildCertificateChainCleaner(Platform.kt:160)
    at okhttp3.internal.platform.Android10Platform.buildCertificateChainCleaner(Android10Platform.kt:82)
    at okhttp3.internal.tls.CertificateChainCleaner$Companion.get(CertificateChainCleaner.kt:42)
    at okhttp3.OkHttpClient$Builder.sslSocketFactory(OkHttpClient.kt:870)
    at com.nextcloud.common.PlainClient$Companion.createDefaultClient(PlainClient.kt:62)
    at com.nextcloud.common.PlainClient$Companion.access$createDefaultClient(PlainClient.kt:47)
    at com.nextcloud.common.PlainClient.<init>(PlainClient.kt:45)
    at com.nextcloud.client.network.ClientFactoryImpl.createPlainClient(ClientFactoryImpl.java:94)
    at com.nextcloud.client.network.ConnectivityServiceImpl.isInternetWalled(ConnectivityServiceImpl.java:79)
    at com.owncloud.android.files.services.FileUploader.retryFailedUploads(FileUploader.java:1093)
    at com.owncloud.android.utils.FilesSyncHelper.lambda$restartJobsIfNeeded$0(FilesSyncHelper.java:240)
    at com.owncloud.android.utils.FilesSyncHelper$$ExternalSyntheticLambda0.run(Unknown Source:10)
    at java.lang.Thread.run(Thread.java:920)
```

The stacktrace listed above pointed me in the right direction. The thousands of files are queued up to be uploaded to the Nextcloud server, an out-of-memory error occurs on my device (6GB of RAM). This pull request prevents this OOM because it limits the amount of files that are added to the upload queue to a, somewhat arbitrary, 250 files at a time. This fixes the issue for me. Others seem to have reported having similar issues:
- https://github.com/nextcloud/android/issues/10707#issuecomment-1236186431
- https://github.com/nextcloud/android/issues/9639
- https://github.com/nextcloud/android/issues/10653
- https://github.com/nextcloud/android/issues/10633
- https://github.com/nextcloud/android/issues/10682