### PR TITLE
Fix back arrow appearing as hamburger icon

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1080,6 +1080,8 @@ public class FileDisplayActivity extends FileActivity
             }
         } else if (leftFragment instanceof PreviewTextStringFragment) {
             createMinFragments(null);
+        } else if (leftFragment instanceof PreviewPdfFragment) {
+            super.onBackPressed();
         } else {
             // pop back
             resetScrolling(true);

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1519,7 +1519,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     setTitle(R.string.drawer_item_shared);
                     break;
                 default:
-                    setTitle(themeUtils.getDefaultDisplayNameForRootFolder(getContext()));
+                    setTitle(themeUtils.getDefaultDisplayNameForRootFolder(getContext()), false);
                     break;
             }
         }
@@ -1586,7 +1586,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 ((FileDisplayActivity) activity).initSyncBroadcastReceiver();
             }
 
-            setTitle(themeUtils.getDefaultDisplayNameForRootFolder(getContext()));
+            setTitle(themeUtils.getDefaultDisplayNameForRootFolder(getContext()), false);
             activity.getIntent().removeExtra(OCFileListFragment.SEARCH_EVENT);
         }
 
@@ -1832,18 +1832,30 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
     }
 
+    /**
+     * Theme default action bar according to provided parameters.
+     * Replaces back arrow with hamburger menu icon.
+     *
+     * @param title string res id of title to be shown in action bar
+     */
     protected void setTitle(@StringRes final int title) {
-        setTitle(getContext().getString(title));
+        setTitle(requireContext().getString(title), true);
     }
 
-    protected void setTitle(final String title) {
-        getActivity().runOnUiThread(() -> {
+    /**
+     * Theme default action bar according to provided parameters.
+     *
+     * @param title title to be shown in action bar
+     * @param showBackAsMenu iff true replace back arrow with hamburger menu icon
+     */
+    protected void setTitle(final String title, Boolean showBackAsMenu) {
+        requireActivity().runOnUiThread(() -> {
             if (getActivity() != null) {
                 final ActionBar actionBar = ((FileDisplayActivity) getActivity()).getSupportActionBar();
                 final Context context = getContext();
 
                 if (actionBar != null && context != null) {
-                    viewThemeUtils.files.themeActionBar(context, actionBar, title, true);
+                    viewThemeUtils.files.themeActionBar(context, actionBar, title, showBackAsMenu);
                 }
             }
         });


### PR DESCRIPTION
This fixes an issue where the back navigation icon (←) appeared as a hamburger menu.

fixes #11679

---

- [ ] Tests written, or not not needed
