### PR TITLE
fastlane: add skip_upload_apk to play store config

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -292,6 +292,7 @@ desc "Upload to play store"
 private_lane :uploadToPlaystore_Final do |options|
     upload_to_play_store(
         skip_upload_images: true,
+        skip_upload_apk: true,
         aab: "release/app-gplay-release.aab"
     )
 end


### PR DESCRIPTION
If there is any .apk file in the root dir of the project (like one used for testing prior to release),
the upload_to_play_store lane will pick it up and throw an error because it has both an APK and an AAB.

To fix this, tell it to ignore any APKs and only use the provided AAB.

