### PR TITLE
Refresh UI only when changes are detected on the server

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -252,7 +252,7 @@ public class RefreshFolderOperation extends RemoteOperation {
             mStorageManager.saveFile(mLocalFolder);
         }
 
-        if (!mSyncFullAccount) {
+        if (!mSyncFullAccount && mRemoteFolderChanged) {
             sendLocalBroadcast(
                 EVENT_SINGLE_FOLDER_CONTENTS_SYNCED, mLocalFolder.getRemotePath(), result
             );


### PR DESCRIPTION
Related to #10783.

When changing folder in the app the file list is refreshed - i.e. `OCFileListFragment::listDirectory` and `OCFileListAdapter::swapDirectory` are invoked - after checking for changes on the server (ETag check).

This happens even in the case when there are no changes.

The refresh is executed on the main thread and blocks UI. At the first sight this seems unnecessary (folder contents has been shown already) and this PR is an attempt to avoid the UI refresh.

Any comments? I am not sure about potential negative side effects in other areas of the app.