### PR TITLE
Increase max heap space in base gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ NC_TEST_SERVER_PASSWORD=test
 android.enableJetifier=true
 android.useAndroidX=true
 #android.debug.obsoleteApi=true
+
+# Minimum max heap space to get reliable builds
+org.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
Re: https://github.com/nextcloud/android/pull/11503#issuecomment-1511071254, this PR just increases the max heap space to 1g since builds were failing with the default of 512M

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
