### PR TITLE
Fixed the appearence of keyboard while renaming

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -201,7 +201,7 @@ public class RenameFileDialogFragment
                         InputMethodManager imm = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
                         imm.showSoftInput(binding.userInput, InputMethodManager.SHOW_IMPLICIT);
                     }
-                }, 100); // Delay for 200 milliseconds
+                }, 100); // Delay for 100 milliseconds
             }
         });
         return dialog;

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -27,13 +27,17 @@ package com.owncloud.android.ui.dialog;
  */
 
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Handler;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -185,8 +189,22 @@ public class RenameFileDialogFragment
             .setTitle(R.string.rename_dialog_title);
 
         viewThemeUtils.dialog.colorMaterialAlertDialogBackground(binding.userInputContainer.getContext(), builder);
-
-        return builder.create();
+        AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialogInterface) {
+                Log.d("Dialog", "onShow called");
+                binding.userInput.requestFocus();
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        InputMethodManager imm = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+                        imm.showSoftInput(binding.userInput, InputMethodManager.SHOW_IMPLICIT);
+                    }
+                }, 100); // Delay for 200 milliseconds
+            }
+        });
+        return dialog;
     }
 
 


### PR DESCRIPTION
**Fixed the appearence of keyboard while renaming**

Here's a description of the problem and how it was resolved

The issue was related to the automatic opening of the soft keyboard when displaying a MaterialAlertDialogBuilder dialog. Despite calling showSoftInput() within the onShow() method of the dialog, the keyboard did not open as expected. Instead, the log displayed the message "Ignoring showSoftInput() as view is not served."

**Root Cause Analysis:**

The root cause of the issue appeared to be a race condition between requesting focus for the EditText view and displaying the soft keyboard. The Material Design components used in the layout might have had specific behaviors that affected the timing of these actions.
Resolution:
To resolve this issue, the following steps were taken:
* 		A Handler was introduced to introduce a slight delay between requesting focus and showing the soft keyboard. This delay allowed for better synchronization and prevented the race condition.
* 		The code was modified to use new Handler().postDelayed() to delay the showSoftInput() call by 100 milliseconds after requesting focus on the EditText.

**Result:**

After implementing these changes, the soft keyboard opened automatically when the dialog was shown, as intended. The issue of the keyboard not opening was successfully resolved.

