### PR TITLE
Fix Crash When User Tap Back Button From Add Account Page

### DIFF
--- a/app/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.kt
+++ b/app/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.kt
@@ -196,19 +196,23 @@ class FirstRunActivity : BaseActivity(), ViewPager.OnPageChangeListener, Injecta
     private fun handleOnBackPressed() {
         onBackPressedDispatcher.addCallback(
             this,
-            object : OnBackPressedCallback(true) {
+            object: OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    onFinish()
+                    val isFromAddAccount = intent.getBooleanExtra(EXTRA_ALLOW_CLOSE, false)
 
-                    if (intent.getBooleanExtra(EXTRA_ALLOW_CLOSE, false)) {
-                        onBackPressedDispatcher.onBackPressed()
+                    val destination: Intent = if (isFromAddAccount) {
+                        Intent(applicationContext, FileDisplayActivity::class.java)
                     } else {
-                        val intent = Intent(applicationContext, AuthenticatorActivity::class.java)
-                        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-                        intent.putExtra(EXTRA_EXIT, true)
-                        startActivity(intent)
-                        finish()
+                        Intent(applicationContext, AuthenticatorActivity::class.java)
                     }
+
+                    if (!isFromAddAccount) {
+                        destination.putExtra(EXTRA_EXIT, true)
+                    }
+
+                    destination.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    startActivity(destination)
+                    finish()
                 }
             }
         )

--- a/app/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.kt
+++ b/app/src/main/java/com/nextcloud/client/onboarding/FirstRunActivity.kt
@@ -196,7 +196,7 @@ class FirstRunActivity : BaseActivity(), ViewPager.OnPageChangeListener, Injecta
     private fun handleOnBackPressed() {
         onBackPressedDispatcher.addCallback(
             this,
-            object: OnBackPressedCallback(true) {
+            object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     val isFromAddAccount = intent.getBooleanExtra(EXTRA_ALLOW_CLOSE, false)
 


### PR DESCRIPTION
Steps to produce

1. Open app
2. From top right tap current user
3. Tap Add account button
4. Navigate back via software button

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
