### PR TITLE
Refactor onCreate() method by breaking it down into smaller methods

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -6,6 +6,7 @@
  * @author Andy Scherzinger
  * @author Chris Narkiewicz
  * @author TSI-mc
+ * @author Archontis E. Kostis
  * Copyright (C) 2011  Bartek Przybylski
  * Copyright (C) 2016 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -254,16 +254,7 @@ public class FileDisplayActivity extends FileActivity
 
         /// USER INTERFACE
         initLayout();
-        
-        // setup toolbar
-        setupHomeSearchToolbarWithSortAndListButtons();
-
-        mMenuButton.setOnClickListener(v -> openDrawer());
-
-        mSwitchAccountButton.setOnClickListener(v -> showManageAccountsDialog());
-
-
-        fastScrollUtils.fixAppBarForFastScroll(binding.appbar.appbar, binding.rootLayout);
+        initUI();
 
 
         // Init Fragment without UI to retain AsyncTask across configuration changes
@@ -305,6 +296,13 @@ public class FileDisplayActivity extends FileActivity
         // Inflate and set the layout view
         binding = FilesBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+    }
+
+    private void initUI() {
+        setupHomeSearchToolbarWithSortAndListButtons();
+        mMenuButton.setOnClickListener(v -> openDrawer());
+        mSwitchAccountButton.setOnClickListener(v -> showManageAccountsDialog());
+        fastScrollUtils.fixAppBarForFastScroll(binding.appbar.appbar, binding.rootLayout);
     }
 
     private void checkStoragePath() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -251,12 +251,10 @@ public class FileDisplayActivity extends FileActivity
 
         super.onCreate(savedInstanceState);
         loadSavedInstanceState(savedInstanceState);
+
         /// USER INTERFACE
-
-        // Inflate and set the layout view
-        binding = FilesBinding.inflate(getLayoutInflater());
-        setContentView(binding.getRoot());
-
+        initLayout();
+        
         // setup toolbar
         setupHomeSearchToolbarWithSortAndListButtons();
 
@@ -301,6 +299,12 @@ public class FileDisplayActivity extends FileActivity
             mSyncInProgress = false;
             mWaitingToSend = null;
         }
+    }
+
+    private void initLayout() {
+        // Inflate and set the layout view
+        binding = FilesBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
     }
 
     private void checkStoragePath() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -250,19 +250,7 @@ public class FileDisplayActivity extends FileActivity
         setTheme(R.style.Theme_ownCloud_Toolbar_Drawer);
 
         super.onCreate(savedInstanceState);
-        /// Load of saved instance state
-        if (savedInstanceState != null) {
-            mWaitingToPreview = savedInstanceState.getParcelable(FileDisplayActivity.KEY_WAITING_TO_PREVIEW);
-            mSyncInProgress = savedInstanceState.getBoolean(KEY_SYNC_IN_PROGRESS);
-            mWaitingToSend = savedInstanceState.getParcelable(FileDisplayActivity.KEY_WAITING_TO_SEND);
-            searchQuery = savedInstanceState.getString(KEY_SEARCH_QUERY);
-            searchOpen = savedInstanceState.getBoolean(FileDisplayActivity.KEY_IS_SEARCH_OPEN, false);
-        } else {
-            mWaitingToPreview = null;
-            mSyncInProgress = false;
-            mWaitingToSend = null;
-        }
-
+        loadSavedInstanceState(savedInstanceState);
         /// USER INTERFACE
 
         // Inflate and set the layout view
@@ -299,6 +287,20 @@ public class FileDisplayActivity extends FileActivity
         checkStoragePath();
 
         initSyncBroadcastReceiver();
+    }
+
+    private void loadSavedInstanceState(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            mWaitingToPreview = savedInstanceState.getParcelable(FileDisplayActivity.KEY_WAITING_TO_PREVIEW);
+            mSyncInProgress = savedInstanceState.getBoolean(KEY_SYNC_IN_PROGRESS);
+            mWaitingToSend = savedInstanceState.getParcelable(FileDisplayActivity.KEY_WAITING_TO_SEND);
+            searchQuery = savedInstanceState.getString(KEY_SEARCH_QUERY);
+            searchOpen = savedInstanceState.getBoolean(FileDisplayActivity.KEY_IS_SEARCH_OPEN, false);
+        } else {
+            mWaitingToPreview = null;
+            mSyncInProgress = false;
+            mWaitingToSend = null;
+        }
     }
 
     private void checkStoragePath() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -255,17 +255,7 @@ public class FileDisplayActivity extends FileActivity
         /// USER INTERFACE
         initLayout();
         initUI();
-
-
-        // Init Fragment without UI to retain AsyncTask across configuration changes
-        FragmentManager fm = getSupportFragmentManager();
-        TaskRetainerFragment taskRetainerFragment =
-            (TaskRetainerFragment) fm.findFragmentByTag(TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT);
-        if (taskRetainerFragment == null) {
-            taskRetainerFragment = new TaskRetainerFragment();
-            fm.beginTransaction()
-                .add(taskRetainerFragment, TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT).commit();
-        }   // else, Fragment already created and retained across configuration change
+        initTaskRetainerFragment();
 
         if (Intent.ACTION_VIEW.equals(getIntent().getAction())) {
             handleOpenFileViaIntent(getIntent());
@@ -303,6 +293,18 @@ public class FileDisplayActivity extends FileActivity
         mMenuButton.setOnClickListener(v -> openDrawer());
         mSwitchAccountButton.setOnClickListener(v -> showManageAccountsDialog());
         fastScrollUtils.fixAppBarForFastScroll(binding.appbar.appbar, binding.rootLayout);
+    }
+
+    private void initTaskRetainerFragment() {
+        // Init Fragment without UI to retain AsyncTask across configuration changes
+        FragmentManager fm = getSupportFragmentManager();
+        TaskRetainerFragment taskRetainerFragment =
+            (TaskRetainerFragment) fm.findFragmentByTag(TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT);
+        if (taskRetainerFragment == null) {
+            taskRetainerFragment = new TaskRetainerFragment();
+            fm.beginTransaction()
+                .add(taskRetainerFragment, TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT).commit();
+        }   // else, Fragment already created and retained across configuration change
     }
 
     private void checkStoragePath() {


### PR DESCRIPTION
- [x] Tests written, or not not needed

This pull request refactors the `onCreate()` method in `FileDisplayActivity` class by breaking it down into smaller methods. The following changes have been made:

- Created `initLayout()` method to handle the inflation and setting of the layout view.
- Created `initUI()` to handle the setup of the toolbar and UI components.
- Creaed `initTaskRetainerFragment()` to handle the initialization of the fragment without UI.

These changes aim to help on reducing the the complexity of `onCreate()` method and make it easier to read and maintain.
