### PR TITLE
Revert "Bump targetSdk to 32"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 32
+        targetSdkVersion 31
 
         buildConfigField 'boolean', 'CI', ciBuild.toString()
         buildConfigField 'boolean', 'RUNTIME_PERF_ANALYSIS', perfAnalysis.toString()


### PR DESCRIPTION
This targetSDK causes inability to login on first run on devices running android 13.

When a notification channel is created in android 13 with targetSDK < 33, a notifications permission
dialog is shown. With targetSDK 31 this works fine, but with targetSDK 32 it causes the FirstRunActivity to
hang when "log in" is clicked.

I believe this to be because it somehow messes up the activity stack, as it hangs after `finish()` is called.
It works fine if I run `MainApp.notificationChannels()` in `FirstRunActivity.onCreate` instead of `MainApp.onCreate`,
which further confirms my theory.

However, when we target SDK 33 we'll need to ask for notification permission explicitly, so let's just skip SDK 32 to
not do the work twice.


This reverts commit 8c8723c7c5608952ccf0e160289728c486286402 and PR  #11075

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
