### PR TITLE
User check added when sync folder runs after user clears the data.

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -11,7 +11,7 @@
  * Copyright (C) 2016 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
  * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
- * Copyright (C) 2022 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2009,7 +2009,7 @@ public class FileDisplayActivity extends FileActivity
 
         // the execution is slightly delayed to allow the activity get the window focus if it's being started
         // or if the method is called from a dialog that is being dismissed
-        if (TextUtils.isEmpty(searchQuery)) {
+        if (TextUtils.isEmpty(searchQuery) && getUser().isPresent()) {
             getHandler().postDelayed(
                 new Runnable() {
                     @Override


### PR DESCRIPTION
**Actions Performed**
1. Open the App
2. Login
3. Close the app
4. Clear the app's data
5. Reopen the app

**Expected Result**
App is stable and will restart

**Actual Result**
App crashes

**Error Logs:**
`12-17 10:53:47.396  4789  4789 E AndroidRuntime: java.lang.RuntimeException
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at com.owncloud.android.ui.activities.ActivitiesActivity$$ExternalSyntheticLambda0.get(Unknown Source:2)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at com.nextcloud.java.util.Optional.orElseThrow(Optional.java:309)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at com.owncloud.android.ui.activity.FileDisplayActivity$8.run(FileDisplayActivity.java:2061)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:942)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:226)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:313)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8741)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
12-17 10:53:47.396  4789  4789 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)`

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
