### PR TITLE
Avoid search collapse after page refresh

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1340,17 +1340,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     }
                 }
 
-                if (searchView != null && !searchView.isIconified() && !fromSearch) {
-                    searchView.post(() -> {
-                        searchView.setQuery("", false);
-                        Activity activity;
-                        if ((activity = getActivity()) != null && activity instanceof FileDisplayActivity) {
-                            FileDisplayActivity fileDisplayActivity = (FileDisplayActivity) activity;
-                            fileDisplayActivity.hideSearchView(fileDisplayActivity.getCurrentDir());
-                        }
-                    });
-                }
-
                 mAdapter.swapDirectory(
                     accountManager.getUser(),
                     directory,

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1343,15 +1343,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 if (searchView != null && !searchView.isIconified() && !fromSearch) {
                     searchView.post(() -> {
                         searchView.setQuery("", false);
-                        searchView.onActionViewCollapsed();
                         Activity activity;
                         if ((activity = getActivity()) != null && activity instanceof FileDisplayActivity) {
                             FileDisplayActivity fileDisplayActivity = (FileDisplayActivity) activity;
                             fileDisplayActivity.hideSearchView(fileDisplayActivity.getCurrentDir());
-                            if (getCurrentFile() != null) {
-                                fileDisplayActivity
-                                    .setDrawerIndicatorEnabled(fileDisplayActivity.isRoot(getCurrentFile()));
-                            }
                         }
                     });
                 }


### PR DESCRIPTION
**Actions Performed**
1. Open the app and login
2. Now open the menu
3. Go to another area
4. Open the menu again
5. Go back to the main files page
6. Select the search
7. Start entering a search term

**Expected Result**
The search remains being properly opened.

**Actual Result**
The search now closes incorrectly after a short period of time.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
