### PR TITLE
Download limit for file link share

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
@@ -6,7 +6,7 @@
  * @author TSI-mc
  * Copyright (C) 2020 Tobias Kaminsky
  * Copyright (C) 2020 Nextcloud GmbH
- * Copyright (C) 2021 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/app/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/fragment/FileDetailSharingFragmentIT.kt
@@ -269,6 +269,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         onView(ViewMatchers.withId(R.id.share_process_set_password_switch)).check(matches(isDisplayed()))
         onView(ViewMatchers.withId(R.id.share_process_change_name_switch)).check(matches(isDisplayed()))
         onView(ViewMatchers.withId(R.id.share_process_allow_resharing_checkbox)).check(matches(not(isDisplayed())))
+        onView(ViewMatchers.withId(R.id.share_process_download_limit_switch)).check(matches(not(isDisplayed())))
 
         // read-only
         onView(ViewMatchers.withId(R.id.share_process_permission_read_only)).check(matches(isChecked()))
@@ -396,6 +397,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         onView(ViewMatchers.withId(R.id.share_process_set_password_switch)).check(matches(isDisplayed()))
         onView(ViewMatchers.withId(R.id.share_process_change_name_switch)).check(matches(isDisplayed()))
         onView(ViewMatchers.withId(R.id.share_process_allow_resharing_checkbox)).check(matches(not(isDisplayed())))
+        onView(ViewMatchers.withId(R.id.share_process_download_limit_switch)).check(matches(isDisplayed()))
 
         // read-only
         publicShare.permissions = 17 // from server
@@ -513,6 +515,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         onView(ViewMatchers.withId(R.id.share_process_set_password_switch)).check(matches(not(isDisplayed())))
         onView(ViewMatchers.withId(R.id.share_process_change_name_switch)).check(matches(not(isDisplayed())))
         onView(ViewMatchers.withId(R.id.share_process_allow_resharing_checkbox)).check(matches(isDisplayed()))
+        onView(ViewMatchers.withId(R.id.share_process_download_limit_switch)).check(matches(not(isDisplayed())))
 
         // read-only
         userShare.permissions = 17 // from server
@@ -636,6 +639,7 @@ class FileDetailSharingFragmentIT : AbstractIT() {
         onView(ViewMatchers.withId(R.id.share_process_set_password_switch)).check(matches(not(isDisplayed())))
         onView(ViewMatchers.withId(R.id.share_process_change_name_switch)).check(matches(not(isDisplayed())))
         onView(ViewMatchers.withId(R.id.share_process_allow_resharing_checkbox)).check(matches(isDisplayed()))
+        onView(ViewMatchers.withId(R.id.share_process_download_limit_switch)).check(matches(not(isDisplayed())))
 
         // read-only
         userShare.permissions = 17 // from server

--- a/app/src/main/java/com/owncloud/android/operations/UpdateShareInfoOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UpdateShareInfoOperation.java
@@ -27,10 +27,14 @@ import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
+import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.GetShareRemoteOperation;
 import com.owncloud.android.lib.resources.shares.OCShare;
+import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.lib.resources.shares.UpdateShareRemoteOperation;
 import com.owncloud.android.operations.common.SyncOperation;
+import com.owncloud.android.operations.download_limit.DeleteShareDownloadLimitRemoteOperation;
+import com.owncloud.android.operations.download_limit.UpdateShareDownloadLimitRemoteOperation;
 
 
 /**
@@ -38,6 +42,7 @@ import com.owncloud.android.operations.common.SyncOperation;
  */
 public class UpdateShareInfoOperation extends SyncOperation {
 
+    private static final String TAG = UpdateShareInfoOperation.class.getSimpleName();
     private OCShare share;
     private long shareId;
     private long expirationDateInMillis;
@@ -46,6 +51,8 @@ public class UpdateShareInfoOperation extends SyncOperation {
     private int permissions = -1;
     private String password;
     private String label;
+    //download limit for link share
+    private long downloadLimit;
 
     /**
      * Constructor
@@ -116,12 +123,53 @@ public class UpdateShareInfoOperation extends SyncOperation {
             if (result.isSuccess() && shareId > 0) {
                 OCShare ocShare = (OCShare) result.getData().get(0);
                 ocShare.setPasswordProtected(!TextUtils.isEmpty(password));
+
+                executeShareDownloadLimitOperation(client, ocShare);
+
                 getStorageManager().saveShare(ocShare);
             }
 
         }
 
         return result;
+    }
+
+    /**
+     * method will be used to update or delete the download limit for the particular share
+     *
+     * @param client
+     * @param ocShare share object
+     */
+    private void executeShareDownloadLimitOperation(OwnCloudClient client, OCShare ocShare) {
+        //if share type is of Link Share then only we have to update the download limit if configured by user
+        if (ocShare.getShareType() == ShareType.PUBLIC_LINK && !ocShare.isFolder()) {
+
+            //if download limit it greater than 0 then update the limit
+            //else delete the download limit
+            if (downloadLimit > 0) {
+                //api will update the download limit for the particular share
+                UpdateShareDownloadLimitRemoteOperation updateShareDownloadLimitRemoteOperation =
+                    new UpdateShareDownloadLimitRemoteOperation(ocShare.getToken(), downloadLimit);
+
+                RemoteOperationResult downloadLimitOp =
+                    updateShareDownloadLimitRemoteOperation.execute(client);
+                if (downloadLimitOp.isSuccess()) {
+                    Log_OC.d(TAG, "Download limit updated for the share.");
+                    Log_OC.d(TAG, "Download limit " + downloadLimit);
+                }
+            } else {
+                //api will delete the download limit for the particular share
+                DeleteShareDownloadLimitRemoteOperation limitRemoteOperation =
+                    new DeleteShareDownloadLimitRemoteOperation(ocShare.getToken());
+
+                RemoteOperationResult deleteDownloadLimitOp =
+                    limitRemoteOperation.execute(client);
+                if (deleteDownloadLimitOp.isSuccess()) {
+                    Log_OC.d(TAG, "Download limit delete for the share.");
+                }
+            }
+
+        }
     }
 
     public void setExpirationDateInMillis(long expirationDateInMillis) {
@@ -146,6 +194,10 @@ public class UpdateShareInfoOperation extends SyncOperation {
 
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public void setDownloadLimit(long downloadLimit) {
+        this.downloadLimit = downloadLimit;
     }
 }
 

--- a/app/src/main/java/com/owncloud/android/operations/UpdateShareInfoOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UpdateShareInfoOperation.java
@@ -2,7 +2,7 @@
  * Nextcloud Android client application
  *
  * @author TSI-mc
- * Copyright (C) 2021 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  * Copyright (C) 2021 Nextcloud GmbH
  *
  * This program is free software: you can redistribute it and/or modify

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/DeleteShareDownloadLimitRemoteOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/DeleteShareDownloadLimitRemoteOperation.kt
@@ -1,0 +1,77 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author TSI-mc Copyright (C) 2021 TSI-mc
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation.
+ *
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http:></http:>//www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.operations.download_limit
+
+import com.owncloud.android.lib.common.OwnCloudClient
+import com.owncloud.android.lib.common.operations.RemoteOperation
+import com.owncloud.android.lib.common.operations.RemoteOperationResult
+import com.owncloud.android.lib.common.utils.Log_OC
+import org.apache.commons.httpclient.HttpStatus
+import org.apache.commons.httpclient.methods.DeleteMethod
+
+/**
+ * class to delete the download limit for the link share
+ * this has to be executed when user has toggled off the download limit
+ *
+ *
+ * API : //DELETE to /ocs/v2.php/apps/files_downloadlimit/{share_token}/limit
+ */
+class DeleteShareDownloadLimitRemoteOperation(private val shareToken: String) :
+    RemoteOperation<DownloadLimitResponse>() {
+    override fun run(client: OwnCloudClient): RemoteOperationResult<DownloadLimitResponse> {
+        var result: RemoteOperationResult<DownloadLimitResponse>
+        val status: Int
+        var deleteMethod: DeleteMethod? = null
+        try {
+            // Post Method
+            deleteMethod = DeleteMethod(
+                client.baseUri.toString() + ShareDownloadLimitUtils.getDownloadLimitApiPath(
+                    shareToken
+                )
+            )
+            deleteMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
+            status = client.executeMethod(deleteMethod)
+            if (isSuccess(status)) {
+                val response = deleteMethod.responseBodyAsString
+                Log_OC.d(TAG, "Delete Download Limit response: $response")
+                val parser = DownloadLimitXMLParser()
+                result = parser.parse(true, response)
+                if (result.isSuccess) {
+                    return result
+                }
+            } else {
+                result = RemoteOperationResult<DownloadLimitResponse>(false, deleteMethod)
+            }
+        } catch (e: Exception) {
+            result = RemoteOperationResult<DownloadLimitResponse>(e)
+            Log_OC.e(TAG, "Exception while deleting share download limit", e)
+        } finally {
+            deleteMethod?.releaseConnection()
+        }
+        return result
+    }
+
+    private fun isSuccess(status: Int): Boolean {
+        return status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_REQUEST
+    }
+
+    companion object {
+        private val TAG = DeleteShareDownloadLimitRemoteOperation::class.java.simpleName
+    }
+}

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/DeleteShareDownloadLimitRemoteOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/DeleteShareDownloadLimitRemoteOperation.kt
@@ -1,21 +1,25 @@
-/**
- * ownCloud Android client application
+/*
  *
- * @author TSI-mc Copyright (C) 2021 TSI-mc
+ * Nextcloud Android client application
  *
+ * @author TSI-mc
+ * Copyright (C) 2023 TSI-mc
+ * Copyright (C) 2023 Nextcloud GmbH
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
- *
- *
- * You should have received a copy of the GNU General Public License along with this program.  If not, see
- * <http:></http:>//www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+
 package com.owncloud.android.operations.download_limit
 
 import com.owncloud.android.lib.common.OwnCloudClient

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitResponse.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitResponse.kt
@@ -1,0 +1,18 @@
+package com.owncloud.android.operations.download_limit
+
+/**
+ * response from the Get download limit api
+ *
+ * <ocs>
+ * <meta></meta>
+ * <status>ok</status>
+ * <statuscode>200</statuscode>
+ * <message>OK</message>
+ *
+ * <data>
+ * <limit>5</limit>
+ * <count>0</count>
+</data> *
+</ocs> *
+ */
+data class DownloadLimitResponse(var limit: Long = 0, var count: Long = 0)

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitResponse.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitResponse.kt
@@ -1,3 +1,25 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author TSI-mc
+ * Copyright (C) 2023 TSI-mc
+ * Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.owncloud.android.operations.download_limit
 
 /**

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitXMLParser.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitXMLParser.kt
@@ -1,0 +1,263 @@
+package com.owncloud.android.operations.download_limit
+
+import android.util.Xml
+import com.owncloud.android.lib.common.operations.RemoteOperationResult
+import com.owncloud.android.lib.common.utils.Log_OC
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * class to parse the Download Limit api XML response This class code referenced from java in NC library
+ */
+class DownloadLimitXMLParser {
+    // Getters and Setters
+    var status: String? = null
+    var statusCode = 0
+    var message = ""
+    val isSuccess: Boolean
+        get() = statusCode == SUCCESS || statusCode == OK
+    private val isForbidden: Boolean
+        get() = statusCode == ERROR_FORBIDDEN
+    private val isNotFound: Boolean
+        get() = statusCode == ERROR_NOT_FOUND
+    private val isWrongParameter: Boolean
+        get() = statusCode == ERROR_WRONG_PARAMETER
+
+    /**
+     * method to parse the Download limit response
+     * @param isGet check if parsing has to do for GET api or not
+     * because the parsing will depend on that
+     * if API is GET then response will have <data> tag else it wont have
+     * @param serverResponse
+     * @return
+    </data> */
+    fun parse(isGet: Boolean, serverResponse: String?): RemoteOperationResult<DownloadLimitResponse> {
+        if (serverResponse == null || serverResponse.isEmpty()) {
+            return RemoteOperationResult(RemoteOperationResult.ResultCode.WRONG_SERVER_RESPONSE)
+        }
+        var result: RemoteOperationResult<DownloadLimitResponse>
+        try {
+            // Parse xml response and obtain the list of downloadLimitResponse
+            val inputStream: InputStream = ByteArrayInputStream(serverResponse.toByteArray())
+            val downloadLimitResponse = parseXMLResponse(inputStream)
+            if (isSuccess) {
+                if (isGet) {
+                    result = RemoteOperationResult(RemoteOperationResult.ResultCode.OK)
+                    result.setResultData(downloadLimitResponse)
+                } else {
+                    result = RemoteOperationResult(RemoteOperationResult.ResultCode.WRONG_SERVER_RESPONSE)
+                    Log_OC.e(TAG, "Successful status with no share in the response")
+                }
+            } else if (isWrongParameter) {
+                result = RemoteOperationResult(RemoteOperationResult.ResultCode.SHARE_WRONG_PARAMETER)
+                result.setMessage(message)
+            } else if (isNotFound) {
+                result = RemoteOperationResult(RemoteOperationResult.ResultCode.SHARE_NOT_FOUND)
+                result.setMessage(message)
+            } else if (isForbidden) {
+                result = RemoteOperationResult(RemoteOperationResult.ResultCode.SHARE_FORBIDDEN)
+                result.setMessage(message)
+            } else {
+                result = RemoteOperationResult(RemoteOperationResult.ResultCode.WRONG_SERVER_RESPONSE)
+                result.setMessage(message)
+            }
+        } catch (e: XmlPullParserException) {
+            Log_OC.e(TAG, "Error parsing response from server ", e)
+            result = RemoteOperationResult(RemoteOperationResult.ResultCode.WRONG_SERVER_RESPONSE)
+        } catch (e: IOException) {
+            Log_OC.e(TAG, "Error reading response from server ", e)
+            result = RemoteOperationResult(RemoteOperationResult.ResultCode.WRONG_SERVER_RESPONSE)
+        }
+        return result
+    }
+
+    /**
+     * Parse is as response of Share API
+     *
+     * @param `is` InputStream to parse
+     * @return List of ShareRemoteFiles
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun parseXMLResponse(inputStream: InputStream): DownloadLimitResponse {
+        return inputStream.use {
+            // XMLPullParser
+            val factory = XmlPullParserFactory.newInstance()
+            factory.isNamespaceAware = true
+            val parser = Xml.newPullParser()
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
+            parser.setInput(it, null)
+            parser.nextTag()
+            readOCS(parser)
+        }
+    }
+
+    /**
+     * Parse OCS node
+     *
+     * @param parser
+     * @return List of ShareRemoteFiles
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun readOCS(parser: XmlPullParser): DownloadLimitResponse {
+        var downloadLimitResponse = DownloadLimitResponse()
+        parser.require(XmlPullParser.START_TAG, ns, NODE_OCS)
+        while (parser.next() != XmlPullParser.END_TAG) {
+            if (parser.eventType != XmlPullParser.START_TAG) {
+                continue
+            }
+            val name = parser.name
+            // read NODE_META and NODE_DATA
+            if (NODE_META.equals(name, ignoreCase = true)) {
+                readMeta(parser)
+            } else if (NODE_DATA.equals(name, ignoreCase = true)) {
+                downloadLimitResponse = readData(parser)
+            } else {
+                skip(parser)
+            }
+        }
+        return downloadLimitResponse
+    }
+
+    /**
+     * Parse Meta node
+     *
+     * @param parser
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun readMeta(parser: XmlPullParser) {
+        parser.require(XmlPullParser.START_TAG, ns, NODE_META)
+        while (parser.next() != XmlPullParser.END_TAG) {
+            if (parser.eventType != XmlPullParser.START_TAG) {
+                continue
+            }
+            val name = parser.name
+            if (NODE_STATUS.equals(name, ignoreCase = true)) {
+                status = readNode(parser, NODE_STATUS)
+            } else if (NODE_STATUS_CODE.equals(name, ignoreCase = true)) {
+                statusCode = readNode(parser, NODE_STATUS_CODE).toInt()
+            } else if (NODE_MESSAGE.equals(name, ignoreCase = true)) {
+                message = readNode(parser, NODE_MESSAGE)
+            } else {
+                skip(parser)
+            }
+        }
+    }
+
+    /**
+     * Parse Data node
+     *
+     * @param parser
+     * @return
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun readData(parser: XmlPullParser): DownloadLimitResponse {
+        val downloadLimitResponse = DownloadLimitResponse()
+        parser.require(XmlPullParser.START_TAG, ns, NODE_DATA)
+        //Log_OC.d(TAG, "---- NODE DATA ---");
+        while (parser.next() != XmlPullParser.END_TAG) {
+            if (parser.eventType != XmlPullParser.START_TAG) {
+                continue
+            }
+            val name = parser.name
+            if (NODE_LIMIT.equals(name, ignoreCase = true)) {
+                val downloadLimit = readNode(parser, NODE_LIMIT)
+                downloadLimitResponse.limit = if (downloadLimit.isNotEmpty()) downloadLimit.toLong() else 0L
+            } else if (NODE_COUNT.equals(name, ignoreCase = true)) {
+                val downloadCount = readNode(parser, NODE_COUNT)
+                downloadLimitResponse.count = if (downloadCount.isNotEmpty()) downloadCount.toLong() else 0L
+            } else {
+                skip(parser)
+            }
+        }
+        return downloadLimitResponse
+    }
+
+    /**
+     * Parse a node, to obtain its text. Needs readText method
+     *
+     * @param parser
+     * @param node
+     * @return Text of the node
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun readNode(parser: XmlPullParser, node: String): String {
+        parser.require(XmlPullParser.START_TAG, ns, node)
+        val value = readText(parser)
+        //Log_OC.d(TAG, "node= " + node + ", value= " + value);
+        parser.require(XmlPullParser.END_TAG, ns, node)
+        return value
+    }
+
+    /**
+     * Read the text from a node
+     *
+     * @param parser
+     * @return Text of the node
+     * @throws IOException
+     * @throws XmlPullParserException
+     */
+    @Throws(IOException::class, XmlPullParserException::class)
+    private fun readText(parser: XmlPullParser): String {
+        var result = ""
+        if (parser.next() == XmlPullParser.TEXT) {
+            result = parser.text
+            parser.nextTag()
+        }
+        return result
+    }
+
+    /**
+     * Skip tags in parser procedure
+     *
+     * @param parser
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun skip(parser: XmlPullParser) {
+        check(parser.eventType == XmlPullParser.START_TAG)
+        var depth = 1
+        while (depth != 0) {
+            when (parser.next()) {
+                XmlPullParser.END_TAG -> depth--
+                XmlPullParser.START_TAG -> depth++
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = DownloadLimitXMLParser::class.java.simpleName
+
+        // No namespaces
+        private val ns: String? = null
+
+        // NODES for XML Parser
+        private const val NODE_OCS = "ocs"
+        private const val NODE_META = "meta"
+        private const val NODE_STATUS = "status"
+        private const val NODE_STATUS_CODE = "statuscode"
+        private const val NODE_MESSAGE = "message"
+        private const val NODE_DATA = "data"
+        private const val NODE_LIMIT = "limit"
+        private const val NODE_COUNT = "count"
+        private const val SUCCESS = 100
+        private const val OK = 200
+        private const val ERROR_WRONG_PARAMETER = 400
+        private const val ERROR_FORBIDDEN = 403
+        private const val ERROR_NOT_FOUND = 404
+    }
+}

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitXMLParser.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/DownloadLimitXMLParser.kt
@@ -1,3 +1,25 @@
+/*
+ *
+ * Nextcloud Android client application
+ *
+ * @author TSI-mc
+ * Copyright (C) 2023 TSI-mc
+ * Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.owncloud.android.operations.download_limit
 
 import android.util.Xml

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/GetShareDownloadLimitOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/GetShareDownloadLimitOperation.kt
@@ -1,0 +1,79 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author TSI-mc Copyright (C) 2021 TSI-mc
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation.
+ *
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http:></http:>//www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.operations.download_limit
+
+import com.owncloud.android.lib.common.OwnCloudClient
+import com.owncloud.android.lib.common.operations.RemoteOperation
+import com.owncloud.android.lib.common.operations.RemoteOperationResult
+import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.operations.download_limit.ShareDownloadLimitUtils.getDownloadLimitApiPath
+import org.apache.commons.httpclient.HttpStatus
+import org.apache.commons.httpclient.methods.GetMethod
+
+/**
+ * class to fetch the download limit for the link share it requires share token to fetch the data
+ *
+ *
+ * API : //GET to /ocs/v2.php/apps/files_downloadlimit/{share_token}/limit
+ */
+class GetShareDownloadLimitOperation(
+    //share token from OCShare
+    private val shareToken: String
+) : RemoteOperation<DownloadLimitResponse>() {
+    override fun run(client: OwnCloudClient): RemoteOperationResult<DownloadLimitResponse> {
+        var result: RemoteOperationResult<DownloadLimitResponse>
+        var status = -1
+        var get: GetMethod? = null
+        try {
+            // Get Method
+            get = GetMethod(
+                client.baseUri.toString() + getDownloadLimitApiPath(
+                    shareToken
+                )
+            )
+            get.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
+            status = client.executeMethod(get)
+            if (isSuccess(status)) {
+                val response = get.responseBodyAsString
+                Log_OC.d(TAG, "Get Download Limit response: $response")
+                val parser = DownloadLimitXMLParser()
+                result = parser.parse(true, response)
+                if (result.isSuccess) {
+                    Log_OC.d(TAG, "Got " + result.resultData + " Response")
+                }
+            } else {
+                result = RemoteOperationResult<DownloadLimitResponse>(false, get)
+            }
+        } catch (e: Exception) {
+            result = RemoteOperationResult<DownloadLimitResponse>(e)
+            Log_OC.e(TAG, "Exception while getting share download limit", e)
+        } finally {
+            get?.releaseConnection()
+        }
+        return result
+    }
+
+    private fun isSuccess(status: Int): Boolean {
+        return status == HttpStatus.SC_OK
+    }
+
+    companion object {
+        private val TAG = GetShareDownloadLimitOperation::class.java.simpleName
+    }
+}

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/GetShareDownloadLimitOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/GetShareDownloadLimitOperation.kt
@@ -1,21 +1,25 @@
-/**
- * ownCloud Android client application
+/*
  *
- * @author TSI-mc Copyright (C) 2021 TSI-mc
+ * Nextcloud Android client application
  *
+ * @author TSI-mc
+ * Copyright (C) 2023 TSI-mc
+ * Copyright (C) 2023 Nextcloud GmbH
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
- *
- *
- * You should have received a copy of the GNU General Public License along with this program.  If not, see
- * <http:></http:>//www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+
 package com.owncloud.android.operations.download_limit
 
 import com.owncloud.android.lib.common.OwnCloudClient

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/ShareDownloadLimitUtils.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/ShareDownloadLimitUtils.kt
@@ -1,17 +1,23 @@
-/**
- * ownCloud Android client application
+/*
  *
- * @author TSI-mc Copyright (C) 2021 TSI-mc
- * <p>
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
- * <p>
- * You should have received a copy of the GNU General Public License along with this program.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * Nextcloud Android client application
+ *
+ * @author TSI-mc
+ * Copyright (C) 2023 TSI-mc
+ * Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.owncloud.android.operations.download_limit

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/ShareDownloadLimitUtils.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/ShareDownloadLimitUtils.kt
@@ -1,0 +1,30 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author TSI-mc Copyright (C) 2021 TSI-mc
+ * <p>
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.operations.download_limit
+
+object ShareDownloadLimitUtils {
+
+    private const val SHARE_TOKEN_PATH = "{share_token}"
+
+    //ocs route
+    //replace the {share_token}
+    private const val SHARE_DOWNLOAD_LIMIT_API_PATH = "/ocs/v2.php/apps/files_downloadlimit/$SHARE_TOKEN_PATH/limit"
+
+    fun getDownloadLimitApiPath(shareToken: String): String {
+        return SHARE_DOWNLOAD_LIMIT_API_PATH.replace(SHARE_TOKEN_PATH, shareToken)
+    }
+}

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/UpdateShareDownloadLimitRemoteOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/UpdateShareDownloadLimitRemoteOperation.kt
@@ -1,21 +1,25 @@
-/**
- * ownCloud Android client application
+/*
  *
- * @author TSI-mc Copyright (C) 2021 TSI-mc
+ * Nextcloud Android client application
  *
+ * @author TSI-mc
+ * Copyright (C) 2023 TSI-mc
+ * Copyright (C) 2023 Nextcloud GmbH
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
- *
- *
- * You should have received a copy of the GNU General Public License along with this program.  If not, see
- * <http:></http:>//www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+
 package com.owncloud.android.operations.download_limit
 
 import android.util.Pair

--- a/app/src/main/java/com/owncloud/android/operations/download_limit/UpdateShareDownloadLimitRemoteOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/download_limit/UpdateShareDownloadLimitRemoteOperation.kt
@@ -1,0 +1,96 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author TSI-mc Copyright (C) 2021 TSI-mc
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation.
+ *
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http:></http:>//www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.operations.download_limit
+
+import android.util.Pair
+import com.owncloud.android.lib.common.OwnCloudClient
+import com.owncloud.android.lib.common.operations.RemoteOperation
+import com.owncloud.android.lib.common.operations.RemoteOperationResult
+import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.operations.download_limit.ShareDownloadLimitUtils.getDownloadLimitApiPath
+import org.apache.commons.httpclient.HttpStatus
+import org.apache.commons.httpclient.methods.PutMethod
+import org.apache.commons.httpclient.methods.StringRequestEntity
+
+/**
+ * class to update the download limit for the link share
+ *
+ *
+ * API : //PUT to /ocs/v2.php/apps/files_downloadlimit/{share_token}/limit
+ *
+ *
+ * Body: {"token" : "Bpd4oEAgPqn3AbG", "limit" : 5}
+ */
+class UpdateShareDownloadLimitRemoteOperation(private val shareToken: String, private val downloadLimit: Long) :
+    RemoteOperation<DownloadLimitResponse>() {
+    override fun run(client: OwnCloudClient): RemoteOperationResult<DownloadLimitResponse> {
+        var result: RemoteOperationResult<DownloadLimitResponse>
+        val status: Int
+        var put: PutMethod? = null
+        try {
+            // Post Method
+            put = PutMethod(
+                client.baseUri.toString() + getDownloadLimitApiPath(
+                    shareToken
+                )
+            )
+            put.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
+            val parametersToUpdate: MutableList<Pair<String, String>> = ArrayList()
+            parametersToUpdate.add(Pair(PARAM_TOKEN, shareToken))
+            parametersToUpdate.add(Pair(PARAM_LIMIT, downloadLimit.toString()))
+            for (parameter in parametersToUpdate) {
+                put.requestEntity = StringRequestEntity(
+                    parameter.first + "=" + parameter.second,
+                    ENTITY_CONTENT_TYPE,
+                    ENTITY_CHARSET
+                )
+            }
+            status = client.executeMethod(put)
+            if (isSuccess(status)) {
+                val response = put.responseBodyAsString
+                Log_OC.d(TAG, "Download Limit response: $response")
+                val parser = DownloadLimitXMLParser()
+                result = parser.parse(true, response)
+                if (result.isSuccess) {
+                    return result
+                }
+            } else {
+                result = RemoteOperationResult<DownloadLimitResponse>(false, put)
+            }
+        } catch (e: Exception) {
+            result = RemoteOperationResult<DownloadLimitResponse>(e)
+            Log_OC.e(TAG, "Exception while updating share download limit", e)
+        } finally {
+            put?.releaseConnection()
+        }
+        return result
+    }
+
+    private fun isSuccess(status: Int): Boolean {
+        return status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_REQUEST
+    }
+
+    companion object {
+        private val TAG = UpdateShareDownloadLimitRemoteOperation::class.java.simpleName
+        private const val PARAM_TOKEN = "token"
+        private const val PARAM_LIMIT = "limit"
+        private const val ENTITY_CONTENT_TYPE = "application/x-www-form-urlencoded"
+        private const val ENTITY_CHARSET = "UTF-8"
+    }
+}

--- a/app/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/app/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -7,7 +7,7 @@
  *   @author TSI-mc
  *   Copyright (C) 2015 ownCloud Inc.
  *   Copyright (C) 2018 Andy Scherzinger
- *   Copyright (C) 2021 TSI-mc
+ *   Copyright (C) 2023 TSI-mc
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/app/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/app/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -73,6 +73,7 @@ import com.owncloud.android.operations.UpdateNoteForShareOperation;
 import com.owncloud.android.operations.UpdateShareInfoOperation;
 import com.owncloud.android.operations.UpdateSharePermissionsOperation;
 import com.owncloud.android.operations.UpdateShareViaLinkOperation;
+import com.owncloud.android.operations.download_limit.GetShareDownloadLimitOperation;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -109,6 +110,8 @@ public class OperationsService extends Service {
     public static final String EXTRA_SHARE_ID = "SHARE_ID";
     public static final String EXTRA_SHARE_NOTE = "SHARE_NOTE";
     public static final String EXTRA_IN_BACKGROUND = "IN_BACKGROUND";
+    public static final String EXTRA_SHARE_TOKEN = "SHARE_TOKEN";
+    public static final String EXTRA_SHARE_DOWNLOAD_LIMIT = "SHARE_DOWNLOAD_LIMIT";
 
     public static final String ACTION_CREATE_SHARE_VIA_LINK = "CREATE_SHARE_VIA_LINK";
     public static final String ACTION_CREATE_SECURE_FILE_DROP = "CREATE_SECURE_FILE_DROP";
@@ -129,6 +132,7 @@ public class OperationsService extends Service {
     public static final String ACTION_COPY_FILE = "COPY_FILE";
     public static final String ACTION_CHECK_CURRENT_CREDENTIALS = "CHECK_CURRENT_CREDENTIALS";
     public static final String ACTION_RESTORE_VERSION = "RESTORE_VERSION";
+    public static final String ACTION_GET_SHARE_DOWNLOAD_LIMIT = "GET_SHARE_DOWNLOAD_LIMIT";
 
     private ServiceHandler mOperationsHandler;
     private OperationsServiceBinder mOperationsBinder;
@@ -643,6 +647,12 @@ public class OperationsService extends Service {
                                 updateShare.setLabel(operationIntent.getStringExtra(EXTRA_SHARE_PUBLIC_LABEL));
                             }
 
+                            //download limit for link share type
+                            if (operationIntent.hasExtra(EXTRA_SHARE_DOWNLOAD_LIMIT)) {
+                                updateShare.setDownloadLimit(operationIntent.getLongExtra(EXTRA_SHARE_DOWNLOAD_LIMIT,
+                                                                                          0L));
+                            }
+
                             operation = updateShare;
                         }
                         break;
@@ -732,6 +742,13 @@ public class OperationsService extends Service {
                         FileVersion fileVersion = operationIntent.getParcelableExtra(EXTRA_FILE_VERSION);
                         operation = new RestoreFileVersionRemoteOperation(fileVersion.getLocalId(),
                                                                           fileVersion.getFileName());
+                        break;
+
+                    case ACTION_GET_SHARE_DOWNLOAD_LIMIT:
+                        String shareToken = operationIntent.getStringExtra(EXTRA_SHARE_TOKEN);
+                        if (!TextUtils.isEmpty(shareToken)) {
+                            operation = new GetShareDownloadLimitOperation(shareToken);
+                        }
                         break;
 
                     default:

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -7,7 +7,7 @@
  *   Copyright (C) 2011  Bartek Przybylski
  *   Copyright (C) 2016 ownCloud Inc.
  *   Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
- *   Copyright (C) 2021 TSI-mc
+ *   Copyright (C) 2023 TSI-mc
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -78,6 +78,8 @@ import com.owncloud.android.operations.UpdateNoteForShareOperation;
 import com.owncloud.android.operations.UpdateShareInfoOperation;
 import com.owncloud.android.operations.UpdateSharePermissionsOperation;
 import com.owncloud.android.operations.UpdateShareViaLinkOperation;
+import com.owncloud.android.operations.download_limit.DownloadLimitResponse;
+import com.owncloud.android.operations.download_limit.GetShareDownloadLimitOperation;
 import com.owncloud.android.providers.UsersAndGroupsSearchProvider;
 import com.owncloud.android.services.OperationsService;
 import com.owncloud.android.services.OperationsService.OperationsServiceBinder;
@@ -89,6 +91,7 @@ import com.owncloud.android.ui.dialog.ShareLinkToDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import com.owncloud.android.ui.fragment.FileDetailFragment;
 import com.owncloud.android.ui.fragment.FileDetailSharingFragment;
+import com.owncloud.android.ui.fragment.FileDetailsSharingProcessFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
 import com.owncloud.android.ui.helpers.FileOperationsHelper;
 import com.owncloud.android.ui.preview.PreviewImageActivity;
@@ -415,6 +418,8 @@ public abstract class FileActivity extends DrawerActivity
             onUpdateShareInformation(result, R.string.unsharing_failed);
         } else if (operation instanceof UpdateNoteForShareOperation) {
             onUpdateNoteForShareOperationFinish(result);
+        } else if (operation instanceof GetShareDownloadLimitOperation) {
+            onShareDownloadLimitFetched(result);
         }
     }
 
@@ -846,6 +851,24 @@ public abstract class FileActivity extends DrawerActivity
     }
 
     /**
+     * method will be called when download limit is fetched
+     *
+     * @param result
+     */
+    private void onShareDownloadLimitFetched(RemoteOperationResult result) {
+        FileDetailSharingFragment sharingFragment = getShareFileFragment();
+
+        if (result.isSuccess() && sharingFragment != null) {
+            if (result.isSuccess() && result.getResultData() != null) {
+                if (result.getResultData() instanceof DownloadLimitResponse) {
+                    onLinkShareDownloadLimitFetched(((DownloadLimitResponse) result.getResultData()).getLimit(),
+                                                    ((DownloadLimitResponse) result.getResultData()).getCount());
+                }
+            }
+        }
+    }
+
+    /**
      * Shortcut to get access to the {@link FileDetailSharingFragment} instance, if any
      *
      * @return A {@link FileDetailSharingFragment} instance, or null
@@ -919,6 +942,14 @@ public abstract class FileActivity extends DrawerActivity
         FileDetailFragment fragment = getFileDetailFragment();
         if (fragment != null) {
             fragment.editExistingShare(share, screenTypePermission, isReshareShown, isExpiryDateShown);
+        }
+    }
+
+    @Override
+    public void onLinkShareDownloadLimitFetched(long downloadLimit, long downloadCount) {
+        Fragment fileDetailsSharingProcessFragment = getSupportFragmentManager().findFragmentByTag(FileDetailsSharingProcessFragment.TAG);
+        if (fileDetailsSharingProcessFragment != null) {
+            ((FileDetailsSharingProcessFragment) fileDetailsSharingProcessFragment).onLinkShareDownloadLimitFetched(downloadLimit, downloadCount);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2018 Andy Scherzinger
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
- * Copyright (C) 2020 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -551,5 +551,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                                boolean isExpiryDateShown);
 
         void onShareProcessClosed();
+
+        void onLinkShareDownloadLimitFetched(long downloadLimit, long downloadCount);
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -2,7 +2,7 @@
  * Nextcloud Android client application
  *
  * @author TSI-mc
- * Copyright (C) 2021 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  * Copyright (C) 2021 Nextcloud GmbH
  *
  * This program is free software: you can redistribute it and/or modify

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -777,7 +777,7 @@ public class FileOperationsHelper {
      */
     public void updateShareInformation(OCShare share, int permissions,
                                        boolean hideFileDownload, String password, long expirationTimeInMillis,
-                                       String label) {
+                                       String label, String downloadLimit) {
         Intent updateShareIntent = new Intent(fileActivity, OperationsService.class);
         updateShareIntent.setAction(OperationsService.ACTION_UPDATE_SHARE_INFO);
         updateShareIntent.putExtra(OperationsService.EXTRA_ACCOUNT, fileActivity.getAccount());
@@ -787,6 +787,26 @@ public class FileOperationsHelper {
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PASSWORD, (password == null) ? "" : password);
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_EXPIRATION_DATE_IN_MILLIS, expirationTimeInMillis);
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PUBLIC_LABEL, (label == null) ? "" : label);
+
+        //download limit for link share type
+        updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_DOWNLOAD_LIMIT,
+                                   (downloadLimit == null || downloadLimit.equals("")) ? 0 :
+                                       Long.parseLong(downloadLimit));
+
+        queueShareIntent(updateShareIntent);
+    }
+
+    /**
+     * method to fetch the download limit for the particular share Note: Download limit is only for Link share type
+     *
+     * @param shareToken of the OCShare
+     */
+    public void getShareDownloadLimit(String shareToken) {
+        Intent updateShareIntent = new Intent(fileActivity, OperationsService.class);
+        updateShareIntent.setAction(OperationsService.ACTION_GET_SHARE_DOWNLOAD_LIMIT);
+        updateShareIntent.putExtra(OperationsService.EXTRA_ACCOUNT, fileActivity.getAccount());
+        updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_TOKEN, shareToken);
+
         queueShareIntent(updateShareIntent);
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -11,7 +11,7 @@
  * Copyright (C) 2015 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
  * Copyright (C) 2020 Chris Narkiewicz <hello@ezaquarii.com>
- * Copyright (C) 2021 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -636,9 +636,10 @@ public class FileOperationsHelper {
 
     private void queueShareIntent(Intent shareIntent) {
         // Unshare the file
-        mWaitingForOpId = fileActivity.getOperationsServiceBinder().queueNewOperation(shareIntent);
-
-        fileActivity.showLoadingDialog(fileActivity.getApplicationContext().getString(R.string.wait_a_moment));
+        if(fileActivity.getOperationsServiceBinder() != null) {
+            mWaitingForOpId = fileActivity.getOperationsServiceBinder().queueNewOperation(shareIntent);
+            fileActivity.showLoadingDialog(fileActivity.getApplicationContext().getString(R.string.wait_a_moment));
+        }
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt
@@ -22,7 +22,9 @@
 
 package com.owncloud.android.utils
 
+import android.app.Activity
 import android.content.Context
+import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import javax.inject.Inject
@@ -39,6 +41,12 @@ class KeyboardUtils @Inject constructor() {
                 inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT)
             }
         }, SHOW_INPUT_DELAY_MILLIS)
+    }
+
+    fun hideKeyboardFrom(context: Context, view: View) {
+        view.clearFocus()
+        val imm = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
     }
 
     companion object {

--- a/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt
@@ -2,8 +2,10 @@
  * Nextcloud Android client application
  *
  *  @author Álvaro Brey
+ *  @author TSI-mc
  *  Copyright (C) 2022 Álvaro Brey
  *  Copyright (C) 2022 Nextcloud GmbH
+ *  Copyright (C) 2023 TSI-mc
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/app/src/main/res/layout/file_details_sharing_process_fragment.xml
+++ b/app/src/main/res/layout/file_details_sharing_process_fragment.xml
@@ -227,6 +227,60 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/share_process_download_limit_switch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_half_margin"
+                android:minHeight="@dimen/minimum_size_for_touchable_area"
+                android:text="@string/link_download_limit"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/share_process_change_name_container" />
+
+            <!--  Limiting to max 18 input size to avoid taking more input -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/share_process_download_limit_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_download_limit"
+                android:minHeight="@dimen/minimum_size_for_touchable_area"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/share_process_download_limit_switch"
+                tools:visibility="visible">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/share_process_download_limit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:digits="0123456789"
+                    android:gravity="top"
+                    android:imeOptions="actionDone"
+                    android:importantForAutofill="no"
+                    android:inputType="number"
+                    android:maxLength="18"
+                    android:maxLines="1">
+
+                </com.google.android.material.textfield.TextInputEditText>
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/share_process_remaining_download_count_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/standard_margin"
+                android:layout_marginTop="@dimen/standard_half_margin"
+                android:layout_marginRight="@dimen/standard_margin"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/share_process_download_limit_container"
+                tools:text="@string/download_text"
+                tools:visibility="visible" />
+
             <androidx.constraintlayout.widget.Group
                 android:id="@+id/share_process_group_one"
                 android:layout_width="wrap_content"
@@ -238,7 +292,8 @@
                 share_process_allow_resharing_checkbox, share_process_set_password_switch,
                 share_process_set_exp_date_switch, share_process_enter_password_container,
                 share_process_select_exp_date, share_process_change_name_switch,
-                share_process_change_name_container" />
+                share_process_change_name_container, share_process_download_limit_switch,
+                share_process_download_limit_container, share_process_remaining_download_count_tv" />
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/share_process_message_title"

--- a/app/src/main/res/layout/file_details_sharing_process_fragment.xml
+++ b/app/src/main/res/layout/file_details_sharing_process_fragment.xml
@@ -3,7 +3,7 @@
  Nextcloud Android client application
 
  @author TSI-mc
- Copyright (C) 2021 TSI-mc
+ Copyright (C) 2023 TSI-mc
  Copyright (C) 2021 Nextcloud GmbH
 
  This program is free software: you can redistribute it and/or modify

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -991,6 +991,11 @@
     <string name="delete_link">Delete Link</string>
     <string name="share_settings">Settings</string>
     <string name="common_confirm">Confirm</string>
+    <string name="link_download_limit">Download Limit</string>
+    <string name="download_limit_empty">Download limit cannot be empty.</string>
+    <string name="hint_download_limit">Enter download limit</string>
+    <string name="download_text">Downloads: %s</string>
+    <string name="download_limit_zero">Download limit should be greater than 0.</string>
     <string name="strict_mode">Strict mode: no HTTP connection allowed!</string>
     <string name="destination_filename">Destination filename</string>
     <string name="suggest">Suggest</string>


### PR DESCRIPTION
Implemented download limit for files where share type is Link.
Showing the download count once the download limit is specified.

Conditions to show download limit:
1. Only applicable for files
2. Only applicable where share type is link.
3. Not applicable for Internal, External or any other shares.

Requires the implementation of: https://github.com/nextcloud/files_downloadlimit

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
