### PR TITLE
Bumps on master after 3.22 branched out

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,7 @@ services:
     image: ghcr.io/nextcloud/continuous-integration-server:latest # also change in updateScreenshots.sh
     environment:
       EVAL: true
-      SERVER_VERSION: 'stable24'
+      SERVER_VERSION: 'stable25'
     commands:
       - BRANCH="$SERVER_VERSION" /usr/local/bin/initnc.sh
       - echo 127.0.0.1 server >> /etc/hosts

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,7 @@ configurations.configureEach {
 
 // semantic versioning for version code
 def versionMajor = 3
-def versionMinor = 22
+def versionMinor = 23
 def versionPatch = 0
 def versionBuild = 0 // 0-50=Alpha / 51-98=RC / 90-99=stable
 


### PR DESCRIPTION
- Bump app to 3.23.x on master
- Drone: test on Nextcloud 25

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
