### PR TITLE
Bump compileSDK to 32

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ file("$project.rootDir/ndk.env").readLines().each() {
 
 android {
 
-    compileSdkVersion 31
+    compileSdkVersion 32
     // install this NDK version and Cmake to produce smaller APKs. Build will still work if not installed
     ndkVersion "${ndkEnv.get("NDK_VERSION")}"
 


### PR DESCRIPTION
Once again it's blocking library updates. See https://github.com/nextcloud/android/pull/10841 for example

- [x] Tests written, or not not needed
