### PR TITLE
CHANGELOG: Add last two production releases, fix dates, add link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,29 @@
-## 3.24.1 (February 21, 2022)
+## 3.26.0 (September 16, 2023)
+
+- image editing
+- image details, with map
+- show other Nextcloud apps
+
+Minimum: NC 16 Server, Android 6.0 Marshmallow
+
+For a full list, please see https://github.com/nextcloud/android/milestone/84
+
+## 3.25.0 (June 13, 2023)
+
+- show Groupfolder
+- Tag in file listing
+
+Minimum: NC 16 Server, Android 6.0 Marshmallow
+
+For a full list, please see https://github.com/nextcloud/android/milestone/81
+
+## 3.24.1 (February 21, 2023)
 
 - Fix crash in previous version when connecting to old server versions
 
 Minimum: NC 16 Server, Android 6.0 Marshmallow
+
+For a full list, please see https://github.com/nextcloud/android/milestone/80
 
 ## 3.24.0 (February 13, 2023)
 


### PR DESCRIPTION
* Added 3.26.0
* Added 3.25.0
* Fixed year on 3.24.1
* Added milestone link on existing 3.24.1 entry to match others

Also related to this PR:
- fixed the dates on the 3.24.x releases in GH (https://github.com/nextcloud/android/releases)
- added a missing milestone link

There's room for further improvement (and automation) but this at least brings up to par with the status quo. 

### Aside

I'd personally like to see the notes expanded a bit, even if they're still kept extremely brief and not necessarily 100% thorough, but doing so requires either additional dev time for each release and/or someone volunteering that is good at translating PRs into notes.

P.S. I'm *not* volunteering (at least for now) just noting this for the future reference. 

P.P.S. That said, would anyone object if attempted to expand the notes a bit for *if* I happen to get bored _and_ find the time/focus to do so at some point for say, 3.26.0 (or whatever is then current)?

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
