### PR TITLE
Fix preview media file update for file action

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -4,9 +4,11 @@
  *   @author David A. Velasco
  *   @author Chris Narkiewicz
  *   @author Andy Scherzinger
+ *   @author TSI-mc
  *   Copyright (C) 2016 ownCloud Inc.
  *   Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
  *   Copyright (C) 2020 Andy Scherzinger
+ *   Copyright (C) 2023 TSI-mc
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -410,7 +412,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
 
                 final OCFile fileNew = getFile();
                 if (fileNew != null) {
-                    showFileActions(file);
+                    showFileActions(fileNew);
                 }
             }
         }


### PR DESCRIPTION
**Steps to reproduce:**

1. Launch the app and login

2. Open video/audio file in preview and click on 3-dot menu button and select "**Sync**"

3. After 1st download again click on 3-dot menu option and click on "**Sync**".

4. After 2nd download, again click on 3-dot menu option and check the "**Sync**" option


Actual result:
**Sync** option still shows even the download is complete.

Expected result:
**Sync** option should get removed after successful download.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
