### PR TITLE
Bumps on master after 3.24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,7 @@ configurations.configureEach {
 
 // semantic versioning for version code
 def versionMajor = 3
-def versionMinor = 24
+def versionMinor = 25
 def versionPatch = 0
 def versionBuild = 0 // 0-50=Alpha / 51-98=RC / 90-99=stable
 

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -127,7 +127,7 @@ import static com.owncloud.android.ui.activity.ContactsPreferenceActivity.PREFER
  */
 public class MainApp extends MultiDexApplication implements HasAndroidInjector {
 
-    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = NextcloudVersion.nextcloud_22;
+    public static final OwnCloudVersion OUTDATED_SERVER_VERSION = NextcloudVersion.nextcloud_23;
     public static final OwnCloudVersion MINIMUM_SUPPORTED_SERVER_VERSION = OwnCloudVersion.nextcloud_16;
 
     private static final String TAG = MainApp.class.getSimpleName();


### PR DESCRIPTION
- Bump version to 3.25.0
- Bump `OUTDATED_SERVER_VERSION` to Nextcloud 23, as it has reached EOL

Note: we're in the position to raise `minSdk` to 24, as 23 usage has finally fallen down below 0.5%. However that means removing fair amounts of code that only makes sense with minSdk 23, so I'll make a separate PR for that.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
