### PR TITLE
Skip check for existing files when reading file data from local DB

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -882,6 +882,19 @@ public class FileDataStorageManager {
         ocFile.setParentId(nullToZero(fileEntity.getParent()));
         ocFile.setMimeType(fileEntity.getContentType());
         ocFile.setStoragePath(fileEntity.getStoragePath());
+        if (ocFile.getStoragePath() == null && ocFile.isFolder()) {
+            // Apparently storagePath is filled only for regular files - even in the current (Jan 2022) implementation.
+            // Check below is still required for directories.
+            //
+            // try to find existing file and bind it with current account;
+            // with the current update of SynchronizeFolderOperation, this won't be
+            // necessary anymore after a full synchronization of the account
+            File file = new File(FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), ocFile));
+            if (file.exists()) {
+                ocFile.setStoragePath(file.getAbsolutePath());
+                ocFile.setLastSyncDateForData(file.lastModified());
+            }
+        }
         ocFile.setFileLength(nullToZero(fileEntity.getContentLength()));
         ocFile.setCreationTimestamp(nullToZero(fileEntity.getCreation()));
         ocFile.setModificationTimestamp(nullToZero(fileEntity.getModified()));

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -882,16 +882,6 @@ public class FileDataStorageManager {
         ocFile.setParentId(nullToZero(fileEntity.getParent()));
         ocFile.setMimeType(fileEntity.getContentType());
         ocFile.setStoragePath(fileEntity.getStoragePath());
-        if (ocFile.getStoragePath() == null) {
-            // try to find existing file and bind it with current account;
-            // with the current update of SynchronizeFolderOperation, this won't be
-            // necessary anymore after a full synchronization of the account
-            File file = new File(FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), ocFile));
-            if (file.exists()) {
-                ocFile.setStoragePath(file.getAbsolutePath());
-                ocFile.setLastSyncDateForData(file.lastModified());
-            }
-        }
         ocFile.setFileLength(nullToZero(fileEntity.getContentLength()));
         ocFile.setCreationTimestamp(nullToZero(fileEntity.getCreation()));
         ocFile.setModificationTimestamp(nullToZero(fileEntity.getModified()));


### PR DESCRIPTION
As discussed in #10783 and #11181.

It seems that the code to check for existing files when reading file data from the local DB is no longer needed.

In my "standard" benchmark (~330 files in a directory on a low-powered device), with this change  the average execution time of the `OCFileListFragment::listDirectory` call is reduced from **~320 ms** to **~280 ms** (but the timings are not very consistent).

I have not noticed any negative side effects, but to be honest, I have no idea how to really test it.