### PR TITLE
After successful upload update permission to have correct resharing info

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/AbstractOnServerIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/AbstractOnServerIT.java
@@ -234,6 +234,7 @@ public abstract class AbstractOnServerIT extends AbstractIT {
             getFileByDecryptedRemotePath(parentFolder.getDecryptedRemotePath() + uploadedFileName);
 
         assertNotNull(uploadedFile.getRemoteId());
+        assertNotNull(uploadedFile.getPermissions());
 
         if (localBehaviour == FileUploader.LOCAL_BEHAVIOUR_COPY ||
             localBehaviour == FileUploader.LOCAL_BEHAVIOUR_MOVE) {

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -1389,6 +1389,7 @@ public class UploadFileOperation extends SyncOperation {
         file.setModificationTimestampAtLastSyncForData(remoteFile.getModifiedTimestamp());
         file.setEtag(remoteFile.getEtag());
         file.setRemoteId(remoteFile.getRemoteId());
+        file.setPermissions(remoteFile.getPermissions());
     }
 
     public interface OnRenameListener {


### PR DESCRIPTION
Step to reproduce:
1. Launch the NextCloud app and login
2. Create a folder and inside upload pdf or any apk file
3. Click on pdf file- it open share overview page
4. Click sharing tab
5. Observe on the Shard tab on share overview page

Actual result:
"Re-sharing is not allowed " display
> User can do share when he refresh the app

Expected result:
User should able to do share

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
