### PR TITLE
File list "jumps" after scrolling when an asynchronous operation finishes

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/FileDisplayActivityScreenshotIT.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/FileDisplayActivityScreenshotIT.kt
@@ -57,7 +57,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
         shortSleep()
         sut.runOnUiThread {
             sut.listOfFilesFragment!!.setFabEnabled(false)
-            sut.resetScrolling()
+            sut.resetScrolling(true)
             sut.listOfFilesFragment!!.setEmptyListLoadingMessage()
             sut.listOfFilesFragment!!.isLoading = false
         }
@@ -109,7 +109,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
         shortSleep()
         sut.runOnUiThread {
             sut.hideInfoBox()
-            sut.resetScrolling()
+            sut.resetScrolling(true)
             sut.listOfFilesFragment!!.setFabEnabled(false)
             sut.listOfFilesFragment!!.setEmptyListLoadingMessage()
             sut.listOfFilesFragment!!.isLoading = false

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -594,7 +594,7 @@ public class FileDisplayActivity extends FileActivity
 
     protected void resetTitleBarAndScrolling() {
         updateActionBarTitleAndHomeButton(null);
-        resetScrolling();
+        resetScrolling(true);
     }
 
     public void updateListOfFilesFragment(boolean fromSearch) {
@@ -1070,7 +1070,7 @@ public class FileDisplayActivity extends FileActivity
             createMinFragments(null);
         } else {
             // pop back
-            resetScrolling();
+            resetScrolling(true);
             hideSearchView(getCurrentDir());
             showSortListGroup(true);
             super.onBackPressed();
@@ -1328,7 +1328,7 @@ public class FileDisplayActivity extends FileActivity
                                 if (ocFileListFragment.isEmpty()) {
                                     lockScrolling();
                                 } else {
-                                    resetScrolling();
+                                    resetScrolling(false);
                                 }
                             }
                         }
@@ -1568,7 +1568,7 @@ public class FileDisplayActivity extends FileActivity
     public void showDetails(OCFile file, int activeTab) {
         User currentUser = getUser().orElseThrow(RuntimeException::new);
 
-        resetScrolling();
+        resetScrolling(true);
 
         Fragment detailFragment = FileDetailFragment.newInstance(file, currentUser, activeTab);
         setLeftFragment(detailFragment);
@@ -1592,11 +1592,13 @@ public class FileDisplayActivity extends FileActivity
      * Resets content scrolling and toolbar collapse
      */
     @VisibleForTesting
-    public void resetScrolling() {
+    public void resetScrolling(boolean expandAppBar) {
         AppBarLayout.LayoutParams appbarParams = (AppBarLayout.LayoutParams) binding.appbar.toolbarFrame.getLayoutParams();
         appbarParams.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
         binding.appbar.toolbarFrame.setLayoutParams(appbarParams);
-        binding.appbar.appbar.setExpanded(true, false);
+        if (expandAppBar) {
+            binding.appbar.appbar.setExpanded(true, false);
+        }
     }
 
     @Override


### PR DESCRIPTION
During investigation of #10783 I have found that after scrolling up, the file list "jumps" when an asynchronous operation finishes.

This seems to be caused by AppBar being expanded during refresh (after completion of the async operations). If the AppBar was hidden earlier by the user scrolling up, this causes a "jump".

@tobiasKaminsky - this is the issue that we discussed briefly during the conference - fix proposed.

See short videos below.

https://user-images.githubusercontent.com/8277636/201758099-ea13bec8-9834-4d95-a123-496cb65f2c6e.mp4

https://user-images.githubusercontent.com/8277636/201758268-f7a6dd09-503b-44cd-b439-4a75bd2c92e9.mp4