### PR TITLE
Avoid multiple API calls on create button click

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -108,6 +108,8 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
 
     ChooseTemplateBinding binding;
 
+    private CreateFileFromTemplateTask createFileFromTemplateTask = null;
+
     @NextcloudServer(max = 18) // will be removed in favor of generic direct editing
     public static ChooseRichDocumentsTemplateDialogFragment newInstance(OCFile parentFolder, Type type) {
         ChooseRichDocumentsTemplateDialogFragment frag = new ChooseRichDocumentsTemplateDialogFragment();
@@ -231,10 +233,16 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
+        createFileFromTemplateTask = null;
     }
 
     private void createFromTemplate(Template template, String path) {
-        new CreateFileFromTemplateTask(this, client, template, path, currentAccount.getUser()).execute();
+        if (createFileFromTemplateTask != null && createFileFromTemplateTask.getStatus() != AsyncTask.Status.FINISHED) {
+            Log_OC.d(TAG, "CreateFileFromTemplateTask already running skipping another click event");
+            return;
+        }
+        createFileFromTemplateTask = new CreateFileFromTemplateTask(this, client, template, path, currentAccount.getUser());
+        createFileFromTemplateTask.execute();
     }
 
     public void setTemplateList(List<Template> templateList) {


### PR DESCRIPTION
**Actions Performed**
Logged in
1. Open app
2. Go to Files
3. Tap Plus-button and create a new Collabora Office Document / Spreadsheet / or Presentation
4. Enter some individual name for the fiel that doesn't exist yet
5. Double-tap on the "Create" button (not unrealistic speeed-tapping etc., just two successive touches on the "Create" button, which would easily happen for example if the finger bounces on the screen etc.)

**Expected Result**
There should not be a problem with the Create-button; successive activations of this button should be ignored by the app

**Actual Result**
The "Create" button is responsive to more than one activation (successive finger touches on button), although this action results in a crash every time
Furthermore duplicates of the file are created and saved in the cloud this way, like [filename], [filename] (1), ...

**Crash Logs:**
`Exception in thread "AsyncTask #4" java.lang.RuntimeException: An error occurred while executing doInBackground()
    at android.os.AsyncTask$4.done(AsyncTask.java:415)
    at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
    at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
    at java.util.concurrent.FutureTask.run(FutureTask.java:271)
    at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:923)
Caused by: Exception in thread "AsyncTask #4" java.lang.IllegalStateException: Fragment ChooseRichDocumentsTemplateDialogFragment{fa07d9c} (e309cf32-a54c-46b8-96dc-4e03e92ed0a4) not attached to a context.
    at androidx.fragment.app.Fragment.requireContext(Fragment.java:972)
    at com.owncloud.android.ui.dialog.ChooseRichDocumentsTemplateDialogFragment$CreateFileFromTemplateTask.doInBackground(ChooseRichDocumentsTemplateDialogFragment.java:344)
    at com.owncloud.android.ui.dialog.ChooseRichDocumentsTemplateDialogFragment$CreateFileFromTemplateTask.doInBackground(ChooseRichDocumentsTemplateDialogFragment.java:309)
    at android.os.AsyncTask$3.call(AsyncTask.java:394)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
`

This PR fix both the issues by avoiding multiple api calls:
1. **IllegalStateException** crash
2. Avoid creating multiple office files.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
