### PR TITLE
Fix login colors in NC25

### DIFF
--- a/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -105,6 +105,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCode;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.status.GetCapabilitiesRemoteOperation;
+import com.owncloud.android.lib.resources.status.NextcloudVersion;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.lib.resources.users.GetUserInfoRemoteOperation;
@@ -137,6 +138,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -443,8 +445,13 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                 accountSetupWebviewBinding.loginWebviewProgressBar.setVisibility(View.GONE);
                 accountSetupWebviewBinding.loginWebview.setVisibility(View.VISIBLE);
 
-                viewThemeUtils.platform.colorStatusBar(AuthenticatorActivity.this, primaryColor);
-                getWindow().setNavigationBarColor(primaryColor);
+                if (mServerInfo.mVersion != null && mServerInfo.mVersion.isOlderThan(NextcloudVersion.nextcloud_25)) {
+                    viewThemeUtils.platform.colorStatusBar(AuthenticatorActivity.this, primaryColor);
+                    getWindow().setNavigationBarColor(primaryColor);
+                } else {
+                    viewThemeUtils.platform.resetStatusBar(AuthenticatorActivity.this);
+                    getWindow().setNavigationBarColor(ContextCompat.getColor(AuthenticatorActivity.this, R.color.bg_default));
+                }
             }
 
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {


### PR DESCRIPTION
- AuthenticatorActivity: fetch user capability after account creation
- AuthenticatorActivity: on NC25, don't tint status/navigation bars

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
