### PR TITLE
Fix empty state for media view

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
@@ -6,7 +6,7 @@
  * @author TSI-mc
  * Copyright (C) 2022 Tobias Kaminsky
  * Copyright (C) 2022 Nextcloud GmbH
- * Copyright (C) 2022 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -195,14 +195,14 @@ class GalleryAdapter(
 
         if (finalSortedList.isEmpty()) {
             photoFragment.setEmptyListMessage(SearchType.GALLERY_SEARCH)
-        } else {
-            files = finalSortedList
-                .groupBy { firstOfMonth(it.modificationTimestamp) }
-                .map { GalleryItems(it.key, transformToRows(it.value)) }
-                .sortedBy { it.date }.reversed()
-
-            Handler(Looper.getMainLooper()).post { notifyDataSetChanged() }
         }
+
+        files = finalSortedList
+            .groupBy { firstOfMonth(it.modificationTimestamp) }
+            .map { GalleryItems(it.key, transformToRows(it.value)) }
+            .sortedBy { it.date }.reversed()
+
+        Handler(Looper.getMainLooper()).post { notifyDataSetChanged() }
     }
 
     private fun transformToRows(list: List<OCFile>): List<GalleryRow> {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -5,7 +5,7 @@
  * @author TSI-mc
  * Copyright (C) 2019 Tobias Kaminsky
  * Copyright (C) 2019 Nextcloud GmbH
- * Copyright (C) 2022 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.ui.EmptyRecyclerView;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.activity.FolderPickerActivity;
 import com.owncloud.android.ui.activity.ToolbarActivity;
@@ -161,6 +162,10 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
 
         setRecyclerViewAdapter(mAdapter);
 
+        //update the footer as there is no footer shown in media view
+        if (getRecyclerView() instanceof EmptyRecyclerView) {
+            ((EmptyRecyclerView) getRecyclerView()).setHasFooter(false);
+        }
 
         GridLayoutManager layoutManager = new GridLayoutManager(getContext(), 1);
         mAdapter.setLayoutManager(layoutManager);


### PR DESCRIPTION
**Steps to reproduce:**
1. Select a folder which contains only videos or images
2. Now filter only videos or images from 3 dot menu
3. The list is not updated with empty state.

Or

1. Select a folder which has some media files
2. Now select any empty folder
3. Still previously selected media shows but not the current folder data (empty state)

**Cause:**
The reason behind this was not setting setHasFooter false for media view as there is no footer used and due to which EmptyRecyclerView always has 1 item count and doesn't hide the recyceler view when list is empty. 


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
