### PR TITLE
When deleting image in preview activity, move to the next image

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -232,7 +232,15 @@ public class PreviewImageActivity extends FileActivity implements
         super.onRemoteOperationFinish(operation, result);
 
         if (operation instanceof RemoveFileOperation) {
-            finish();
+            // initialize the pager with the new file list
+            initViewPager(getUser().get());
+            if (mViewPager.getAdapter().getCount() > 0) {
+                // Trigger page reselection, to update the title
+                onPageSelected(mViewPager.getCurrentItem());
+            } else {
+                // Last file has been deleted, so finish the activity
+                finish();
+            }
         } else if (operation instanceof SynchronizeFileOperation) {
             onSynchronizeFileOperationFinish(result);
         }


### PR DESCRIPTION
Instead of closing the preview after the deletion of an image file, the next image is shown. This allows to conveniently go through a list of images and delete unwanted ones, without the flow being interrupted.

Closes #11918

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
