### PR TITLE
Bugfix Disable focus change via tap

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -42,6 +42,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.authentication.PassCodeManager;
 import com.owncloud.android.databinding.PasscodelockBinding;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.ui.components.PassCodeEditText;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import java.util.Arrays;
@@ -74,7 +75,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     @Inject PassCodeManager passCodeManager;
     @Inject ViewThemeUtils viewThemeUtils;
     private PasscodelockBinding binding;
-    private final EditText[] passCodeEditTexts = new EditText[4];
+    private final PassCodeEditText[] passCodeEditTexts = new PassCodeEditText[4];
     private String[] passCodeDigits = {"", "", "", ""};
     private boolean confirmingPassCode;
     private boolean changed = true; // to control that only one blocks jump
@@ -174,7 +175,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     @SuppressLint("ClickableViewAccessibility")
     protected void setTextListeners() {
         for (int i = 0; i < passCodeEditTexts.length; i++) {
-            final EditText editText = passCodeEditTexts[i];
+            final PassCodeEditText editText = passCodeEditTexts[i];
             boolean isLast = (i == 3);
 
             editText.addTextChangedListener(new PassCodeDigitTextWatcher(i, isLast));
@@ -276,8 +277,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                 (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
             inputMethodManager.hideSoftInputFromWindow(
                 focusedView.getWindowToken(),
-                0
-                                                      );
+                0);
         }
     }
 
@@ -412,7 +412,6 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         }
     }
 
-
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -434,6 +433,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         PassCodeDigitTextWatcher(int index, boolean lastOne) {
             mIndex = index;
             mLastOne = lastOne;
+
             if (mIndex < 0) {
                 throw new IllegalArgumentException(
                     "Invalid index in " + PassCodeDigitTextWatcher.class.getSimpleName() +
@@ -457,8 +457,13 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         public void afterTextChanged(Editable s) {
             if (s.length() > 0) {
                 if (!confirmingPassCode) {
-                    passCodeDigits[mIndex] = passCodeEditTexts[mIndex].getText().toString();
+                    Editable passCodeText = passCodeEditTexts[mIndex].getText();
+
+                    if (passCodeText != null) {
+                        passCodeDigits[mIndex] = passCodeText.toString();
+                    }
                 }
+
                 passCodeEditTexts[next()].requestFocus();
 
                 if (mLastOne) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -23,7 +23,6 @@
  */
 package com.owncloud.android.ui.activity;
 
-import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -172,7 +172,6 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     /**
      * Binds the appropriate listeners to the input boxes receiving each digit of the pass code.
      */
-    @SuppressLint("ClickableViewAccessibility")
     protected void setTextListeners() {
         for (int i = 0; i < passCodeEditTexts.length; i++) {
             final PassCodeEditText editText = passCodeEditTexts[i];
@@ -185,11 +184,6 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
 
             int finalIndex = i;
             editText.setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(finalIndex));
-
-            // Disable focus change via tap gesture
-            editText.setSelectAllOnFocus(false);
-            editText.setTextIsSelectable(false);
-            editText.setOnTouchListener((v, event) -> true);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -185,12 +185,10 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
             int finalIndex = i;
             editText.setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(finalIndex));
 
-            // Disable touch event for focus change via tap gesture
+            // Disable focus change via tap gesture
             editText.setSelectAllOnFocus(false);
             editText.setTextIsSelectable(false);
-            editText.setOnTouchListener((v, event) -> {
-                return true;
-            });
+            editText.setOnTouchListener((v, event) -> true);
         }
     }
 
@@ -478,4 +476,5 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         @Override
         public void onTextChanged(CharSequence s, int start, int before, int count) {}
     }
+
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -256,9 +256,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                 savePassCodeAndExit();
 
             } else {
-                showErrorAndRestart(
-                    R.string.pass_code_mismatch, R.string.pass_code_configure_your_pass_code, View.VISIBLE
-                                   );
+                showErrorAndRestart(R.string.pass_code_mismatch, R.string.pass_code_configure_your_pass_code, View.VISIBLE);
             }
         }
     }
@@ -318,11 +316,13 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     protected boolean confirmPassCode() {
         confirmingPassCode = false;
 
-        boolean result = true;
-        for (int i = 0; i < passCodeEditTexts.length && result; i++) {
-            result = passCodeEditTexts[i].getText().toString().equals(passCodeDigits[i]);
+        for (int i = 0; i < passCodeEditTexts.length; i++) {
+            Editable passCodeText = passCodeEditTexts[i].getText();
+            if (passCodeText == null || !passCodeText.toString().equals(passCodeDigits[i])) {
+                return false;
+            }
         }
-        return result;
+        return true;
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -23,6 +23,7 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
@@ -30,7 +31,6 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -91,7 +91,6 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         binding = PasscodelockBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-
         viewThemeUtils.platform.colorTextButtons(binding.cancel);
 
         passCodeEditTexts[0] = binding.txt0;
@@ -104,7 +103,6 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         }
 
         passCodeEditTexts[0].requestFocus();
-
 
         Window window = getWindow();
         if (window != null) {
@@ -125,7 +123,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                 passCodeDigits = savedInstanceState.getStringArray(PassCodeActivity.KEY_PASSCODE_DIGITS);
             }
             if (confirmingPassCode) {
-                // the app was in the passcodeconfirmation
+                // the app was in the passcode confirmation
                 requestPassCodeConfirmation();
             } else {
                 // pass code preference has just been activated in SettingsActivity;
@@ -158,12 +156,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     protected void setCancelButtonEnabled(boolean enabled) {
         if (enabled) {
             binding.cancel.setVisibility(View.VISIBLE);
-            binding.cancel.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    finish();
-                }
-            });
+            binding.cancel.setOnClickListener(v -> finish());
         } else {
             binding.cancel.setVisibility(View.INVISIBLE);
             binding.cancel.setOnClickListener(null);
@@ -178,21 +171,27 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     /**
      * Binds the appropriate listeners to the input boxes receiving each digit of the pass code.
      */
+    @SuppressLint("ClickableViewAccessibility")
     protected void setTextListeners() {
-        passCodeEditTexts[0].addTextChangedListener(new PassCodeDigitTextWatcher(0, false));
-        passCodeEditTexts[1].addTextChangedListener(new PassCodeDigitTextWatcher(1, false));
-        passCodeEditTexts[2].addTextChangedListener(new PassCodeDigitTextWatcher(2, false));
-        passCodeEditTexts[3].addTextChangedListener(new PassCodeDigitTextWatcher(3, true));
+        for (int i = 0; i < passCodeEditTexts.length; i++) {
+            final EditText editText = passCodeEditTexts[i];
+            boolean isLast = (i == 3);
 
-        setOnKeyListener(1);
-        setOnKeyListener(2);
-        setOnKeyListener(3);
+            editText.addTextChangedListener(new PassCodeDigitTextWatcher(i, isLast));
+            if (i > 0) {
+                setOnKeyListener(i);
+            }
 
-        passCodeEditTexts[1].setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(1));
+            int finalIndex = i;
+            editText.setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(finalIndex));
 
-        passCodeEditTexts[2].setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(2));
-
-        passCodeEditTexts[3].setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(3));
+            // Disable touch event for focus change via tap gesture
+            editText.setSelectAllOnFocus(false);
+            editText.setTextIsSelectable(false);
+            editText.setOnTouchListener((v, event) -> {
+                return true;
+            });
+        }
     }
 
     private void onPassCodeEditTextFocusChange(final int passCodeIndex) {
@@ -284,8 +283,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         }
     }
 
-    private void showErrorAndRestart(int errorMessage, int headerMessage,
-                                     int explanationVisibility) {
+    private void showErrorAndRestart(int errorMessage, int headerMessage, int explanationVisibility) {
         Arrays.fill(passCodeDigits, null);
         Snackbar.make(findViewById(android.R.id.content), getString(errorMessage), Snackbar.LENGTH_LONG).show();
         binding.header.setText(headerMessage);                          // TODO check if really needed
@@ -312,8 +310,6 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
      * @return 'True' if entered pass code equals to the saved one.
      */
     protected boolean checkPassCode() {
-
-
         String[] savedPassCodeDigits = preferences.getPassCode();
 
         boolean result = true;
@@ -401,7 +397,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                 @Override
                 public void run() {
                     try {
-                        Thread.sleep(delay * 1000);
+                        Thread.sleep(delay * 1000L);
 
                         runOnUiThread(() -> {
                             binding.explanation.setVisibility(View.INVISIBLE);
@@ -477,13 +473,9 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         }
 
         @Override
-        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            // nothing to do
-        }
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         @Override
-        public void onTextChanged(CharSequence s, int start, int before, int count) {
-            // nothing to do
-        }
+        public void onTextChanged(CharSequence s, int start, int before, int count) {}
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -26,9 +26,11 @@ package com.owncloud.android.ui.activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -75,6 +77,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     private final EditText[] passCodeEditTexts = new EditText[4];
     private String[] passCodeDigits = {"", "", "", ""};
     private boolean confirmingPassCode;
+    private boolean changed = true; // to control that only one blocks jump
 
     /**
      * Initializes the activity.
@@ -155,7 +158,12 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
     protected void setCancelButtonEnabled(boolean enabled) {
         if (enabled) {
             binding.cancel.setVisibility(View.VISIBLE);
-            binding.cancel.setOnClickListener(v -> finish());
+            binding.cancel.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    finish();
+                }
+            });
         } else {
             binding.cancel.setVisibility(View.INVISIBLE);
             binding.cancel.setOnClickListener(null);
@@ -171,16 +179,46 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
      * Binds the appropriate listeners to the input boxes receiving each digit of the pass code.
      */
     protected void setTextListeners() {
+        passCodeEditTexts[0].addTextChangedListener(new PassCodeDigitTextWatcher(0, false));
+        passCodeEditTexts[1].addTextChangedListener(new PassCodeDigitTextWatcher(1, false));
+        passCodeEditTexts[2].addTextChangedListener(new PassCodeDigitTextWatcher(2, false));
+        passCodeEditTexts[3].addTextChangedListener(new PassCodeDigitTextWatcher(3, true));
 
-        passCodeEditTexts[0].addTextChangedListener(new PinTextWatcher(0));
-        passCodeEditTexts[1].addTextChangedListener(new PinTextWatcher(1));
-        passCodeEditTexts[2].addTextChangedListener(new PinTextWatcher(2));
-        passCodeEditTexts[3].addTextChangedListener(new PinTextWatcher(3));
+        setOnKeyListener(1);
+        setOnKeyListener(2);
+        setOnKeyListener(3);
 
-        passCodeEditTexts[0].setOnKeyListener(new PinOnKeyListener(0));
-        passCodeEditTexts[1].setOnKeyListener(new PinOnKeyListener(1));
-        passCodeEditTexts[2].setOnKeyListener(new PinOnKeyListener(2));
-        passCodeEditTexts[3].setOnKeyListener(new PinOnKeyListener(3));
+        passCodeEditTexts[1].setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(1));
+
+        passCodeEditTexts[2].setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(2));
+
+        passCodeEditTexts[3].setOnFocusChangeListener((v, hasFocus) -> onPassCodeEditTextFocusChange(3));
+    }
+
+    private void onPassCodeEditTextFocusChange(final int passCodeIndex) {
+        for (int i = 0; i < passCodeIndex; i++) {
+            if (TextUtils.isEmpty(passCodeEditTexts[i].getText())) {
+                passCodeEditTexts[i].requestFocus();
+                break;
+            }
+        }
+    }
+
+    private void setOnKeyListener(final int passCodeIndex) {
+        passCodeEditTexts[passCodeIndex].setOnKeyListener((v, keyCode, event) -> {
+            if (keyCode == KeyEvent.KEYCODE_DEL && changed) {
+                passCodeEditTexts[passCodeIndex - 1].requestFocus();
+                if (!confirmingPassCode) {
+                    passCodeDigits[passCodeIndex - 1] = "";
+                }
+                passCodeEditTexts[passCodeIndex - 1].setText("");
+                changed = false;
+
+            } else if (!changed) {
+                changed = true;
+            }
+            return false;
+        });
     }
 
     /**
@@ -363,7 +401,7 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                 @Override
                 public void run() {
                     try {
-                        Thread.sleep(delay * 1000L);
+                        Thread.sleep(delay * 1000);
 
                         runOnUiThread(() -> {
                             binding.explanation.setVisibility(View.INVISIBLE);
@@ -388,107 +426,64 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
         outState.putStringArray(PassCodeActivity.KEY_PASSCODE_DIGITS, passCodeDigits);
     }
 
-    private class PinTextWatcher implements TextWatcher {
+    private class PassCodeDigitTextWatcher implements TextWatcher {
 
-        private final int currentIndex;
-        private boolean isFirst = false, isLast = false;
-        private String newTypedString = "";
+        private int mIndex = -1;
+        private boolean mLastOne;
 
-        PinTextWatcher(int currentIndex) {
-            this.currentIndex = currentIndex;
+        /**
+         * Constructor
+         *
+         * @param index   Position in the pass code of the input field that will be bound to this watcher.
+         * @param lastOne 'True' means that watcher corresponds to the last position of the pass code.
+         */
+        PassCodeDigitTextWatcher(int index, boolean lastOne) {
+            mIndex = index;
+            mLastOne = lastOne;
+            if (mIndex < 0) {
+                throw new IllegalArgumentException(
+                    "Invalid index in " + PassCodeDigitTextWatcher.class.getSimpleName() +
+                        " constructor"
+                );
+            }
+        }
 
-            if (currentIndex == 0)
-                this.isFirst = true;
-            else if (currentIndex == passCodeEditTexts.length - 1)
-                this.isLast = true;
+        private int next() {
+            return mLastOne ? 0 : mIndex + 1;
+        }
+
+        /**
+         * Performs several actions when the user types a digit in an input field: - saves the input digit to the state
+         * of the activity; this will allow retyping the pass code to confirm it. - moves the focus automatically to the
+         * next field - for the last field, triggers the processing of the full pass code
+         *
+         * @param s Changed text
+         */
+        @Override
+        public void afterTextChanged(Editable s) {
+            if (s.length() > 0) {
+                if (!confirmingPassCode) {
+                    passCodeDigits[mIndex] = passCodeEditTexts[mIndex].getText().toString();
+                }
+                passCodeEditTexts[next()].requestFocus();
+
+                if (mLastOne) {
+                    processFullPassCode();
+                }
+
+            } else {
+                Log_OC.d(TAG, "Text box " + mIndex + " was cleaned");
+            }
         }
 
         @Override
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
+            // nothing to do
         }
 
         @Override
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            newTypedString = s.subSequence(start, start + count).toString().trim();
+            // nothing to do
         }
-
-        @Override
-        public void afterTextChanged(Editable s) {
-            String text = newTypedString;
-
-            if (text.length() > 1) {
-                text = String.valueOf(text.charAt(0));
-
-                passCodeEditTexts[currentIndex].removeTextChangedListener(this);
-                passCodeEditTexts[currentIndex].setText(text);
-                passCodeEditTexts[currentIndex].setSelection(text.length());
-                passCodeEditTexts[currentIndex].addTextChangedListener(this);
-
-                if (!confirmingPassCode) {
-                    passCodeDigits[currentIndex] = passCodeEditTexts[currentIndex].getText().toString();
-                }
-
-                if (text.length() == 1) {
-                    moveToNext();
-                } else if (text.length() == 0) {
-                    moveToPrevious();
-                }
-
-                if (isLast) {
-                    processFullPassCode();
-                }
-            }
-        }
-
-        private void moveToNext() {
-            if (!isLast)
-                passCodeEditTexts[currentIndex + 1].requestFocus();
-
-            if (isAllEditTextsFilled() && isLast) { // isLast is optional
-                passCodeEditTexts[currentIndex].clearFocus();
-                hideKeyboard();
-            }
-        }
-
-        private void moveToPrevious() {
-            if (!isFirst)
-                passCodeEditTexts[currentIndex - 1].requestFocus();
-        }
-
-        private boolean isAllEditTextsFilled() {
-            for (EditText editText : passCodeEditTexts)
-                if (editText.getText().toString().trim().length() == 0)
-                    return false;
-            return true;
-        }
-
-        private void hideKeyboard() {
-            if (getCurrentFocus() != null) {
-                InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
-                inputMethodManager.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
-            }
-        }
-
-    }
-
-    private class PinOnKeyListener implements View.OnKeyListener {
-
-        private final int currentIndex;
-
-        PinOnKeyListener(int currentIndex) {
-            this.currentIndex = currentIndex;
-        }
-
-        @Override
-        public boolean onKey(View v, int keyCode, KeyEvent event) {
-            if (keyCode == KeyEvent.KEYCODE_DEL && event.getAction() == KeyEvent.ACTION_DOWN) {
-                if (passCodeEditTexts[currentIndex].getText().toString().isEmpty() && currentIndex != 0) {
-                    passCodeEditTexts[currentIndex - 1].requestFocus();
-                }
-            }
-            return false;
-        }
-
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -458,10 +458,10 @@ public class PassCodeActivity extends AppCompatActivity implements Injectable {
                     }
                 }
 
-                passCodeEditTexts[next()].requestFocus();
-
                 if (mLastOne) {
                     processFullPassCode();
+                } else {
+                    passCodeEditTexts[next()].requestFocus();
                 }
 
             } else {

--- a/app/src/main/java/com/owncloud/android/ui/components/PassCodeEditText.kt
+++ b/app/src/main/java/com/owncloud/android/ui/components/PassCodeEditText.kt
@@ -1,0 +1,39 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Alper Ozturk
+ * Copyright (C) 2023 Alper Ozturk
+ * Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.ui.components
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.KeyEvent
+import androidx.appcompat.widget.AppCompatEditText
+
+class PassCodeEditText(context: Context, attrs: AttributeSet?): AppCompatEditText(context, attrs) {
+
+    override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
+        val isBackButtonPressed = (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP)
+        if (isBackButtonPressed) {
+            // Override default behaviour and prevent dismissing the keyboard
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+}

--- a/app/src/main/java/com/owncloud/android/ui/components/PassCodeEditText.kt
+++ b/app/src/main/java/com/owncloud/android/ui/components/PassCodeEditText.kt
@@ -20,12 +20,26 @@
  */
 package com.owncloud.android.ui.components
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
 import androidx.appcompat.widget.AppCompatEditText
 
+@SuppressLint("ClickableViewAccessibility")
 class PassCodeEditText(context: Context, attrs: AttributeSet?): AppCompatEditText(context, attrs) {
+
+    init {
+        disableFocusChangeViaTap()
+    }
+
+    private fun disableFocusChangeViaTap() {
+        setSelectAllOnFocus(false)
+        setTextIsSelectable(false)
+        setOnTouchListener { _: View?, _: MotionEvent? -> true }
+    }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
         val isBackButtonPressed = (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP)

--- a/app/src/main/java/com/owncloud/android/ui/components/PassCodeEditText.kt
+++ b/app/src/main/java/com/owncloud/android/ui/components/PassCodeEditText.kt
@@ -29,7 +29,7 @@ import android.view.View
 import androidx.appcompat.widget.AppCompatEditText
 
 @SuppressLint("ClickableViewAccessibility")
-class PassCodeEditText(context: Context, attrs: AttributeSet?): AppCompatEditText(context, attrs) {
+class PassCodeEditText(context: Context, attrs: AttributeSet?) : AppCompatEditText(context, attrs) {
 
     init {
         disableFocusChangeViaTap()
@@ -49,5 +49,4 @@ class PassCodeEditText(context: Context, attrs: AttributeSet?): AppCompatEditTex
         }
         return super.dispatchKeyEvent(event)
     }
-
 }

--- a/app/src/main/res/layout/passcodelock.xml
+++ b/app/src/main/res/layout/passcodelock.xml
@@ -73,13 +73,10 @@
                         android:id="@+id/txt0"
                         style="@style/PassCodeStyle"
                         android:cursorVisible="false"
-                        android:focusable="true"
                         android:hint="@string/hidden_character"
                         android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no"
                         tools:text="123">
-
-                        <requestFocus />
                     </com.google.android.material.textfield.TextInputEditText>
 
                     <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/passcodelock.xml
+++ b/app/src/main/res/layout/passcodelock.xml
@@ -72,7 +72,6 @@
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/txt0"
                         style="@style/PassCodeStyle"
-                        android:cursorVisible="false"
                         android:hint="@string/hidden_character"
                         android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no"
@@ -82,7 +81,6 @@
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/txt1"
                         style="@style/PassCodeStyle"
-                        android:cursorVisible="false"
                         android:hint="@string/hidden_character"
                         android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no" />
@@ -90,7 +88,6 @@
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/txt2"
                         style="@style/PassCodeStyle"
-                        android:cursorVisible="false"
                         android:hint="@string/hidden_character"
                         android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no" />
@@ -98,7 +95,6 @@
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/txt3"
                         style="@style/PassCodeStyle"
-                        android:cursorVisible="false"
                         android:hint="@string/hidden_character"
                         android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no" />

--- a/app/src/main/res/layout/passcodelock.xml
+++ b/app/src/main/res/layout/passcodelock.xml
@@ -69,34 +69,26 @@
                     android:layout_height="wrap_content"
                     android:gravity="center_horizontal">
 
-                    <com.google.android.material.textfield.TextInputEditText
+                    <com.owncloud.android.ui.components.PassCodeEditText
                         android:id="@+id/txt0"
                         style="@style/PassCodeStyle"
-                        android:hint="@string/hidden_character"
-                        android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no"
                         tools:text="123">
-                    </com.google.android.material.textfield.TextInputEditText>
+                    </com.owncloud.android.ui.components.PassCodeEditText>
 
-                    <com.google.android.material.textfield.TextInputEditText
+                    <com.owncloud.android.ui.components.PassCodeEditText
                         android:id="@+id/txt1"
                         style="@style/PassCodeStyle"
-                        android:hint="@string/hidden_character"
-                        android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no" />
 
-                    <com.google.android.material.textfield.TextInputEditText
+                    <com.owncloud.android.ui.components.PassCodeEditText
                         android:id="@+id/txt2"
                         style="@style/PassCodeStyle"
-                        android:hint="@string/hidden_character"
-                        android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no" />
 
-                    <com.google.android.material.textfield.TextInputEditText
+                    <com.owncloud.android.ui.components.PassCodeEditText
                         android:id="@+id/txt3"
                         style="@style/PassCodeStyle"
-                        android:hint="@string/hidden_character"
-                        android:imeOptions="flagNoExtractUi"
                         android:importantForAutofill="no" />
                 </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -331,6 +331,7 @@
         <item name="android:inputType">numberDecimal</item>
         <item name="android:numeric">decimal</item>
         <item name="android:digits">1234567890</item>
+        <item name="android:maxLength">1</item>
         <item name="android:password">true</item>
         <item name="android:maxLines">1</item>
         <item name="colorPrimary">@color/text_color</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -327,6 +327,7 @@
         <item name="android:layout_width">50dp</item>
         <item name="android:layout_height">50dp</item>
         <item name="android:gravity">center</item>
+        <item name="android:cursorVisible">false</item>
         <item name="android:layout_margin">10dp</item>
         <item name="android:inputType">numberDecimal</item>
         <item name="android:numeric">decimal</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -324,6 +324,7 @@
     </style>
 
     <style name="PassCodeStyle">
+        <item name="android:hint">@string/hidden_character</item>
         <item name="android:layout_width">50dp</item>
         <item name="android:layout_height">50dp</item>
         <item name="android:gravity">center</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -331,7 +331,6 @@
         <item name="android:inputType">numberDecimal</item>
         <item name="android:numeric">decimal</item>
         <item name="android:digits">1234567890</item>
-        <item name="android:maxLength">1</item>
         <item name="android:password">true</item>
         <item name="android:maxLines">1</item>
         <item name="colorPrimary">@color/text_color</item>


### PR DESCRIPTION
Users are capable of inadvertently changing focus through tapping, which can result in accidental input and lead to confusion for App passcode enter.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ Done ] Tests written, or not not needed
