### PR TITLE
Improve UX when creating rich document

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -87,6 +87,7 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
     private static final String TAG = ChooseRichDocumentsTemplateDialogFragment.class.getSimpleName();
     private static final String DOT = ".";
     public static final int SINGLE_TEMPLATE = 1;
+    private static final String WAIT_DIALOG_TAG = "WAIT";
 
     private Set<String> fileNames;
 
@@ -99,6 +100,7 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
     private OCFile parentFolder;
     private OwnCloudClient client;
     private Button positiveButton;
+    private DialogFragment waitDialog;
 
     public enum Type {
         DOCUMENT,
@@ -234,6 +236,8 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
     }
 
     private void createFromTemplate(Template template, String path) {
+        waitDialog = IndeterminateProgressDialog.newInstance(R.string.wait_a_moment, false);
+        waitDialog.show(getParentFragmentManager(), WAIT_DIALOG_TAG);
         new CreateFileFromTemplateTask(this, client, template, path, currentAccount.getUser()).execute();
     }
 
@@ -364,6 +368,10 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
             ChooseRichDocumentsTemplateDialogFragment fragment = chooseTemplateDialogFragmentWeakReference.get();
 
             if (fragment != null && fragment.isAdded()) {
+                if (fragment.waitDialog != null) {
+                    fragment.waitDialog.dismiss();
+                }
+
                 if (url.isEmpty()) {
                     DisplayUtils.showSnackMessage(fragment.binding.list, R.string.error_creating_file_from_template);
                 } else {

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -373,7 +373,8 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
                 }
 
                 if (url.isEmpty()) {
-                    DisplayUtils.showSnackMessage(fragment.binding.list, R.string.error_creating_file_from_template);
+                    fragment.dismiss();
+                    DisplayUtils.showSnackMessage(fragment.requireActivity(), R.string.error_creating_file_from_template);
                 } else {
                     Intent collaboraWebViewIntent = new Intent(MainApp.getAppContext(), RichDocumentsEditorWebView.class);
                     collaboraWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_TITLE, "Collabora");
@@ -424,7 +425,8 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
 
             if (fragment != null) {
                 if (templateList.isEmpty()) {
-                    DisplayUtils.showSnackMessage(fragment.binding.list, R.string.error_retrieving_templates);
+                    fragment.dismiss();
+                    DisplayUtils.showSnackMessage(fragment.requireActivity(), R.string.error_retrieving_templates);
                 } else {
                     if (templateList.size() == SINGLE_TEMPLATE) {
                         fragment.onTemplateChosen(templateList.get(0));


### PR DESCRIPTION
This is an alternative solution to #11815. (see https://github.com/nextcloud/android/pull/11815#issuecomment-1651275217)

Previously it was possible to select *Create* multiple times when creating a rich document (+ → Create document/spreadsheet/presentation). This would either result in multiple files being created or a crash.

This change introduces a *Wait a moment...* dialogue to block the UI while providing a progress indicator.

---

- [x] Tests written, or not not needed
