### PR TITLE
Fix crash when opening password-protected pdfs.

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/pdf/PreviewPdfFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/pdf/PreviewPdfFragment.kt
@@ -37,6 +37,7 @@ import com.nextcloud.utils.MenuUtils
 import com.owncloud.android.R
 import com.owncloud.android.databinding.PreviewPdfFragmentBinding
 import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.preview.PreviewBitmapActivity
 import com.owncloud.android.utils.DisplayUtils
@@ -75,7 +76,13 @@ class PreviewPdfFragment : Fragment(), Injectable {
         setupObservers()
 
         file = requireArguments().getParcelable(ARG_FILE)!!
-        viewModel.process(file)
+        try {
+            viewModel.process(file)
+        } catch (e: SecurityException) {
+            Log_OC.e(this, "onViewCreated: trying to open password protected PDF", e)
+            parentFragmentManager.popBackStack()
+            DisplayUtils.showSnackMessage(binding.root, R.string.pdf_password_protected)
+        }
     }
 
     private fun setupObservers() {

--- a/app/src/main/java/com/owncloud/android/ui/preview/pdf/PreviewPdfViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/pdf/PreviewPdfViewModel.kt
@@ -66,6 +66,9 @@ class PreviewPdfViewModel @Inject constructor(val appPreferences: AppPreferences
         }
     }
 
+    /**
+     * @throws SecurityException if file points to a password-protected document
+     */
     fun process(file: OCFile) {
         closeRenderer()
         _pdfRenderer.value =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1080,4 +1080,5 @@
     <string name="download_download_invalid_local_file_name">Invalid filename for local file</string>
     <string name="drawer_item_groupfolders">Groupfolders</string>
     <string name="tags_more" translatable="false">+%1$d</string>
+    <string name="pdf_password_protected">Unable to open password-protected PDF. Please use an external PDF viewer.</string>
 </resources>


### PR DESCRIPTION
This fixes an issue where attempting to open a password-protected PDF resulted in a crash. An error message is now displayed stating that this is not supported.

- [ ] Tests written, or not not needed
