### PR TITLE
Fix infinite loop in upload worker

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -365,12 +365,7 @@ public class UploadsStorageManager extends Observable {
     }
 
     private OCUpload[] getUploads(@Nullable String selection, @Nullable String... selectionArgs) {
-        return getUploads(0, selection, selectionArgs);
-    }
-
-
-    private OCUpload[] getUploads(final int limit, @Nullable String selection, @Nullable String... selectionArgs) {
-        ArrayList<OCUpload> uploads = new ArrayList<>();
+        final List<OCUpload> uploads = new ArrayList<>();
         long page = 0;
         long rowsRead;
         long rowsTotal = 0;
@@ -392,11 +387,8 @@ public class UploadsStorageManager extends Observable {
                                        ));
             uploads.addAll(uploadsPage);
             page++;
-        } while (rowsRead > 0 && (limit <= 0 || rowsRead < limit));
+        } while (rowsRead > 0);
 
-        if (limit > 0 && uploads.size() > limit) {
-            uploads = new ArrayList<>(uploads.subList(0, limit));
-        }
 
         Log_OC.v(TAG, String.format(Locale.ENGLISH,
                                     "getUploads() returning %d (%d) rows after reading %d pages",
@@ -507,11 +499,7 @@ public class UploadsStorageManager extends Observable {
     }
 
     public OCUpload[] getCurrentAndPendingUploadsForAccount(final @NonNull String accountName) {
-        return getCurrentAndPendingUploadsForAccount(0, accountName);
-    }
-
-    public OCUpload[] getCurrentAndPendingUploadsForAccount(final int limit, final @NonNull String accountName) {
-        return getUploads(limit, ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
                               " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
                               "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
                               " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +


### PR DESCRIPTION
With the previous approach (uploadsStorageManager.gtCurrentAndPendingUploadsForAccount),
an upload that is, for example, waiting for wifi, would always be returned in the call,
thus the list would never be empty.

To avoid this but still process the uploads in pages to avoid OOM, we'll request them page-wise
from the StorageManager, with the pages ordered by ascending ID. This way we will only process each upload once,
but newly added uploads after we start will not be missed.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
