### PR TITLE
tries to fix loading message on empty shared folder

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
@@ -20,10 +20,15 @@
  */
 package com.owncloud.android.ui.fragment
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import android.os.Handler
 import android.view.View
 import androidx.lifecycle.lifecycleScope
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.nextcloud.client.account.User
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.logger.Logger
@@ -34,6 +39,7 @@ import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation
 import com.owncloud.android.lib.resources.files.SearchRemoteOperation
 import com.owncloud.android.lib.resources.files.model.RemoteFile
 import com.owncloud.android.lib.resources.shares.GetSharesRemoteOperation
+import com.owncloud.android.operations.RefreshFolderOperation
 import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.events.SearchEvent
 import com.owncloud.android.utils.DisplayUtils
@@ -51,6 +57,11 @@ class SharedListFragment : OCFileListFragment(), Injectable {
 
     @Inject
     lateinit var logger: Logger
+
+    @Inject
+    lateinit var localBroadcastManager: LocalBroadcastManager
+
+    var syncBroadcastReceiver: SyncBroadcastReceiver? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,6 +84,34 @@ class SharedListFragment : OCFileListFragment(), Injectable {
                 val fileDisplayActivity = activity as FileDisplayActivity
                 fileDisplayActivity.updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_item_shared))
                 fileDisplayActivity.setMainFabVisible(false)
+            }
+        }
+
+        if (activity is FileDisplayActivity) {
+            if (syncBroadcastReceiver == null) {
+                val syncIntentFilter = IntentFilter(RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED)
+                syncBroadcastReceiver = SyncBroadcastReceiver()
+                if (syncBroadcastReceiver != null) {
+                    localBroadcastManager.registerReceiver(syncBroadcastReceiver!!, syncIntentFilter)
+                }
+            }
+        }
+    }
+
+    inner class SyncBroadcastReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED) {
+                if (currentFile != null && currentFile.fileLength == 0L &&
+                    mContainerActivity.storageManager.getFolderContent(currentFile, false).isEmpty()
+                ) {
+                    setEmptyListMessage(SearchType.NO_SEARCH)
+                    isLoading = false
+                    mRefreshListLayout.isRefreshing = false
+                } else {
+                    mEmptyListContainer.visibility = View.GONE
+                }
+
+                adapter.notifyDataSetChanged()
             }
         }
     }


### PR DESCRIPTION
Now this works:
- fresh installation
- open shared view
- click on empty folder

but now clicking on a non-empty folder does not show folder content…

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
