### PR TITLE
Handling empty state for rich document dialog.

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -3,8 +3,10 @@
  * Nextcloud Android client application
  *
  * @author Tobias Kaminsky
+ * @author TSI-mc
  * Copyright (C) 2019 Tobias Kaminsky
  * Copyright (C) 2019 Nextcloud GmbH
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
@@ -327,7 +327,7 @@ class ChooseTemplateDialogFragment : DialogFragment(), View.OnClickListener, Tem
             val fragment = chooseTemplateDialogFragmentWeakReference.get()
             if (fragment != null && fragment.isAdded) {
                 if (url.isEmpty()) {
-                    DisplayUtils.showSnackMessage(fragment.binding.list, "Error creating file from template")
+                    DisplayUtils.showSnackMessage(fragment.binding.list, R.string.error_creating_file_from_template)
                 } else {
                     val editorWebView = Intent(MainApp.getAppContext(), TextEditorWebView::class.java)
                     editorWebView.putExtra(ExternalSiteWebView.EXTRA_TITLE, "Text")

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
@@ -3,10 +3,12 @@
  *
  * @author Tobias Kaminsky
  * @author Chris Narkiewicz
+ * @author TSI-mc
  *
  * Copyright (C) 2018 Tobias Kaminsky
  * Copyright (C) 2018 Nextcloud GmbH.
  * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 20223TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
When input field is empty for rich document template the button was enabled and no error message was shown.
![Template_Dialog_Disable_Button_Old](https://user-images.githubusercontent.com/89455194/233454340-ed43a1ff-63fb-4e04-bebd-61b904471563.png)

With this fix the Positive button will be disabled when input field is empty and empty error message is shown.
![Template_Dialog_Disable_Button](https://user-images.githubusercontent.com/89455194/233454360-0822e3be-e1c9-418d-a101-8ea8daadd8fa.png)


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
