### PR TITLE
Bump to 3.22.1 to fix crashes in 3.22.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ configurations.configureEach {
 // semantic versioning for version code
 def versionMajor = 3
 def versionMinor = 22
-def versionPatch = 0
+def versionPatch = 1
 def versionBuild = 90 // 0-50=Alpha / 51-98=RC / 90-99=stable
 
 

--- a/fastlane/metadata/android/en-US/changelogs/30220190.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30220190.txt
@@ -1,0 +1,7 @@
+## 3.22.1 (October 20, 2022)
+
+- Bug fixes
+
+Minimum: NC 16 Server, Android 6.0 Marshmallow
+
+For a full list, please see https://github.com/nextcloud/android/milestone/73


### PR DESCRIPTION
See https://github.com/nextcloud/android/milestone/73 for adressed crashes
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
