### PR TITLE
PreviewMediaFragment: UI/UX improvements

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -295,7 +295,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     private void setGenericThumbnail() {
         Drawable logo = AppCompatResources.getDrawable(requireContext(), R.drawable.logo);
         if (logo != null) {
-            DrawableCompat.setTint(logo, getResources().getColor(R.color.primary));
+            DrawableCompat.setTint(logo, getResources().getColor(R.color.primary, requireContext().getTheme()));
             binding.imagePreview.setImageDrawable(logo);
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -292,10 +292,16 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
         }
     }
 
+    /**
+     * Set generic icon (logo) as placeholder for thumbnail in preview.
+     */
     private void setGenericThumbnail() {
         Drawable logo = AppCompatResources.getDrawable(requireContext(), R.drawable.logo);
         if (logo != null) {
-            DrawableCompat.setTint(logo, getResources().getColor(R.color.primary, requireContext().getTheme()));
+            if (!getResources().getBoolean(R.bool.is_branded_client)) {
+                // only colour logo of non-branded client
+                DrawableCompat.setTint(logo, getResources().getColor(R.color.primary, requireContext().getTheme()));
+            }
             binding.imagePreview.setImageDrawable(logo);
         }
     }

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -31,6 +31,7 @@
     <bool name="share_with_users_feature">true</bool>
     <bool name="show_external_links">true</bool>
     <bool name="show_outdated_server_warning">true</bool>
+    <bool name="is_branded_client">false</bool>
 
     <!-- Calendar & Contacts backup -->
     <string name="contacts_backup_folder">/.Contacts-Backup</string>


### PR DESCRIPTION
This change affects media playback via the PreviewMediaFragment.

- allow media to be downloaded in Preview via the actions menu
- hide the *Pin to Home Screen* action in Preview
- fix exception when returning from external player
- autoplay videos only once
  - e.g. not when returning from an external app
- remember playback position when switching apps or opening *Details* view
- show logo when no audio thumbnail is available
  - used to be the colour as the background

---

- [ ] Tests written, or not not needed
