### PR TITLE
Fix text duplication when using TextEditorWebView

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ExternalSiteWebView.java
@@ -154,6 +154,12 @@ public class ExternalSiteWebView extends FileActivity {
         getWebView().loadUrl(url);
     }
 
+    @Override
+    protected void onDestroy() {
+        getWebView().destroy();
+        super.onDestroy();
+    }
+
     protected void bindView() {
         binding = ExternalsiteWebviewBinding.inflate(getLayoutInflater());
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.java
@@ -145,13 +145,6 @@ public class RichDocumentsEditorWebView extends EditorWebView {
     }
 
     @Override
-    protected void onDestroy() {
-        getWebView().destroy();
-
-        super.onDestroy();
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
 


### PR DESCRIPTION
This fixes an issue when closing a text editor using the Android back button. When another document is opened, text from the previous document might paste into the current document.

fixes #11600

- [ ] Tests written, or not not needed
