### PR TITLE
ChooseTemplateDialogFragment: check selectedTemplate is not null before attempting to get the extension

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
@@ -251,7 +251,11 @@ class ChooseTemplateDialogFragment : DialogFragment(), View.OnClickListener, Tem
         if (positiveButton != null) {
             val selectedTemplate = adapter!!.selectedTemplate
             val name = binding.filename.text.toString().trim()
-            val isNameEmpty = name.isEmpty() || name.equals(DOT + selectedTemplate.extension, ignoreCase = true)
+            val isNameJustExtension = selectedTemplate != null && name.equals(
+                DOT + selectedTemplate.extension,
+                ignoreCase = true
+            )
+            val isNameEmpty = name.isEmpty() || isNameJustExtension
             val state = selectedTemplate != null && !isNameEmpty && !fileNames.contains(name)
 
             positiveButton?.isEnabled = state


### PR DESCRIPTION
Fixes #10668

- [x] Tests written, or not not needed
