### PR TITLE
Chore: copy wait_for_server from library

### DIFF
--- a/scripts/wait_for_server.sh
+++ b/scripts/wait_for_server.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-status=""
 counter=0
-checkcounter=0
+status=""
 
 until [[ $status = "false" ]]; do
     status=$(curl 2>/dev/null "http://$1/status.php" | jq .maintenance)
-    echo "($checkcounter) $status"
+
+    echo "($counter) $status"
 
     if [[ "$status" =~ "false" || "$status" = "" ]]; then
         let "counter += 1"
@@ -16,8 +16,5 @@ until [[ $status = "false" ]]; do
         fi
     fi
 
-    let "checkcounter += 1"
     sleep 10
 done
-
-echo "($checkcounter) Done"


### PR DESCRIPTION
Get rid of duplicated countr

- [x] Tests written, or not not needed
