### PR TITLE
when resuming note directly after creating, url is not working anymore, thus we need a new one

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
@@ -60,24 +60,24 @@ class TextEditorWebView : EditorWebView() {
         val editor = editorUtils.getEditor(user.get(), file.mimeType)
 
         if (editor != null && editor.id == "onlyoffice") {
-            getWebView().settings.userAgentString = generateOnlyOfficeUserAgent()
+            webView.settings.userAgentString = generateOnlyOfficeUserAgent()
         }
 
-        getWebView().addJavascriptInterface(MobileInterface(), "DirectEditingMobileInterface")
+        webView.addJavascriptInterface(MobileInterface(), "DirectEditingMobileInterface")
 
         if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
             WebSettingsCompat.setForceDarkStrategy(
-                getWebView().settings,
+                webView.settings,
                 WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
             )
         }
         if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK) && PlatformThemeUtil.isDarkMode(this)) {
-            WebSettingsCompat.setForceDark(getWebView().settings, WebSettingsCompat.FORCE_DARK_ON)
+            WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_ON)
         }
 
-        getWebView().setDownloadListener { url, _, _, _, _ -> downloadFile(Uri.parse(url)) }
+        webView.setDownloadListener { url, _, _, _, _ -> downloadFile(Uri.parse(url)) }
 
-        loadUrl(intent.getStringExtra(ExternalSiteWebView.EXTRA_URL))
+        loadUrl(null)
     }
 
     override fun loadUrl(url: String?) {


### PR DESCRIPTION
@AlvaroBrey no idea how to test this :S

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
