### PR TITLE
Give groupfolders priority when choosing icon for folder

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -142,7 +142,9 @@ public final class MimeTypeUtil {
                                              ViewThemeUtils viewThemeUtils) {
         int drawableId;
 
-        if (isSharedViaLink) {
+        if (WebdavEntry.MountType.GROUP == mountType || isGroupFolder) {
+            drawableId = R.drawable.folder_group;
+        } else if (isSharedViaLink) {
             drawableId = R.drawable.folder_shared_link;
         } else if (isSharedViaUsers) {
             drawableId = R.drawable.folder_shared_users;
@@ -150,8 +152,6 @@ public final class MimeTypeUtil {
             drawableId = R.drawable.folder_encrypted;
         } else if (WebdavEntry.MountType.EXTERNAL == mountType) {
             drawableId = R.drawable.folder_external;
-        } else if (WebdavEntry.MountType.GROUP == mountType || isGroupFolder) {
-            drawableId = R.drawable.folder_group;
         } else {
             drawableId = R.drawable.folder;
         }


### PR DESCRIPTION
In the server UI, a groupfolder that also has a link shows as a groupfolder.
In the app, it shows as a link. This fixes that.



<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
