### PR TITLE
Minor updates to README for Windows syntax for logcat instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Easy starting points are also reviewing [pull requests](https://github.com/nextc
 *   download and install [Minimal ADB and fastboot](https://forum.xda-developers.com/t/tool-minimal-adb-and-fastboot-2-9-18.2317790/#post-42407269)
 *   enable USB-Debugging in your smartphones developer settings and connect it via USB
 *   launch Minimal ADB and fastboot
-*   enter `adb shell pidof -s 'com.nextcloud.client` and use the output as `<processID>` in the following command:
-*   `adb logcat --pid=<processID> > %HOMEPATH%\Downloads\logcatOutput.txt` (This will produce a `logcatOutput.txt` file in your downloads)
-*   if the processID is `18841`, an example command is: `adb logcat --pid=18841 > %HOMEPATH%\Downloads\logcatOutput.txt` (You might cancel the process after a while manually: it will not be exited automatically.)
+*   enter `adb shell pidof -s 'com.nextcloud.client'` and use the output as `<processID>` in the following command:
+*   `adb logcat --pid=<processID> > "%USERPROFILE%\Downloads\logcatOutput.txt"` (This will produce a `logcatOutput.txt` file in your downloads)
+*   if the processID is `18841`, an example command is: `adb logcat --pid=18841 > "%USERPROFILE%\Downloads\logcatOutput.txt"` (You might cancel the process after a while manually: it will not be exited automatically.)
+*   For a PowerShell terminal, replace `%USERPROFILE%` with `$env:USERPROFILE` in the commands above.
 
 #### On a device (with root) :wrench:
 


### PR DESCRIPTION
Modified 3 lines in README.md

Line 58 had:
`adb shell pidof -s 'com.nextcloud.client` (just one single-quote). Added a second single-quote to close the string and make it: `adb shell pidof -s 'com.nextcloud.client'`, otherwise the terminal will give you new lines waiting for the closing quote.

Line 59 & 60 use %HOMEPATH% environment var instead of %USERPROFILE%

- %HOMEPATH% will return `\Users\username`
- %USERPROFILE% will return `C:\Users\username`

Also added double-quotes around the entire path string in case username contains spaces, e.g. `C:\Users\user name`

For a PowerShell.exe terminal (what MS is starting to recommend over cmd.exe), the same lines can be used with a var reference of `$env:USERPROFILE` instead of `%USERPROFILE%`. I added in an extra hint line in the instructions to remind people of this.

(FYI: first pull request I created, I forgot to sign-off on the commits. I cancelled that pull request, completely deleted my fork, and started over from a new fork. Hopefully that doesn't affect anything.)

Signed-off-by: Kerbalnut <Kerbalnut@users.noreply.github.com>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
