### PR TITLE
Camera permission rationale

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -462,6 +462,9 @@ public class FileDisplayActivity extends FileActivity
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted
                     getFileOperationsHelper().uploadFromCamera(this, FileDisplayActivity.REQUEST_CODE__UPLOAD_FROM_CAMERA);
+                } else if (!shouldShowRequestPermissionRationale(permissions[0])) {
+                    // user CHECKED "never ask again"
+                    DisplayUtils.showSnackMessage(this, R.string.camera_permission_rationale);
                 }
                 break;
             default:

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -941,6 +941,7 @@
     <string name="version_dev_download">Herunterladen</string>
     <string name="video_overlay_icon">Video Überlagerungsicon</string>
     <string name="wait_a_moment">Bitte warten…</string>
+    <string name="camera_permission_rationale">Bitte geben Sie unter Apps &amp; Benachrichtigungen in den Einstellungen manuell die Erlaubnis.</string>
     <string name="wait_checking_credentials">Überprüfe gespeicherte Anmeldeinformationen</string>
     <string name="wait_for_tmp_copy_from_private_storage">Kopiere Datei von privatem Speicher</string>
     <string name="webview_version_check_alert_dialog_message">Bitte aktualisieren Sie die Android System WebView-App für eine Anmeldung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1021,6 +1021,7 @@
     <string name="link_name">Link Name</string>
     <string name="delete_link">Delete Link</string>
     <string name="share_settings">Settings</string>
+    <string name="camera_permission_rationale">Please navigate to App info in settings and give permission manually.</string>
     <string name="common_confirm">Confirm</string>
     <string name="strict_mode">Strict mode: no HTTP connection allowed!</string>
     <string name="destination_filename">Destination filename</string>


### PR DESCRIPTION
**Pre condition:**
App camera permission should not enabled

**Step to reproduce:**
1. Launch the  app and login
2. Click on '+' icon and select "Upload from camera", Permission pop will open and click on "Allow". (error message coming).
3. Again run step 2 to verify permission applied or not.(Now not asking any permission and open camera)

Actual result:
After allow permission applied successfully but error message coming to set permission manually.

Expected result:
Error message should not come if permission set successfully

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
