### PR TITLE
Typo in deletion dialog: it's content -> its content

### DIFF
--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -150,7 +150,7 @@
     <string name="confirm_removal">Remove local encryption</string>
     <string name="confirmation_remove_file_alert">Do you really want to delete %1$s?</string>
     <string name="confirmation_remove_files_alert">Do you really want to delete the selected items?</string>
-    <string name="confirmation_remove_folder_alert">Do you really want to delete %1$s and it\'s content?</string>
+    <string name="confirmation_remove_folder_alert">Do you really want to delete %1$s and its content?</string>
     <string name="confirmation_remove_folders_alert">Do you really want to delete the selected items and their contents?</string>
     <string name="confirmation_remove_local">Local only</string>
     <string name="conflict_dialog_error">Error creating conflict dialogue!</string>


### PR DESCRIPTION
If this needs to be edited on Transifex instead, please do so. I don't have an account and don't want to create one.

I just want this fixed and a PR seemed to be more precise than filing an issue.
Please consider any required sign-off, license or permission given to commit this typo fix in any commit of your liking.

- [x] Tests written, or not not needed
