### PR TITLE
Fastfile: fix check for screenshots

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -259,7 +259,7 @@ end
 
 desc "check if screenshots exists and exit"
 private_lane :checkIfScreenshotsExist do
-    sh(" if [ -e  metadata/android/*/images ] ; then echo 'Screenshots in fastlane folder exist; aborting!' ; exit 1 ; fi")
+    sh(" if [ $(find metadata/android/*/images -type f -not -name icon.png  | grep -c . ) -gt 0 ] ; then echo 'Screenshots in fastlane folder exist; aborting!' ; exit 1 ; fi")
 end
 
 private_lane :tag do |options|


### PR DESCRIPTION
We now have the app icon in the fastlane folder, so this check fails.


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
