### PR TITLE
fix persistent text preview fragment in the background

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1096,8 +1096,6 @@ public class FileDisplayActivity extends FileActivity
                 resetTitleBarAndScrolling();
                 setDrawerAllFiles();
             }
-        } else if (leftFragment instanceof PreviewTextStringFragment) {
-            createMinFragments(null);
         } else if (leftFragment instanceof PreviewPdfFragment) {
             super.onBackPressed();
         } else {


### PR DESCRIPTION
Solves: #11836 


https://github.com/nextcloud/android/assets/111801812/881516af-24dc-4c55-be45-559e53004b1e


https://github.com/nextcloud/android/assets/111801812/07b6eeaf-c522-49eb-b4b2-9c13cb34e490




### What this PR includes?
- Solve the issue by removing [this](https://github.com/nextcloud/android/blob/266e27f9ddd5e33fa59d6ee2ee345ccb5549c3ae/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java#L500) method which was causing the new fragment launch and end up having two same fragments.
- That method was originally added to solve this [issue](https://github.com/nextcloud/android/issues/7197#issue-734004562) and here's the [PR](https://github.com/nextcloud/android/pull/7229#issue-736096633), But now removing this call does not reproduce that same issue also. You can see below -->

https://github.com/nextcloud/android/assets/111801812/2fcbb85d-56e2-4dde-ae2f-92a0a48967b0

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
