### PR TITLE
Moved splash screen setup strings to avoid merge issue during build process

### DIFF
--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -6,8 +6,6 @@
 
     <!-- App name  and other strings-->
     <string name="app_name">Nextcloud</string>
-    <string name="splashScreenBold"></string>
-    <string name="splashScreenNormal"></string>
     <string name="account_type">nextcloud</string>     <!-- better if was a domain name; but changing it now would require migrate accounts when the app is updated -->
     <string name="authority">org.nextcloud</string>    <!-- better if was the app package with ".provider" appended ; it identifies the provider -->
     <string name="users_and_groups_search_authority">com.nextcloud.android.providers.UsersAndGroupsSearchProvider</string>
@@ -117,6 +115,10 @@
 
     <!-- Push server url -->
     <string name="push_server_url" translatable="false"></string>
+
+    <!-- if contains values, will be used to show branding title below app icon in splash screen -->
+    <string name="splashScreenBold"></string>
+    <string name="splashScreenNormal"></string>
 
     <!-- Dev settings -->
     <string name="dev_link">https://download.nextcloud.com/android/dev/nextcloud-dev-</string>


### PR DESCRIPTION
During the merging build process the app_name and other setup strings gets duplicated as the placement of splashScreenBold strings are right after the app_name. 

![Screenshot 2023-06-12 195223](https://github.com/nextcloud/android/assets/89455194/98f99b27-3c11-4fa4-8691-6003a6c96555)
setup.xml output

So to avoid this issue we have to place the text somewhere bottom.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
