### PR TITLE
Fix file owner and account name check ignore case.

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/account/UserAccountManagerImplTest.java
+++ b/app/src/androidTest/java/com/nextcloud/client/account/UserAccountManagerImplTest.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.owncloud.android.AbstractOnServerIT;
+import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 
 import org.junit.Before;
@@ -47,5 +48,26 @@ public class UserAccountManagerImplTest extends AbstractOnServerIT {
 
         // assume that userId == loginname (as we manually set it)
         assertEquals(userId, accountManager.getUserData(account, AccountUtils.Constants.KEY_USER_ID));
+    }
+
+    @Test
+    public void checkName() {
+        UserAccountManagerImpl sut = new UserAccountManagerImpl(targetContext, accountManager);
+
+        Account owner = new Account("John@nextcloud.local", "nextcloud");
+        Account account1 = new Account("John@nextcloud.local", "nextcloud");
+        Account account2 = new Account("john@nextcloud.local", "nextcloud");
+
+        OCFile file1 = new OCFile("/test1.pdf");
+        file1.setOwnerId("John");
+
+        assertTrue(sut.accountOwnsFile(file1, owner));
+        assertTrue(sut.accountOwnsFile(file1, account1));
+        assertTrue(sut.accountOwnsFile(file1, account2));
+
+        file1.setOwnerId("john");
+        assertTrue(sut.accountOwnsFile(file1, owner));
+        assertTrue(sut.accountOwnsFile(file1, account1));
+        assertTrue(sut.accountOwnsFile(file1, account2));
     }
 }

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -340,7 +340,7 @@ public class UserAccountManagerImpl implements UserAccountManager {
     @Override
     public  boolean accountOwnsFile(OCFile file, Account account) {
         final String ownerId = file.getOwnerId();
-        return TextUtils.isEmpty(ownerId) || account.name.split("@")[0].equals(ownerId);
+        return TextUtils.isEmpty(ownerId) || account.name.split("@")[0].equalsIgnoreCase(ownerId);
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2019 Chris Narkiewicz
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE


### PR DESCRIPTION
This PR will fix the following scenario:
If file owner name is **John** and account name is **john** then the check will fail.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
