### PR TITLE
Fix: Migrate OwncloudClient to NextCloudClient for empty trashbin

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/trashbin/RemoteTrashbinRepository.java
+++ b/app/src/main/java/com/owncloud/android/ui/trashbin/RemoteTrashbinRepository.java
@@ -2,11 +2,13 @@
  * Nextcloud Android client application
  *
  * @author Tobias Kaminsky
+ * @author TSI-mc
  * @author Chris Narkiewicz
  *
  * Copyright (C) 2018 Tobias Kaminsky
  * Copyright (C) 2018 Nextcloud GmbH.
  * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
**Prerequisite:**
1. Checkout the latest master
2. Install the build from master branch.

**Steps to reproduce:**
1. Open app and navigate to Deleted files.
2. Click on 3 dot overflow menu and select "Empty trash bin".
3. App will crash.

**Reason of crash:** EmptyTrashbinRemoteOpertation is using NextcloudClient for execution but while calling from RemoteTrashbinRepository OwncloudClient (deprecated) one is getting used.

![crash_logs](https://github.com/nextcloud/android/assets/89455194/25919f9c-5a68-49ec-a581-b5bee6c3f60a)
Crash logs

**Fix:** Migrating the operation call from OwncloudClient to NextcloudClient.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
