### PR TITLE
Fix missing title in ConfirmationDialogFragment

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConfirmationDialogFragment.kt
@@ -75,10 +75,15 @@ open class ConfirmationDialogFragment : DialogFragment(), Injectable {
         val message = getString(messageId, *messageArguments)
 
         val builder = MaterialAlertDialogBuilder(requireActivity())
-            .setTitle(if (titleId == 0) { R.string.dialog_alert_title } else { titleId })
             .setIcon(com.owncloud.android.R.drawable.ic_warning)
             .setIconAttribute(R.attr.alertDialogIcon)
             .setMessage(message)
+
+        if (titleId == 0) {
+            builder.setTitle(R.string.dialog_alert_title)
+        } else if (titleId != -1) {
+            builder.setTitle(titleId)
+        }
 
         if (positiveButtonTextId != -1) {
             builder.setPositiveButton(positiveButtonTextId) { dialog: DialogInterface, _: Int ->


### PR DESCRIPTION
This change fixes a crash that would occur when attempting to delete any file. (`Resources.NotFoundException`)

#### Analysis
The `RemoveFilesDialogFragment` extends the `ConfirmationDialogFragment` and thus inherits all methods. Upon instantiation, a an argument bundle is created and set appropriately. This bundle does, however, not include any title for the aforementioned dialogue.

This needs to be considered in the super class, when setting up the ui. A recent change unfortunately removed the [necessary check](https://github.com/nextcloud/android/pull/12111/files#diff-fcd4084665d5f956334103105bf953b83aea08f7e09c2cc3426b8cebf04f7ee9L85).

---
- [x] Tests written, or not not needed
