### PR TITLE
Implementation of  granularity for autoupload subfolders

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/SyncedFoldersActivityIT.java
+++ b/app/src/androidTest/java/com/nextcloud/client/SyncedFoldersActivityIT.java
@@ -65,6 +65,7 @@ public class SyncedFoldersActivityIT extends AbstractIT {
                                                                    false,
                                                                    false,
                                                                    true,
+                                                                   1,
                                                                    "test@https://nextcloud.localhost",
                                                                    0,
                                                                    0,

--- a/app/src/main/java/com/nextcloud/client/database/entity/SyncedFolderEntity.kt
+++ b/app/src/main/java/com/nextcloud/client/database/entity/SyncedFolderEntity.kt
@@ -48,6 +48,8 @@ data class SyncedFolderEntity(
     val enabledTimestampMs: Int?,
     @ColumnInfo(name = ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE)
     val subfolderByDate: Int?,
+    @ColumnInfo(name = ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_GRANULARITY, defaultValue = "1")
+    val subfolderGranularity: Int?,
     @ColumnInfo(name = ProviderTableMeta.SYNCED_FOLDER_ACCOUNT)
     val account: String?,
     @ColumnInfo(name = ProviderTableMeta.SYNCED_FOLDER_UPLOAD_ACTION)

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
@@ -40,6 +40,7 @@ public class SyncedFolder implements Serializable, Cloneable {
     private boolean chargingOnly;
     private boolean existing;
     private boolean subfolderByDate;
+    private int subfolderGranularity;
     private String account;
     private int uploadAction;
     private int nameCollisionPolicy;
@@ -56,7 +57,8 @@ public class SyncedFolder implements Serializable, Cloneable {
      * @param wifiOnly            upload on wifi only flag
      * @param chargingOnly        upload on charging only
      * @param existing            upload existing files
-     * @param subfolderByDate     create sub-folders by date (month)
+     * @param subfolderByDate     create sub-folders by granularity below
+     * @param subfolderGranularity     set subfolder granulariy (YYYY vs YYYY/MM vs YYYY/MM/DD)
      * @param account             the account owning the synced folder
      * @param uploadAction        the action to be done after the upload
      * @param nameCollisionPolicy the behaviour to follow if detecting a collision
@@ -71,6 +73,7 @@ public class SyncedFolder implements Serializable, Cloneable {
                         boolean chargingOnly,
                         boolean existing,
                         boolean subfolderByDate,
+                        int subfolderGranularity,
                         String account,
                         int uploadAction,
                         int nameCollisionPolicy,
@@ -85,6 +88,7 @@ public class SyncedFolder implements Serializable, Cloneable {
              chargingOnly,
              existing,
              subfolderByDate,
+             subfolderGranularity,
              account,
              uploadAction,
              nameCollisionPolicy,
@@ -106,6 +110,7 @@ public class SyncedFolder implements Serializable, Cloneable {
                            boolean chargingOnly,
                            boolean existing,
                            boolean subfolderByDate,
+                           int subfolderGranularity,
                            String account,
                            int uploadAction,
                            int nameCollisionPolicy,
@@ -120,6 +125,7 @@ public class SyncedFolder implements Serializable, Cloneable {
         this.chargingOnly = chargingOnly;
         this.existing = existing;
         this.subfolderByDate = subfolderByDate;
+        this.subfolderGranularity = subfolderGranularity;
         this.account = account;
         this.uploadAction = uploadAction;
         this.nameCollisionPolicy = nameCollisionPolicy;
@@ -170,6 +176,10 @@ public class SyncedFolder implements Serializable, Cloneable {
 
     public boolean isSubfolderByDate() {
         return this.subfolderByDate;
+    }
+
+    public int getSubfolderGranularity() {
+        return this.subfolderGranularity;
     }
 
     public String getAccount() {
@@ -230,6 +240,10 @@ public class SyncedFolder implements Serializable, Cloneable {
 
     public void setSubfolderByDate(boolean subfolderByDate) {
         this.subfolderByDate = subfolderByDate;
+    }
+
+    public void setSubfolderGranularity(int subfolderGranularity) {
+        this.subfolderGranularity = subfolderGranularity;
     }
 
     public void setAccount(String account) {

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderDisplayItem.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderDisplayItem.java
@@ -41,7 +41,8 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
      * @param wifiOnly        upload on wifi only flag
      * @param chargingOnly    upload on charging only
      * @param existing        also upload existing
-     * @param subfolderByDate create sub-folders by date (month)
+     * @param subfolderByDate create sub-folders by granularity below
+     * @param subfolderGranularity set subfolder granulariy (YYYY vs YYYY/MM vs YYYY/MM/DD)
      * @param account         the account owning the synced folder
      * @param uploadAction    the action to be done after the upload
      * @param enabled         flag if synced folder config is active
@@ -58,6 +59,7 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
                                    boolean chargingOnly,
                                    boolean existing,
                                    boolean subfolderByDate,
+                                   int subfolderGranularity,
                                    String account,
                                    int uploadAction,
                                    int nameCollisionPolicy,
@@ -75,6 +77,7 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
               chargingOnly,
               existing,
               subfolderByDate,
+              subfolderGranularity,
               account,
               uploadAction,
               nameCollisionPolicy,
@@ -94,6 +97,7 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
                                    boolean chargingOnly,
                                    boolean existing,
                                    boolean subfolderByDate,
+                                   int subfolderGranularity,
                                    String account,
                                    int uploadAction,
                                    int nameCollisionPolicy,
@@ -109,6 +113,7 @@ public class SyncedFolderDisplayItem extends SyncedFolder {
               chargingOnly,
               existing,
               subfolderByDate,
+              subfolderGranularity,
               account,
               uploadAction,
               nameCollisionPolicy,

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -346,6 +346,8 @@ public class SyncedFolderProvider extends Observable {
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_EXISTING)) == 1;
             boolean subfolderByDate = cursor.getInt(cursor.getColumnIndexOrThrow(
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE)) == 1;
+            int subfolderGranularity = cursor.getInt(cursor.getColumnIndexOrThrow(
+                ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_GRANULARITY));
             String accountName = cursor.getString(cursor.getColumnIndexOrThrow(
                     ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT));
             int uploadAction = cursor.getInt(cursor.getColumnIndexOrThrow(
@@ -368,6 +370,7 @@ public class SyncedFolderProvider extends Observable {
                                             chargingOnly,
                                             existing,
                                             subfolderByDate,
+                                            subfolderGranularity,
                                             accountName,
                                             uploadAction,
                                             nameCollisionPolicy,
@@ -396,6 +399,7 @@ public class SyncedFolderProvider extends Observable {
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ENABLED, syncedFolder.isEnabled());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ENABLED_TIMESTAMP_MS, syncedFolder.getEnabledTimestampMs());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_BY_DATE, syncedFolder.isSubfolderByDate());
+        cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_SUBFOLDER_GRANULARITY, syncedFolder.getSubfolderGranularity());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT, syncedFolder.getAccount());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_UPLOAD_ACTION, syncedFolder.getUploadAction());
         cv.put(ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_NAME_COLLISION_POLICY,

--- a/app/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/app/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -283,6 +283,7 @@ public class ProviderMeta {
         public static final String SYNCED_FOLDER_ENABLED_TIMESTAMP_MS = "enabled_timestamp_ms";
         public static final String SYNCED_FOLDER_TYPE = "type";
         public static final String SYNCED_FOLDER_SUBFOLDER_BY_DATE = "subfolder_by_date";
+        public static final String SYNCED_FOLDER_SUBFOLDER_GRANULARITY = "subfolder_granularity";
         public static final String SYNCED_FOLDER_ACCOUNT = "account";
         public static final String SYNCED_FOLDER_UPLOAD_ACTION = "upload_option";
         public static final String SYNCED_FOLDER_NAME_COLLISION_POLICY = "name_collision_policy";

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -390,6 +390,7 @@ class SyncedFoldersActivity :
             syncedFolder.isChargingOnly,
             syncedFolder.isExisting,
             syncedFolder.isSubfolderByDate,
+            syncedFolder.subfolderGranularity,
             syncedFolder.account,
             syncedFolder.uploadAction,
             syncedFolder.nameCollisionPolicyInt,
@@ -419,6 +420,7 @@ class SyncedFoldersActivity :
             syncedFolder.isChargingOnly,
             syncedFolder.isExisting,
             syncedFolder.isSubfolderByDate,
+            syncedFolder.subfolderGranularity,
             syncedFolder.account,
             syncedFolder.uploadAction,
             syncedFolder.nameCollisionPolicyInt,
@@ -447,6 +449,7 @@ class SyncedFoldersActivity :
             false,
             true,
             false,
+            1,
             account.name,
             FileUploader.LOCAL_BEHAVIOUR_FORGET,
             NameCollisionPolicy.ASK_USER.serialize(),
@@ -540,6 +543,7 @@ class SyncedFoldersActivity :
                         false,
                         true,
                         false,
+                        1,
                         account.name,
                         FileUploader.LOCAL_BEHAVIOUR_FORGET,
                         NameCollisionPolicy.ASK_USER.serialize(),
@@ -649,6 +653,7 @@ class SyncedFoldersActivity :
                 syncedFolder.isChargingOnly,
                 syncedFolder.isExisting,
                 syncedFolder.isSubfolderByDate,
+                syncedFolder.subfolderGranularity,
                 syncedFolder.account,
                 syncedFolder.uploadAction,
                 syncedFolder.nameCollisionPolicy.serialize(),
@@ -671,6 +676,7 @@ class SyncedFoldersActivity :
                 syncedFolder.isChargingOnly,
                 syncedFolder.isExisting,
                 syncedFolder.isSubfolderByDate,
+                syncedFolder.subfolderGranularity,
                 syncedFolder.uploadAction,
                 syncedFolder.nameCollisionPolicy.serialize(),
                 syncedFolder.isEnabled
@@ -751,6 +757,7 @@ class SyncedFoldersActivity :
         chargingOnly: Boolean,
         existing: Boolean,
         subfolderByDate: Boolean,
+        subfolderGranularity: Int,
         uploadAction: Int,
         nameCollisionPolicy: Int,
         enabled: Boolean
@@ -762,6 +769,7 @@ class SyncedFoldersActivity :
         item.isChargingOnly = chargingOnly
         item.isExisting = existing
         item.isSubfolderByDate = subfolderByDate
+        item.subfolderGranularity = subfolderGranularity
         item.uploadAction = uploadAction
         item.setNameCollisionPolicy(nameCollisionPolicy)
         item.setEnabled(enabled, clock.currentTime)

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.java
@@ -30,6 +30,8 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 
 import com.google.android.material.button.MaterialButton;
@@ -87,6 +89,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment implem
     private AppCompatCheckBox mUploadOnChargingCheckbox;
     private AppCompatCheckBox mUploadExistingCheckbox;
     private AppCompatCheckBox mUploadUseSubfoldersCheckbox;
+    private RadioGroup mUploadUseSubfoldersGranularity;
     private TextView mUploadBehaviorSummary;
     private TextView mNameCollisionPolicySummary;
     private TextView mLocalFolderPath;
@@ -182,6 +185,8 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment implem
 
         mUploadUseSubfoldersCheckbox = binding.settingInstantUploadPathUseSubfoldersCheckbox;
 
+        mUploadUseSubfoldersGranularity = binding.settingInstantUploadPathUseSubfoldersGranularityRadioGroup;
+
         viewThemeUtils.platform.themeCheckbox(mUploadOnWifiCheckbox,
                                               mUploadOnChargingCheckbox,
                                               mUploadExistingCheckbox,
@@ -226,6 +231,8 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment implem
 
         mUploadExistingCheckbox.setChecked(mSyncedFolder.isExisting());
         mUploadUseSubfoldersCheckbox.setChecked(mSyncedFolder.isSubfolderByDate());
+
+        mUploadUseSubfoldersGranularity.check(((RadioButton)mUploadUseSubfoldersGranularity.getChildAt(mSyncedFolder.getSubfolderGranularity())).getId());
 
         mUploadBehaviorSummary.setText(mUploadBehaviorItemStrings[mSyncedFolder.getUploadActionInteger()]);
 
@@ -330,6 +337,12 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment implem
         binding.settingInstantUploadPathUseSubfoldersContainer.setEnabled(enable);
         binding.settingInstantUploadPathUseSubfoldersContainer.setAlpha(alpha);
 
+        binding.settingInstantUploadPathUseSubfoldersGranularityLabelContainer.setEnabled(enable);
+        binding.settingInstantUploadPathUseSubfoldersGranularityLabelContainer.setAlpha(alpha);
+
+        binding.settingInstantUploadPathUseSubfoldersGranularityRadioContainer.setEnabled(enable);
+        binding.settingInstantUploadPathUseSubfoldersGranularityRadioContainer.setAlpha(alpha);
+
         binding.remoteFolderContainer.setEnabled(enable);
         binding.remoteFolderContainer.setAlpha(alpha);
 
@@ -343,6 +356,7 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment implem
         mUploadOnChargingCheckbox.setEnabled(enable);
         mUploadExistingCheckbox.setEnabled(enable);
         mUploadUseSubfoldersCheckbox.setEnabled(enable);
+        mUploadUseSubfoldersGranularity.setEnabled(enable);
 
         checkWritableFolder();
     }
@@ -390,6 +404,17 @@ public class SyncedFolderPreferencesDialogFragment extends DialogFragment implem
                 public void onClick(View v) {
                     mSyncedFolder.setSubfolderByDate(!mSyncedFolder.isSubfolderByDate());
                     mUploadUseSubfoldersCheckbox.toggle();
+                }
+            });
+
+        binding.settingInstantUploadPathUseSubfoldersGranularityRadioContainer.setOnClickListener(
+            new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    int granularityRadioButtonId = mUploadUseSubfoldersGranularity.getCheckedRadioButtonId();
+                    View granularityRadioButton = mUploadUseSubfoldersGranularity.findViewById(granularityRadioButtonId);
+                    int granularityRadioButtonIndex = mUploadUseSubfoldersGranularity.indexOfChild(granularityRadioButton);
+                    mSyncedFolder.setSubfolderGranularity(granularityRadioButtonIndex);
                 }
             });
 

--- a/app/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
@@ -40,6 +40,7 @@ public class SyncedFolderParcelable implements Parcelable {
     private boolean existing = true;
     private boolean enabled = false;
     private boolean subfolderByDate = false;
+    private int subfolderGranularity = 1;
     private Integer uploadAction;
     private NameCollisionPolicy nameCollisionPolicy = NameCollisionPolicy.ASK_USER;
     private MediaFolderType type;
@@ -58,6 +59,7 @@ public class SyncedFolderParcelable implements Parcelable {
         existing = syncedFolderDisplayItem.isExisting();
         enabled = syncedFolderDisplayItem.isEnabled();
         subfolderByDate = syncedFolderDisplayItem.isSubfolderByDate();
+        subfolderGranularity = syncedFolderDisplayItem.getSubfolderGranularity();
         type = syncedFolderDisplayItem.getType();
         account = syncedFolderDisplayItem.getAccount();
         uploadAction = syncedFolderDisplayItem.getUploadAction();
@@ -77,6 +79,7 @@ public class SyncedFolderParcelable implements Parcelable {
         existing = read.readInt() != 0;
         enabled = read.readInt() != 0;
         subfolderByDate = read.readInt() != 0;
+        subfolderGranularity = read.readInt();
         type = MediaFolderType.getById(read.readInt());
         account = read.readString();
         uploadAction = read.readInt();
@@ -100,6 +103,7 @@ public class SyncedFolderParcelable implements Parcelable {
         dest.writeInt(existing ? 1 : 0);
         dest.writeInt(enabled ? 1 : 0);
         dest.writeInt(subfolderByDate ? 1 : 0);
+        dest.writeInt(subfolderGranularity);
         dest.writeInt(type.getId());
         dest.writeString(account);
         dest.writeInt(uploadAction);
@@ -188,6 +192,10 @@ public class SyncedFolderParcelable implements Parcelable {
         return this.subfolderByDate;
     }
 
+    public int getSubfolderGranularity() {
+        return this.subfolderGranularity;
+    }
+
     public Integer getUploadAction() {
         return this.uploadAction;
     }
@@ -246,6 +254,10 @@ public class SyncedFolderParcelable implements Parcelable {
 
     public void setSubfolderByDate(boolean subfolderByDate) {
         this.subfolderByDate = subfolderByDate;
+    }
+
+    public void setSubfolderGranularity(int subfolderGranularity) {
+        this.subfolderGranularity = subfolderGranularity;
     }
 
     public void setNameCollisionPolicy(NameCollisionPolicy nameCollisionPolicy) {

--- a/app/src/main/res/layout/synced_folders_settings_layout.xml
+++ b/app/src/main/res/layout/synced_folders_settings_layout.xml
@@ -304,6 +304,91 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_label_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="horizontal">
+
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="@dimen/standard_padding">
+                    <TextView
+                        android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Subfolder Granularity:" />
+                </RelativeLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_radio_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="horizontal">
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="@dimen/standard_padding">
+
+                    <RadioGroup
+                        android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_radio_group"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:orientation="horizontal" >
+
+                        <Space
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <RadioButton
+                            android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_radio_button_year"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Year" />
+
+                        <Space
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <RadioButton
+                            android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_radio_button_month"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Month" />
+
+                        <Space
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <RadioButton
+                            android:id="@+id/setting_instant_upload_path_use_subfolders_granularity_radio_button_day"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Day" />
+
+                        <Space
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                    </RadioGroup>
+
+                </RelativeLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
                 android:id="@+id/setting_instant_behaviour_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/test/java/com/owncloud/android/ui/activity/SyncedFoldersActivityTest.java
+++ b/app/src/test/java/com/owncloud/android/ui/activity/SyncedFoldersActivityTest.java
@@ -167,6 +167,7 @@ public class SyncedFoldersActivityTest {
                                            true,
                                            true,
                                            true,
+                                           1,
                                            "test@nextcloud.com",
                                            FileUploader.LOCAL_BEHAVIOUR_MOVE,
                                            NameCollisionPolicy.ASK_USER.serialize(),


### PR DESCRIPTION
Hello,
I was tackling the implementation of autoupload subfolders to give the user choice of which granularity to use, either only the year, year/month or year/month/day

I've done similar work for the iOS app (https://github.com/nextcloud/ios/pull/2305) and it worked well in my tests, even though not yet merged I'm now rewriting it for the last update.

I wanted to implement the same on android, following the same general idea.

**However** I'm stuck even before starting; the first step I wanted to implement was the interface and handling of the setting, but I can't seem to get the radio buttons work ok.
The idea would be to have the month radio button selected by default (as it is current behaviour) and let user choose if needed one of the others.
You can see the changes in logic I made, but I'm not sure I understood all the code flow.
If somebody with knowledge of this part of code could help get past the settings problem, I can then try to edit the rest of the code accordingly.

Also, not that used to code for android, so let open to any suggestions.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests not yet written for year and day granularity (only edited current for default)
