### PR TITLE
Triggering one email for newly created share.

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
@@ -5,7 +5,7 @@
  *   @author David A. Velasco
  *   @author TSI-mc
  *   Copyright (C) 2015 ownCloud Inc.
- *   Copyright (C) 2021 TSI-mc
+ *   Copyright (C) 2023 TSI-mc
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -131,7 +131,8 @@ public class CreateShareWithShareeOperation extends SyncOperation {
             shareeName,
             false,
             sharePassword,
-            permissions
+            permissions,
+            noteMessage
         );
         operation.setGetShareDetails(true);
         RemoteOperationResult result = operation.execute(client);
@@ -144,7 +145,6 @@ public class CreateShareWithShareeOperation extends SyncOperation {
             UpdateShareInfoOperation updateShareInfoOperation = new UpdateShareInfoOperation(share, getStorageManager());
             updateShareInfoOperation.setExpirationDateInMillis(expirationDateInMillis);
             updateShareInfoOperation.setHideFileDownload(hideFileDownload);
-            updateShareInfoOperation.setNote(noteMessage);
             updateShareInfoOperation.setLabel(label);
 
             //execute and save the result in database


### PR DESCRIPTION
Required Library PR: https://github.com/nextcloud/android-library/pull/772
Earlier two emails were getting triggered for new shares when entering note message.
1. First email for shared file/folder.
2. Second email for Note message.

With this fix only one email will be triggered for newly created share.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
