### PR TITLE
PreviewVideoFullscreenDialog: fix immersive mode logic

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFullscreenDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFullscreenDialog.kt
@@ -109,8 +109,8 @@ class PreviewVideoFullscreenDialog(
         if (isPlaying) {
             sourceExoPlayer.pause()
         }
-        enableImmersiveMode()
         setOnShowListener {
+            enableImmersiveMode()
             switchTargetViewFromSource()
             setListeners()
             if (isPlaying) {
@@ -157,8 +157,8 @@ class PreviewVideoFullscreenDialog(
         if (isPlaying) {
             mExoPlayer.pause()
         }
-        disableImmersiveMode()
         setOnDismissListener {
+            disableImmersiveMode()
             playingStateListener?.let {
                 mExoPlayer.removeListener(it)
             }
@@ -180,12 +180,7 @@ class PreviewVideoFullscreenDialog(
     }
 
     private fun enableImmersiveMode() {
-        // for immersive mode to work properly, need to disable statusbar on activity window, but nav bar in dialog
-        // otherwise dialog navbar is not hidden, or statusbar padding is the wrong color
         activity.window?.let {
-            hideInset(it, WindowInsetsCompat.Type.statusBars())
-        }
-        window?.let {
             hideInset(it, WindowInsetsCompat.Type.systemBars())
         }
     }


### PR DESCRIPTION
This was breaking the window in Android 9 when going back twice from a fullscreen video.

Testing steps:
1. Open a video
2. Go to fullscreen
3. Close fullscreen
4. Press Back

This caused a white screen in Android 9 before this PR

Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
