### PR TITLE
Disable StrictMode by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,6 +407,22 @@ and thereof we'd ask contributors to be mindful of their code testability:
    should at least not make future efforts more challenging
 3. whenever possible, testability should be improved even if the code is not covered by tests
 
+### Performance
+
+If you're interested in improving the app's performance, please check the [official documentation](https://developer.android.com/topic/performance)
+for ways you can inspect and improve performance.
+
+For additional analysis, set the `perfAnalysis` property
+in your Gradle build:
+
+```shell
+./gradlew installGplayDebug -P perfAnalysis
+```
+
+This will install the app with [LeakCanary](https://square.github.io/leakcanary/) and 
+[StrictMode](https://developer.android.com/reference/android/os/StrictMode) enabled and configured.
+These tools can help find memory leaks, foreground operations that should be in background, and other performance
+problems.
 
 # Releases
 At the moment we are releasing the app in two app stores:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,8 @@ file("$project.rootDir/ndk.env").readLines().each() {
     ndkEnv.put(key, value)
 }
 
+def perfAnalysis = project.hasProperty('perfAnalysis')
+
 android {
 
     compileSdkVersion 32
@@ -85,6 +87,7 @@ android {
         targetSdkVersion 31
 
         buildConfigField 'boolean', 'CI', ciBuild.toString()
+        buildConfigField 'boolean', 'RUNTIME_PERF_ANALYSIS', perfAnalysis.toString()
 
         javaCompileOptions {
             annotationProcessorOptions {
@@ -309,7 +312,7 @@ dependencies {
         }
     }
 
-    if (project.hasProperty("leakCanary")) {
+    if (perfAnalysis) {
         debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
     }
 

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -488,7 +488,8 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
     }
 
     private void enableStrictMode() {
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG && BuildConfig.RUNTIME_PERF_ANALYSIS) {
+            Log_OC.d(TAG, "Enabling StrictMode");
             StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
                                            .detectDiskReads()
                                            .detectDiskWrites()


### PR DESCRIPTION
StrictMode is not a good fit for the state of our app, since we are way too far from async disk operations or correct threading.
As a result, we find ourselves disabling the strict mode manually every time we actually want to work on something, as otherwise the logspam drowns everything else.

With this PR I propose to disable StrictMode unless a prop is set in the Gradle build, which will also control LeakCanary.
Running `./gradlew installGplayDebug -P perfAnalysis` will install the app with both LeakCanary and StrictMode enabled.
This allows us to analyze performance problems on demand, without making our daily work harder.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
