### PR TITLE
Fix: new folder/file share permission

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
@@ -147,6 +147,9 @@ public class CreateShareWithShareeOperation extends SyncOperation {
             updateShareInfoOperation.setHideFileDownload(hideFileDownload);
             updateShareInfoOperation.setLabel(label);
 
+            //update permissions for external share (will otherwise default to read-only)
+            updateShareInfoOperation.setPermissions(permissions);
+
             //execute and save the result in database
             RemoteOperationResult updateShareInfoResult = updateShareInfoOperation.execute(client);
             if (updateShareInfoResult.isSuccess() && updateShareInfoResult.getData().size() > 0) {


### PR DESCRIPTION
Steps to reproduce:
1. Create a new folder or file.
2. Now do internal or external share by selecting any other permission (File drop or Edit) except View Only.
3. It will always take the View only permission.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
