### PR TITLE
Comment Typo: it's capacity -> its capacity

### DIFF
--- a/app/src/test/java/com/nextcloud/client/logger/LoggerTest.kt
+++ b/app/src/test/java/com/nextcloud/client/logger/LoggerTest.kt
@@ -224,7 +224,7 @@ class LoggerTest {
         //      logger event loop is no running
 
         // WHEN
-        //      queue is filled up to it's capacity
+        //      queue is filled up to its capacity
         for (i in 0 until QUEUE_CAPACITY + 1) {
             logger.d("tag", "Message $i")
         }


### PR DESCRIPTION
I just want this fixed and a PR seemed to be more precise than filing an issue.
Please consider any required sign-off, license or permission given to commit this typo fix in any commit of your liking.

- [x] Tests written, or not not needed 