### PR TITLE
fix(EditorWebView): Move local image upload to the editor web view

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -23,6 +23,7 @@
 package com.owncloud.android.ui.activity;
 
 import android.app.DownloadManager;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -31,6 +32,8 @@ import android.net.Uri;
 import android.os.Handler;
 import android.view.View;
 import android.webkit.JavascriptInterface;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.Toast;
 
@@ -45,6 +48,8 @@ import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 
 public abstract class EditorWebView extends ExternalSiteWebView {
+    public static final int REQUEST_LOCAL_FILE = 101;
+    public ValueCallback<Uri[]> uploadMessage;
     protected Snackbar loadingSnackbar;
 
     protected String fileName;
@@ -104,6 +109,34 @@ public abstract class EditorWebView extends ExternalSiteWebView {
     protected void postOnCreate() {
         super.postOnCreate();
 
+        getWebView().setWebChromeClient(new WebChromeClient() {
+            EditorWebView activity = EditorWebView.this;
+
+            @Override
+            public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback,
+                                             FileChooserParams fileChooserParams) {
+                if (uploadMessage != null) {
+                    uploadMessage.onReceiveValue(null);
+                    uploadMessage = null;
+                }
+
+                activity.uploadMessage = filePathCallback;
+
+                Intent intent = fileChooserParams.createIntent();
+                intent.setType("image/*");
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                try {
+                    activity.startActivityForResult(intent, REQUEST_LOCAL_FILE);
+                } catch (ActivityNotFoundException e) {
+                    uploadMessage = null;
+                    Toast.makeText(getBaseContext(), "Cannot open file chooser", Toast.LENGTH_LONG).show();
+                    return false;
+                }
+
+                return true;
+            }
+        });
+
         setFile(getIntent().getParcelableExtra(ExternalSiteWebView.EXTRA_FILE));
 
         if (getFile() == null) {
@@ -122,6 +155,42 @@ public abstract class EditorWebView extends ExternalSiteWebView {
             return;
         }
         initLoadingScreen(user.get());
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (RESULT_OK != resultCode) {
+            if (requestCode == REQUEST_LOCAL_FILE) {
+                this.uploadMessage.onReceiveValue(null);
+                this.uploadMessage = null;
+            }
+            return;
+        }
+
+        handleActivityResult(requestCode, resultCode, data);
+
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    protected void handleActivityResult(int requestCode, int resultCode, Intent data) {
+        switch (requestCode) {
+            case REQUEST_LOCAL_FILE:
+                handleLocalFile(data, resultCode);
+                break;
+
+            default:
+                // unexpected, do nothing
+                break;
+        }
+    }
+
+    protected void handleLocalFile(Intent data, int resultCode) {
+        if (uploadMessage == null) {
+            return;
+        }
+
+        uploadMessage.onReceiveValue(WebChromeClient.FileChooserParams.parseResult(resultCode, data));
+        uploadMessage = null;
     }
 
     protected WebView getWebView() {


### PR DESCRIPTION
This makes sure that direct editing apps like text can also use regular
upload image methods through file input elements in the webview

fixes #11215
fixes #10744

As this logic is kind of shared now between the RichDocumentsEditorWebView and
the EditorWebView I introduced a new handleActivityResult method to reuse the
parent class logic as much as possible.

Signed-off-by: Julius Härtl <jus@bitgrid.net>

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
