### PR TITLE
Fix webauthn crashes due to PendingIntent mutability

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -257,8 +257,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'com.vanniktech:emoji-google:0.9.0'
 
-    implementation "com.github.cotechde.hwsecurity:hwsecurity-fido:$fidoVersion"
-    implementation "com.github.cotechde.hwsecurity:hwsecurity-fido2:$fidoVersion"
+    implementation "com.github.nextcloud-deps.hwsecurity:hwsecurity-fido:$fidoVersion"
+    implementation "com.github.nextcloud-deps.hwsecurity:hwsecurity-fido2:$fidoVersion"
 
     // document scanner not available on FDroid (generic) due to OpenCV binaries
     gplayImplementation "com.github.zynkware:Document-Scanning-Android-SDK:$documentScannerVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -344,7 +344,7 @@
 
         <activity
             android:name=".authentication.AuthenticatorActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.ownCloud.noActionBar.Login">

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         mockkVersion = "1.13.2"
         espressoVersion = "3.4.0"
         workRuntime = "2.7.1"
-        fidoVersion = "4.1.0"
+        fidoVersion = "4.1.0-patch1"
         checkerVersion = "3.21.2"
         exoplayerVersion = "2.18.1"
         documentScannerVersion = "1.0.1"


### PR DESCRIPTION
- Persist AuthenticatorActivity through keyboard config changes
- Use forked hwsecurity lib to avoid PendingIntent crashes

Fixes #10309 

- [x] Tests written, or not not needed
- [x] Fork transfered to nextcloud-deps and tagged
