### PR TITLE
List fragments: Add empty list as a child of SwipeRefreshLayout, not outside it.

### DIFF
--- a/app/src/main/res/layout/list_fragment.xml
+++ b/app/src/main/res/layout/list_fragment.xml
@@ -29,15 +29,16 @@
         android:footerDividersEnabled="false"
         android:visibility="visible"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <com.owncloud.android.ui.EmptyRecyclerView
-            android:id="@+id/list_root"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent">
+            <com.owncloud.android.ui.EmptyRecyclerView
+                android:id="@+id/list_root"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+            <include
+                android:id="@+id/empty_list"
+                layout="@layout/empty_list" />
+        </FrameLayout>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-    <include
-        android:id="@+id/empty_list"
-        layout="@layout/empty_list" />
-
 </RelativeLayout>


### PR DESCRIPTION
This allows swiping to refresh on empty folders.

Fixes #10973

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
