### PR TITLE
Fix folder picker empty state headline text

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -1,7 +1,8 @@
 /*
  *   ownCloud Android client application
- *
+ *   @author TSI-mc
  *   Copyright (C) 2016 ownCloud Inc.
+ *   Copyright (C) 2023 TSI-mc
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -178,7 +179,7 @@ open class FolderPickerActivity :
         if (listFragment != null) {
             if (!mSyncInProgress) {
                 listFragment.setMessageForEmptyList(
-                    R.string.file_list_empty_headline,
+                    R.string.folder_list_empty_headline,
                     R.string.file_list_empty_moving,
                     R.drawable.ic_list_empty_create_folder,
                     true


### PR DESCRIPTION
This PR has the fix for empty state headline text while doing Folder Selection from FolderPickerActivity.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
