### PR TITLE
Rotate images

### DIFF
--- a/app/src/main/java/com/nextcloud/client/files/downloader/UploadTask.kt
+++ b/app/src/main/java/com/nextcloud/client/files/downloader/UploadTask.kt
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2021 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -86,6 +88,7 @@ class UploadTask(
             applicationContext,
             upload.isUseWifiOnly,
             upload.isWhileChargingOnly,
+            false,
             false,
             fileDataStorageManager
         )

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -101,6 +103,7 @@ class BackgroundJobFactory @Inject constructor(
                 CalendarBackupWork::class -> createCalendarBackupWork(context, workerParameters)
                 CalendarImportWork::class -> createCalendarImportWork(context, workerParameters)
                 FilesExportWork::class -> createFilesExportWork(context, workerParameters)
+                UploadImagesWorker::class -> createUploadImagesWork(context, workerParameters)
                 else -> null // caller falls back to default factory
             }
         }
@@ -240,6 +243,16 @@ class BackgroundJobFactory @Inject constructor(
             clock,
             eventBus,
             preferences
+        )
+    }
+
+    private fun createUploadImagesWork(context: Context, params: WorkerParameters): UploadImagesWorker {
+        return UploadImagesWorker(
+            context = context,
+            params = params,
+            notificationManager,
+            accountManager,
+            themeColorUtils
         )
     }
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -138,6 +140,8 @@ interface BackgroundJobManager {
 
     fun startNotificationJob(subject: String, signature: String)
     fun startAccountRemovalJob(accountName: String, remoteWipe: Boolean)
+
+    fun scheduleImmediateUploadImagesJob(): LiveData<JobInfo?>
 
     fun scheduleTestJob()
     fun startImmediateTestJob()

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -80,6 +82,7 @@ internal class BackgroundJobManagerImpl(
         const val JOB_ACCOUNT_REMOVAL = "account_removal"
         const val JOB_IMMEDIATE_CALENDAR_BACKUP = "immediate_calendar_backup"
         const val JOB_IMMEDIATE_FILES_EXPORT = "immediate_files_export"
+        const val JOB_IMAGE_FILES_UPLOAD = "immediate_image_files_upload"
 
         const val JOB_TEST = "test_job"
 
@@ -446,6 +449,14 @@ internal class BackgroundJobManagerImpl(
             .build()
 
         workManager.enqueue(request)
+    }
+
+    override fun scheduleImmediateUploadImagesJob(): LiveData<JobInfo?> {
+        val request = oneTimeRequestBuilder(UploadImagesWorker::class, JOB_IMAGE_FILES_UPLOAD)
+            .build()
+
+        workManager.enqueueUniqueWork(JOB_IMAGE_FILES_UPLOAD, ExistingWorkPolicy.APPEND_OR_REPLACE, request)
+        return workManager.getJobInfo(request.id)
     }
 
     override fun scheduleTestJob() {

--- a/app/src/main/java/com/nextcloud/client/jobs/UploadImagesWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/UploadImagesWorker.kt
@@ -1,0 +1,162 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author TSI-mc
+ * Copyright (C) 2022 TSI-mc
+ * Copyright (C) 2022 NextCloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.client.jobs
+
+import android.app.NotificationManager
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.core.app.NotificationCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.nextcloud.client.account.UserAccountManager
+import com.owncloud.android.R
+import com.owncloud.android.files.services.FileUploader
+import com.owncloud.android.files.services.NameCollisionPolicy
+import com.owncloud.android.operations.UploadFileOperation
+import com.owncloud.android.ui.notifications.NotificationUtils
+import com.owncloud.android.ui.preview.PreviewImageActivity
+import com.owncloud.android.ui.preview.PreviewImageFragment
+import com.owncloud.android.utils.FileUtil
+import com.owncloud.android.utils.theme.ThemeColorUtils
+import java.io.File
+import java.security.SecureRandom
+
+/**
+ * worker to upload the files in background when app is not running or app is killed
+ * right now we are using it for to save rotated images
+ */
+class UploadImagesWorker constructor(
+    private val context: Context,
+    params: WorkerParameters,
+    private val notificationManager: NotificationManager,
+    private val accountManager: UserAccountManager,
+    private val themeColorUtils: ThemeColorUtils,
+) : Worker(context, params) {
+
+    private val savedFiles = mutableListOf<String>()
+    private val remotePaths = mutableListOf<String>()
+
+    companion object {
+        const val TAG = "UploadImagesWorkerJob"
+        const val IMAGE_COMPRESSION_PERCENTAGE = 100
+    }
+
+    override fun doWork(): Result {
+
+        val bitmapHashMap: HashMap<Int, PreviewImageFragment.LoadImage> = HashMap(PreviewImageActivity.bitmapHashMap)
+
+        // clear the static bitmap once the images are stored in work manager instance
+        PreviewImageActivity.bitmapHashMap.clear()
+
+        val randomId = SecureRandom()
+        val pushNotificationId = randomId.nextInt()
+        showNotification(pushNotificationId)
+
+        for ((_, value) in bitmapHashMap) {
+            val fileName = value.ocFile.fileName
+            // get the file extension
+            val extension: String = fileName.substring(fileName.lastIndexOf("."))
+            // get the file name without extension
+            val fileNameWithoutExt: String = fileName.replace(extension, "")
+
+            // if extension is jpg then save the image as jpg
+            if (extension == ".jpg" || extension == ".jpeg") {
+                val jpgFile =
+                    FileUtil.saveJpgImage(context, value.bitmap, fileNameWithoutExt, IMAGE_COMPRESSION_PERCENTAGE)
+
+                // if file is available on local then rewrite the file as well
+                if (value.ocFile.isDown) {
+                    FileUtil.saveJpgImage(
+                        context,
+                        value.bitmap,
+                        File(value.ocFile.storagePath),
+                        IMAGE_COMPRESSION_PERCENTAGE
+                    )
+                }
+                onImageSaveSuccess(value, jpgFile)
+
+                // if extension is png then save the image as png
+            } else if (extension == ".png") {
+                val pngFile =
+                    FileUtil.savePngImage(context, value.bitmap, fileNameWithoutExt, IMAGE_COMPRESSION_PERCENTAGE)
+
+                // if file is available on local then rewrite the file as well
+                if (value.ocFile.isDown) {
+                    FileUtil.savePngImage(
+                        context,
+                        value.bitmap,
+                        File(value.ocFile.storagePath),
+                        IMAGE_COMPRESSION_PERCENTAGE
+                    )
+                }
+                onImageSaveSuccess(value, pngFile)
+            }
+        }
+
+        notificationManager.cancel(pushNotificationId)
+
+        // upload image files
+        if (!savedFiles.isNullOrEmpty() && !remotePaths.isNullOrEmpty()) {
+            uploadImageFiles()
+        }
+
+        return Result.success()
+    }
+
+    private fun onImageSaveSuccess(
+        value: PreviewImageFragment.LoadImage,
+        imageFile: File
+    ) {
+        savedFiles.add(imageFile.path)
+        remotePaths.add(value.ocFile.remotePath)
+    }
+
+    private fun showNotification(pushNotificationId: Int) {
+        val notificationBuilder =
+            NotificationCompat.Builder(context, NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD)
+                .setSmallIcon(R.drawable.notification_icon)
+                .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
+                .setColor(themeColorUtils.primaryColor(context, true))
+                .setContentTitle(context.resources.getString(R.string.app_name))
+                .setContentText(context.resources.getString(R.string.foreground_service_save))
+                .setAutoCancel(false)
+
+        notificationManager.notify(pushNotificationId, notificationBuilder.build())
+    }
+
+    private fun uploadImageFiles() {
+        FileUploader.uploadNewFile(
+            context,
+            accountManager.user,
+            savedFiles.toTypedArray(),
+            remotePaths.toTypedArray(),
+            null, // MIME type will be detected from file name
+            FileUploader.LOCAL_BEHAVIOUR_DELETE,
+            false, // do not create parent folder if not existent
+            UploadFileOperation.CREATED_BY_USER,
+            false,
+            false,
+            NameCollisionPolicy.OVERWRITE, // overwrite the images
+            true
+        )
+    }
+}

--- a/app/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/app/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -5,8 +5,10 @@
  * @author masensio
  * @author David A. Velasco
  * @author Tobias Kaminsky
+ * @author TSI-mc
  * Copyright (C) 2016 ownCloud Inc.
  * Copyright (C) 2018 Nextcloud GmbH.
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -129,6 +131,8 @@ public class OCUpload implements Parcelable {
     private long fixedUploadEndTimeStamp;
     private long fixedUploadId;
 
+    private boolean isRotatedImages;
+
     /**
      * Main constructor.
      *
@@ -180,6 +184,7 @@ public class OCUpload implements Parcelable {
         useWifiOnly = true;
         whileChargingOnly = false;
         folderUnlockToken = "";
+        isRotatedImages = false;
     }
 
     public void setDataFixed(FileUploader.FileUploaderBinder binder) {
@@ -291,6 +296,7 @@ public class OCUpload implements Parcelable {
         useWifiOnly = source.readInt() == 1;
         whileChargingOnly = source.readInt() == 1;
         folderUnlockToken = source.readString();
+        isRotatedImages = source.readInt() == 1;
     }
 
     @Override
@@ -316,7 +322,8 @@ public class OCUpload implements Parcelable {
             createdBy == other.createdBy &&
             useWifiOnly == other.useWifiOnly &&
             whileChargingOnly == other.whileChargingOnly &&
-            folderUnlockToken.equals(other.folderUnlockToken);
+            folderUnlockToken.equals(other.folderUnlockToken) &&
+            isRotatedImages == other.isRotatedImages;
     }
 
     @Override
@@ -335,6 +342,7 @@ public class OCUpload implements Parcelable {
         dest.writeInt(useWifiOnly ? 1 : 0);
         dest.writeInt(whileChargingOnly ? 1 : 0);
         dest.writeString(folderUnlockToken);
+        dest.writeInt(isRotatedImages ? 1 : 0);
     }
 
     public long getUploadId() {
@@ -443,5 +451,13 @@ public class OCUpload implements Parcelable {
 
     public void setFolderUnlockToken(String folderUnlockToken) {
         this.folderUnlockToken = folderUnlockToken;
+    }
+
+    public boolean isRotatedImages() {
+        return isRotatedImages;
+    }
+
+    public void setRotatedImages(boolean rotatedImages) {
+        isRotatedImages = rotatedImages;
     }
 }

--- a/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -3,8 +3,10 @@
  *
  * @author David A. Velasco
  * @author Andy Scherzinger
+ * @author TSI-mc
  * Copyright (C) 2015 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -174,7 +176,7 @@ public class FileMenuFilter {
         }
     }
 
-    private static void showMenuItem(MenuItem item) {
+    public static void showMenuItem(MenuItem item) {
         if (item != null) {
             item.setVisible(true);
             item.setEnabled(true);

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -6,10 +6,12 @@
  *  @author LukeOwnCloud
  *  @author David A. Velasco
  *  @author Chris Narkiewicz
+ *  @author TSI-mc
  *
  *  Copyright (C) 2012 Bartek Przybylski
  *  Copyright (C) 2012-2016 ownCloud Inc.
  *  Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
+ *  Copyright (C) 2022 TSI-mc
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2,
@@ -181,6 +183,11 @@ public class FileUploader extends Service
      * Set to true if the HTTP library should disable automatic retries of uploads.
      */
     public static final String KEY_DISABLE_RETRIES = "DISABLE_RETRIES";
+
+    /**
+     * Set to true if the image files are uploading after rotating them
+     */
+    public static final String KEY_ROTATED_IMAGE = "ROTATED_IMAGE";
 
     public static final int LOCAL_BEHAVIOUR_COPY = 0;
     public static final int LOCAL_BEHAVIOUR_MOVE = 1;
@@ -423,6 +430,7 @@ public class FileUploader extends Service
         boolean isCreateRemoteFolder = intent.getBooleanExtra(KEY_CREATE_REMOTE_FOLDER, false);
         int createdBy = intent.getIntExtra(KEY_CREATED_BY, UploadFileOperation.CREATED_BY_USER);
         boolean disableRetries = intent.getBooleanExtra(KEY_DISABLE_RETRIES, true);
+        boolean isRotatedImages = intent.getBooleanExtra(KEY_ROTATED_IMAGE, false);
         try {
             for (OCFile file : files) {
                 startNewUpload(
@@ -435,7 +443,8 @@ public class FileUploader extends Service
                     isCreateRemoteFolder,
                     createdBy,
                     file,
-                    disableRetries
+                    disableRetries,
+                    isRotatedImages
                               );
             }
         } catch (IllegalArgumentException e) {
@@ -465,7 +474,8 @@ public class FileUploader extends Service
         boolean isCreateRemoteFolder,
         int createdBy,
         OCFile file,
-        boolean disableRetries
+        boolean disableRetries,
+        boolean isRotatedImages
                                ) {
         OCUpload ocUpload = new OCUpload(file, user);
         ocUpload.setFileSize(file.getFileLength());
@@ -476,6 +486,7 @@ public class FileUploader extends Service
         ocUpload.setUseWifiOnly(onWifiOnly);
         ocUpload.setWhileChargingOnly(whileChargingOnly);
         ocUpload.setUploadStatus(UploadStatus.UPLOAD_IN_PROGRESS);
+        ocUpload.setRotatedImages(isRotatedImages);
 
         UploadFileOperation newUpload = new UploadFileOperation(
             mUploadsStorageManager,
@@ -490,6 +501,7 @@ public class FileUploader extends Service
             onWifiOnly,
             whileChargingOnly,
             disableRetries,
+            isRotatedImages,
             new FileDataStorageManager(user, getContentResolver())
         );
         newUpload.setCreatedBy(createdBy);
@@ -526,6 +538,7 @@ public class FileUploader extends Service
 
         onWifiOnly = upload.isUseWifiOnly();
         whileChargingOnly = upload.isWhileChargingOnly();
+        boolean isRotateImages = upload.isRotatedImages();
 
         UploadFileOperation newUpload = new UploadFileOperation(
             mUploadsStorageManager,
@@ -540,6 +553,7 @@ public class FileUploader extends Service
             onWifiOnly,
             whileChargingOnly,
             true,
+            isRotateImages,
             new FileDataStorageManager(user, getContentResolver())
         );
 
@@ -942,7 +956,8 @@ public class FileUploader extends Service
             createdBy,
             requiresWifi,
             requiresCharging,
-            nameCollisionPolicy
+            nameCollisionPolicy,
+            false
         );
     }
 
@@ -960,7 +975,8 @@ public class FileUploader extends Service
         int createdBy,
         boolean requiresWifi,
         boolean requiresCharging,
-        NameCollisionPolicy nameCollisionPolicy
+        NameCollisionPolicy nameCollisionPolicy,
+        boolean isRotatedImages
     ) {
         Intent intent = new Intent(context, FileUploader.class);
 
@@ -975,6 +991,7 @@ public class FileUploader extends Service
         intent.putExtra(FileUploader.KEY_WHILE_ON_WIFI_ONLY, requiresWifi);
         intent.putExtra(FileUploader.KEY_WHILE_CHARGING_ONLY, requiresCharging);
         intent.putExtra(FileUploader.KEY_NAME_COLLISION_POLICY, nameCollisionPolicy);
+        intent.putExtra(FileUploader.KEY_ROTATED_IMAGE, isRotatedImages);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(intent);

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -3,8 +3,10 @@
  *
  * @author David A. Velasco
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2016 ownCloud GmbH.
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -120,6 +122,7 @@ public class UploadFileOperation extends SyncOperation {
     private boolean mWhileChargingOnly;
     private boolean mIgnoringPowerSaveMode;
     private final boolean mDisableRetries;
+    private final boolean mIsRotatedImages;
 
     private boolean mWasRenamed;
     private long mOCUploadId;
@@ -195,6 +198,7 @@ public class UploadFileOperation extends SyncOperation {
              onWifiOnly,
              whileChargingOnly,
              true,
+             false,
              storageManager);
     }
 
@@ -210,6 +214,7 @@ public class UploadFileOperation extends SyncOperation {
                                boolean onWifiOnly,
                                boolean whileChargingOnly,
                                boolean disableRetries,
+                               boolean isRotatedImages,
                                FileDataStorageManager storageManager) {
         super(storageManager);
 
@@ -250,6 +255,7 @@ public class UploadFileOperation extends SyncOperation {
         mIgnoringPowerSaveMode = mCreatedBy == CREATED_BY_USER;
         mFolderUnlockToken = upload.getFolderUnlockToken();
         mDisableRetries = disableRetries;
+        mIsRotatedImages = isRotatedImages;
     }
 
     public boolean isWifiRequired() {
@@ -1359,7 +1365,27 @@ public class UploadFileOperation extends SyncOperation {
             // coincidence; nothing else is needed, the storagePath is right
             // in the instance returned by mCurrentUpload.getFile()
         }
-        file.setUpdateThumbnailNeeded(true);
+
+        //if uploaded file is image then set the preview available as true
+        //this will be used to update the rotated image thumbnail for media view
+        //since media view listing depends upon then storage manager
+        //so we have to update this flag in local db
+        if (MimeTypeUtil.isImage(file.getMimeType())) {
+            //preview available true is required so that thumbnail gets updated automatically
+            //and user doesn't has to refresh the list manually
+            file.setPreviewAvailable(true);
+        }
+
+        //setUpdateThumbnailNeeded FALSE
+        //if the file is media file set thumbnail needed flag as false
+        //as this will avoid showing shimmer in OCFileListAdapter on refresh
+        //as we are creating thumbnail over here as well and also in OCFileListAdapter if not available
+        //this is specially for MediaView
+
+        //setUpdateThumbnailNeeded TRUE
+        //for other files we can set the thumbnail needed true
+        file.setUpdateThumbnailNeeded(!mIsRotatedImages);
+
         getStorageManager().saveFile(file);
         getStorageManager().saveConflict(file, null);
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -944,7 +944,8 @@ public class FileDisplayActivity extends FileActivity
                 UploadFileOperation.CREATED_BY_USER,
                 false,
                 false,
-                NameCollisionPolicy.ASK_USER
+                NameCollisionPolicy.ASK_USER,
+                false
                                       );
 
         } else {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -6,9 +6,11 @@
  * @author David A. Velasco
  * @author Andy Scherzinger
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2011  Bartek Przybylski
  * Copyright (C) 2016 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -1346,6 +1348,17 @@ public class OCFileListFragment extends ExtendedListFragment implements
             handleSearchEvent(searchEvent);
             mRefreshListLayout.setRefreshing(false);
         }
+
+        //Notify the adapter only for Gallery
+        //this will be used when user rotated the image and comes back
+        //so we have to update the thumbnail of the rotated image
+        //this method will also be called when uploading of the any file (rotated image) is finished
+        if (searchEvent != null
+            && searchEvent.getSearchType() == SearchRemoteOperation.SearchType.PHOTO_SEARCH
+            && getRecyclerView().getAdapter() != null) {
+            getRecyclerView().getAdapter().notifyDataSetChanged();
+        }
+
     }
 
     public void updateOCFile(OCFile file) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -3,9 +3,11 @@
  *
  * @author David A. Velasco
  * @author Chris Narkiewicz
+ * @author TSI-mc
  *
  * Copyright (C) 2015 ownCloud Inc.
  * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -27,6 +29,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.Matrix;
 import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
@@ -34,6 +37,8 @@ import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.PictureDrawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Process;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
@@ -72,11 +77,16 @@ import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeType;
 import com.owncloud.android.utils.MimeTypeUtil;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -84,6 +94,7 @@ import javax.inject.Inject;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.os.HandlerCompat;
 import androidx.fragment.app.FragmentStatePagerAdapter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import pl.droidsonroids.gif.GifDrawable;
@@ -108,6 +119,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
     private static final String ARG_FILE = "FILE";
     private static final String ARG_IGNORE_FIRST = "IGNORE_FIRST";
     private static final String ARG_SHOW_RESIZED_IMAGE = "SHOW_RESIZED_IMAGE";
+    private static final String ARG_CURRENT_INDEX = "CURRENT_INDEX";
     private static final String MIME_TYPE_PNG = "image/png";
     private static final String MIME_TYPE_GIF = "image/gif";
     private static final String MIME_TYPE_SVG = "image/svg+xml";
@@ -127,6 +139,14 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
     @Inject BackgroundJobManager backgroundJobManager;
     private PreviewImageFragmentBinding binding;
 
+    private static final int rotationDegrees = 90;
+    private long lastRotationEventTs = 0L;
+    private int currentIndex;
+    private boolean isRotationInProgress;
+    private boolean isImageLoadingFailed;//flag to check if image loading is failed or not
+    private final ExecutorService rotationExecutorService = Executors.newSingleThreadExecutor();
+    private final Handler rotationHandler = HandlerCompat.createAsync(Looper.getMainLooper());
+
     /**
      * Public factory method to create a new fragment that previews an image.
      *
@@ -143,13 +163,15 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
      */
     public static PreviewImageFragment newInstance(@NonNull OCFile imageFile,
                                                    boolean ignoreFirstSavedState,
-                                                   boolean showResizedImage) {
+                                                   boolean showResizedImage,
+                                                   int currentIndex) {
         PreviewImageFragment frag = new PreviewImageFragment();
         frag.showResizedImage = showResizedImage;
         Bundle args = new Bundle();
         args.putParcelable(ARG_FILE, imageFile);
         args.putBoolean(ARG_IGNORE_FIRST, ignoreFirstSavedState);
         args.putBoolean(ARG_SHOW_RESIZED_IMAGE, showResizedImage);
+        args.putInt(ARG_CURRENT_INDEX, currentIndex);
         frag.setArguments(args);
         return frag;
     }
@@ -182,6 +204,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
 
         ignoreFirstSavedState = args.getBoolean(ARG_IGNORE_FIRST);
         showResizedImage = args.getBoolean(ARG_SHOW_RESIZED_IMAGE);
+        currentIndex = args.getInt(ARG_CURRENT_INDEX);
         setHasOptionsMenu(true);
     }
 
@@ -231,7 +254,26 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
     @Override
     public void onStart() {
         super.onStart();
-        if (getFile() != null) {
+
+        //get the rotated bitmap from hashmap
+        Bitmap rotatedBitmap = null;
+        if (requireActivity() instanceof PreviewImageActivity) {
+            rotatedBitmap = ((PreviewImageActivity) requireActivity()).getCurrentBitmap(currentIndex);
+        }
+
+        //set the rotated bitmap to image view if user swipes back to already rotated image
+        if (rotatedBitmap != null) {
+            isImageLoadingFailed = false;
+            binding.image.setImageBitmap(rotatedBitmap);
+            binding.image.setVisibility(View.VISIBLE);
+            binding.emptyListView.setVisibility(View.GONE);
+            binding.emptyListProgress.setVisibility(View.GONE);
+            binding.image.setBackgroundColor(getResources().getColor(R.color.background_color_inverse));
+
+            //make copy of rotated bitmap to avoid issue during recycle
+            bitmap = rotatedBitmap.copy(rotatedBitmap.getConfig(), true);
+        } else if (getFile() != null) {
+            isImageLoadingFailed = false;
             binding.image.setTag(getFile().getFileId());
 
             Point screenSize = DisplayUtils.getScreenSize(getActivity());
@@ -400,6 +442,26 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
         if (getFile() != null && getFile().isSharedWithMe() && !getFile().canReshare()) {
             FileMenuFilter.hideMenuItem(menu.findItem(R.id.action_send_share_file));
         }
+
+        //this condition will only run when image is rotated
+        //get the rotated bitmap from hashmap
+        if (requireActivity() instanceof PreviewImageActivity) {
+            Bitmap rotatedBitmap = ((PreviewImageActivity) requireActivity()).getCurrentBitmap(currentIndex);
+            //check if it should not be null
+            if (rotatedBitmap != null) {
+                FileMenuFilter.showMenuItem(menu.findItem(R.id.action_send_share_file));
+            }
+        }
+
+
+        //enable rotate image if image is png or jpg
+        //we are not rotating svg, gif or any other format of images
+        //image loading should not be failed to show rotate images
+        if (MimeTypeUtil.isJpgOrPngFile(getFile().getFileName())
+            && !isImageLoadingFailed
+            && binding.emptyListProgress.getVisibility() == View.GONE) {
+            menu.findItem(R.id.action_rotate_image).setVisible(true);
+        }
     }
 
 
@@ -407,7 +469,11 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
      * {@inheritDoc}
      */
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NotNull MenuItem item) {
+        if (isRotationInProgress) {
+            return true;
+        }
+
         int itemId = item.getItemId();
         if (itemId == R.id.action_send_share_file) {
             if (getFile().isSharedWithMe() && !getFile().canReshare()) {
@@ -444,8 +510,70 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
                                                                     getView(),
                                                                     backgroundJobManager);
             return true;
+
+        } else if (itemId == R.id.action_rotate_image) {
+            rotateImage();
+            return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void rotateImage() {
+        if (System.currentTimeMillis() - lastRotationEventTs < 350) {
+            return;
+        }
+
+        showHideViewDuringRotation(true);
+
+        //execute the rotation task in background
+        rotationExecutorService.execute(() -> {
+            //rotate the image using matrix
+            Matrix matrix = new Matrix();
+            matrix.postRotate(rotationDegrees);
+            //get the bitmap of rotated image
+            Bitmap rotatedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+            //make copy of rotated bitmap to avoid issue during recycle
+            bitmap = rotatedBitmap.copy(rotatedBitmap.getConfig(), true);
+
+            //rotate the cached thumbnail for this image
+
+            //1. Get the thumbnail
+            Bitmap thumbnailBitmap = getThumbnailBitmap(getFile());
+            if (thumbnailBitmap != null) {
+                //2. Rotate the thumbnail
+                Bitmap rotatedThumbBitmap = Bitmap.createBitmap(thumbnailBitmap, 0, 0, thumbnailBitmap.getWidth(), thumbnailBitmap.getHeight(),
+                                                                matrix, true);
+
+                //3. Add the rotated thumbnail back to cache
+                ThumbnailsCacheManager.addBitmapToCache(ThumbnailsCacheManager.PREFIX_THUMBNAIL + getFile().getRemoteId(), rotatedThumbBitmap);
+            }
+
+            //if image resized is enabled then add the current rotated bitmap image to cache
+            if (showResizedImage) {
+                ThumbnailsCacheManager.addBitmapToCache(ThumbnailsCacheManager.PREFIX_RESIZED_IMAGE + getFile().getRemoteId(), rotatedBitmap);
+            }
+
+            rotationHandler.post(() -> {
+                //set the rotated bitmap to image view
+                binding.image.setImageBitmap(bitmap);
+
+                //add the rotated bitmap to hashmap
+                if (requireActivity() instanceof PreviewImageActivity) {
+                    LoadImage loadImage = new LoadImage(rotatedBitmap, null, getFile());
+                    ((PreviewImageActivity) requireActivity()).addBitmap(loadImage);
+                }
+
+                lastRotationEventTs = System.currentTimeMillis();
+
+                showHideViewDuringRotation(false);
+            });
+        });
+    }
+
+    private void showHideViewDuringRotation(boolean isRotationInProgress) {
+        this.isRotationInProgress = isRotationInProgress;
+        binding.progressBar.setVisibility(isRotationInProgress ? View.VISIBLE : View.GONE);
+        binding.image.setVisibility(isRotationInProgress ? View.INVISIBLE : View.VISIBLE);
     }
 
     private void seeDetails() {
@@ -470,6 +598,10 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
     private void openFile() {
         containerActivity.getFileOperationsHelper().openFile(getFile());
         finish();
+    }
+
+    public void setImageBitmap(Bitmap bitmap) {
+        this.bitmap = bitmap;
     }
 
     private class LoadBitmapTask extends AsyncTask<OCFile, Void, LoadImage> {
@@ -605,6 +737,7 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
         @Override
         protected void onPostExecute(LoadImage result) {
             if (result.bitmap != null || result.drawable != null) {
+                isImageLoadingFailed = false;
                 showLoadedImage(result);
             } else {
                 showErrorMessage(mErrorMessageId);
@@ -720,6 +853,8 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
         binding.image.setVisibility(View.GONE);
         binding.emptyListView.setVisibility(View.VISIBLE);
         binding.emptyListProgress.setVisibility(View.GONE);
+        isImageLoadingFailed = true;
+        requireActivity().invalidateOptionsMenu();
     }
 
     public void setErrorPreviewMessage() {
@@ -817,10 +952,10 @@ public class PreviewImageFragment extends FileFragment implements Injectable {
         return binding.image;
     }
 
-    private class LoadImage {
-        private final Bitmap bitmap;
+    public static class LoadImage {
+        public final Bitmap bitmap;
         private final Drawable drawable;
-        private final OCFile ocFile;
+        public final OCFile ocFile;
 
         LoadImage(Bitmap bitmap, Drawable drawable, OCFile ocFile) {
             this.bitmap = bitmap;

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -2,7 +2,9 @@
  *   ownCloud Android client application
  *
  *   @author David A. Velasco
+ *   @author TSI-mc
  *   Copyright (C) 2015  ownCloud Inc.
+ *   Copyright (C) 2022 TSI-mc
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -157,7 +159,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
             fragment = PreviewImageErrorFragment.newInstance();
 
         } else if (file.isDown()) {
-            fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), false);
+            fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), false, i);
         } else {
             if (mDownloadErrors.remove(i)) {
                 fragment = FileDownloadFragment.newInstance(file, user, true);
@@ -168,7 +170,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
                 } else if (PreviewMediaFragment.canBePreviewed(file)) {
                     fragment = PreviewMediaFragment.newInstance(file, user, 0, false);
                 } else {
-                    fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), true);
+                    fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), true, i);
                 }
             }
         }

--- a/app/src/main/java/com/owncloud/android/utils/FileUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileUtil.java
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Andy Scherzinger
+ * @author TSI-mc
  * Copyright (C) 2020 Andy Scherzinger
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -20,13 +22,19 @@
 
 package com.owncloud.android.utils;
 
+import android.content.Context;
+import android.graphics.Bitmap;
 import android.os.Build;
+import android.os.Environment;
 import android.text.TextUtils;
 
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.UploadFileRemoteOperation;
+import com.owncloud.android.ui.helpers.FileOperationsHelper;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -36,6 +44,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public final class FileUtil {
+
+    private static final String TAG = FileUtil.class.getSimpleName();
+
+    private static final int JPG_FILE_TYPE = 1;
+    private static final int PNG_FILE_TYPE = 2;
 
     private FileUtil() {
         // utility class -> private constructor
@@ -76,5 +89,71 @@ public final class FileUtil {
                      "Failed to read creation timestamp for file: " + file.getName());
             return null;
         }
+    }
+
+    public static File saveJpgImage(Context context, Bitmap bitmap, String imageName, int quality) {
+        return createFileAndSaveImage(context, bitmap, imageName, quality, JPG_FILE_TYPE);
+    }
+
+    public static File savePngImage(Context context, Bitmap bitmap, String imageName, int quality) {
+        return createFileAndSaveImage(context, bitmap, imageName, quality, PNG_FILE_TYPE);
+    }
+
+    public static File saveJpgImage(Context context, Bitmap bitmap, File file, int quality) {
+        return saveImage(file, bitmap, quality, JPG_FILE_TYPE);
+    }
+
+    public static File savePngImage(Context context, Bitmap bitmap, File file, int quality) {
+        return saveImage(file, bitmap, quality, PNG_FILE_TYPE);
+    }
+
+    private static File createFileAndSaveImage(Context context, Bitmap bitmap, String imageName, int quality,
+                                               int fileType) {
+        File file = fileType == PNG_FILE_TYPE ? getPngImageName(context, imageName) : getJpgImageName(context,
+                                                                                                      imageName);
+        return saveImage(file, bitmap, quality, fileType);
+    }
+
+    private static File saveImage(File file, Bitmap bitmap, int quality, int fileType) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, bos);
+            byte[] bitmapData = bos.toByteArray();
+
+            FileOutputStream fileOutputStream = new FileOutputStream(file);
+            fileOutputStream.write(bitmapData);
+            fileOutputStream.flush();
+            fileOutputStream.close();
+            return file;
+        } catch (Exception e) {
+            Log_OC.e(TAG, " Failed to save image : " + e.getLocalizedMessage());
+            return null;
+        }
+    }
+
+    private static File getJpgImageName(Context context, String imageName) {
+        File imageFile = getOutputMediaFile(context);
+        if (!TextUtils.isEmpty(imageName)) {
+            return new File(imageFile.getPath() + File.separator + imageName + ".jpg");
+        } else {
+            return new File(imageFile.getPath() + File.separator + "IMG_" + FileOperationsHelper.getCapturedImageName());
+        }
+    }
+
+    private static File getPngImageName(Context context, String imageName) {
+        File imageFile = getOutputMediaFile(context);
+        if (!TextUtils.isEmpty(imageName)) {
+            return new File(imageFile.getPath() + File.separator + imageName + ".png");
+        } else {
+            return new File(imageFile.getPath() + File.separator + "IMG_" + FileOperationsHelper.getCapturedImageName().replace(".jpg", ".png"));
+        }
+    }
+
+    public static File getOutputMediaFile(Context context) {
+        File file = new File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "");
+        if (!file.exists()) {
+            file.mkdir();
+        }
+        return file;
     }
 }

--- a/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -1,7 +1,9 @@
 /*
  * ownCloud Android client application
+ * @author TSI-mc
  * <p>
  * Copyright (C) 2016 ownCloud Inc.
+ * Copyright (C) 2022 TSI-mc
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -259,6 +261,14 @@ public final class MimeTypeUtil {
 
     public static boolean isImageOrVideo(ServerFileInterface file) {
         return isImage(file) || isVideo(file);
+    }
+
+    //check if file is png or jpg image
+    public static boolean isJpgOrPngFile(String fileName) {
+        String extension = fileName.substring(fileName.lastIndexOf("."));
+        return extension.equalsIgnoreCase(".png")
+            || extension.equalsIgnoreCase(".jpg")
+            || extension.equalsIgnoreCase(".jpeg");
     }
 
     /**

--- a/app/src/main/res/layout/preview_image_fragment.xml
+++ b/app/src/main/res/layout/preview_image_fragment.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
+  @author TSI-mc
+
   Copyright (C) 2015  ownCloud Inc.
+  Copyright (C) 2022 TSI-mc
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -18,6 +21,7 @@
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/top"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -105,4 +109,13 @@
             android:src="@drawable/ic_image_outline" />
 
     </FrameLayout>
+
+    <!-- Progress bar used to show while doing some process on image like Rotation -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
 </FrameLayout>

--- a/app/src/main/res/menu/item_file.xml
+++ b/app/src/main/res/menu/item_file.xml
@@ -2,8 +2,11 @@
 <!--
   ownCloud Android client application
 
+  @author TSI-mc
+
   Copyright (C) 2012 Bartek Przybylski
   Copyright (C) 2015 ownCloud Inc.
+  Copyright (C) 2022 TSI-mc
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -100,6 +103,14 @@
         android:title="@string/actionbar_copy"
         app:showAsAction="never"
         android:showAsAction="never" />
+
+    <!-- rotate image will only visible for preview image -->
+    <item
+        android:id="@+id/action_rotate_image"
+        android:showAsAction="never"
+        android:title="@string/action_rotate"
+        android:visible="false"
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/action_download_file"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -626,6 +626,7 @@
 
     <string name="foreground_service_upload">Uploading files…</string>
     <string name="foreground_service_download">Downloading files…</string>
+    <string name="foreground_service_save">Saving files…</string>
 
     <string name="prefs_sourcecode">Get source code</string>
     <string name="prefs_license">License</string>
@@ -1041,4 +1042,5 @@
     <string name="file_already_exists">Filename already exists</string>
     <string name="filedetails_export">Export</string>
     <string name="locate_folder">Locate folder</string>
+    <string name="action_rotate">Rotate</string>
 </resources>


### PR DESCRIPTION
Rotate image functionality added to image files.

**How it works:**
1. Open any image in preview mode.
2. Click on 3 dot menu at top right and then click on Rotate menu option. ![Rotate Menu Option](https://user-images.githubusercontent.com/89455194/191985534-fbebd0bb-8eab-452e-b113-3ab175fd7616.png)
3. On clicking Rotate menu option it will rotate the image 90° clockwise.
4. Now the rotated image will be uploaded to cloud under 2 case:
       4.1. When user rotates the screen i.e. configuration changes.
       4.2. When user comes back from the preview screen. 
![Uploading rotate image notification](https://user-images.githubusercontent.com/89455194/191985569-25d3c1a0-f4d6-4f86-97d6-9ee629690a13.png)
5. We are updating the image thumbnail in cache to give seamless experience to user and also updating the new rotated image file with current one.

**Note: Rotate functionality only applicable to JPG and PNG files.** 
