### PR TITLE
Fix build failure after update in library

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -381,7 +381,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
 
     @Override
     public void showProfileBottomSheet(User user, String shareWith) {
-        if (user.getServer().getVersion().isNewerOrEqual(NextcloudVersion.Companion.getNextcloud_23())) {
+        if (user.getServer().getVersion().isNewerOrEqual(NextcloudVersion.nextcloud_23)) {
             new RetrieveHoverCardAsyncTask(user,
                                            shareWith,
                                            fileActivity,


### PR DESCRIPTION
NextcloudVersion now has `@JvmStatic` in all members, so getters do no longer exist


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
