### PR TITLE
Fix crash when exiting preview of deleted file

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -90,7 +90,6 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCo
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.RestoreFileVersionRemoteOperation;
 import com.owncloud.android.lib.resources.files.SearchRemoteOperation;
-import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.operations.CopyFileOperation;
 import com.owncloud.android.operations.CreateFolderOperation;
 import com.owncloud.android.operations.MoveFileOperation;
@@ -1733,8 +1732,9 @@ public class FileDisplayActivity extends FileActivity
             boolean fileAvailable = getStorageManager().fileExists(removedFile.getFileId());
 
             if (leftFragment instanceof FileFragment && !fileAvailable && removedFile.equals(((FileFragment) leftFragment).getFile())) {
-                if (leftFragment instanceof PreviewMediaFragment) {
-                    ((PreviewMediaFragment) leftFragment).stopPreview(true);
+                if (leftFragment instanceof PreviewMediaFragment previewMediaFragment) {
+                    previewMediaFragment.stopPreview(true);
+                    onBackPressed();
                 }
                 setFile(getStorageManager().getFileById(removedFile.getParentId()));
                 resetTitleBarAndScrolling();
@@ -1742,8 +1742,8 @@ public class FileDisplayActivity extends FileActivity
             OCFile parentFile = getStorageManager().getFileById(removedFile.getParentId());
             if (parentFile != null && parentFile.equals(getCurrentDir())) {
                 updateListOfFilesFragment(false);
-            } else if (getLeftFragment() instanceof GalleryFragment) {
-                ((GalleryFragment) getLeftFragment()).onRefresh();
+            } else if (getLeftFragment() instanceof GalleryFragment galleryFragment) {
+                galleryFragment.onRefresh();
             }
             supportInvalidateOptionsMenu();
         } else {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -673,10 +673,9 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     }
 
     public void stopPreview(boolean stopAudio) {
-        OCFile file = getFile();
-        if (MimeTypeUtil.isAudio(file) && stopAudio) {
-            mediaPlayerServiceConnection.pause();
-        } else if (MimeTypeUtil.isVideo(file)) {
+        if (stopAudio && mediaPlayerServiceConnection != null) {
+            mediaPlayerServiceConnection.stop();
+        } else if (exoPlayer != null) {
             savedPlaybackPosition = exoPlayer.getCurrentPosition();
             exoPlayer.stop();
         }


### PR DESCRIPTION
This change addresses an issue, where the app would crash, along with minor ux improvements. The following sequence of events would reliably crash the app:

1. Open a video file in the build-in media preview
2. Select *Delete* from the overflow menu
3. Press "←" or navigate back
4. The app would terminate unexpectedly

Closes #11981
Blocked by #12117

---
- [ ] Tests written, or not not needed
