### PR TITLE
Fix actions in folder picker

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -107,20 +107,8 @@ public abstract class AbstractIT {
                 }
             }
 
-            Account temp = new Account("test@https://nextcloud.localhost", MainApp.getAccountType(targetContext));
-            platformAccountManager.addAccountExplicitly(temp, "password", null);
-            platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL, "https://nextcloud.localhost");
-            platformAccountManager.setUserData(temp, KEY_USER_ID, "test");
-
-            final UserAccountManager userAccountManager = UserAccountManagerImpl.fromContext(targetContext);
-            account = userAccountManager.getAccountByName("test@https://nextcloud.localhost");
-
-            if (account == null) {
-                throw new ActivityNotFoundException();
-            }
-
-            Optional<User> optionalUser = userAccountManager.getUser(account.name);
-            user = optionalUser.orElseThrow(IllegalAccessError::new);
+            account = createAccount("test@https://nextcloud.localhost");
+            user = getUser(account);
 
             client = OwnCloudClientFactory.createOwnCloudClient(account, targetContext);
             nextcloudClient = OwnCloudClientFactory.createNextcloudClient(user, targetContext);
@@ -447,4 +435,31 @@ public abstract class AbstractIT {
     public static String getUserId(User user) {
         return AccountManager.get(targetContext).getUserData(user.toPlatformAccount(), KEY_USER_ID);
     }
+
+    protected static User getUser(Account account) {
+        Optional<User> optionalUser = UserAccountManagerImpl.fromContext(targetContext).getUser(account.name);
+        return optionalUser.orElseThrow(IllegalAccessError::new);
+    }
+
+    protected static Account createAccount(String name) {
+        AccountManager platformAccountManager = AccountManager.get(targetContext);
+
+        Account temp = new Account(name, MainApp.getAccountType(targetContext));
+        int atPos = name.lastIndexOf('@');
+        platformAccountManager.addAccountExplicitly(temp, "password", null);
+        platformAccountManager.setUserData(temp, AccountUtils.Constants.KEY_OC_BASE_URL,
+                                           name.substring(atPos + 1));
+        platformAccountManager.setUserData(temp, KEY_USER_ID, name.substring(0, atPos));
+
+        Account account = UserAccountManagerImpl.fromContext(targetContext).getAccountByName(name);
+        if (account == null) {
+            throw new ActivityNotFoundException();
+        }
+        return account;
+    }
+
+    protected static boolean removeUser(User user) {
+        return UserAccountManagerImpl.fromContext(targetContext).removeUser(user);
+    }
+
 }

--- a/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -458,8 +458,8 @@ public abstract class AbstractIT {
         return account;
     }
 
-    protected static boolean removeUser(User user) {
-        return UserAccountManagerImpl.fromContext(targetContext).removeUser(user);
+    protected static boolean removeAccount(Account account) {
+        return AccountManager.get(targetContext).removeAccountExplicitly(account);
     }
 
 }

--- a/app/src/androidTest/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivityIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivityIT.kt
@@ -38,4 +38,12 @@ class ReceiveExternalFilesActivityIT : AbstractIT() {
         val sut: Activity = activityRule.launchActivity(null)
         screenshot(sut)
     }
+
+    @Test
+    @ScreenshotTest
+    fun openMultiAccount() {
+        val secondUser = getUser(createAccount("secondtest@https://nextcloud.localhost"))
+        open()
+        removeUser(secondUser)
+    }
 }

--- a/app/src/androidTest/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivityIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivityIT.kt
@@ -42,8 +42,8 @@ class ReceiveExternalFilesActivityIT : AbstractIT() {
     @Test
     @ScreenshotTest
     fun openMultiAccount() {
-        val secondUser = getUser(createAccount("secondtest@https://nextcloud.localhost"))
+        val secondAccount = createAccount("secondtest@https://nextcloud.localhost")
         open()
-        removeUser(secondUser)
+        removeAccount(secondAccount)
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -41,21 +41,10 @@ import android.os.Looper;
 import android.os.Parcelable;
 import android.text.TextUtils;
 import android.text.format.DateFormat;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
+import android.view.*;
 import android.view.WindowManager.LayoutParams;
-import android.widget.AdapterView;
+import android.widget.*;
 import android.widget.AdapterView.OnItemClickListener;
-import android.widget.ArrayAdapter;
-import android.widget.EditText;
-import android.widget.ImageView;
-import android.widget.Spinner;
-import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.android.material.button.MaterialButton;
 import com.nextcloud.client.account.User;
@@ -79,19 +68,11 @@ import com.owncloud.android.operations.UploadFileOperation;
 import com.owncloud.android.syncadapter.FileSyncAdapter;
 import com.owncloud.android.ui.adapter.UploaderAdapter;
 import com.owncloud.android.ui.asynctasks.CopyAndUploadContentUrisTask;
-import com.owncloud.android.ui.dialog.AccountChooserInterface;
-import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
-import com.owncloud.android.ui.dialog.CreateFolderDialogFragment;
-import com.owncloud.android.ui.dialog.MultipleAccountsDialog;
-import com.owncloud.android.ui.dialog.SortingOrderDialogFragment;
+import com.owncloud.android.ui.dialog.*;
 import com.owncloud.android.ui.fragment.TaskRetainerFragment;
 import com.owncloud.android.ui.helpers.FileOperationsHelper;
 import com.owncloud.android.ui.helpers.UriUploader;
-import com.owncloud.android.utils.DataHolderUtil;
-import com.owncloud.android.utils.DisplayUtils;
-import com.owncloud.android.utils.ErrorMessageAdapter;
-import com.owncloud.android.utils.FileSortOrder;
-import com.owncloud.android.utils.MimeType;
+import com.owncloud.android.utils.*;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import java.io.File;
@@ -99,15 +80,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-import java.util.Vector;
+import java.util.*;
 
 import javax.inject.Inject;
 
@@ -1025,8 +998,8 @@ public class ReceiveExternalFilesActivity extends FileActivity
         inflater.inflate(R.menu.activity_receive_external_files, menu);
 
         if (!isHaveMultipleAccount()) {
-            MenuItem switchAccountMenu = menu.findItem(R.id.action_switch_account);
-            switchAccountMenu.setVisible(false);
+            menu.findItem(R.id.action_switch_account).setVisible(false);
+            menu.findItem(R.id.action_create_dir).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
         }
 
         // tint search event

--- a/app/src/main/res/layout/receive_external_files.xml
+++ b/app/src/main/res/layout/receive_external_files.xml
@@ -22,8 +22,7 @@
     android:id="@+id/upload_files_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/bg_default">
+    android:orientation="vertical">
 
     <include
         android:id="@+id/toolbar_layout"
@@ -39,6 +38,7 @@
             android:id="@android:id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@color/bg_default"
             android:divider="@color/transparent"
             android:dividerHeight="0dip"
             android:nestedScrollingEnabled="true"
@@ -59,6 +59,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/bg_default"
         android:gravity="center"
         android:orientation="horizontal"
         android:padding="@dimen/standard_padding">

--- a/app/src/main/res/layout/receive_external_files.xml
+++ b/app/src/main/res/layout/receive_external_files.xml
@@ -22,7 +22,8 @@
     android:id="@+id/upload_files_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="@color/bg_default">
 
     <include
         android:id="@+id/toolbar_layout"

--- a/app/src/main/res/menu/activity_folder_picker.xml
+++ b/app/src/main/res/menu/activity_folder_picker.xml
@@ -36,5 +36,6 @@
         android:icon="@drawable/ic_action_create_dir"
         android:orderInCategory="1"
         android:title="@string/actionbar_mkdir"
-        app:showAsAction="never" />
+        app:iconTint="?attr/colorOnSurface"
+        app:showAsAction="ifRoom"/>
 </menu>

--- a/app/src/main/res/menu/activity_receive_external_files.xml
+++ b/app/src/main/res/menu/activity_receive_external_files.xml
@@ -39,13 +39,7 @@
         android:icon="@drawable/ic_action_create_dir"
         android:orderInCategory="1"
         android:title="@string/actionbar_mkdir"
-        app:showAsAction="never"/>
-    <item
-        android:id="@+id/action_select_all"
-        android:contentDescription="@string/select_all"
-        android:icon="@drawable/ic_select_all"
-        android:orderInCategory="1"
-        android:title="@string/select_all"
+        app:iconTint="?attr/colorOnSurface"
         app:showAsAction="never"/>
 
 </menu>


### PR DESCRIPTION
This fixes some minor display inconsistencies concerning the *Choose upload folder* dialogue when uploading a file from an external app. Additionally this change also affects the *Copy to* and *Move to* dialogues.

- removed *Select all*
- show create folder icon instead of single item overflow menu
- adjust theming in *Choose upload folder* dialogue

---

- [x] Tests written, or not not needed
