### PR TITLE
Fixed outdated server condition for server version

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -437,12 +437,10 @@ public class FileDisplayActivity extends FileActivity
 
     private void checkOutdatedServer() {
         Optional<User> user = getUser();
-        OwnCloudVersion serverVersion = user.get().getServer().getVersion();
-
         // show outdated warning
         if (user.isPresent() &&
             CapabilityUtils.checkOutdatedWarning(getResources(),
-                                                 serverVersion,
+                                                 user.get().getServer().getVersion(),
                                                  getCapabilities().getExtendedSupport().isTrue())) {
             DisplayUtils.showServerOutdatedSnackbar(this, Snackbar.LENGTH_LONG);
         }


### PR DESCRIPTION
Fixed server version check condition for the following crash:
<img src="https://github.com/nextcloud/android/assets/89455194/301f9c30-3d9e-4e11-a984-df3068b5d811" height="520">


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
