### PR TITLE
handle files that have just been uploaded in DocumentStorageProvider

### DIFF
--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -211,8 +211,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         int accessMode = ParcelFileDescriptor.parseMode(mode);
         boolean writeOnly = (accessMode & MODE_WRITE_ONLY) != 0;
-        boolean wasNotYetStored = ocFile.getStoragePath() == null;
-        boolean needsDownload = (!writeOnly || wasNotYetStored) && (!ocFile.isDown() || hasServerChange(document));
+        boolean needsDownload = !ocFile.existsOnDevice() || (!writeOnly && hasServerChange(document));
         if (needsDownload) {
             if (ocFile.getLocalModificationTimestamp() > ocFile.getLastSyncDateForData()) {
                 // TODO show a conflict notification with a pending intent that shows a ConflictResolveDialog


### PR DESCRIPTION
fixes #11283

Directly after upload, UploadFileOperation may change paths to the empty string (see commit a7304351b1). Most accessors of OCFile handle this, so DocumentStorageProvider must use one that does.


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

~I see an instrumented testcase for DocumentsStorageProvider, but the explanation in CONTRIBUTING.md is outdated (`createGplayDebugCoverageReport` does not exist) and I have no idea how to run it. ¯\\\_(ツ)\_/¯~

Edit: was able to run tests by running a local server with `docker run -p 8080:80 nextcloud` and setting these in ~/.gradle/gradle.properties:
```
NC_TEST_SERVER_BASEURL=http://<host machine lan ip>:8080
NC_TEST_SERVER_USERNAME=test
NC_TEST_SERVER_PASSWORD=test.123_123
```

Login on http://localhost:8080, create user with above credentials, then run `./gradlew connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.owncloud.android.providers.DocumentsStorageProviderIT`