### PR TITLE
When entering fullscreen, allow for paused state

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFullscreenDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFullscreenDialog.kt
@@ -150,6 +150,9 @@ class PreviewVideoFullscreenDialog(
         }
         mExoPlayer.addListener(playListener)
         playingStateListener = playListener
+
+        // Run once to set initial state of play or pause buttons
+        playListener.onIsPlayingChanged(sourceExoPlayer.isPlaying)
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
Resolves #11842.

When entering fullscreen, check if the video is paused and ensure to display the play button instead.

I'm not sure if this change requires unit tests or not. If they are required, I'll take a look.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
