### PR TITLE
if e2e server app is disabled, do not show secure file drop

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -445,21 +445,8 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                                                                                    ShareType.PUBLIC_LINK,
                                                                                    "");
 
-//
-//        boolean supportsSecureFiledrop = file.isEncrypted() &&
-//            capabilities.getVersion().isNewerOrEqual(NextcloudVersion.nextcloud_26);
-//
-//        if (publicShares.isEmpty() &&
-//            containsNoNewPublicShare(adapter.getShares()) &&
-//            (!file.isEncrypted() || supportsSecureFiledrop)) {
-//            final OCShare ocShare = new OCShare();
-//            ocShare.setShareType(ShareType.NEW_PUBLIC_LINK);
-//            publicShares.add(ocShare);
-//        } else {
-//            adapter.removeNewPublicShare();
-//        }
-
-        if (publicShares.isEmpty() && containsNoNewPublicShare(adapter.getShares())) {
+        if (publicShares.isEmpty() && containsNoNewPublicShare(adapter.getShares()) &&
+            (!file.isEncrypted() || capabilities.getEndToEndEncryption().isTrue())) {
             final OCShare ocShare = new OCShare();
             ocShare.setShareType(ShareType.NEW_PUBLIC_LINK);
             publicShares.add(ocShare);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
