### PR TITLE
ThumbnailsCacheManager: null out cache when clearing it

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -77,11 +77,10 @@ import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.net.URLEncoder;
 import java.util.List;
-import java.util.Locale;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.content.res.ResourcesCompat;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -152,7 +151,7 @@ public final class ThumbnailsCacheManager {
                         mThumbnailCache = new DiskLruImageCache(diskCacheDir, DISK_CACHE_SIZE, mCompressFormat,
                                                                 mCompressQuality);
                     } catch (Exception e) {
-                        Log_OC.d(TAG, String.format(Locale.US, "Disk cache init failed: %s", e.getMessage()));
+                        Log_OC.d(TAG, "Disk cache init failed", e);
                         mThumbnailCache = null;
                     }
                 }
@@ -1378,6 +1377,7 @@ public final class ThumbnailsCacheManager {
     @VisibleForTesting
     public static void clearCache() {
         mThumbnailCache.clearCache();
+        mThumbnailCache = null;
     }
 
     private static Bitmap doResizedImageInBackground(OCFile file, FileDataStorageManager storageManager) {


### PR DESCRIPTION
Cache is closed when clearing, so it becomes unusable. This way ThumbnailsCacheManager will work as expected

Fixes #10818
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
