### PR TITLE
Prevent having double entries after rotate

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
@@ -199,6 +199,8 @@ class FileActionsBottomSheet : BottomSheetDialogFragment(), Injectable {
     private fun displayActions(
         actions: List<FileAction>
     ) {
+        binding.fileActionsList.removeAllViews()
+
         actions.forEach { action ->
             val view = inflateActionView(action)
             binding.fileActionsList.addView(view)

--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
@@ -199,11 +199,11 @@ class FileActionsBottomSheet : BottomSheetDialogFragment(), Injectable {
     private fun displayActions(
         actions: List<FileAction>
     ) {
-        binding.fileActionsList.removeAllViews()
-
-        actions.forEach { action ->
-            val view = inflateActionView(action)
-            binding.fileActionsList.addView(view)
+        if (binding.fileActionsList.isEmpty()) {
+            actions.forEach { action ->
+                val view = inflateActionView(action)
+                binding.fileActionsList.addView(view)
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
@@ -35,6 +35,7 @@ import android.widget.Toast
 import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.os.bundleOf
+import androidx.core.view.isEmpty
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.setFragmentResult


### PR DESCRIPTION
To test
- open image 
- open menu
- rotate
- see no duplicated menu entries

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
