### PR TITLE
Fix pending intent mutability for widget

### DIFF
--- a/app/src/main/java/com/nextcloud/client/widget/DashboardWidgetUpdater.kt
+++ b/app/src/main/java/com/nextcloud/client/widget/DashboardWidgetUpdater.kt
@@ -22,7 +22,6 @@
 
 package com.nextcloud.client.widget
 
-import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.Context
@@ -101,17 +100,17 @@ class DashboardWidgetUpdater @Inject constructor(
         )
     }
 
-    // clickPI needs to me mutable, as it is re-used. PendingIntent.FLAG_IMMUTABLE requires S (API 31)
-    @SuppressLint("UnspecifiedImmutableFlag")
     private fun setPendingClick(remoteViews: RemoteViews) {
-        val clickPI = PendingIntent.getActivity(
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+        val clickIntent = PendingIntent.getActivity(
             context,
             0,
             Intent(),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            flags
         )
 
-        remoteViews.setPendingIntentTemplate(R.id.list, clickPI)
+        remoteViews.setPendingIntentTemplate(R.id.list, clickIntent)
     }
 
     private fun setAddButton(addButton: DashboardButton?, appWidgetId: Int, remoteViews: RemoteViews) {


### PR DESCRIPTION
Mutability flag is compulsory from SDK 31 upwards, `FLAG_IMMUTABLE` is available in all our targeted APIs, and our app will always be able to update the same intent, as `FLAG_UPDATE_CURRENT` is set.

Fixes #10826
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
