### PR TITLE
Fixed unknown error while encrypting empty shared folder.

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -11,7 +11,7 @@
  * Copyright (C) 2015 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
- * Copyright (C) 2021 TSI-mc
+ * Copyright (C) 2022 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -913,6 +913,12 @@ public class FileOperationsHelper {
     }
 
     public void toggleEncryption(OCFile file, boolean shouldBeEncrypted) {
+        //shared folders cannot be encrypted
+        if (file.isSharedWithMe() || file.isSharedWithSharee() || file.isSharedViaLink()) {
+            DisplayUtils.showSnackMessage(fileActivity, R.string.shared_folder_end_to_end_encryption_error);
+            return;
+        }
+
         if (file.isEncrypted() != shouldBeEncrypted) {
             EventBus.getDefault().post(new EncryptionEvent(file.getLocalId(),
                                                            file.getRemoteId(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1053,4 +1053,5 @@
     <string name="no_items">No items</string>
     <string name="check_back_later_or_reload">Check back later or reload.</string>
     <string name="e2e_not_yet_setup">E2E not yet setup</string>
+    <string name="shared_folder_end_to_end_encryption_error">Shared folders cannot be encrypted.</string>
 </resources>


### PR DESCRIPTION
**Precondition:**
User is logged in
Files / Folders available

 
**Steps:**

1. Start the app
2. Create a folder 


3. share the folder
4. set encryption to the shared folder
 

**Actual result:**

unknown error appears as an in app notification


**Expected result:**

error is displayed that shared folders cannot be encrypted




![error_screenshot](https://user-images.githubusercontent.com/89455194/202127442-133a152d-3376-467f-ad2e-cae1cb497bec.png)
**"Unknown error" screenshot**

![fixed_screenshot](https://user-images.githubusercontent.com/89455194/202127473-a6775b81-8211-4534-b630-a27389afd728.png)
**Correct error message screenshot**

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
