### PR TITLE
Hide actionbar title when search input field is opened

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -180,19 +180,17 @@ public abstract class ToolbarActivity extends BaseActivity implements Injectable
      * Updates title bar and home buttons (state and icon).
      */
     public void updateActionBarTitleAndHomeButtonByString(String title) {
-        String titleToSet = getString(R.string.app_name);    // default
-
-        if (title != null) {
-            titleToSet = title;
-        }
-
         // set & color the chosen title
         ActionBar actionBar = getSupportActionBar();
 
         // set home button properties
         if (actionBar != null) {
-            actionBar.setTitle(titleToSet);
-            actionBar.setDisplayShowTitleEnabled(true);
+            if (title != null) {
+                actionBar.setTitle(title);
+                actionBar.setDisplayShowTitleEnabled(true);
+            } else {
+                actionBar.setDisplayShowTitleEnabled(false);
+            }
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -137,7 +137,7 @@ class UnifiedSearchFragment : Fragment(), Injectable, UnifiedSearchListInterface
         vm.query.observe(this) { query ->
             if (activity is FileDisplayActivity) {
                 (activity as FileDisplayActivity)
-                    .updateActionBarTitleAndHomeButtonByString("\"${query}\"")
+                    .updateActionBarTitleAndHomeButtonByString(null)
             }
         }
         vm.browserUri.observe(this) { uri ->
@@ -169,7 +169,7 @@ class UnifiedSearchFragment : Fragment(), Injectable, UnifiedSearchListInterface
         if (activity is FileDisplayActivity) {
             val fileDisplayActivity = activity as FileDisplayActivity
             fileDisplayActivity.setMainFabVisible(false)
-            fileDisplayActivity.updateActionBarTitleAndHomeButtonByString("\"${vm.query.value!!}\"")
+            fileDisplayActivity.updateActionBarTitleAndHomeButtonByString(null)
         }
 
         val gridLayoutManager = GridLayoutManager(requireContext(), 1)

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -27,6 +27,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.MenuItemCompat
@@ -65,6 +66,7 @@ class UnifiedSearchFragment : Fragment(), Injectable, UnifiedSearchListInterface
     private lateinit var adapter: UnifiedSearchListAdapter
     private var _binding: ListFragmentBinding? = null
     private val binding get() = _binding!!
+    private var searchView: SearchView? = null
     lateinit var vm: IUnifiedSearchViewModel
 
     @Inject
@@ -224,14 +226,15 @@ class UnifiedSearchFragment : Fragment(), Injectable, UnifiedSearchListInterface
         setUpViewModel()
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         val item = menu.findItem(R.id.action_search)
-        val searchView = MenuItemCompat.getActionView(item) as SearchView
-        viewThemeUtils.androidx.themeToolbarSearchView(searchView)
-        searchView.setQuery(vm.query.value, false)
-        searchView.setOnQueryTextListener(this)
-        searchView.isIconified = false
-        searchView.clearFocus()
+        searchView = MenuItemCompat.getActionView(item) as SearchView
+        viewThemeUtils.androidx.themeToolbarSearchView(searchView!!)
+        searchView?.setQuery(vm.query.value, false)
+        searchView?.setOnQueryTextListener(this)
+        searchView?.isIconified = false
+        searchView?.clearFocus()
     }
 
     companion object {
@@ -257,7 +260,12 @@ class UnifiedSearchFragment : Fragment(), Injectable, UnifiedSearchListInterface
     }
 
     override fun onQueryTextChange(newText: String?): Boolean {
-        // noop
+        val closeButton = searchView?.findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
+        if (newText?.isEmpty() == true) {
+            closeButton?.visibility = View.INVISIBLE
+        } else {
+            closeButton?.visibility = View.VISIBLE
+        }
         return true
     }
 }


### PR DESCRIPTION
This change addresses a display issue, where *"...* would be displayed in the actionbar, when searching for files.

---

- [x] Tests written, or not not needed
