### PR TITLE
Codecov config improvements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,6 +17,8 @@ coverage:
 comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default
+  require_changes: true
+  after_n_builds: 2
 
 github_checks:
     annotations: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,8 @@ codecov:
   branch: master
   ci:
     - drone.nextcloud.com
+  notify:
+    after_n_builds: 2
 
 coverage:
   precision: 2


### PR DESCRIPTION
- Codecov: don't post status until 2 builds received
- Codecov: post comment only if there are coverage changes AND 2 reports have been received

This is because we upload 2 coverage reports (unit + integration) and coverage is inconsistent if one of them is missing (for example, drone skips tests if no code changes are detected)

Note: CI for this PR has been skipped
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
