### PR TITLE
PermissionUtil: ensure fragment result is listened to on activity thread

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -31,6 +31,7 @@ import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
 import android.os.Environment
 import android.provider.Settings
 import androidx.annotation.RequiresApi
@@ -213,10 +214,7 @@ object PermissionUtil {
         if (shouldRequestPermission &&
             activity.supportFragmentManager.findFragmentByTag(PERMISSION_CHOICE_DIALOG_TAG) == null
         ) {
-            activity.supportFragmentManager.setFragmentResultListener(
-                StoragePermissionDialogFragment.REQUEST_KEY,
-                activity
-            ) { _, resultBundle ->
+            val listener: (requestKey: String, result: Bundle) -> Unit = { _, resultBundle ->
                 val result: StoragePermissionDialogFragment.Result? =
                     resultBundle.getParcelable(StoragePermissionDialogFragment.RESULT_KEY)
                 if (result != null) {
@@ -236,6 +234,14 @@ object PermissionUtil {
                         StoragePermissionDialogFragment.Result.CANCEL -> {}
                     }
                 }
+            }
+
+            activity.runOnUiThread {
+                activity.supportFragmentManager.setFragmentResultListener(
+                    StoragePermissionDialogFragment.REQUEST_KEY,
+                    activity,
+                    listener
+                )
             }
 
             val dialogFragment = StoragePermissionDialogFragment.newInstance(permissionRequired)


### PR DESCRIPTION
Prevents a crash if called from background


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
