### PR TITLE
Open app internal preview for files in upload section

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2557,6 +2557,7 @@ public class FileDisplayActivity extends FileActivity
     private Unit onFileRequestError(Throwable throwable) {
         dismissLoadingDialog();
         DisplayUtils.showSnackMessage(this, getString(R.string.error_retrieving_file));
+        Log_OC.e(TAG, "Requesting file from remote failed!", throwable);
         return null;
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2507,8 +2507,7 @@ public class FileDisplayActivity extends FileActivity
         setUser(user);
 
         if (fileId == null) {
-            dismissLoadingDialog();
-            DisplayUtils.showSnackMessage(this, getString(R.string.error_retrieving_file));
+            onFileRequestError(null);
             return;
         }
 
@@ -2529,8 +2528,7 @@ public class FileDisplayActivity extends FileActivity
         setUser(user);
 
         if (filepath == null) {
-            dismissLoadingDialog();
-            DisplayUtils.showSnackMessage(this, getString(R.string.error_retrieving_file));
+            onFileRequestError(null);
             return;
         }
 
@@ -2544,8 +2542,7 @@ public class FileDisplayActivity extends FileActivity
         try {
             client = clientFactory.create(user);
         } catch (ClientFactory.CreationException e) {
-            dismissLoadingDialog();
-            DisplayUtils.showSnackMessage(this, getString(R.string.error_retrieving_file));
+            onFileRequestError(null);
             return;
         }
 
@@ -2554,8 +2551,15 @@ public class FileDisplayActivity extends FileActivity
                                                                     client,
                                                                     storageManager,
                                                                     user);
-        asyncRunner.postQuickTask(getRemoteFileTask, this::onFileRequestResult, null);
+        asyncRunner.postQuickTask(getRemoteFileTask, this::onFileRequestResult, this::onFileRequestError);
     }
+
+    private Unit onFileRequestError(Throwable throwable) {
+        dismissLoadingDialog();
+        DisplayUtils.showSnackMessage(this, getString(R.string.error_retrieving_file));
+        return null;
+    }
+
 
     private Unit onFileRequestResult(GetRemoteFileTask.Result result) {
         dismissLoadingDialog();

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -348,6 +348,17 @@ public class UploadListActivity extends FileActivity {
     }
 
     /**
+     * Switches to FileDisplayActivity and shows file (eg. image preview).
+     */
+    public void openFile(String remotePath) {
+        Intent intent = new Intent(this, FileDisplayActivity.class);
+        intent.setAction(Intent.ACTION_VIEW);
+        intent.putExtra(FileDisplayActivity.KEY_FILE_PATH, remotePath);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+    }
+
+    /**
      * Once the file upload has changed its status -> update uploads list view
      */
     private class UploadMessagesReceiver extends BroadcastReceiver {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -348,17 +348,6 @@ public class UploadListActivity extends FileActivity {
     }
 
     /**
-     * Switches to FileDisplayActivity and shows file (eg. image preview).
-     */
-    public void openFile(String remotePath) {
-        Intent intent = new Intent(this, FileDisplayActivity.class);
-        intent.setAction(Intent.ACTION_VIEW);
-        intent.putExtra(FileDisplayActivity.KEY_FILE_PATH, remotePath);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(intent);
-    }
-
-    /**
      * Once the file upload has changed its status -> update uploads list view
      */
     private class UploadMessagesReceiver extends BroadcastReceiver {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -62,6 +62,7 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.operations.RefreshFolderOperation;
 import com.owncloud.android.ui.activity.ConflictsResolveActivity;
 import com.owncloud.android.ui.activity.FileActivity;
+import com.owncloud.android.ui.activity.UploadListActivity;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
@@ -346,11 +347,14 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 itemViewHolder.binding.uploadRightButton.setOnClickListener(v -> removeUpload(item));
             }
             itemViewHolder.binding.uploadRightButton.setVisibility(View.VISIBLE);
-        } else {    // UploadStatus.UPLOAD_SUCCESS
+        } else {    // UploadStatus.UPLOAD_SUCCEEDED
             itemViewHolder.binding.uploadRightButton.setVisibility(View.INVISIBLE);
         }
 
         itemViewHolder.binding.uploadListItemLayout.setOnClickListener(null);
+
+        // Set icon or thumbnail
+        itemViewHolder.binding.thumbnail.setImageResource(R.drawable.file);
 
         // click on item
         if (item.getUploadStatus() == UploadStatus.UPLOAD_FAILED) {
@@ -381,12 +385,15 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                     );
                 }
             });
-        } else {
-            itemViewHolder.binding.uploadListItemLayout.setOnClickListener(v -> onUploadItemClick(item));
+        } else if (item.getUploadStatus() == UploadStatus.UPLOAD_SUCCEEDED){
+            itemViewHolder.binding.uploadListItemLayout.setOnClickListener(v -> onUploadedItemClick(item));
         }
 
-        // Set icon or thumbnail
-        itemViewHolder.binding.thumbnail.setImageResource(R.drawable.file);
+
+        // click on thumbnail to open locally
+        if (item.getUploadStatus() != UploadStatus.UPLOAD_SUCCEEDED){
+            itemViewHolder.binding.thumbnail.setOnClickListener(v -> onUploadingItemClick(item));
+        }
 
         /*
          * Cancellation needs do be checked and done before changing the drawable in fileIcon, or
@@ -738,12 +745,24 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         notifyDataSetChanged();
     }
 
-    private void onUploadItemClick(OCUpload file) {
+    /**
+     * Open local file.
+     */
+    private void onUploadingItemClick(OCUpload file) {
         File f = new File(file.getLocalPath());
         if (!f.exists()) {
             DisplayUtils.showSnackMessage(parentActivity, R.string.local_file_not_found_message);
         } else {
             openFileWithDefault(file.getLocalPath());
+        }
+    }
+
+    /**
+     * Open remote file.
+     */
+    private void onUploadedItemClick(OCUpload file) {
+        if (parentActivity instanceof UploadListActivity uploadListActivity) {
+            uploadListActivity.openFile(file.getRemotePath());
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -62,7 +62,8 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.operations.RefreshFolderOperation;
 import com.owncloud.android.ui.activity.ConflictsResolveActivity;
 import com.owncloud.android.ui.activity.FileActivity;
-import com.owncloud.android.ui.activity.UploadListActivity;
+import com.owncloud.android.ui.activity.FileDisplayActivity;
+import com.owncloud.android.ui.preview.PreviewImageFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
@@ -760,9 +761,24 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
     /**
      * Open remote file.
      */
-    private void onUploadedItemClick(OCUpload file) {
-        if (parentActivity instanceof UploadListActivity uploadListActivity) {
-            uploadListActivity.openFile(file.getRemotePath());
+    private void onUploadedItemClick(OCUpload upload) {
+        final OCFile file = parentActivity.getStorageManager().getFileByEncryptedRemotePath(upload.getRemotePath());
+        if (file == null){
+            DisplayUtils.showSnackMessage(parentActivity, R.string.error_retrieving_file);
+            Log_OC.i(TAG, "Could not find uploaded file on remote.");
+            return;
+        }
+
+        if (PreviewImageFragment.canBePreviewed(file)){
+            //show image preview and stay in uploads tab
+            Intent intent = FileDisplayActivity.openFileIntent(parentActivity, parentActivity.getUser().get(), file);
+            parentActivity.startActivity(intent);
+        }else{
+            Intent intent = new Intent(parentActivity, FileDisplayActivity.class);
+            intent.setAction(Intent.ACTION_VIEW);
+            intent.putExtra(FileDisplayActivity.KEY_FILE_PATH, upload.getRemotePath());
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            parentActivity.startActivity(intent);
         }
     }
 


### PR DESCRIPTION
In upload tab uploading / failed/ waiting items can be viewed locally with android image view by clicking on file icon/ thumbnail.
Files that are finished with uploading lead you when clicked to the cloud file view and opens the file (as if it was opened via the all files tab) to e.g. share it.

- Is it a problem that files that are uploaded and, via the upload option, are kept at the original location of the client device are downloaded again into the Nextcloud save folder in the device to preview? 
- Do I need tests here? 
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

- [x] Tests written, or not not needed
