### PR TITLE
Fix softKeyboard not appearing

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -138,7 +138,7 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
     @Override
     public void onResume() {
         super.onResume();
-        keyboardUtils.showKeyboardForEditText(binding.filename);
+        keyboardUtils.showKeyboardForEditText(requireDialog().getWindow(), binding.filename);
     }
 
     @NonNull

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
@@ -119,7 +119,7 @@ class ChooseTemplateDialogFragment : DialogFragment(), View.OnClickListener, Tem
 
     override fun onResume() {
         super.onResume()
-        keyboardUtils.showKeyboardForEditText(binding.filename)
+        keyboardUtils.showKeyboardForEditText(dialog?.window, binding.filename)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -116,7 +116,7 @@ public class CreateFolderDialogFragment
         super.onResume();
 
         bindButton();
-        keyboardUtils.showKeyboardForEditText(binding.userInput);
+        keyboardUtils.showKeyboardForEditText(requireDialog().getWindow(), binding.userInput);
     }
 
     @NonNull

--- a/app/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/NoteDialogFragment.java
@@ -90,7 +90,7 @@ public class NoteDialogFragment extends DialogFragment implements DialogInterfac
     @Override
     public void onResume() {
         super.onResume();
-        keyboardUtils.showKeyboardForEditText(binding.noteText);
+        keyboardUtils.showKeyboardForEditText(requireDialog().getWindow(), binding.noteText);
     }
 
     @NonNull

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -110,7 +110,7 @@ public class RenameFileDialogFragment
     @Override
     public void onResume() {
         super.onResume();
-        keyboardUtils.showKeyboardForEditText(binding.userInput);
+        keyboardUtils.showKeyboardForEditText(requireDialog().getWindow(), binding.userInput);
     }
 
     @NonNull

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenamePublicShareDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenamePublicShareDialogFragment.java
@@ -83,7 +83,7 @@ public class RenamePublicShareDialogFragment
     @Override
     public void onResume() {
         super.onResume();
-        keyboardUtils.showKeyboardForEditText(binding.userInput);
+        keyboardUtils.showKeyboardForEditText(requireDialog().getWindow(), binding.userInput);
     }
 
     @NonNull

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.java
@@ -99,7 +99,7 @@ public class SharePasswordDialogFragment extends DialogFragment implements Dialo
     @Override
     public void onResume() {
         super.onResume();
-        keyboardUtils.showKeyboardForEditText(binding.sharePassword);
+        keyboardUtils.showKeyboardForEditText(requireDialog().getWindow(), binding.sharePassword);
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt
@@ -1,7 +1,9 @@
 /*
  * Nextcloud Android client application
  *
+ *  @author ZetaTom
  *  @author Álvaro Brey
+ *  Copyright (C) 2023 ZetaTom
  *  Copyright (C) 2022 Álvaro Brey
  *  Copyright (C) 2022 Nextcloud GmbH
  *
@@ -22,26 +24,18 @@
 
 package com.owncloud.android.utils
 
-import android.content.Context
-import android.view.inputmethod.InputMethodManager
+import android.view.Window
 import android.widget.EditText
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import javax.inject.Inject
 
 class KeyboardUtils @Inject constructor() {
 
-    fun showKeyboardForEditText(editText: EditText) {
-        editText.requestFocus()
-        // needs 100ms delay to account for focus animations
-        editText.postDelayed({
-            val context = editText.context
-            if (context != null) {
-                val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT)
-            }
-        }, SHOW_INPUT_DELAY_MILLIS)
-    }
-
-    companion object {
-        private const val SHOW_INPUT_DELAY_MILLIS = 100L
+    fun showKeyboardForEditText(window: Window?, editText: EditText) {
+        if (window != null) {
+            editText.requestFocus()
+            WindowCompat.getInsetsController(window, editText).show(WindowInsetsCompat.Type.ime())
+        }
     }
 }


### PR DESCRIPTION
This change fixes an issue, where the soft keyboard would not automatically appear when a dialogue requiring user input is opened. Specifically, it replaces the [current method](https://github.com/nextcloud/android/blob/3b3c5baaacd9177be4f854844a8823ef8aa29c3a/app/src/main/java/com/owncloud/android/utils/KeyboardUtils.kt#L32) of requesting the soft keyboard with the [recommended method](https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/visibility#ShowReliably), which relies on [`WindowInsetsControllerCompat`](https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat).

The cause of this specific problem has been thoroughly analysed by @Miniman45 in #11987.

---

- [ ] Tests written, or not not needed
