### PR TITLE
Crash fix for shared and fav section

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -6,9 +6,11 @@
  * @author David A. Velasco
  * @author Andy Scherzinger
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2011  Bartek Przybylski
  * Copyright (C) 2016 ownCloud Inc.
  * Copyright (C) 2018 Andy Scherzinger
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -1654,6 +1656,12 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
     protected void handleSearchEvent(SearchEvent event) {
         if (SearchRemoteOperation.SearchType.PHOTO_SEARCH == event.getSearchType()) {
+            return;
+        }
+
+        // avoid calling api multiple times if async task is already executing
+        if (remoteOperationAsyncTask != null && remoteOperationAsyncTask.getStatus() != AsyncTask.Status.FINISHED) {
+            Log_OC.d(TAG, "OCFileListSearchAsyncTask already running skipping new api call for search event: " + searchEvent.getSearchType());
             return;
         }
 


### PR DESCRIPTION
**Crash type  -- Occasionally**

Sometimes while switching between Shared and Favourites section leads to crash.

There are two kinds of exceptions:
1. **ConcurrentModificationException**
![ConcurrentModificationException](https://github.com/nextcloud/android/assets/89455194/4f1ffaa9-ecab-4346-9e5b-1dc2a8e15c5d)

3. **IndexOutOfBoundsException - Inconsistency detected:**

`07-12 06:04:59.099 E/AndroidRuntime(28883): java.lang.IndexOutOfBoundsException: Inconsistency detected. Invalid item position 6(offset:6).state:12 com.owncloud.android.ui.EmptyRecyclerView{62ac027 VFED..... ......ID 0,0-1080,2002 #7f0a02d2 app:id/list_root}, adapter:com.owncloud.android.ui.adapter.OCFileListAdapter@868d6d9, layout:androidx.recyclerview.widget.LinearLayoutManager@a197ff2, context:com.owncloud.android.ui.activity.FileDisplayActivity@b1ade7e
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6752)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6688)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6684)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java:2362)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1662)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1622)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.LinearLayoutManager.onLayoutChildren(LinearLayoutManager.java:687)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep2(RecyclerView.java:4604)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.RecyclerView.dispatchLayout(RecyclerView.java:4307)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.recyclerview.widget.RecyclerView.onLayout(RecyclerView.java:4873)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.View.layout(View.java:24475)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.ViewGroup.layout(ViewGroup.java:7383)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.View.layout(View.java:24475)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.ViewGroup.layout(ViewGroup.java:7383)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.swiperefreshlayout.widget.SwipeRefreshLayout.onLayout(SwipeRefreshLayout.java:689)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.View.layout(View.java:24475)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.ViewGroup.layout(ViewGroup.java:7383)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.RelativeLayout.onLayout(RelativeLayout.java:1103)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.View.layout(View.java:24475)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.ViewGroup.layout(ViewGroup.java:7383)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.View.layout(View.java:24475)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.ViewGroup.layout(ViewGroup.java:7383)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1829)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.widget.LinearLayout.layoutHorizontal(LinearLayout.java:1818)
07-12 05:58:25.060 W/NotificationHistory( 1245): Attempted to add notif for locked/gone/disabled user 0
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.View.layout(View.java:24475)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at android.view.ViewGroup.layout(ViewGroup.java:7383)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at com.google.android.material.appbar.HeaderScrollingViewBehavior.layoutChild(HeaderScrollingViewBehavior.java:149)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at com.google.android.material.appbar.ViewOffsetBehavior.onLayoutChild(ViewOffsetBehavior.java:43)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior.onLayoutChild(AppBarLayout.java:2376)
07-12 06:04:59.099 E/AndroidRuntime(28883): 	at androidx.coordinatorlayout.widget.CoordinatorLayout.onLayout(CoordinatorLayout.java:918)`

This exceptions are occurring due to api getting called 2 times for  both the sections sometimes:
1. First api call when a section is selected
2. Second api call when the screen is onResumed

**Exception Cause: When both the api calls concurrently try to modify content the exceptions comes.**

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
