### PR TITLE
Unintended UI elements showing

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -144,6 +144,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Stack;
 
 import javax.inject.Inject;
 
@@ -233,7 +234,7 @@ public class FileDisplayActivity extends FileActivity
     private PlayerServiceConnection mPlayerConnection;
     private Optional<User> lastDisplayedUser = Optional.empty();
     private int menuItemId = -1;
-
+    private Stack<Boolean> previousSortGroupState;
     @Inject
     AppPreferences preferences;
 
@@ -622,7 +623,7 @@ public class FileDisplayActivity extends FileActivity
 
         //clear the subtitle while navigating to any other screen from Media screen
         clearToolbarSubtitle();
-        showSortListGroup(showSortListGroup);
+        setSortListGroup(sortListGroupVisibility(), showSortListGroup);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.addToBackStack(null);
         transaction.replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES);
@@ -1027,9 +1028,9 @@ public class FileDisplayActivity extends FileActivity
     }
 
     private void popBack() {
-        // pop back
+        // pop back fragment
         resetScrolling(true);
-        showSortListGroup(true);
+        popSortListGroupVisibility();
         super.onBackPressed();
     }
 
@@ -1038,7 +1039,6 @@ public class FileDisplayActivity extends FileActivity
         setFile(listOfFiles.getCurrentFile());
         listOfFiles.setFabVisible(true);
         listOfFiles.registerFabListener();
-        showSortListGroup(true);
         resetTitleBarAndScrolling();
         setDrawerAllFiles();
     }
@@ -1058,9 +1058,10 @@ public class FileDisplayActivity extends FileActivity
                 hideSearchView(getCurrentDir());
                 setDrawerIndicatorEnabled(isDrawerIndicatorAvailable());
             }
-        }
-        if (leftFragment instanceof UnifiedSearchFragment) {
-            super.onBackPressed();
+            if (leftFragment instanceof UnifiedSearchFragment) {
+                popSortListGroupVisibility();
+                super.onBackPressed();
+            }
         }
     }
 
@@ -2611,4 +2612,13 @@ public class FileDisplayActivity extends FileActivity
         }
     }
 
+    private void setSortListGroup(boolean currentListGroupVisibility, boolean show) {
+        previousSortGroupState.push(currentListGroupVisibility);
+        showSortListGroup(show);
+    }
+
+    private void popSortListGroupVisibility() {
+        boolean popped = previousSortGroupState.pop();
+        showSortListGroup(popped);
+    }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1007,8 +1007,8 @@ public class FileDisplayActivity extends FileActivity
      * BackPressed priority/hierarchy:
      *    1. close search view if opened
      *    2. close drawer if opened
-     *    3. close FAB if open (only if drawer isn't open)
-     *    4. navigate up (only if drawer and FAB aren't open)
+     *    3. if it is OCFileListFragment and it's in Root -> (finish Activity) or it's not Root -> (browse up)
+     *    4. otherwise pop up the fragment and sortGroup view visibility and call super.onBackPressed()
      */
     @SuppressFBWarnings("ITC_INHERITANCE_TYPE_CHECKING")
     @Override
@@ -1037,6 +1037,11 @@ public class FileDisplayActivity extends FileActivity
         }
     }
 
+    /**
+     * Use this method when want to pop the fragment on back press. It resets Scrolling (See
+     * {@link #resetScrolling(boolean) with true} and pop the visibility for sortListGroup (See
+     * {@link #setSortListGroup(boolean, boolean)}. At last call to super.onBackPressed()
+     */
     private void popBack() {
         // pop back fragment
         resetScrolling(true);
@@ -1053,6 +1058,9 @@ public class FileDisplayActivity extends FileActivity
         setDrawerAllFiles();
     }
 
+    /**
+     * It resets the Search Action (call when search is open)
+     */
     private void resetSearchAction() {
         Fragment leftFragment = getLeftFragment();
         if (isSearchOpen() && searchView != null) {
@@ -2623,11 +2631,20 @@ public class FileDisplayActivity extends FileActivity
         }
     }
 
+    /**
+     * Use this method to set the visibility of SortListGroup while going to another fragment/view (which needs
+     * different visibility) It internally sets the visibility as well as save the previous one in the stack so that on
+     * going back it pops out the correct visibility. Also see {@link #popSortListGroupVisibility()}
+     */
     private void setSortListGroup(boolean currentListGroupVisibility, boolean show) {
         previousSortGroupState.push(currentListGroupVisibility);
         showSortListGroup(show);
     }
 
+    /**
+     * Use this method to set the visibility of SortListGroup when coming back from a view/fragment (which changed the
+     * visibility earlier using {@link #setSortListGroup(boolean, boolean)}
+     */
     private void popSortListGroupVisibility() {
         boolean popped = previousSortGroupState.pop();
         showSortListGroup(popped);

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -193,6 +193,7 @@ public class FileDisplayActivity extends FileActivity
     public static final String KEY_FILE_PATH = "KEY_FILE_PATH";
     public static final String KEY_ACCOUNT = "KEY_ACCOUNT";
     public static final String KEY_SORT_GROUP_STATE = "KEY_SORT_GROUP_STATE";
+    public static final String KEY_IS_SORT_GROUP_VISIBLE = "KEY_IS_SORT_GROUP_VISIBLE";
 
 
     private static final String KEY_WAITING_TO_PREVIEW = "WAITING_TO_PREVIEW";
@@ -272,6 +273,11 @@ public class FileDisplayActivity extends FileActivity
         initLayout();
         initUI();
         initTaskRetainerFragment();
+
+        // Restoring after UI has been inflated.
+        if (savedInstanceState != null) {
+            showSortListGroup(savedInstanceState.getBoolean(KEY_IS_SORT_GROUP_VISIBLE));
+        }
 
         if (Intent.ACTION_VIEW.equals(getIntent().getAction())) {
             handleOpenFileViaIntent(getIntent());
@@ -1085,6 +1091,7 @@ public class FileDisplayActivity extends FileActivity
         }
         outState.putString(KEY_SEARCH_QUERY, searchQuery);
         outState.putSerializable(KEY_SORT_GROUP_STATE, previousSortGroupState);
+        outState.putBoolean(KEY_IS_SORT_GROUP_VISIBLE, sortListGroupVisibility());
         Log_OC.v(TAG, "onSaveInstanceState() end");
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -192,6 +192,7 @@ public class FileDisplayActivity extends FileActivity
     public static final String KEY_FILE_ID = "KEY_FILE_ID";
     public static final String KEY_FILE_PATH = "KEY_FILE_PATH";
     public static final String KEY_ACCOUNT = "KEY_ACCOUNT";
+    public static final String KEY_SORT_GROUP_STATE = "KEY_SORT_GROUP_STATE";
 
 
     private static final String KEY_WAITING_TO_PREVIEW = "WAITING_TO_PREVIEW";
@@ -283,14 +284,17 @@ public class FileDisplayActivity extends FileActivity
         initSyncBroadcastReceiver();
     }
 
+    @SuppressWarnings("unchecked")
     private void loadSavedInstanceState(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
+            previousSortGroupState = (Stack<Boolean>) savedInstanceState.getSerializable(KEY_SORT_GROUP_STATE);
             mWaitingToPreview = savedInstanceState.getParcelable(FileDisplayActivity.KEY_WAITING_TO_PREVIEW);
             mSyncInProgress = savedInstanceState.getBoolean(KEY_SYNC_IN_PROGRESS);
             mWaitingToSend = savedInstanceState.getParcelable(FileDisplayActivity.KEY_WAITING_TO_SEND);
             searchQuery = savedInstanceState.getString(KEY_SEARCH_QUERY);
             searchOpen = savedInstanceState.getBoolean(FileDisplayActivity.KEY_IS_SEARCH_OPEN, false);
         } else {
+            previousSortGroupState = new Stack<>();
             mWaitingToPreview = null;
             mSyncInProgress = false;
             mWaitingToSend = null;
@@ -1080,7 +1084,7 @@ public class FileDisplayActivity extends FileActivity
             outState.putBoolean(KEY_IS_SEARCH_OPEN, !searchView.isIconified());
         }
         outState.putString(KEY_SEARCH_QUERY, searchQuery);
-
+        outState.putSerializable(KEY_SORT_GROUP_STATE, previousSortGroupState);
         Log_OC.v(TAG, "onSaveInstanceState() end");
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -166,10 +166,7 @@ import static com.owncloud.android.utils.PermissionUtil.PERMISSION_CHOICE_DIALOG
 /**
  * Displays, what files the user has available in his ownCloud. This is the main view.
  */
-public class FileDisplayActivity extends FileActivity
-    implements FileFragment.ContainerActivity,
-    OnEnforceableRefreshListener, SortingOrderDialogFragment.OnSortingOrderListener,
-    SendShareDialog.SendShareDialogDownloader, Injectable {
+public class FileDisplayActivity extends FileActivity implements FileFragment.ContainerActivity, OnEnforceableRefreshListener, SortingOrderDialogFragment.OnSortingOrderListener, SendShareDialog.SendShareDialogDownloader, Injectable {
 
     public static final String RESTART = "RESTART";
     public static final String ALL_FILES = "ALL_FILES";
@@ -237,20 +234,15 @@ public class FileDisplayActivity extends FileActivity
     private Optional<User> lastDisplayedUser = Optional.empty();
     private int menuItemId = -1;
     private Stack<Boolean> previousSortGroupState;
-    @Inject
-    AppPreferences preferences;
+    @Inject AppPreferences preferences;
 
-    @Inject
-    AppInfo appInfo;
+    @Inject AppInfo appInfo;
 
-    @Inject
-    ConnectivityService connectivityService;
+    @Inject ConnectivityService connectivityService;
 
-    @Inject
-    InAppReviewHelper inAppReviewHelper;
+    @Inject InAppReviewHelper inAppReviewHelper;
 
-    @Inject
-    FastScrollUtils fastScrollUtils;
+    @Inject FastScrollUtils fastScrollUtils;
     @Inject AsyncRunner asyncRunner;
 
     public static Intent openFileIntent(Context context, User user, OCFile file) {
@@ -323,12 +315,10 @@ public class FileDisplayActivity extends FileActivity
     private void initTaskRetainerFragment() {
         // Init Fragment without UI to retain AsyncTask across configuration changes
         FragmentManager fm = getSupportFragmentManager();
-        TaskRetainerFragment taskRetainerFragment =
-            (TaskRetainerFragment) fm.findFragmentByTag(TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT);
+        TaskRetainerFragment taskRetainerFragment = (TaskRetainerFragment) fm.findFragmentByTag(TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT);
         if (taskRetainerFragment == null) {
             taskRetainerFragment = new TaskRetainerFragment();
-            fm.beginTransaction()
-                .add(taskRetainerFragment, TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT).commit();
+            fm.beginTransaction().add(taskRetainerFragment, TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT).commit();
         }   // else, Fragment already created and retained across configuration change
     }
 
@@ -342,12 +332,7 @@ public class FileDisplayActivity extends FileActivity
             MainApp.setStoragePath(newStorage);
 
             try {
-                AlertDialog alertDialog = new AlertDialog.Builder(this, R.style.Theme_ownCloud_Dialog)
-                    .setTitle(R.string.wrong_storage_path)
-                    .setMessage(R.string.wrong_storage_path_desc)
-                    .setPositiveButton(R.string.dialog_close, (dialog, which) -> dialog.dismiss())
-                    .setIcon(R.drawable.ic_settings)
-                    .create();
+                AlertDialog alertDialog = new AlertDialog.Builder(this, R.style.Theme_ownCloud_Dialog).setTitle(R.string.wrong_storage_path).setMessage(R.string.wrong_storage_path_desc).setPositiveButton(R.string.dialog_close, (dialog, which) -> dialog.dismiss()).setIcon(R.drawable.ic_settings).create();
 
                 alertDialog.show();
                 viewThemeUtils.platform.colorTextButtons(alertDialog.getButton(AlertDialog.BUTTON_POSITIVE));
@@ -362,9 +347,7 @@ public class FileDisplayActivity extends FileActivity
         super.onConfigurationChanged(newConfig);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            StoragePermissionDialogFragment fragment =
-                (StoragePermissionDialogFragment) getSupportFragmentManager()
-                    .findFragmentByTag(PERMISSION_CHOICE_DIALOG_TAG);
+            StoragePermissionDialogFragment fragment = (StoragePermissionDialogFragment) getSupportFragmentManager().findFragmentByTag(PERMISSION_CHOICE_DIALOG_TAG);
             if (fragment != null) {
                 Dialog dialog = fragment.getDialog();
 
@@ -407,8 +390,7 @@ public class FileDisplayActivity extends FileActivity
             onOpenFileIntent(getIntent());
         } else if (RESTART.equals(getIntent().getAction())) {
             // most likely switched to different account
-            DisplayUtils.showSnackMessage(this, String.format(getString(R.string.logged_in_as),
-                                                              accountManager.getUser().getAccountName()));
+            DisplayUtils.showSnackMessage(this, String.format(getString(R.string.logged_in_as), accountManager.getUser().getAccountName()));
         }
 
         upgradeNotificationForInstantUpload();
@@ -427,41 +409,31 @@ public class FileDisplayActivity extends FileActivity
         if (preferences.instantPictureUploadEnabled() || preferences.instantVideoUploadEnabled()) {
             preferences.removeLegacyPreferences();
             // show info pop-up
-            new AlertDialog.Builder(this, R.style.Theme_ownCloud_Dialog)
-                .setTitle(R.string.drawer_synced_folders)
-                .setMessage(R.string.synced_folders_new_info)
-                .setPositiveButton(R.string.drawer_open, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                        // show instant upload
-                        Intent syncedFoldersIntent = new Intent(getApplicationContext(), SyncedFoldersActivity.class);
-                        dialog.dismiss();
-                        startActivity(syncedFoldersIntent);
-                    }
-                })
-                .setNegativeButton(R.string.drawer_close, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                })
-                .setIcon(R.drawable.nav_synced_folders)
-                .show();
+            new AlertDialog.Builder(this, R.style.Theme_ownCloud_Dialog).setTitle(R.string.drawer_synced_folders).setMessage(R.string.synced_folders_new_info).setPositiveButton(R.string.drawer_open, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    // show instant upload
+                    Intent syncedFoldersIntent = new Intent(getApplicationContext(), SyncedFoldersActivity.class);
+                    dialog.dismiss();
+                    startActivity(syncedFoldersIntent);
+                }
+            }).setNegativeButton(R.string.drawer_close, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                }
+            }).setIcon(R.drawable.nav_synced_folders).show();
         }
     }
 
     private void checkOutdatedServer() {
         Optional<User> user = getUser();
         // show outdated warning
-        if (user.isPresent() &&
-            CapabilityUtils.checkOutdatedWarning(getResources(),
-                                                 user.get().getServer().getVersion(),
-                                                 getCapabilities().getExtendedSupport().isTrue())) {
+        if (user.isPresent() && CapabilityUtils.checkOutdatedWarning(getResources(), user.get().getServer().getVersion(), getCapabilities().getExtendedSupport().isTrue())) {
             DisplayUtils.showServerOutdatedSnackbar(this, Snackbar.LENGTH_LONG);
         }
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
             case PermissionUtil.PERMISSIONS_POST_NOTIFICATIONS:
                 // handle notification permission on API level >= 33
@@ -470,8 +442,7 @@ public class FileDisplayActivity extends FileActivity
                 break;
             case PermissionUtil.PERMISSIONS_EXTERNAL_STORAGE:
                 // If request is cancelled, result arrays are empty.
-                if (grantResults.length > 0
-                    && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted
                     EventBus.getDefault().post(new TokenPushEvent());
                     syncAndUpdateFolder(true);
@@ -482,8 +453,7 @@ public class FileDisplayActivity extends FileActivity
                 // If request is cancelled, result arrays are empty.
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted
-                    getFileOperationsHelper()
-                        .uploadFromCamera(this, FileDisplayActivity.REQUEST_CODE__UPLOAD_FROM_CAMERA);
+                    getFileOperationsHelper().uploadFromCamera(this, FileDisplayActivity.REQUEST_CODE__UPLOAD_FROM_CAMERA);
                 }
                 break;
             default:
@@ -496,8 +466,7 @@ public class FileDisplayActivity extends FileActivity
             OCFileListFragment listOfFiles = new OCFileListFragment();
             Bundle args = new Bundle();
 
-            args.putParcelable(OCFileListFragment.SEARCH_EVENT,
-                               getIntent().getParcelableExtra(OCFileListFragment.SEARCH_EVENT));
+            args.putParcelable(OCFileListFragment.SEARCH_EVENT, getIntent().getParcelableExtra(OCFileListFragment.SEARCH_EVENT));
             args.putBoolean(OCFileListFragment.ARG_ALLOW_CONTEXTUAL_ACTIONS, true);
 
             listOfFiles.setArguments(args);
@@ -643,16 +612,13 @@ public class FileDisplayActivity extends FileActivity
     }
 
 
-    public @androidx.annotation.Nullable
-    Fragment getLeftFragment() {
+    public @androidx.annotation.Nullable Fragment getLeftFragment() {
         return getSupportFragmentManager().findFragmentByTag(FileDisplayActivity.TAG_LIST_OF_FILES);
     }
 
     public @androidx.annotation.Nullable
-    @Deprecated
-    OCFileListFragment getListOfFilesFragment() {
-        Fragment listOfFiles = getSupportFragmentManager().findFragmentByTag(
-            FileDisplayActivity.TAG_LIST_OF_FILES);
+    @Deprecated OCFileListFragment getListOfFilesFragment() {
+        Fragment listOfFiles = getSupportFragmentManager().findFragmentByTag(FileDisplayActivity.TAG_LIST_OF_FILES);
         if (listOfFiles instanceof OCFileListFragment) {
             return (OCFileListFragment) listOfFiles;
         }
@@ -681,16 +647,13 @@ public class FileDisplayActivity extends FileActivity
         }
     }
 
-    protected void refreshDetailsFragmentIfVisible(String downloadEvent, String downloadedRemotePath,
-                                                   boolean success) {
+    protected void refreshDetailsFragmentIfVisible(String downloadEvent, String downloadedRemotePath, boolean success) {
         Fragment leftFragment = getLeftFragment();
         if (leftFragment instanceof FileDetailFragment) {
-            boolean waitedPreview = mWaitingToPreview != null
-                && mWaitingToPreview.getRemotePath().equals(downloadedRemotePath);
+            boolean waitedPreview = mWaitingToPreview != null && mWaitingToPreview.getRemotePath().equals(downloadedRemotePath);
             FileDetailFragment detailsFragment = (FileDetailFragment) leftFragment;
             OCFile fileInFragment = detailsFragment.getFile();
-            if (fileInFragment != null &&
-                !downloadedRemotePath.equals(fileInFragment.getRemotePath())) {
+            if (fileInFragment != null && !downloadedRemotePath.equals(fileInFragment.getRemotePath())) {
                 // the user browsed to other file ; forget the automatic preview
                 mWaitingToPreview = null;
 
@@ -772,8 +735,7 @@ public class FileDisplayActivity extends FileActivity
             });
         }
 
-        final View mSearchEditFrame = searchView
-            .findViewById(androidx.appcompat.R.id.search_edit_frame);
+        final View mSearchEditFrame = searchView.findViewById(androidx.appcompat.R.id.search_edit_frame);
 
         searchView.setOnCloseListener(() -> {
             if (TextUtils.isEmpty(searchView.getQuery().toString())) {
@@ -846,22 +808,15 @@ public class FileDisplayActivity extends FileActivity
      */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REQUEST_CODE__SELECT_CONTENT_FROM_APPS &&
-            (resultCode == RESULT_OK ||
-                resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE)) {
+        if (requestCode == REQUEST_CODE__SELECT_CONTENT_FROM_APPS && (resultCode == RESULT_OK || resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE)) {
 
             requestUploadOfContentFromApps(data, resultCode);
 
-        } else if (requestCode == REQUEST_CODE__SELECT_FILES_FROM_FILE_SYSTEM &&
-            (resultCode == RESULT_OK ||
-                resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE ||
-                resultCode == UploadFilesActivity.RESULT_OK_AND_DO_NOTHING ||
-                resultCode == UploadFilesActivity.RESULT_OK_AND_DELETE)) {
+        } else if (requestCode == REQUEST_CODE__SELECT_FILES_FROM_FILE_SYSTEM && (resultCode == RESULT_OK || resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE || resultCode == UploadFilesActivity.RESULT_OK_AND_DO_NOTHING || resultCode == UploadFilesActivity.RESULT_OK_AND_DELETE)) {
 
             requestUploadOfFilesFromFileSystem(data, resultCode);
 
-        } else if (requestCode == REQUEST_CODE__UPLOAD_FROM_CAMERA &&
-            (resultCode == RESULT_OK || resultCode == UploadFilesActivity.RESULT_OK_AND_DELETE)) {
+        } else if (requestCode == REQUEST_CODE__UPLOAD_FROM_CAMERA && (resultCode == RESULT_OK || resultCode == UploadFilesActivity.RESULT_OK_AND_DELETE)) {
 
             new CheckAvailableSpaceTask(new CheckAvailableSpaceTask.CheckAvailableSpaceListener() {
                 @Override
@@ -882,9 +837,7 @@ public class FileDisplayActivity extends FileActivity
                             return;
                         }
 
-                        requestUploadOfFilesFromFileSystem(renamedFile.getParentFile().getAbsolutePath(),
-                                                           new String[]{renamedFile.getAbsolutePath()},
-                                                           FileUploader.LOCAL_BEHAVIOUR_DELETE);
+                        requestUploadOfFilesFromFileSystem(renamedFile.getParentFile().getAbsolutePath(), new String[]{renamedFile.getAbsolutePath()}, FileUploader.LOCAL_BEHAVIOUR_DELETE);
                     }
                 }
             }, new String[]{FileOperationsHelper.createImageFile(getActivity()).getAbsolutePath()}).execute();
@@ -942,19 +895,8 @@ public class FileDisplayActivity extends FileActivity
                     break;
             }
 
-            FileUploader.uploadNewFile(
-                this,
-                getUser().orElseThrow(RuntimeException::new),
-                filePaths,
-                remotePaths,
-                null,           // MIME type will be detected from file name
-                behaviour,
-                true,
-                UploadFileOperation.CREATED_BY_USER,
-                false,
-                false,
-                NameCollisionPolicy.ASK_USER
-                                      );
+            FileUploader.uploadNewFile(this, getUser().orElseThrow(RuntimeException::new), filePaths, remotePaths, null,           // MIME type will be detected from file name
+                                       behaviour, true, UploadFileOperation.CREATED_BY_USER, false, false, NameCollisionPolicy.ASK_USER);
 
         } else {
             Log_OC.d(TAG, "User clicked on 'Update' with no selection");
@@ -976,20 +918,13 @@ public class FileDisplayActivity extends FileActivity
             streamsToUpload.add(contentIntent.getData());
         }
 
-        int behaviour = (resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE) ? FileUploader.LOCAL_BEHAVIOUR_MOVE :
-            FileUploader.LOCAL_BEHAVIOUR_COPY;
+        int behaviour = (resultCode == UploadFilesActivity.RESULT_OK_AND_MOVE) ? FileUploader.LOCAL_BEHAVIOUR_MOVE : FileUploader.LOCAL_BEHAVIOUR_COPY;
 
         OCFile currentDir = getCurrentDir();
         String remotePath = (currentDir != null) ? currentDir.getRemotePath() : OCFile.ROOT_PATH;
 
-        UriUploader uploader = new UriUploader(
-            this,
-            streamsToUpload,
-            remotePath,
-            getUser().orElseThrow(RuntimeException::new),
-            behaviour,
-            false, // Not show waiting dialog while file is being copied from private storage
-            null  // Not needed copy temp task listener
+        UriUploader uploader = new UriUploader(this, streamsToUpload, remotePath, getUser().orElseThrow(RuntimeException::new), behaviour, false, // Not show waiting dialog while file is being copied from private storage
+                                               null  // Not needed copy temp task listener
         );
 
         uploader.uploadUris();
@@ -1070,11 +1005,13 @@ public class FileDisplayActivity extends FileActivity
             searchView.onActionViewCollapsed();
             searchView.clearFocus();
 
-            // Remove the list to the original state
-            ArrayList<String> listOfHiddenFiles = listOfFiles.getAdapter().listOfHiddenFiles;
-            listOfFiles.performSearch("", listOfHiddenFiles, true);
-
             if (isRoot(getCurrentDir()) && leftFragment instanceof OCFileListFragment) {
+                OCFileListFragment listOfFiles = (OCFileListFragment) leftFragment;
+
+                // Remove the list to the original state
+                ArrayList<String> listOfHiddenFiles = listOfFiles.getAdapter().listOfHiddenFiles;
+                listOfFiles.performSearch("", listOfHiddenFiles, true);
+
                 hideSearchView(getCurrentDir());
                 setDrawerIndicatorEnabled(isDrawerIndicatorAvailable());
             }
@@ -1248,12 +1185,9 @@ public class FileDisplayActivity extends FileActivity
                 Log_OC.d(TAG, "Received broadcast " + event);
                 String accountName = intent.getStringExtra(FileSyncAdapter.EXTRA_ACCOUNT_NAME);
 
-                String synchFolderRemotePath =
-                    intent.getStringExtra(FileSyncAdapter.EXTRA_FOLDER_PATH);
-                RemoteOperationResult synchResult = (RemoteOperationResult)
-                    DataHolderUtil.getInstance().retrieve(intent.getStringExtra(FileSyncAdapter.EXTRA_RESULT));
-                boolean sameAccount = getAccount() != null &&
-                    accountName.equals(getAccount().name) && getStorageManager() != null;
+                String synchFolderRemotePath = intent.getStringExtra(FileSyncAdapter.EXTRA_FOLDER_PATH);
+                RemoteOperationResult synchResult = (RemoteOperationResult) DataHolderUtil.getInstance().retrieve(intent.getStringExtra(FileSyncAdapter.EXTRA_RESULT));
+                boolean sameAccount = getAccount() != null && accountName.equals(getAccount().name) && getStorageManager() != null;
 
                 if (sameAccount) {
 
@@ -1261,18 +1195,12 @@ public class FileDisplayActivity extends FileActivity
                         mSyncInProgress = true;
 
                     } else {
-                        OCFile currentFile = (getFile() == null) ? null :
-                            getStorageManager().getFileByPath(getFile().getRemotePath());
-                        OCFile currentDir = (getCurrentDir() == null) ? null :
-                            getStorageManager().getFileByPath(getCurrentDir().getRemotePath());
+                        OCFile currentFile = (getFile() == null) ? null : getStorageManager().getFileByPath(getFile().getRemotePath());
+                        OCFile currentDir = (getCurrentDir() == null) ? null : getStorageManager().getFileByPath(getCurrentDir().getRemotePath());
 
                         if (currentDir == null) {
                             // current folder was removed from the server
-                            DisplayUtils.showSnackMessage(
-                                getActivity(),
-                                R.string.sync_current_folder_was_removed,
-                                synchFolderRemotePath
-                                                         );
+                            DisplayUtils.showSnackMessage(getActivity(), R.string.sync_current_folder_was_removed, synchFolderRemotePath);
 
                             browseToRoot();
 
@@ -1293,11 +1221,9 @@ public class FileDisplayActivity extends FileActivity
                             setFile(currentFile);
                         }
 
-                        mSyncInProgress = !FileSyncAdapter.EVENT_FULL_SYNC_END.equals(event) &&
-                            !RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED.equals(event);
+                        mSyncInProgress = !FileSyncAdapter.EVENT_FULL_SYNC_END.equals(event) && !RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED.equals(event);
 
-                        if (RefreshFolderOperation.EVENT_SINGLE_FOLDER_CONTENTS_SYNCED.equals(event) &&
-                            synchResult != null) {
+                        if (RefreshFolderOperation.EVENT_SINGLE_FOLDER_CONTENTS_SYNCED.equals(event) && synchResult != null) {
 
                             if (synchResult.isSuccess()) {
                                 hideInfoBox();
@@ -1369,9 +1295,7 @@ public class FileDisplayActivity extends FileActivity
     }
 
     private boolean checkForRemoteOperationError(RemoteOperationResult syncResult) {
-        return ResultCode.UNAUTHORIZED == syncResult.getCode() ||
-            (syncResult.isException() && syncResult.getException()
-                instanceof AuthenticatorException);
+        return ResultCode.UNAUTHORIZED == syncResult.getCode() || (syncResult.isException() && syncResult.getException() instanceof AuthenticatorException);
     }
 
     /**
@@ -1380,15 +1304,11 @@ public class FileDisplayActivity extends FileActivity
     private void setBackgroundText() {
         final OCFileListFragment ocFileListFragment = getListOfFilesFragment();
         if (ocFileListFragment != null) {
-            if (mSyncInProgress ||
-                getFile().getFileLength() > 0 && getStorageManager().getFolderContent(getFile(), false).isEmpty()) {
+            if (mSyncInProgress || getFile().getFileLength() > 0 && getStorageManager().getFolderContent(getFile(), false).isEmpty()) {
                 ocFileListFragment.setEmptyListLoadingMessage();
             } else {
                 if (MainApp.isOnlyOnDevice()) {
-                    ocFileListFragment.setMessageForEmptyList(R.string.file_list_empty_headline,
-                                                              R.string.file_list_empty_on_device,
-                                                              R.drawable.ic_list_empty_folder,
-                                                              true);
+                    ocFileListFragment.setMessageForEmptyList(R.string.file_list_empty_headline, R.string.file_list_empty_on_device, R.drawable.ic_list_empty_folder, true);
                 } else {
                     ocFileListFragment.setEmptyListMessage(SearchType.NO_SEARCH);
                 }
@@ -1413,25 +1333,19 @@ public class FileDisplayActivity extends FileActivity
             String accountName = intent.getStringExtra(FileUploader.ACCOUNT_NAME);
             boolean sameAccount = getAccount() != null && accountName.equals(getAccount().name);
             OCFile currentDir = getCurrentDir();
-            boolean isDescendant = currentDir != null && uploadedRemotePath != null &&
-                uploadedRemotePath.startsWith(currentDir.getRemotePath());
+            boolean isDescendant = currentDir != null && uploadedRemotePath != null && uploadedRemotePath.startsWith(currentDir.getRemotePath());
 
             if (sameAccount && isDescendant) {
-                String linkedToRemotePath =
-                    intent.getStringExtra(FileUploader.EXTRA_LINKED_TO_PATH);
+                String linkedToRemotePath = intent.getStringExtra(FileUploader.EXTRA_LINKED_TO_PATH);
                 if (linkedToRemotePath == null || isAscendant(linkedToRemotePath)) {
                     updateListOfFilesFragment(false);
                 }
             }
 
-            boolean uploadWasFine = intent.getBooleanExtra(
-                FileUploader.EXTRA_UPLOAD_RESULT,
-                false);
-            boolean renamedInUpload = getFile().getRemotePath().
-                equals(intent.getStringExtra(FileUploader.EXTRA_OLD_REMOTE_PATH));
+            boolean uploadWasFine = intent.getBooleanExtra(FileUploader.EXTRA_UPLOAD_RESULT, false);
+            boolean renamedInUpload = getFile().getRemotePath().equals(intent.getStringExtra(FileUploader.EXTRA_OLD_REMOTE_PATH));
 
-            boolean sameFile = getFile().getRemotePath().equals(uploadedRemotePath) ||
-                renamedInUpload;
+            boolean sameFile = getFile().getRemotePath().equals(uploadedRemotePath) || renamedInUpload;
             Fragment details = getLeftFragment();
 
             if (sameAccount && sameFile && details instanceof FileDetailFragment) {
@@ -1443,11 +1357,7 @@ public class FileDisplayActivity extends FileActivity
                 }
                 if (renamedInUpload) {
                     String newName = new File(uploadedRemotePath).getName();
-                    DisplayUtils.showSnackMessage(
-                        getActivity(),
-                        R.string.filedetails_renamed_in_upload_msg,
-                        newName
-                                                 );
+                    DisplayUtils.showSnackMessage(getActivity(), R.string.filedetails_renamed_in_upload_msg, newName);
                 }
                 if (uploadWasFine || getFile().fileExists()) {
                     ((FileDetailFragment) details).updateFileDetails(false, true);
@@ -1499,17 +1409,13 @@ public class FileDisplayActivity extends FileActivity
                 if (linkedToRemotePath == null || isAscendant(linkedToRemotePath)) {
                     updateListOfFilesFragment(false);
                 }
-                refreshDetailsFragmentIfVisible(
-                    intent.getAction(),
-                    downloadedRemotePath,
-                    intent.getBooleanExtra(FileDownloader.EXTRA_DOWNLOAD_RESULT, false));
+                refreshDetailsFragmentIfVisible(intent.getAction(), downloadedRemotePath, intent.getBooleanExtra(FileDownloader.EXTRA_DOWNLOAD_RESULT, false));
             }
 
             if (mWaitingToSend != null) {
                 // update file after downloading
                 mWaitingToSend = getStorageManager().getFileByRemoteId(mWaitingToSend.getRemoteId());
-                if (mWaitingToSend != null && mWaitingToSend.isDown() &&
-                    OCFileListFragment.DOWNLOAD_SEND.equals(downloadBehaviour)) {
+                if (mWaitingToSend != null && mWaitingToSend.isDown() && OCFileListFragment.DOWNLOAD_SEND.equals(downloadBehaviour)) {
                     String packageName = intent.getStringExtra(SendShareDialog.PACKAGE_NAME);
                     String activityName = intent.getStringExtra(SendShareDialog.ACTIVITY_NAME);
 
@@ -1519,8 +1425,7 @@ public class FileDisplayActivity extends FileActivity
 
             if (mWaitingToPreview != null) {
                 mWaitingToPreview = getStorageManager().getFileByRemoteId(mWaitingToPreview.getRemoteId());
-                if (mWaitingToPreview != null && mWaitingToPreview.isDown() &&
-                    EditImageActivity.OPEN_IMAGE_EDITOR.equals(downloadBehaviour)) {
+                if (mWaitingToPreview != null && mWaitingToPreview.isDown() && EditImageActivity.OPEN_IMAGE_EDITOR.equals(downloadBehaviour)) {
                     startImageEditor(mWaitingToPreview);
                 }
             }
@@ -1528,15 +1433,12 @@ public class FileDisplayActivity extends FileActivity
 
         private boolean isDescendant(String downloadedRemotePath) {
             OCFile currentDir = getCurrentDir();
-            return currentDir != null &&
-                downloadedRemotePath != null &&
-                downloadedRemotePath.startsWith(currentDir.getRemotePath());
+            return currentDir != null && downloadedRemotePath != null && downloadedRemotePath.startsWith(currentDir.getRemotePath());
         }
 
         private boolean isAscendant(String linkedToRemotePath) {
             OCFile currentDir = getCurrentDir();
-            return currentDir != null &&
-                currentDir.getRemotePath().startsWith(linkedToRemotePath);
+            return currentDir != null && currentDir.getRemotePath().startsWith(linkedToRemotePath);
         }
 
         private boolean isSameAccount(Intent intent) {
@@ -1651,8 +1553,7 @@ public class FileDisplayActivity extends FileActivity
                         requestForDownload();
                     }
                 }
-            } else if (component.equals(new ComponentName(FileDisplayActivity.this,
-                                                          FileUploader.class))) {
+            } else if (component.equals(new ComponentName(FileDisplayActivity.this, FileUploader.class))) {
                 Log_OC.d(TAG, "Upload service connected");
                 mUploaderBinder = (FileUploaderBinder) service;
             } else {
@@ -1661,8 +1562,7 @@ public class FileDisplayActivity extends FileActivity
             // a new chance to get the mDownloadBinder through
             // getFileDownloadBinder() - THIS IS A MESS
             OCFileListFragment listOfFiles = getListOfFilesFragment();
-            if (listOfFiles != null && (getIntent() == null ||
-                (getIntent() != null && getIntent().getParcelableExtra(EXTRA_FILE) == null))) {
+            if (listOfFiles != null && (getIntent() == null || (getIntent() != null && getIntent().getParcelableExtra(EXTRA_FILE) == null))) {
                 listOfFiles.listDirectory(MainApp.isOnlyOnDevice(), false);
             }
             Fragment leftFragment = getLeftFragment();
@@ -1739,12 +1639,10 @@ public class FileDisplayActivity extends FileActivity
      * @param operation Removal operation performed.
      * @param result    Result of the removal.
      */
-    private void onRemoveFileOperationFinish(RemoveFileOperation operation,
-                                             RemoteOperationResult result) {
+    private void onRemoveFileOperationFinish(RemoveFileOperation operation, RemoteOperationResult result) {
 
         if (!operation.isInBackground()) {
-            DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation,
-                                                                                         getResources()));
+            DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
         }
 
         if (result.isSuccess()) {
@@ -1820,15 +1718,12 @@ public class FileDisplayActivity extends FileActivity
      * @param operation Move operation performed.
      * @param result    Result of the move operation.
      */
-    private void onMoveFileOperationFinish(MoveFileOperation operation,
-                                           RemoteOperationResult result) {
+    private void onMoveFileOperationFinish(MoveFileOperation operation, RemoteOperationResult result) {
         if (result.isSuccess()) {
             syncAndUpdateFolder(true);
         } else {
             try {
-                DisplayUtils.showSnackMessage(
-                    this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
-                                             );
+                DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -1847,9 +1742,7 @@ public class FileDisplayActivity extends FileActivity
             updateListOfFilesFragment(false);
         } else {
             try {
-                DisplayUtils.showSnackMessage(
-                    this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
-                                             );
+                DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -1863,8 +1756,7 @@ public class FileDisplayActivity extends FileActivity
      * @param operation Renaming operation performed.
      * @param result    Result of the renaming.
      */
-    private void onRenameFileOperationFinish(RenameFileOperation operation,
-                                             RemoteOperationResult result) {
+    private void onRenameFileOperationFinish(RenameFileOperation operation, RemoteOperationResult result) {
         Optional<User> optionalUser = getUser();
         OCFile renamedFile = operation.getFile();
         if (result.isSuccess() && optionalUser.isPresent()) {
@@ -1872,13 +1764,11 @@ public class FileDisplayActivity extends FileActivity
             Fragment leftFragment = getLeftFragment();
             if (leftFragment instanceof FileFragment) {
                 final FileFragment fileFragment = (FileFragment) leftFragment;
-                if (fileFragment instanceof FileDetailFragment &&
-                    renamedFile.equals(fileFragment.getFile())) {
+                if (fileFragment instanceof FileDetailFragment && renamedFile.equals(fileFragment.getFile())) {
                     ((FileDetailFragment) fileFragment).updateFileDetails(renamedFile, currentUser);
                     showDetails(renamedFile);
 
-                } else if (fileFragment instanceof PreviewMediaFragment &&
-                    renamedFile.equals(fileFragment.getFile())) {
+                } else if (fileFragment instanceof PreviewMediaFragment && renamedFile.equals(fileFragment.getFile())) {
                     ((PreviewMediaFragment) fileFragment).updateFile(renamedFile);
                     if (PreviewMediaFragment.canBePreviewed(renamedFile)) {
                         long position = ((PreviewMediaFragment) fileFragment).getPosition();
@@ -1886,8 +1776,7 @@ public class FileDisplayActivity extends FileActivity
                     } else {
                         getFileOperationsHelper().openFile(renamedFile);
                     }
-                } else if (fileFragment instanceof PreviewTextFragment &&
-                    renamedFile.equals(fileFragment.getFile())) {
+                } else if (fileFragment instanceof PreviewTextFragment && renamedFile.equals(fileFragment.getFile())) {
                     ((PreviewTextFileFragment) fileFragment).updateFile(renamedFile);
                     if (PreviewTextFileFragment.canBePreviewed(renamedFile)) {
                         startTextPreview(renamedFile, true);
@@ -1903,9 +1792,7 @@ public class FileDisplayActivity extends FileActivity
             }
 
         } else {
-            DisplayUtils.showSnackMessage(
-                this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
-                                         );
+            DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
 
             if (result.isSslRecoverableException()) {
                 mLastSslUntrustedServerResult = result;
@@ -1915,8 +1802,7 @@ public class FileDisplayActivity extends FileActivity
     }
 
 
-    private void onSynchronizeFileOperationFinish(SynchronizeFileOperation operation,
-                                                  RemoteOperationResult result) {
+    private void onSynchronizeFileOperationFinish(SynchronizeFileOperation operation, RemoteOperationResult result) {
         if (result.isSuccess() && operation.transferWasRequested()) {
             OCFile syncedFile = operation.getLocalFile();
             onTransferStateChanged(syncedFile, true, true);
@@ -1931,8 +1817,7 @@ public class FileDisplayActivity extends FileActivity
      * @param operation Creation operation performed.
      * @param result    Result of the creation.
      */
-    private void onCreateFolderOperationFinish(CreateFolderOperation operation,
-                                               RemoteOperationResult result) {
+    private void onCreateFolderOperationFinish(CreateFolderOperation operation, RemoteOperationResult result) {
         if (result.isSuccess()) {
             OCFileListFragment fileListFragment = getListOfFilesFragment();
             if (fileListFragment != null) {
@@ -1943,8 +1828,7 @@ public class FileDisplayActivity extends FileActivity
                 if (ResultCode.FOLDER_ALREADY_EXISTS == result.getCode()) {
                     DisplayUtils.showSnackMessage(this, R.string.folder_already_exists);
                 } else {
-                    DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation,
-                                                                                                 getResources()));
+                    DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
                 }
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -2027,45 +1911,29 @@ public class FileDisplayActivity extends FileActivity
         // the execution is slightly delayed to allow the activity get the window focus if it's being started
         // or if the method is called from a dialog that is being dismissed
         if (TextUtils.isEmpty(searchQuery) && getUser().isPresent()) {
-            getHandler().postDelayed(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        if (ignoreFocus || hasWindowFocus()) {
-                            long currentSyncTime = System.currentTimeMillis();
-                            mSyncInProgress = true;
+            getHandler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    if (ignoreFocus || hasWindowFocus()) {
+                        long currentSyncTime = System.currentTimeMillis();
+                        mSyncInProgress = true;
 
-                            // perform folder synchronization
-                            RemoteOperation synchFolderOp = new RefreshFolderOperation(folder,
-                                                                                       currentSyncTime,
-                                                                                       false,
-                                                                                       ignoreETag,
-                                                                                       getStorageManager(),
-                                                                                       getUser().orElseThrow(RuntimeException::new),
-                                                                                       getApplicationContext()
-                            );
-                            synchFolderOp.execute(
-                                getAccount(),
-                                MainApp.getAppContext(),
-                                FileDisplayActivity.this,
-                                null,
-                                null
-                                                 );
+                        // perform folder synchronization
+                        RemoteOperation synchFolderOp = new RefreshFolderOperation(folder, currentSyncTime, false, ignoreETag, getStorageManager(), getUser().orElseThrow(RuntimeException::new), getApplicationContext());
+                        synchFolderOp.execute(getAccount(), MainApp.getAppContext(), FileDisplayActivity.this, null, null);
 
-                            OCFileListFragment fragment = getListOfFilesFragment();
+                        OCFileListFragment fragment = getListOfFilesFragment();
 
-                            if (fragment != null && !(fragment instanceof GalleryFragment)) {
-                                fragment.setLoading(true);
-                            }
+                        if (fragment != null && !(fragment instanceof GalleryFragment)) {
+                            fragment.setLoading(true);
+                        }
 
-                            setBackgroundText();
+                        setBackgroundText();
 
-                        }   // else: NOTHING ; lets' not refresh when the user rotates the device but there is
-                        // another window floating over
-                    }
-                },
-                DELAY_TO_REQUEST_REFRESH_OPERATION_LATER
-                                    );
+                    }   // else: NOTHING ; lets' not refresh when the user rotates the device but there is
+                    // another window floating over
+                }
+            }, DELAY_TO_REQUEST_REFRESH_OPERATION_LATER);
         }
     }
 
@@ -2106,8 +1974,7 @@ public class FileDisplayActivity extends FileActivity
      * @param packageName
      * @param activityName
      */
-    public void startDownloadForSending(OCFile file, String downloadBehaviour, String packageName,
-                                        String activityName) {
+    public void startDownloadForSending(OCFile file, String downloadBehaviour, String packageName, String activityName) {
         mWaitingToSend = file;
         requestForDownload(mWaitingToSend, downloadBehaviour, packageName, activityName);
     }
@@ -2125,9 +1992,7 @@ public class FileDisplayActivity extends FileActivity
         if (showPreview) {
             startActivity(showDetailsIntent);
         } else {
-            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this,
-                                                                                 getUserAccountManager(),
-                                                                                 connectivityService, editorUtils);
+            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this, getUserAccountManager(), connectivityService, editorUtils);
             fileOperationsHelper.startSyncForFileAndIntent(file, showDetailsIntent);
         }
     }
@@ -2147,9 +2012,7 @@ public class FileDisplayActivity extends FileActivity
         if (showPreview) {
             startActivity(showDetailsIntent);
         } else {
-            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this,
-                                                                                 getUserAccountManager(),
-                                                                                 connectivityService, editorUtils);
+            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this, getUserAccountManager(), connectivityService, editorUtils);
             fileOperationsHelper.startSyncForFileAndIntent(file, showDetailsIntent);
         }
     }
@@ -2161,11 +2024,7 @@ public class FileDisplayActivity extends FileActivity
      * @param startPlaybackPosition Media position where the playback will be started, in milliseconds.
      * @param autoplay              When 'true', the playback will start without user interactions.
      */
-    public void startMediaPreview(OCFile file,
-                                  long startPlaybackPosition,
-                                  boolean autoplay,
-                                  boolean showPreview,
-                                  boolean streamMedia) {
+    public void startMediaPreview(OCFile file, long startPlaybackPosition, boolean autoplay, boolean showPreview, boolean streamMedia) {
         Optional<User> user = getUser();
         if (!user.isPresent()) {
             return; // not reachable under normal conditions
@@ -2179,9 +2038,7 @@ public class FileDisplayActivity extends FileActivity
             previewIntent.putExtra(EXTRA_FILE, file);
             previewIntent.putExtra(PreviewMediaFragment.EXTRA_START_POSITION, startPlaybackPosition);
             previewIntent.putExtra(PreviewMediaFragment.EXTRA_AUTOPLAY, autoplay);
-            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this,
-                                                                                 getUserAccountManager(),
-                                                                                 connectivityService, editorUtils);
+            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this, getUserAccountManager(), connectivityService, editorUtils);
             fileOperationsHelper.startSyncForFileAndIntent(file, previewIntent);
         }
     }
@@ -2211,9 +2068,7 @@ public class FileDisplayActivity extends FileActivity
             Intent previewIntent = new Intent();
             previewIntent.putExtra(EXTRA_FILE, file);
             previewIntent.putExtra(TEXT_PREVIEW, true);
-            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this,
-                                                                                 getUserAccountManager(),
-                                                                                 connectivityService, editorUtils);
+            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this, getUserAccountManager(), connectivityService, editorUtils);
             fileOperationsHelper.startSyncForFileAndIntent(file, previewIntent);
         }
     }
@@ -2227,9 +2082,7 @@ public class FileDisplayActivity extends FileActivity
         Bundle args = new Bundle();
         args.putParcelable(EXTRA_FILE, folder);
         configureToolbarForPreview(folder);
-        Fragment textPreviewFragment = Fragment.instantiate(getApplicationContext(),
-                                                            PreviewTextStringFragment.class.getName(),
-                                                            args);
+        Fragment textPreviewFragment = Fragment.instantiate(getApplicationContext(), PreviewTextStringFragment.class.getName(), args);
         setLeftFragment(textPreviewFragment, false);
     }
 
@@ -2283,8 +2136,7 @@ public class FileDisplayActivity extends FileActivity
             startActivity(editImageIntent);
         } else {
             mWaitingToPreview = file;
-            requestForDownload(file, EditImageActivity.OPEN_IMAGE_EDITOR, getPackageName(),
-                               this.getClass().getSimpleName());
+            requestForDownload(file, EditImageActivity.OPEN_IMAGE_EDITOR, getPackageName(), this.getClass().getSimpleName());
             updateActionBarTitleAndHomeButton(file);
             setFile(file);
         }
@@ -2298,12 +2150,10 @@ public class FileDisplayActivity extends FileActivity
      */
     public void cancelTransference(OCFile file) {
         getFileOperationsHelper().cancelTransference(file);
-        if (mWaitingToPreview != null &&
-            mWaitingToPreview.getRemotePath().equals(file.getRemotePath())) {
+        if (mWaitingToPreview != null && mWaitingToPreview.getRemotePath().equals(file.getRemotePath())) {
             mWaitingToPreview = null;
         }
-        if (mWaitingToSend != null &&
-            mWaitingToSend.getRemotePath().equals(file.getRemotePath())) {
+        if (mWaitingToSend != null && mWaitingToSend.getRemotePath().equals(file.getRemotePath())) {
             mWaitingToSend = null;
         }
         onTransferStateChanged(file, false, false);
@@ -2375,13 +2225,9 @@ public class FileDisplayActivity extends FileActivity
         if (event.getIntent().getBooleanExtra(TEXT_PREVIEW, false)) {
             startTextPreview((OCFile) bundle.get(EXTRA_FILE), true);
         } else if (bundle.containsKey(PreviewMediaFragment.EXTRA_START_POSITION)) {
-            startMediaPreview((OCFile) bundle.get(EXTRA_FILE),
-                              (long) bundle.get(PreviewMediaFragment.EXTRA_START_POSITION),
-                              (boolean) bundle.get(PreviewMediaFragment.EXTRA_AUTOPLAY), true, true);
+            startMediaPreview((OCFile) bundle.get(EXTRA_FILE), (long) bundle.get(PreviewMediaFragment.EXTRA_START_POSITION), (boolean) bundle.get(PreviewMediaFragment.EXTRA_AUTOPLAY), true, true);
         } else if (bundle.containsKey(PreviewImageActivity.EXTRA_VIRTUAL_TYPE)) {
-            startImagePreview((OCFile) bundle.get(EXTRA_FILE),
-                              (VirtualFolderType) bundle.get(PreviewImageActivity.EXTRA_VIRTUAL_TYPE),
-                              true);
+            startImagePreview((OCFile) bundle.get(EXTRA_FILE), (VirtualFolderType) bundle.get(PreviewImageActivity.EXTRA_VIRTUAL_TYPE), true);
         } else {
             startImagePreview((OCFile) bundle.get(EXTRA_FILE), true);
         }
@@ -2411,8 +2257,7 @@ public class FileDisplayActivity extends FileActivity
                 if (file.isDown() && file.getLastSyncDateForProperties() == 0) {
                     // upload in progress - right now, files are not inserted in the local
                     // cache until the upload is successful get parent from path
-                    parentPath = file.getRemotePath().substring(0,
-                                                                file.getRemotePath().lastIndexOf(file.getFileName()));
+                    parentPath = file.getRemotePath().substring(0, file.getRemotePath().lastIndexOf(file.getFileName()));
                     if (storageManager.getFileByPath(parentPath) == null) {
                         file = null; // not able to know the directory where the file is uploading
                     }
@@ -2431,9 +2276,7 @@ public class FileDisplayActivity extends FileActivity
             setupDrawer();
 
             mSwitchAccountButton.setTag(user.getAccountName());
-            DisplayUtils.setAvatar(user, this, getResources()
-                                       .getDimension(R.dimen.nav_drawer_menu_avatar_radius), getResources(),
-                                   mSwitchAccountButton, this);
+            DisplayUtils.setAvatar(user, this, getResources().getDimension(R.dimen.nav_drawer_menu_avatar_radius), getResources(), mSwitchAccountButton, this);
             final boolean userChanged = !user.nameEquals(lastDisplayedUser.orElse(null));
             if (userChanged) {
                 Log_OC.d(TAG, "Initializing Fragments in onAccountChanged..");
@@ -2511,13 +2354,11 @@ public class FileDisplayActivity extends FileActivity
             userNames[i] = users.get(i).getAccountName();
         }
         final AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder
-            .setTitle(R.string.common_choose_account)
-            .setItems(userNames, (dialog, which) -> {
-                User user = users.get(which);
-                openFile(user, fileId);
-                showLoadingDialog(getString(R.string.retrieving_file));
-            });
+        builder.setTitle(R.string.common_choose_account).setItems(userNames, (dialog, which) -> {
+            User user = users.get(which);
+            openFile(user, fileId);
+            showLoadingDialog(getString(R.string.retrieving_file));
+        });
         final AlertDialog dialog = builder.create();
         dismissLoadingDialog();
         dialog.show();
@@ -2537,10 +2378,7 @@ public class FileDisplayActivity extends FileActivity
             storageManager = new FileDataStorageManager(user, getContentResolver());
         }
 
-        FetchRemoteFileTask fetchRemoteFileTask = new FetchRemoteFileTask(user,
-                                                                          fileId,
-                                                                          storageManager,
-                                                                          this);
+        FetchRemoteFileTask fetchRemoteFileTask = new FetchRemoteFileTask(user, fileId, storageManager, this);
         fetchRemoteFileTask.execute();
     }
 
@@ -2566,11 +2404,7 @@ public class FileDisplayActivity extends FileActivity
             return;
         }
 
-        GetRemoteFileTask getRemoteFileTask = new GetRemoteFileTask(this,
-                                                                    filepath,
-                                                                    client,
-                                                                    storageManager,
-                                                                    user);
+        GetRemoteFileTask getRemoteFileTask = new GetRemoteFileTask(this, filepath, client, storageManager, user);
         asyncRunner.postQuickTask(getRemoteFileTask, this::onFileRequestResult, this::onFileRequestError);
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -633,7 +633,9 @@ public class FileDisplayActivity extends FileActivity
 
         //clear the subtitle while navigating to any other screen from Media screen
         clearToolbarSubtitle();
+
         setSortListGroup(sortListGroupVisibility(), showSortListGroup);
+
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.addToBackStack(null);
         transaction.replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES);

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -611,6 +611,10 @@ public class FileDisplayActivity extends FileActivity
      * @param fragment New Fragment to set.
      */
     private void setLeftFragment(Fragment fragment) {
+        setLeftFragment(fragment, true);
+    }
+
+    private void setLeftFragment(Fragment fragment, boolean showSortListGroup) {
         if (searchView != null) {
             searchView.post(() -> searchView.setQuery(searchQuery, true));
         }
@@ -618,18 +622,11 @@ public class FileDisplayActivity extends FileActivity
 
         //clear the subtitle while navigating to any other screen from Media screen
         clearToolbarSubtitle();
-
+        showSortListGroup(showSortListGroup);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.addToBackStack(null);
         transaction.replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES);
         transaction.commit();
-
-        if (fragment instanceof UnifiedSearchFragment || fragment instanceof PreviewMediaFragment || fragment instanceof PreviewTextFileFragment
-            || fragment instanceof PreviewTextStringFragment) {
-            showSortListGroup(false);
-        } else {
-            showSortListGroup(true);
-        }
     }
 
 
@@ -1569,10 +1566,8 @@ public class FileDisplayActivity extends FileActivity
         resetScrolling(true);
 
         Fragment detailFragment = FileDetailFragment.newInstance(file, currentUser, activeTab);
-        setLeftFragment(detailFragment);
+        setLeftFragment(detailFragment, false);
         configureToolbarForPreview(file);
-//        updateActionBarTitleAndHomeButton(file);
-//        mDrawerToggle.setDrawerIndicatorEnabled(false);
     }
 
     /**
@@ -2156,7 +2151,7 @@ public class FileDisplayActivity extends FileActivity
         if (showPreview && file.isDown() && !file.isDownloading() || streamMedia) {
             configureToolbarForPreview(file);
             Fragment mediaFragment = PreviewMediaFragment.newInstance(file, user.get(), startPlaybackPosition, autoplay, false);
-            setLeftFragment(mediaFragment);
+            setLeftFragment(mediaFragment, false);
         } else {
             Intent previewIntent = new Intent();
             previewIntent.putExtra(EXTRA_FILE, file);
@@ -2170,7 +2165,6 @@ public class FileDisplayActivity extends FileActivity
     }
 
     public void configureToolbarForPreview(OCFile file) {
-        showSortListGroup(false);
         lockScrolling();
         super.updateActionBarTitleAndHomeButton(file);
     }
@@ -2188,9 +2182,8 @@ public class FileDisplayActivity extends FileActivity
         }
         User user = optUser.get();
         if (showPreview) {
-//            showSortListGroup(false);
             PreviewTextFileFragment fragment = PreviewTextFileFragment.create(user, file, searchOpen, searchQuery);
-            setLeftFragment(fragment);
+            setLeftFragment(fragment, false);
             configureToolbarForPreview(file);
         } else {
             Intent previewIntent = new Intent();
@@ -2209,15 +2202,13 @@ public class FileDisplayActivity extends FileActivity
      * @param folder {@link OCFile} to preview its rich workspace.
      */
     public void startRichWorkspacePreview(OCFile folder) {
-//        showSortListGroup(false);
         Bundle args = new Bundle();
         args.putParcelable(EXTRA_FILE, folder);
         configureToolbarForPreview(folder);
-        Log.d(Constant.LOG_TAG, "Rich Preview: " + folder);
         Fragment textPreviewFragment = Fragment.instantiate(getApplicationContext(),
                                                             PreviewTextStringFragment.class.getName(),
                                                             args);
-        setLeftFragment(textPreviewFragment);
+        setLeftFragment(textPreviewFragment, false);
     }
 
     public void startContactListFragment(OCFile file) {
@@ -2232,11 +2223,8 @@ public class FileDisplayActivity extends FileActivity
         } else {
             final Fragment pdfFragment = PreviewPdfFragment.newInstance(file);
 
-            setLeftFragment(pdfFragment);
-
-//            showSortListGroup(false);
+            setLeftFragment(pdfFragment, false);
             configureToolbarForPreview(file);
-            mDrawerToggle.setDrawerIndicatorEnabled(false);
             setMainFabVisible(false);
         }
     }
@@ -2252,7 +2240,7 @@ public class FileDisplayActivity extends FileActivity
     public void startDownloadForPreview(OCFile file, OCFile parentFolder) {
         final User currentUser = getUser().orElseThrow(RuntimeException::new);
         Fragment detailFragment = FileDetailFragment.newInstance(file, parentFolder, currentUser);
-        setLeftFragment(detailFragment);
+        setLeftFragment(detailFragment, false);
         configureToolbarForPreview(file);
         mWaitingToPreview = file;
         requestForDownload();
@@ -2589,7 +2577,7 @@ public class FileDisplayActivity extends FileActivity
 
     public void performUnifiedSearch(String query, ArrayList<String> listOfHiddenFiles) {
         UnifiedSearchFragment unifiedSearchFragment = UnifiedSearchFragment.Companion.newInstance(query, listOfHiddenFiles);
-        setLeftFragment(unifiedSearchFragment);
+        setLeftFragment(unifiedSearchFragment, false);
     }
 
     public void setMainFabVisible(final boolean visible) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -197,7 +197,6 @@ public abstract class ToolbarActivity extends BaseActivity implements Injectable
     /**
      * checks if the given file is the root folder.
      *
-     *
      * @param file file to be checked if it is the root folder
      * @return <code>true</code> if it is <code>null</code> or the root folder, else returns <code>false</code>
      */
@@ -243,6 +242,9 @@ public abstract class ToolbarActivity extends BaseActivity implements Injectable
         findViewById(R.id.sort_list_button_group).setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
+    public boolean sortListGroupVisibility(){
+        return findViewById(R.id.sort_list_button_group).getVisibility() == View.VISIBLE;
+    }
     /**
      * Change the bitmap for the toolbar's preview image.
      *

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -144,12 +144,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
     /**
      * Public factory method to create new FileDetailFragment instances.
-     *
+     * <p>
      * When 'fileToDetail' or 'ocAccount' are null, creates a dummy layout (to use when a file wasn't tapped before).
      *
-     * @param fileToDetail      An {@link OCFile} to show in the fragment
-     * @param user              Currently active user
-     *                          @param activeTab to be active tab
+     * @param fileToDetail An {@link OCFile} to show in the fragment
+     * @param user         Currently active user
+     * @param activeTab    to be active tab
      * @return New fragment with arguments set
      */
     public static FileDetailFragment newInstance(OCFile fileToDetail, User user, int activeTab) {
@@ -224,7 +224,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             user = savedInstanceState.getParcelable(ARG_USER);
         }
 
-        binding = FileDetailsFragmentBinding.inflate(inflater,container,false);
+        binding = FileDetailsFragmentBinding.inflate(inflater, container, false);
         view = binding.getRoot();
 
         if (getFile() == null || user == null) {
@@ -373,8 +373,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         super.onResume();
 
         if (toolbarActivity != null) {
-            toolbarActivity.showSortListGroup(false);
-
             if (previewLoaded) {
                 toolbarActivity.setPreviewImageVisibility(true);
             }
@@ -477,7 +475,8 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     }
 
     /**
-     * Check if the fragment was created with an empty layout. An empty fragment can't show file details, must be replaced.
+     * Check if the fragment was created with an empty layout. An empty fragment can't show file details, must be
+     * replaced.
      *
      * @return True when the fragment was created with the empty layout.
      */
@@ -498,11 +497,11 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
     /**
      * Updates the view with all relevant details about that file.
-     *
+     * <p>
      * TODO Remove parameter when the transferring state of files is kept in database.
      *
-     * @param transferring Flag signaling if the file should be considered as downloading or uploading,
-     *                     although {@link FileDownloaderBinder#isDownloading(User, OCFile)}  and
+     * @param transferring Flag signaling if the file should be considered as downloading or uploading, although
+     *                     {@link FileDownloaderBinder#isDownloading(User, OCFile)}  and
      *                     {@link FileUploaderBinder#isUploading(User, OCFile)} return false.
      * @param refresh      If 'true', try to refresh the whole file from the database
      */
@@ -537,8 +536,8 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             FileDownloaderBinder downloaderBinder = containerActivity.getFileDownloaderBinder();
             FileUploaderBinder uploaderBinder = containerActivity.getFileUploaderBinder();
             if (transferring
-                    || (downloaderBinder != null && downloaderBinder.isDownloading(user, file))
-                    || (uploaderBinder != null && uploaderBinder.isUploading(user, file))) {
+                || (downloaderBinder != null && downloaderBinder.isDownloading(user, file))
+                || (uploaderBinder != null && uploaderBinder.isUploading(user, file))) {
                 setButtonsForTransferring();
 
             } else if (file.isDown()) {
@@ -567,7 +566,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             binding.lastModificationTimestamp.setText(DisplayUtils.unixTimeToHumanReadable(file.getModificationTimestamp()));
         } else {
             binding.lastModificationTimestamp.setText(DisplayUtils.getRelativeTimestamp(getContext(),
-                                                                            file.getModificationTimestamp()));
+                                                                                        file.getModificationTimestamp()));
         }
     }
 
@@ -576,8 +575,8 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             binding.favorite.setImageDrawable(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_star, null));
         } else {
             binding.favorite.setImageDrawable(ResourcesCompat.getDrawable(getResources(),
-                                                                      R.drawable.ic_star_outline,
-                                                                      null));
+                                                                          R.drawable.ic_star_outline,
+                                                                          null));
         }
     }
 
@@ -618,7 +617,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
                 // generate new resized image
                 if (ThumbnailsCacheManager.cancelPotentialThumbnailWork(getFile(), toolbarActivity.getPreviewImageView()) &&
-                        containerActivity.getStorageManager() != null) {
+                    containerActivity.getStorageManager() != null) {
                     final ThumbnailsCacheManager.ResizedImageGenerationTask task =
                         new ThumbnailsCacheManager.ResizedImageGenerationTask(this,
                                                                               toolbarActivity.getPreviewImageView(),
@@ -635,11 +634,11 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                     }
 
                     final ThumbnailsCacheManager.AsyncResizedImageDrawable asyncDrawable =
-                            new ThumbnailsCacheManager.AsyncResizedImageDrawable(
-                                    MainApp.getAppContext().getResources(),
-                                    resizedImage,
-                                    task
-                            );
+                        new ThumbnailsCacheManager.AsyncResizedImageDrawable(
+                            MainApp.getAppContext().getResources(),
+                            resizedImage,
+                            task
+                        );
 
                     toolbarActivity.setPreviewImageDrawable(asyncDrawable);
                     previewLoaded = true;
@@ -664,8 +663,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             //if (getFile().isDownloading()) {
             if (downloaderBinder != null && downloaderBinder.isDownloading(user, getFile())) {
                 binding.progressText.setText(R.string.downloader_download_in_progress_ticker);
-            }
-            else {
+            } else {
                 if (uploaderBinder != null && uploaderBinder.isUploading(user, getFile())) {
                     binding.progressText.setText(R.string.uploader_upload_in_progress_ticker);
                 }
@@ -701,7 +699,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             }
             if (containerActivity.getFileUploaderBinder() != null) {
                 containerActivity.getFileUploaderBinder().
-                        addDatatransferProgressListener(progressListener, user, getFile());
+                    addDatatransferProgressListener(progressListener, user, getFile());
             }
         } else {
             Log_OC.d(TAG, "progressListener == null");
@@ -716,7 +714,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             }
             if (containerActivity.getFileUploaderBinder() != null) {
                 containerActivity.getFileUploaderBinder().
-                        removeDatatransferProgressListener(progressListener, user, getFile());
+                    removeDatatransferProgressListener(progressListener, user, getFile());
             }
         }
     }
@@ -733,6 +731,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
     /**
      * open the sharing process fragment for creating new share
+     *
      * @param shareeName
      * @param shareType
      */
@@ -749,6 +748,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
     /**
      * method will handle the views need to be hidden when sharing process fragment shows
+     *
      * @param isFragmentReplaced
      */
     public void showHideFragmentView(boolean isFragmentReplaced) {
@@ -765,6 +765,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
 
     /**
      * open the new sharing screen process to modify the created share
+     *
      * @param share
      * @param screenTypePermission
      * @param isReshareShown
@@ -816,7 +817,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         @Override
         public void onTransferProgress(long progressRate, long totalTransferredSoFar,
                                        long totalToTransfer, String filename) {
-            int percent = (int)(100.0*((double)totalTransferredSoFar)/((double)totalToTransfer));
+            int percent = (int) (100.0 * ((double) totalTransferredSoFar) / ((double) totalToTransfer));
             if (percent != lastPercent) {
                 ProgressBar pb = progressBarReference.get();
                 if (pb != null) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -73,7 +73,6 @@ import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.activity.DrawerActivity;
-import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.ui.fragment.FileFragment;
@@ -101,8 +100,8 @@ import kotlin.jvm.functions.Function0;
 /**
  * This fragment shows a preview of a downloaded media file (audio or video).
  * <p>
- * Trying to get an instance with NULL {@link OCFile} or ownCloud {@link User} values will produce an {@link
- * IllegalStateException}.
+ * Trying to get an instance with NULL {@link OCFile} or ownCloud {@link User} values will produce an
+ * {@link IllegalStateException}.
  * <p>
  * By now, if the {@link OCFile} passed is not downloaded, an {@link IllegalStateException} is generated on
  * instantiation too.
@@ -116,7 +115,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     public static final String EXTRA_USER = "USER";
     public static final String EXTRA_AUTOPLAY = "AUTOPLAY";
     public static final String EXTRA_START_POSITION = "START_POSITION";
-    
+
     private static final String EXTRA_PLAY_POSITION = "PLAY_POSITION";
     private static final String EXTRA_PLAYING = "PLAYING";
     private static final double MIN_DENSITY_RATIO = 24.0;
@@ -365,7 +364,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
                     Executors.newSingleThreadExecutor().execute(() -> {
                         try {
                             nextcloudClient = clientFactory.createNextcloudClient(accountManager.getUser());
-                            handler.post(() ->{
+                            handler.post(() -> {
                                 exoPlayer = NextcloudExoPlayer.createNextcloudExoplayer(requireContext(), nextcloudClient);
 
                                 exoPlayer.addListener(new ExoplayerListener(requireContext(), binding.exoplayerView, exoPlayer, () -> {
@@ -619,9 +618,6 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     @Override
     public void onResume() {
         super.onResume();
-        if(getActivity() instanceof FileDisplayActivity){
-            ((FileDisplayActivity) getActivity()).configureToolbarForMediaPreview(getFile());
-        }
         Log_OC.v(TAG, "onResume");
     }
 


### PR DESCRIPTION
Resolves #11700 
- [x] Tests written, or not not needed

- Fixes issues mentions in the issue.
- `sortListGroup` visibility handled by Stack. So, it does not go out of sync. Here's how it's handling -->
    - If going into a View which needs to have different visibility (either visible or not).
    - Then, we save the current visibility first and then change the visibility according to upcoming view
    - So, when going back we can pop out the visibility and we will have the correct visibility.
    - This way view visibility will never go out of sync (because of some unhandled case) and we will always have the correct visibility applied since we're saving it in a stack and popping out when going back.
    - It is somewhat like how Fragments are in backstack and going back they popes out.
    - Same way we're stacking up (when going in but only when we need to change the visibility) and popping out (handled to pop only for the cases where it needs to popped).

### Before

https://github.com/nextcloud/android/assets/111801812/b1d7b12d-f8b2-4f9a-97fc-34669faaff53

### After 

https://github.com/nextcloud/android/assets/111801812/c5e4caf0-91f0-4ea3-9fdc-ee61ca6560dd


