### PR TITLE
Fix preview of previously offline images

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -204,7 +204,10 @@ public final class ThumbnailsCacheManager {
         thumbnail = BitmapUtils.rotateImage(thumbnail,path);
 
         // Add thumbnail to cache
-        addBitmapToCache(imageKey, thumbnail);
+        // do not overwrite any pre-existing image
+        if (!mThumbnailCache.containsKey(imageKey)) {
+            addBitmapToCache(imageKey, thumbnail);
+        }
 
         return thumbnail;
     }


### PR DESCRIPTION
This change fixes an issue that occurred when previewing images that were downloaded at one point but have since been deleted locally. Previously, a resized or cropped thumbnail of the actual image was displayed.

---

- [ ] Tests written, or not not needed
