### PR TITLE
Fix storage permission loop when permission denied, and remember permission asked

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -33,10 +33,8 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.Spinner;
 import android.widget.TextView;
 
-import com.google.android.material.button.MaterialButton;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -261,13 +259,6 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
 
     public void showToolbarSpinner() {
         mToolbarSpinner.setVisibility(View.VISIBLE);
-    }
-
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        requestPermissions();
     }
 
     private void fillDirectoryDropdown() {
@@ -677,12 +668,9 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     @Override
     protected void onStart() {
         super.onStart();
-        if (getAccount() != null) {
-            if (!mAccountOnCreation.equals(getAccount())) {
-                setResult(RESULT_CANCELED);
-                finish();
-            }
-
+        final Account account = getAccount();
+        if (mAccountOnCreation != null && mAccountOnCreation.equals(account)) {
+            requestPermissions();
         } else {
             setResult(RESULT_CANCELED);
             finish();

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -131,6 +131,7 @@ object PermissionUtil {
                         requestStoragePermission(
                             activity,
                             Manifest.permission.READ_EXTERNAL_STORAGE,
+                            permissionRequired,
                             viewThemeUtils
                         )
                     }
@@ -138,6 +139,7 @@ object PermissionUtil {
                 else -> requestStoragePermission(
                     activity,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    permissionRequired,
                     viewThemeUtils
                 )
             }
@@ -151,33 +153,40 @@ object PermissionUtil {
     private fun requestStoragePermission(
         activity: Activity,
         permission: String,
+        permissionRequired: Boolean,
         viewThemeUtils: ViewThemeUtils
     ) {
+        val preferences: AppPreferences = AppPreferencesImpl.fromContext(activity)
+        val shouldRequestPermission = !preferences.isStoragePermissionRequested || permissionRequired
+
         fun doRequest() {
             ActivityCompat.requestPermissions(
                 activity,
                 arrayOf(permission),
                 PERMISSIONS_EXTERNAL_STORAGE
             )
+            preferences.isStoragePermissionRequested = true
         }
 
-        // Check if we should show an explanation
-        if (shouldShowRequestPermissionRationale(activity, permission)) {
-            // Show explanation to the user and then request permission
-            Snackbar
-                .make(
-                    activity.findViewById(android.R.id.content),
-                    R.string.permission_storage_access,
-                    Snackbar.LENGTH_INDEFINITE
-                )
-                .setAction(R.string.common_ok) {
-                    doRequest()
-                }
-                .also { viewThemeUtils.material.themeSnackbar(it) }
-                .show()
-        } else {
-            // No explanation needed, request the permission.
-            doRequest()
+        if (shouldRequestPermission) {
+            // Check if we should show an explanation
+            if (shouldShowRequestPermissionRationale(activity, permission)) {
+                // Show explanation to the user and then request permission
+                Snackbar
+                    .make(
+                        activity.findViewById(android.R.id.content),
+                        R.string.permission_storage_access,
+                        Snackbar.LENGTH_INDEFINITE
+                    )
+                    .setAction(R.string.common_ok) {
+                        doRequest()
+                    }
+                    .also { viewThemeUtils.material.themeSnackbar(it) }
+                    .show()
+            } else {
+                // No explanation needed, request the permission.
+                doRequest()
+            }
         }
     }
 
@@ -228,6 +237,7 @@ object PermissionUtil {
                             requestStoragePermission(
                                 activity,
                                 Manifest.permission.READ_EXTERNAL_STORAGE,
+                                permissionRequired,
                                 viewThemeUtils
                             )
                         }


### PR DESCRIPTION
- UploadFilesActivity: request permission on onStart instead of onResume
- PermissionUtil: remember permission requested when requesting media storage permissions

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
