### PR TITLE
Fix encrypted folder icon

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1123,6 +1123,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
             if (file != null) {
                 mContainerActivity.getFileOperationsHelper().toggleEncryption(file, true);
+                mAdapter.setEncryptionAttributeForItemID(file.getRemoteId(), true);
             }
 
             // update state and view of this fragment


### PR DESCRIPTION
Previously, if one selected *Set as encrypted* without having set up end-to-end encryption beforehand, the setup dialogue would appear. After completing the setup, the folder would open. However, when returning to the main menu, the folder would not be shown as encrypted until the view was manually refreshed. This change addresses that behaviour.

---

- [ ] Tests written, or not not needed
