### PR TITLE
Replaced All the Toasts with Snackbars

### DIFF
--- a/app/src/main/java/com/nextcloud/client/errorhandling/ShowErrorActivity.kt
+++ b/app/src/main/java/com/nextcloud/client/errorhandling/ShowErrorActivity.kt
@@ -23,7 +23,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.owncloud.android.R
@@ -69,7 +68,7 @@ class ShowErrorActivity : AppCompatActivity() {
             URLEncoder.encode(binding.textViewError.text.toString(), Charsets.UTF_8.name())
         )
         DisplayUtils.startLinkIntent(this, issueLink)
-        Toast.makeText(this, R.string.copied_to_clipboard, Toast.LENGTH_LONG).show()
+        Snackbar.make(binding.root, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/nextcloud/client/logger/ui/LogsEmailSender.kt
+++ b/app/src/main/java/com/nextcloud/client/logger/ui/LogsEmailSender.kt
@@ -24,8 +24,9 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.widget.Toast
+import android.view.View
 import androidx.core.content.FileProvider
+import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.client.core.AsyncRunner
 import com.nextcloud.client.core.Cancellable
 import com.nextcloud.client.core.Clock
@@ -95,7 +96,7 @@ class LogsEmailSender(private val context: Context, private val clock: Clock, pr
         try {
             context.startActivity(intent)
         } catch (ex: ActivityNotFoundException) {
-            Toast.makeText(context, R.string.log_send_no_mail_app, Toast.LENGTH_SHORT).show()
+            Snackbar.make(View(context), R.string.log_send_no_mail_app, Snackbar.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/media/PlayerService.kt
+++ b/app/src/main/java/com/nextcloud/client/media/PlayerService.kt
@@ -25,9 +25,10 @@ import android.content.Intent
 import android.media.AudioManager
 import android.os.Bundle
 import android.os.IBinder
+import android.view.View
 import android.widget.MediaController
-import android.widget.Toast
 import androidx.core.app.NotificationCompat
+import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.client.account.User
 import com.nextcloud.client.network.ClientFactory
 import com.owncloud.android.R
@@ -79,7 +80,7 @@ class PlayerService : Service() {
         }
 
         override fun onError(error: PlayerError) {
-            Toast.makeText(this@PlayerService, error.message, Toast.LENGTH_SHORT).show()
+            Snackbar.make(View(this@PlayerService), error.message, Snackbar.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
@@ -31,7 +31,6 @@ import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.os.bundleOf
@@ -44,6 +43,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.account.CurrentAccountProvider
 import com.nextcloud.client.di.Injectable
@@ -133,7 +133,7 @@ class FileActionsBottomSheet : BottomSheetDialogFragment(), Injectable {
             FileActionsViewModel.UiState.Loading -> {}
             FileActionsViewModel.UiState.Error -> {
                 context?.let {
-                    Toast.makeText(it, R.string.error_file_actions, Toast.LENGTH_SHORT).show()
+                    Snackbar.make(View(it), R.string.error_file_actions, Snackbar.LENGTH_SHORT).show()
                 }
                 dismissAllowingStateLoss()
             }

--- a/app/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
@@ -30,8 +30,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import android.widget.Toast;
-
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.accounts.AccountTypeUtils;
@@ -109,7 +109,7 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
             final String message = String.format(mContext.getString(R.string.auth_unsupported_multiaccount), mContext.getString(R.string.app_name));
             bundle.putString(AccountManager.KEY_ERROR_MESSAGE, message);
 
-            mHandler.post(() -> Toast.makeText(mContext, message, Toast.LENGTH_SHORT).show());
+            mHandler.post(() -> Snackbar.make(new View(mContext), message, Snackbar.LENGTH_SHORT).show());
         }
 
         return bundle;

--- a/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -72,8 +72,6 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
-import android.widget.Toast;
-
 import com.blikoon.qrcodescanner.QrCodeActivity;
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.android.common.ui.color.ColorUtil;
@@ -688,7 +686,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         if (data != null && data.toString().startsWith(getString(R.string.login_data_own_scheme))) {
             if (!getResources().getBoolean(R.bool.multiaccount_support) &&
                 accountManager.getAccounts().length == 1) {
-                Toast.makeText(this, R.string.no_mutliple_accounts_allowed, Toast.LENGTH_LONG).show();
+                Snackbar.make(new View(this), R.string.no_mutliple_accounts_allowed, Snackbar.LENGTH_LONG).show();
                 finish();
                 return;
             } else {
@@ -1521,7 +1519,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
             if (!getResources().getBoolean(R.bool.multiaccount_support) &&
                 accountManager.getAccounts().length == 1) {
-                Toast.makeText(this, R.string.no_mutliple_accounts_allowed, Toast.LENGTH_LONG).show();
+                Snackbar.make(new View(this), R.string.no_mutliple_accounts_allowed, Snackbar.LENGTH_LONG).show();
             } else {
                 parseAndLoginFromWebView(result);
             }

--- a/app/src/main/java/com/owncloud/android/authentication/DeepLinkLoginActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/DeepLinkLoginActivity.java
@@ -2,9 +2,9 @@ package com.owncloud.android.authentication;
 
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
-
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.R;
 
@@ -16,7 +16,7 @@ public class DeepLinkLoginActivity extends AuthenticatorActivity implements Inje
 
         if (!getResources().getBoolean(R.bool.multiaccount_support) &&
             accountManager.getAccounts().length == 1) {
-            Toast.makeText(this, R.string.no_mutliple_accounts_allowed, Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(this), R.string.no_mutliple_accounts_allowed, Snackbar.LENGTH_LONG).show();
             return;
         }
 
@@ -33,7 +33,7 @@ public class DeepLinkLoginActivity extends AuthenticatorActivity implements Inje
                 loginText.setText(String.format(getString(R.string.direct_login_text), loginUrlInfo.username,
                                                 loginUrlInfo.serverAddress));
             } catch (IllegalArgumentException e) {
-                Toast.makeText(this, R.string.direct_login_failed, Toast.LENGTH_LONG).show();
+                Snackbar.make(new View(this), R.string.direct_login_failed, Snackbar.LENGTH_LONG).show();
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -39,8 +39,9 @@ import android.os.Looper;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.DocumentsProvider;
-import android.widget.Toast;
+import android.view.View;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.files.downloader.DownloadTask;
@@ -170,7 +171,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         if (parentFolder.getFile().isEncrypted() &&
             !FileOperationsHelper.isEndToEndEncryptionSetup(context, parentFolder.getUser())) {
-            Toast.makeText(context, R.string.e2e_not_yet_setup, Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(context), R.string.e2e_not_yet_setup, Snackbar.LENGTH_LONG).show();
             return resultCursor;
         }
 
@@ -226,9 +227,9 @@ public class DocumentsStorageProvider extends DocumentsProvider {
                     if (!result.isSuccess()) {
                         if (ocFile.isDown()) {
                             Handler handler = new Handler(Looper.getMainLooper());
-                            handler.post(() -> Toast.makeText(MainApp.getAppContext(),
-                                                              R.string.file_not_synced,
-                                                              Toast.LENGTH_SHORT).show());
+                            handler.post(() -> Snackbar.make(new View(MainApp.getAppContext()),
+                                                             R.string.file_not_synced,
+                                                             Snackbar.LENGTH_SHORT).show());
                             downloadResult.set(true);
                         } else {
                             Log_OC.e(TAG, result.toString());

--- a/app/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -34,8 +34,9 @@ import android.os.Looper;
 import android.os.ParcelFileDescriptor;
 import android.provider.BaseColumns;
 import android.text.TextUtils;
-import android.widget.Toast;
+import android.view.View;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.R;
@@ -454,9 +455,9 @@ public class UsersAndGroupsSearchProvider extends ContentProvider {
                 throw new IllegalArgumentException("Context may not be null!");
             }
 
-            Toast.makeText(getContext().getApplicationContext(),
-                           ErrorMessageAdapter.getErrorCauseMessage(result, null, getContext().getResources()),
-                           Toast.LENGTH_SHORT).show();
+            Snackbar.make(new View(getContext().getApplicationContext()),
+                          ErrorMessageAdapter.getErrorCauseMessage(result, null, getContext().getResources()),
+                          Snackbar.LENGTH_SHORT).show();
         });
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.java
@@ -20,8 +20,8 @@ package com.owncloud.android.ui.activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.widget.Toast;
-
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.java.util.Optional;
 import com.owncloud.android.R;
@@ -244,7 +244,7 @@ public class ConflictsResolveActivity extends FileActivity implements OnConflict
     }
 
     private void showErrorAndFinish() {
-        runOnUiThread(() -> Toast.makeText(this, R.string.conflict_dialog_error, Toast.LENGTH_LONG).show());
+        runOnUiThread(() -> Snackbar.make(new View(this), R.string.conflict_dialog_error, Snackbar.LENGTH_LONG).show());
         finish();
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -35,8 +35,6 @@ import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
-import android.widget.Toast;
-
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.java.util.Optional;
@@ -94,8 +92,8 @@ public abstract class EditorWebView extends ExternalSiteWebView {
                 }
             }, 10 * 1000);
         } else {
-            Toast.makeText(getApplicationContext(),
-                           R.string.richdocuments_failed_to_load_document, Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(getApplicationContext()),
+                          R.string.richdocuments_failed_to_load_document, Snackbar.LENGTH_LONG).show();
             finish();
         }
     }
@@ -134,7 +132,7 @@ public abstract class EditorWebView extends ExternalSiteWebView {
                     activity.startActivityForResult(intent, REQUEST_LOCAL_FILE);
                 } catch (ActivityNotFoundException e) {
                     uploadMessage = null;
-                    Toast.makeText(getBaseContext(), "Cannot open file chooser", Toast.LENGTH_LONG).show();
+                    Snackbar.make(new View(getBaseContext()), "Cannot open file chooser", Snackbar.LENGTH_LONG).show();
                     return false;
                 }
 
@@ -144,9 +142,8 @@ public abstract class EditorWebView extends ExternalSiteWebView {
 
         setFile(getIntent().getParcelableExtra(ExternalSiteWebView.EXTRA_FILE));
 
-        if (getFile() == null) {
-            Toast.makeText(getApplicationContext(),
-                           R.string.richdocuments_failed_to_load_document, Toast.LENGTH_LONG).show();
+        if (getFile() == null) {Snackbar.make(new View(getApplicationContext()),
+                           R.string.richdocuments_failed_to_load_document, Snackbar.LENGTH_LONG).show();
             finish();
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -47,6 +47,7 @@ import android.widget.*;
 import android.widget.AdapterView.OnItemClickListener;
 
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -222,10 +223,10 @@ public class ReceiveExternalFilesActivity extends FileActivity
         super.onStart();
 
         if (mAccountManager.getAccountsByType(MainApp.getAccountType(this)).length == 0) {
-            Toast.makeText(this,
-                           String.format(getString(R.string.uploader_wrn_no_account_text),
+            Snackbar.make(new View(this),
+                              String.format(getString(R.string.uploader_wrn_no_account_text),
                                          getString(R.string.app_name)),
-                           Toast.LENGTH_LONG).show();
+                              Snackbar.LENGTH_LONG).show();
             return;
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/RequestCredentialsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/RequestCredentialsActivity.java
@@ -25,8 +25,8 @@ import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.SystemClock;
-import android.widget.Toast;
-
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -55,7 +55,7 @@ public class RequestCredentialsActivity extends Activity {
             } else if (resultCode == Activity.RESULT_CANCELED) {
                 finishWithResult(KEY_CHECK_RESULT_CANCEL);
             } else {
-                Toast.makeText(this, R.string.default_credentials_wrong, Toast.LENGTH_SHORT).show();
+                Snackbar.make(new View(this), R.string.default_credentials_wrong, Snackbar.LENGTH_SHORT).show();
                 requestCredentials();
             }
         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/SetupEncryptionActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SetupEncryptionActivity.kt
@@ -24,20 +24,22 @@ package com.owncloud.android.ui.activity
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.client.account.User
 import com.owncloud.android.R
+import com.owncloud.android.databinding.SetupEncryptionDialogBinding
 import com.owncloud.android.ui.dialog.SetupEncryptionDialogFragment
 
 class SetupEncryptionActivity : AppCompatActivity() {
+    lateinit var binding:SetupEncryptionDialogBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        binding = SetupEncryptionDialogBinding.inflate(layoutInflater)
         val user = intent?.getParcelableExtra("EXTRA_USER") as User?
 
         if (user == null) {
-            Toast.makeText(this, getString(R.string.error_showing_encryption_dialog), Toast.LENGTH_LONG).show()
+            Snackbar.make(binding.root, getString(R.string.error_showing_encryption_dialog), Snackbar.LENGTH_LONG).show()
             finish()
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
@@ -23,9 +23,9 @@ package com.owncloud.android.ui.activity
 
 import android.annotation.SuppressLint
 import android.net.Uri
-import android.widget.Toast
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
+import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.android.common.ui.util.PlatformThemeUtil
 import com.nextcloud.client.appinfo.AppInfo
 import com.nextcloud.client.device.DeviceInfo
@@ -53,7 +53,7 @@ class TextEditorWebView : EditorWebView() {
         super.postOnCreate()
 
         if (!user.isPresent) {
-            Toast.makeText(this, getString(R.string.failed_to_start_editor), Toast.LENGTH_LONG).show()
+            Snackbar.make(binding.root, getString(R.string.failed_to_start_editor), Snackbar.LENGTH_LONG).show()
             finish()
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -27,8 +27,8 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.provider.DocumentsContract;
-import android.widget.Toast;
-
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.owncloud.android.R;
 import com.owncloud.android.files.services.FileUploader;
@@ -292,7 +292,7 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                     mAppContext.getString(messageId),
                     mAppContext.getString(R.string.app_name)
                 );
-                Toast.makeText(mAppContext, message, Toast.LENGTH_LONG).show();
+                Snackbar.make(new View(mAppContext), message, Snackbar.LENGTH_LONG).show();
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
@@ -27,9 +27,8 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
-import android.widget.Toast;
-
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.owncloud.android.R;
@@ -115,7 +114,7 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
         AlertDialog alertDialog = (AlertDialog) getDialog();
 
         if (alertDialog == null) {
-            Toast.makeText(getContext(), "Failed to create conflict dialog", Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(getContext()), "Failed to create conflict dialog", Snackbar.LENGTH_LONG).show();
             return;
         }
 
@@ -138,7 +137,7 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
             newFile = (File) getArguments().getSerializable(KEY_NEW_FILE);
             user = getArguments().getParcelable(KEY_USER);
         } else {
-            Toast.makeText(getContext(), "Failed to create conflict dialog", Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(getContext()), "Failed to create conflict dialog", Snackbar.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SendFilesDialog.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SendFilesDialog.java
@@ -4,14 +4,12 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
-
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.utils.IntentUtil;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -85,7 +83,7 @@ public class SendFilesDialog extends BottomSheetDialogFragment {
         Intent sendIntent = IntentUtil.createSendIntent(requireContext(), files);
         List<ResolveInfo> matches = requireActivity().getPackageManager().queryIntentActivities(sendIntent, 0);
         if (matches.isEmpty()) {
-            Toast.makeText(getContext(), R.string.no_send_app, Toast.LENGTH_SHORT).show();
+            Snackbar.make(new View(getContext()), R.string.no_send_app, Snackbar.LENGTH_SHORT).show();
             dismiss();
             return null;
         }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -44,8 +44,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
-import android.widget.Toast;
-
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -548,9 +546,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
         } else {
             Log.w(TAG, "scanDocUpload: Failed to start doc scanning, fileDisplayActivity=" + fileDisplayActivity +
                 ", currentFile=" + currentFile);
-            Toast.makeText(getContext(),
+            Snackbar.make(new View(getContext()),
                            getString(R.string.error_starting_doc_scan),
-                           Toast.LENGTH_SHORT)
+                           Snackbar.LENGTH_SHORT)
                 .show();
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.java
@@ -34,8 +34,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.DatePicker;
-import android.widget.Toast;
-
+import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.jobs.BackgroundJobManager;
@@ -513,7 +512,7 @@ public class BackupFragment extends FileFragment implements DatePickerDialog.OnD
         final ContactsPreferenceActivity contactsPreferenceActivity = (ContactsPreferenceActivity) getActivity();
 
         if (contactsPreferenceActivity == null) {
-            Toast.makeText(getContext(), getString(R.string.error_choosing_date), Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(getContext()), getString(R.string.error_choosing_date), Snackbar.LENGTH_LONG).show();
             return;
         }
 
@@ -605,7 +604,7 @@ public class BackupFragment extends FileFragment implements DatePickerDialog.OnD
         final ContactsPreferenceActivity contactsPreferenceActivity = (ContactsPreferenceActivity) getActivity();
 
         if (contactsPreferenceActivity == null) {
-            Toast.makeText(getContext(), getString(R.string.error_choosing_date), Toast.LENGTH_LONG).show();
+            Snackbar.make(new View(getContext()), getString(R.string.error_choosing_date), Snackbar.LENGTH_LONG).show();
             return;
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupListFragment.java
@@ -32,8 +32,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
-
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
@@ -422,7 +420,7 @@ public class BackupListFragment extends FileFragment implements Injectable {
                             Snackbar.make(getView(), R.string.contactlist_no_permission, Snackbar.LENGTH_LONG)
                                 .show();
                         } else {
-                            Toast.makeText(getContext(), R.string.contactlist_no_permission, Toast.LENGTH_LONG).show();
+                            Snackbar.make(new View(getContext()), R.string.contactlist_no_permission, Snackbar.LENGTH_LONG).show();
                         }
                     }
                     break;
@@ -440,7 +438,7 @@ public class BackupListFragment extends FileFragment implements Injectable {
                             Snackbar.make(getView(), R.string.contactlist_no_permission, Snackbar.LENGTH_LONG)
                                 .show();
                         } else {
-                            Toast.makeText(getContext(), R.string.contactlist_no_permission, Toast.LENGTH_LONG).show();
+                            Snackbar.make(new View(getContext()), R.string.contactlist_no_permission, Snackbar.LENGTH_LONG).show();
                         }
                     }
                     break;

--- a/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/CalendarItemViewHolder.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/CalendarItemViewHolder.java
@@ -25,9 +25,8 @@ package com.owncloud.android.ui.fragment.contactsbackup;
 import android.content.Context;
 import android.view.View;
 import android.widget.ArrayAdapter;
-import android.widget.Toast;
-
 import com.afollestad.sectionedrecyclerview.SectionedViewHolder;
+import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.CalendarlistListItemBinding;
 
@@ -65,9 +64,9 @@ class CalendarItemViewHolder extends SectionedViewHolder {
     public void showCalendars(boolean show) {
         if (show) {
             if (adapter.isEmpty()) {
-                Toast.makeText(context,
-                               context.getResources().getString(R.string.no_calendar_exists),
-                               Toast.LENGTH_LONG)
+                Snackbar.make(new View(context),
+                              context.getResources().getString(R.string.no_calendar_exists),
+                              Snackbar.LENGTH_LONG)
                     .show();
             } else {
                 binding.spinner.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.java
@@ -30,8 +30,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.PopupMenu;
 import android.widget.TextView;
-import android.widget.Toast;
-
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.client.account.CurrentAccountProvider;
 import com.nextcloud.client.account.User;
@@ -94,7 +92,7 @@ public class TrashbinActivity extends DrawerActivity implements
             if (targetUser.isPresent()) {
                 setUser(targetUser.get());
             } else {
-                Toast.makeText(this, R.string.associated_account_not_found, Toast.LENGTH_LONG).show();
+                Snackbar.make(binding.getRoot(), R.string.associated_account_not_found, Snackbar.LENGTH_LONG).show();
                 finish();
                 return;
             }

--- a/app/src/main/java/com/owncloud/android/utils/ClipboardUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/ClipboardUtil.java
@@ -25,8 +25,8 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.text.TextUtils;
-import android.widget.Toast;
-
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
@@ -54,14 +54,14 @@ public final class ClipboardUtil {
                 ((ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE)).setPrimaryClip(clip);
 
                 if (showToast) {
-                    Toast.makeText(activity, R.string.clipboard_text_copied, Toast.LENGTH_SHORT).show();
+                    Snackbar.make(new View(activity), R.string.clipboard_text_copied, Snackbar.LENGTH_SHORT).show();
                 }
             } catch (Exception e) {
-                Toast.makeText(activity, R.string.clipboard_unexpected_error, Toast.LENGTH_SHORT).show();
+                Snackbar.make(new View(activity), R.string.clipboard_unexpected_error, Snackbar.LENGTH_SHORT).show();
                 Log_OC.e(TAG, "Exception caught while copying to clipboard", e);
             }
         } else {
-            Toast.makeText(activity, R.string.clipboard_no_text_to_copy, Toast.LENGTH_SHORT).show();
+            Snackbar.make(new View(activity), R.string.clipboard_no_text_to_copy, Snackbar.LENGTH_SHORT).show();
         }
     }
 }

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -50,8 +50,6 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
-import android.widget.Toast;
-
 import com.bumptech.glide.GenericRequestBuilder;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -795,7 +793,7 @@ public final class DisplayUtils {
     }
 
     static public void showErrorAndFinishActivity(Activity activity, String errorMessage) {
-        Toast.makeText(activity, errorMessage, Toast.LENGTH_LONG).show();
+        Snackbar.make(new View(activity), errorMessage, Snackbar.LENGTH_LONG).show();
         activity.finish();
     }
 


### PR DESCRIPTION
This pull request addresses a key enhancement in our Android application by replacing all instances of the Toast notification system with the more user-friendly and flexible Snackbar implementation. Toasts have been a part of our application for a long time, but switching to Snackbars will provide a more modern and polished user experience.

**Why the Change:**

Toasts to Snackbars Conversion: In this pull request, we've systematically replaced all instances where Toasts were used for displaying notifications with Snackbars.
Snackbars are more accessible, making it easier for all users to receive and understand notifications, including those with visual impairments who rely on screen readers.
Toasts have several limitations, such as their lack of customization, inability to handle actions, and limited visibility. Replacing them with Snackbars not only addresses these issues but also provides a more polished and modern feel to our Android app. Snackbars offer improved user interaction.

- [x] Tests written, or not not needed
- [x] Replaced all Toasts with Snackbars.
- [x] Conducted thorough testing to confirm functionality.


