### PR TITLE
Fix default state of 'Show app switcher' toggle

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -53,6 +53,7 @@
 			android:title="@string/prefs_show_hidden_files"
 			android:key="show_hidden_files"/>
         <com.owncloud.android.ui.ThemeableSwitchPreference
+            android:defaultValue="true"
             android:title="@string/prefs_show_ecosystem_apps"
             android:key="show_ecosystem_apps"
             android:summary="@string/prefs_show_ecosystem_apps_summary"/>


### PR DESCRIPTION
This change fixes the default state of the *Show app switcher* toggle in *Settings* introduced with #11811. Previously this defaulted to `false` requiring the user to tap the toggle twice to achieve the expected result.

---

- [x] Tests written, or not not needed
