### PR TITLE
#10882 Slow Media Tab View

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
@@ -48,8 +48,8 @@ interface FileDao {
     fun getFolderContent(parentId: Long): List<FileEntity>
 
     @Query(
-        "SELECT * FROM filelist WHERE modified >= :startDate" +
-            " AND modified < :endDate" +
+        "SELECT * FROM filelist WHERE created >= :startDate" +
+            " AND created < :endDate" +
             " AND (content_type LIKE 'image/%' OR content_type LIKE 'video/%')" +
             " AND file_owner = :fileOwner" +
             " ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}"

--- a/app/src/main/java/com/nextcloud/client/database/entity/FileEntity.kt
+++ b/app/src/main/java/com/nextcloud/client/database/entity/FileEntity.kt
@@ -43,7 +43,7 @@ data class FileEntity(
     @ColumnInfo(name = ProviderTableMeta.FILE_PARENT)
     val parent: Long?,
     @ColumnInfo(name = ProviderTableMeta.FILE_CREATION)
-    val creation: Long?,
+    val created: Long?,
     @ColumnInfo(name = ProviderTableMeta.FILE_MODIFIED)
     val modified: Long?,
     @ColumnInfo(name = ProviderTableMeta.FILE_CONTENT_TYPE)

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -893,7 +893,7 @@ public class FileDataStorageManager {
             }
         }
         ocFile.setFileLength(nullToZero(fileEntity.getContentLength()));
-        ocFile.setCreationTimestamp(nullToZero(fileEntity.getCreation()));
+        ocFile.setCreationTimestamp(nullToZero(fileEntity.getCreated()));
         ocFile.setModificationTimestamp(nullToZero(fileEntity.getModified()));
         ocFile.setModificationTimestampAtLastSyncForData(nullToZero(fileEntity.getModifiedAtLastSyncForData()));
         ocFile.setLastSyncDateForProperties(nullToZero(fileEntity.getLastSyncDate()));

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
@@ -148,15 +148,16 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
 
             if (localFile == null) {
                 // add new file
+                storageManager.saveFile(ocFile);
                 filesAdded++;
             } else if (!localFile.getEtag().equals(ocFile.getEtag())) {
                 // update file
                 ocFile.setLastSyncDateForData(System.currentTimeMillis());
+                storageManager.saveFile(ocFile);
                 filesUpdated++;
             } else {
                 unchangedFiles++;
             }
-            storageManager.saveFile(ocFile);
         }
 
         // existing files to remove

--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -232,16 +232,17 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
     @SuppressLint("NotifyDataSetChanged")
     public void searchCompleted(boolean emptySearch, long lastTimeStamp) {
         photoSearchQueryRunning = false;
-        mAdapter.notifyDataSetChanged();
 
-        if (mAdapter.isEmpty()) {
+        if (emptySearch && mAdapter.isEmpty()) {
             setEmptyListMessage(SearchType.GALLERY_SEARCH);
-        }
-
-        if (emptySearch && mAdapter.getItemCount() > 0) {
-            Log_OC.d(this, "End gallery search");
             return;
         }
+        if(!emptySearch) {
+            mAdapter.notifyDataSetChanged();
+            this.showAllGalleryItems();
+            return;
+        }
+
         if (daySpan == 30) {
             daySpan = 90;
         } else if (daySpan == 90) {


### PR DESCRIPTION
Signed-off-by: eraser2021999 <bcoticopol@gmail.com>

Fixed unresponsiveness of the Media Tab (Photo Gallery) - more fluent scrolling.
- implemented query search via `created` column and not `modified` to avoid cases when an older modified photo is display wrongly in the chronology;
- changed some logic in media loading to improve the loading speed of the gallery;

Not fixed:
- some issue with selecting a custom folder as gallery folder, I'm unsure if it worked correctly or not since the application crashed a lot;
- some UI issues with the gallery display rectangles;
- loading progress is not displayed correctly when scrolling faster, although the media is loading;

Manually tested with NextCloud Server (25.0.3) via simulator and hardware device (Google Pixel 6) with a media library of more than 10k items.