### PR TITLE
Media view refresh infinite loop

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -498,7 +498,7 @@ open class FolderPickerActivity :
                             )
                             browseToRoot()
                         } else {
-                            if (currentFile == null && !file.isFolder) {
+                            if (currentFile == null && file != null && file.isFolder) {
                                 // currently selected file was removed in the server, and now we know it
                                 currentFile = currentDir
                             }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -1,8 +1,9 @@
 /*
  *   ownCloud Android client application
  *
+ *   @author TSI-mc
  *   Copyright (C) 2016 ownCloud Inc.
- *
+ *   Copyright (C) 2023 TSI-mc
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
  *   as published by the Free Software Foundation.


### PR DESCRIPTION
**Precondition**
1. E2E is activated2
2. User is logged in

**Steps to reproduce**
1. start the app
2. open the burgermenu
3. tap on „media“
4. tap on „…“ in the upper right and select „select media folder“
5. perform a gesture to refresh the view (pull2refresh)

**Actual result**
refresh on "select location" leads to infinite loading circle

**Expected result**
refresh is performed quickly due to fewer files/folders and the loading circle disappears.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
