### PR TITLE
PassCodeManager: add some logic to avoid counting the same activity twice

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/authentication/PassCodeManagerIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/authentication/PassCodeManagerIT.kt
@@ -1,0 +1,87 @@
+/*
+ * Nextcloud Android client application
+ *
+ *  @author Álvaro Brey
+ *  Copyright (C) 2023 Álvaro Brey
+ *  Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.authentication
+
+import android.app.Activity
+import android.os.PowerManager
+import com.nextcloud.client.core.Clock
+import com.nextcloud.client.preferences.AppPreferences
+import com.owncloud.android.ui.activity.SettingsActivity
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * This class should really be unit tests, but PassCodeManager needs a refactor
+ * to decouple the locking logic from the platform classes
+ */
+class PassCodeManagerIT {
+    @MockK
+    lateinit var appPreferences: AppPreferences
+
+    @MockK
+    lateinit var clockImpl: Clock
+
+    lateinit var sut: PassCodeManager
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this, relaxed = true)
+        sut = PassCodeManager(appPreferences, clockImpl)
+    }
+
+    @Test
+    fun testResumeDuplicateActivity() {
+        // mock activity instead of using real one to avoid dealing with activity transitions
+        val activity: Activity = mockk()
+        val powerManager: PowerManager = mockk()
+        every { powerManager.isScreenOn } returns true
+        every { activity.getSystemService(Activity.POWER_SERVICE) } returns powerManager
+        every { activity.window } returns null
+        every { activity.startActivityForResult(any(), any()) } just runs
+        every { activity.moveTaskToBack(any()) } returns true
+
+        // set locked state
+        every { appPreferences.lockPreference } returns SettingsActivity.LOCK_PASSCODE
+        every { appPreferences.lockTimestamp } returns 200
+        every { clockImpl.millisSinceBoot } returns 10000
+
+        // resume activity twice
+        var askedForPin = sut.onActivityResumed(activity)
+        assertTrue("Passcode not requested on first launch", askedForPin)
+        sut.onActivityResumed(activity)
+
+        // stop it once
+        sut.onActivityStopped(activity)
+
+        // resume again. should ask for passcode
+        askedForPin = sut.onActivityResumed(activity)
+        assertTrue("Passcode not requested on subsequent launch after stop", askedForPin)
+    }
+}

--- a/app/src/test/java/com/owncloud/android/authentication/PassCodeManagerTest.kt
+++ b/app/src/test/java/com/owncloud/android/authentication/PassCodeManagerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Nextcloud Android client application
+ *
+ *  @author Álvaro Brey
+ *  Copyright (C) 2023 Álvaro Brey
+ *  Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.authentication
+
+import com.nextcloud.client.core.Clock
+import com.nextcloud.client.preferences.AppPreferences
+import com.owncloud.android.ui.activity.SettingsActivity
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PassCodeManagerTest {
+    @MockK
+    lateinit var appPreferences: AppPreferences
+
+    @MockK
+    lateinit var clockImpl: Clock
+
+    lateinit var sut: PassCodeManager
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this, relaxed = true)
+        sut = PassCodeManager(appPreferences, clockImpl)
+    }
+
+    @Test
+    fun testLocked() {
+        every { appPreferences.lockPreference } returns SettingsActivity.LOCK_PASSCODE
+        every { clockImpl.millisSinceBoot } returns 10000
+        assertTrue("Passcode not requested", sut.passCodeShouldBeRequested(200))
+    }
+
+    @Test
+    fun testPasscodeNotRequested_notEnabled() {
+        every { appPreferences.lockPreference } returns ""
+        every { clockImpl.millisSinceBoot } returns 10000
+        assertFalse("Passcode requested but it shouldn't have been", sut.passCodeShouldBeRequested(200))
+    }
+
+    @Test
+    fun testPasscodeNotRequested_unlockedRecently() {
+        every { appPreferences.lockPreference } returns SettingsActivity.LOCK_PASSCODE
+        every { clockImpl.millisSinceBoot } returns 210
+        assertFalse("Passcode requested but it shouldn't have been", sut.passCodeShouldBeRequested(200))
+    }
+}


### PR DESCRIPTION
This is very specific to the case where an activity extending from AuthenticatorActivity _and_ running as `singleTask`
gets restarted, in which case it calls `PassCodeManager.onActivityResumed` twice (once on `onResume` and once on `onNewIntent`).

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
