### PR TITLE
Avoid JSON deserialization in common trivial cases

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -88,7 +88,8 @@ public class FileDataStorageManager {
     private static final String EXCEPTION_MSG = "Exception in batch of operations ";
 
     public static final int ROOT_PARENT_ID = 0;
-    public static final String NULL_STRING = "null";
+    private static final String JSON_NULL_STRING = "null";
+    private static final String JSON_EMPTY_ARRAY = "[]";
 
     private final ContentResolver contentResolver;
     private final ContentProviderClient contentProviderClient;
@@ -931,7 +932,10 @@ public class FileDataStorageManager {
         ocFile.setLockToken(fileEntity.getLockToken());
 
         String sharees = fileEntity.getSharees();
-        if (sharees == null || NULL_STRING.equals(sharees) || sharees.isEmpty()) {
+        // Surprisingly JSON deserialization causes significant overhead.
+        // Avoid it in common, trivial cases (null/empty).
+        if (sharees == null || sharees.isEmpty() ||
+            JSON_NULL_STRING.equals(sharees) || JSON_EMPTY_ARRAY.equals(sharees)) {
             ocFile.setSharees(new ArrayList<>());
         } else {
             try {
@@ -944,10 +948,18 @@ public class FileDataStorageManager {
         }
 
         String metadataSize = fileEntity.getMetadataSize();
-        ImageDimension imageDimension = gson.fromJson(metadataSize, ImageDimension.class);
-        if (imageDimension != null) {
-            ocFile.setImageDimension(imageDimension);
+        // Surprisingly JSON deserialization causes significant overhead.
+        // Avoid it in common, trivial cases (null/empty).
+        if (!(metadataSize == null || metadataSize.isEmpty() || JSON_NULL_STRING.equals(metadataSize))) {
+            ImageDimension imageDimension = gson.fromJson(metadataSize, ImageDimension.class);
+            if (imageDimension != null) {
+                ocFile.setImageDimension(imageDimension);
+            }
         }
+
+//        Log_OC.d(TAG, "createFileInstance - fileName: " + fileEntity.getPathDecrypted() +
+//            " sharees: -->" + (sharees == null ? "<NULL>" : sharees) + "<--" +
+//            " metadataSize: -->" + (metadataSize == null ? "<NULL>" : metadataSize) + "<--");
 
         return ocFile;
     }

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -957,10 +957,6 @@ public class FileDataStorageManager {
             }
         }
 
-//        Log_OC.d(TAG, "createFileInstance - fileName: " + fileEntity.getPathDecrypted() +
-//            " sharees: -->" + (sharees == null ? "<NULL>" : sharees) + "<--" +
-//            " metadataSize: -->" + (metadataSize == null ? "<NULL>" : metadataSize) + "<--");
-
         return ocFile;
     }
 


### PR DESCRIPTION
This is a very simple approach to reduce time spent on JSON deserialization when reading file data from the local DB - much simpler than originally proposed in #11181.

I have noticed that in my tests, in more than 90% of the cases, the JSON data retrieved from the database is:

-  sharees - `"[]"`
- metadataSize - `"null"`

The proposed changes handle these common trivial cases without invoking the JSON parser.

With this change and #11227 I have observed that the time spent inside `FileDataStorageManager::createFileInstance` method is **less than 10%** of the overall time of `FileDataStorageManager::getFolderContent`. Remaining 90% is in `fileDao.getFolderContent` - as expected.