### PR TITLE
OCFileListFragment: also reset search type when resetting search event

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1536,6 +1536,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
     public void onMessageEvent(ChangeMenuEvent changeMenuEvent) {
         searchFragment = false;
         searchEvent = null;
+        currentSearchType = SearchType.NO_SEARCH;
 
         menuItemAddRemoveValue = MenuItemAddRemove.ADD_GRID_AND_SORT_WITH_SEARCH;
         Activity activity = getActivity();


### PR DESCRIPTION
Fixes an issue where it was persisted after coming back from Favorites, and
the fragment was incorrectly deleting favorite files from the list when unfavoriting.


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
