### PR TITLE
Improve media playback

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -60,6 +60,7 @@ import com.owncloud.android.lib.resources.shares.ShareeUser;
 import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.operations.RemoteOperationFailedException;
+import com.owncloud.android.ui.preview.PreviewMediaFragment;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimeType;
 import com.owncloud.android.utils.MimeTypeUtil;
@@ -190,7 +191,7 @@ public class FileDataStorageManager {
     }
 
 
-    public List<OCFile> getFolderImages(OCFile folder, boolean onlyOnDevice) {
+    public List<OCFile> getFolderMedia(OCFile folder, boolean onlyOnDevice) {
         List<OCFile> imageList = new ArrayList<>();
 
         if (folder != null) {
@@ -198,7 +199,7 @@ public class FileDataStorageManager {
             List<OCFile> folderContent = getFolderContent(folder, onlyOnDevice);
 
             for (OCFile ocFile : folderContent) {
-                if (MimeTypeUtil.isImage(ocFile)) {
+                if (PreviewMediaFragment.canBePreviewed(ocFile)) {
                     imageList.add(ocFile);
                 }
             }

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -60,7 +60,7 @@ import com.owncloud.android.lib.resources.shares.ShareeUser;
 import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.operations.RemoteOperationFailedException;
-import com.owncloud.android.ui.preview.PreviewMediaFragment;
+import com.owncloud.android.ui.preview.PreviewImageActivity;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimeType;
 import com.owncloud.android.utils.MimeTypeUtil;
@@ -199,7 +199,7 @@ public class FileDataStorageManager {
             List<OCFile> folderContent = getFolderContent(folder, onlyOnDevice);
 
             for (OCFile ocFile : folderContent) {
-                if (PreviewMediaFragment.canBePreviewed(ocFile)) {
+                if (PreviewImageActivity.canBePreviewed(ocFile)) {
                     imageList.add(ocFile);
                 }
             }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1437,7 +1437,7 @@ public class FileDisplayActivity extends FileActivity
                 if (uploadWasFine) {
                     OCFile ocFile = getFile();
                     if (PreviewImageFragment.canBePreviewed(ocFile)) {
-                        startImagePreview(getFile(), true);
+                        startMediaPreview(getFile(), true);
                     } else if (PreviewTextFileFragment.canBePreviewed(ocFile)) {
                         startTextPreview(ocFile, true);
                     }
@@ -2097,16 +2097,16 @@ public class FileDisplayActivity extends FileActivity
      *
      * @param file Image {@link OCFile} to show.
      */
-    public void startImagePreview(OCFile file, boolean showPreview) {
-        startImagePreview(file, null, showPreview);
+    public void startMediaPreview(OCFile file, boolean showPreview) {
+        startMediaPreview(file, null, showPreview);
     }
 
     /**
-     * Opens the image gallery showing the image {@link OCFile} received as parameter.
+     * Opens a gallery preview showing the media {@link OCFile} received as parameter.
      *
-     * @param file Image {@link OCFile} to show.
+     * @param file Media {@link OCFile} to preview.
      */
-    public void startImagePreview(OCFile file, VirtualFolderType type, boolean showPreview) {
+    public void startMediaPreview(OCFile file, VirtualFolderType type, boolean showPreview) {
         Intent showDetailsIntent = new Intent(this, PreviewImageActivity.class);
         showDetailsIntent.putExtra(PreviewImageActivity.EXTRA_FILE, file);
         showDetailsIntent.putExtra(EXTRA_USER, getUser().orElseThrow(RuntimeException::new));
@@ -2357,11 +2357,11 @@ public class FileDisplayActivity extends FileActivity
                               (long) bundle.get(PreviewMediaFragment.EXTRA_START_POSITION),
                               (boolean) bundle.get(PreviewMediaFragment.EXTRA_AUTOPLAY), true, true);
         } else if (bundle.containsKey(PreviewImageActivity.EXTRA_VIRTUAL_TYPE)) {
-            startImagePreview((OCFile) bundle.get(EXTRA_FILE),
+            startMediaPreview((OCFile) bundle.get(EXTRA_FILE),
                               (VirtualFolderType) bundle.get(PreviewImageActivity.EXTRA_VIRTUAL_TYPE),
                               true);
         } else {
-            startImagePreview((OCFile) bundle.get(EXTRA_FILE), true);
+            startMediaPreview((OCFile) bundle.get(EXTRA_FILE), true);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -2098,18 +2098,7 @@ public class FileDisplayActivity extends FileActivity
      * @param file Image {@link OCFile} to show.
      */
     public void startImagePreview(OCFile file, boolean showPreview) {
-        Intent showDetailsIntent = new Intent(this, PreviewImageActivity.class);
-        showDetailsIntent.putExtra(EXTRA_FILE, file);
-        showDetailsIntent.putExtra(EXTRA_LIVE_PHOTO_FILE, file.livePhotoVideo);
-        showDetailsIntent.putExtra(EXTRA_USER, getUser().orElseThrow(RuntimeException::new));
-        if (showPreview) {
-            startActivity(showDetailsIntent);
-        } else {
-            FileOperationsHelper fileOperationsHelper = new FileOperationsHelper(this,
-                                                                                 getUserAccountManager(),
-                                                                                 connectivityService, editorUtils);
-            fileOperationsHelper.startSyncForFileAndIntent(file, showDetailsIntent);
-        }
+        startImagePreview(file, null, showPreview);
     }
 
     /**
@@ -2120,9 +2109,12 @@ public class FileDisplayActivity extends FileActivity
     public void startImagePreview(OCFile file, VirtualFolderType type, boolean showPreview) {
         Intent showDetailsIntent = new Intent(this, PreviewImageActivity.class);
         showDetailsIntent.putExtra(PreviewImageActivity.EXTRA_FILE, file);
-
         showDetailsIntent.putExtra(EXTRA_USER, getUser().orElseThrow(RuntimeException::new));
-        showDetailsIntent.putExtra(PreviewImageActivity.EXTRA_VIRTUAL_TYPE, type);
+        showDetailsIntent.putExtra(EXTRA_LIVE_PHOTO_FILE, file.livePhotoVideo);
+
+        if (type != null) {
+            showDetailsIntent.putExtra(PreviewImageActivity.EXTRA_VIRTUAL_TYPE, type);
+        }
 
         if (showPreview) {
             startActivity(showDetailsIntent);

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1038,21 +1038,14 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     getActivity().finish();
                 } else if (!mOnlyFoldersClickable) {
                     // Click on a file
-                    if (PreviewImageFragment.canBePreviewed(file)) {
-                        // preview image - it handles the download, if needed
+                    if (PreviewImageFragment.canBePreviewed(file) || PreviewMediaFragment.canBePreviewed(file)) {
+                        // media preview - it handles the download, if needed
                         if (searchFragment) {
-                            VirtualFolderType type;
-                            switch (currentSearchType) {
-                                case FAVORITE_SEARCH:
-                                    type = VirtualFolderType.FAVORITE;
-                                    break;
-                                case GALLERY_SEARCH:
-                                    type = VirtualFolderType.GALLERY;
-                                    break;
-                                default:
-                                    type = VirtualFolderType.NONE;
-                                    break;
-                            }
+                            VirtualFolderType type = switch (currentSearchType) {
+                                case FAVORITE_SEARCH -> VirtualFolderType.FAVORITE;
+                                case GALLERY_SEARCH -> VirtualFolderType.GALLERY;
+                                default -> VirtualFolderType.NONE;
+                            };
                             ((FileDisplayActivity) mContainerActivity).startImagePreview(file, type, !file.isDown());
                         } else {
                             ((FileDisplayActivity) mContainerActivity).startImagePreview(file, !file.isDown());
@@ -1065,26 +1058,15 @@ public class OCFileListFragment extends ExtendedListFragment implements
                         setFabVisible(false);
                         ((FileDisplayActivity) mContainerActivity).startTextPreview(file, false);
                     } else if (file.isDown()) {
-                        if (PreviewMediaFragment.canBePreviewed(file)) {
-                            // media preview
-                            setFabVisible(false);
-                            ((FileDisplayActivity) mContainerActivity).startMediaPreview(file, 0, true, true, false);
-                        } else {
-                            mContainerActivity.getFileOperationsHelper().openFile(file);
-                        }
+                        mContainerActivity.getFileOperationsHelper().openFile(file);
                     } else {
-                        // file not downloaded, check for streaming, remote editing
+                        // file not downloaded, check for remote editing
                         User account = accountManager.getUser();
                         OCCapability capability = mContainerActivity.getStorageManager()
                             .getCapability(account.getAccountName());
 
-                        if (PreviewMediaFragment.canBePreviewed(file) && !file.isEncrypted()) {
-                            // stream media preview on >= NC14
-                            setFabVisible(false);
-                            ((FileDisplayActivity) mContainerActivity).startMediaPreview(file, 0, true, true, true);
-                        } else if (editorUtils.isEditorAvailable(accountManager.getUser(),
-                                                                 file.getMimeType()) &&
-                            !file.isEncrypted()) {
+                        if (editorUtils.isEditorAvailable(accountManager.getUser(),
+                                                          file.getMimeType()) && !file.isEncrypted()) {
                             mContainerActivity.getFileOperationsHelper().openFileWithTextEditor(file, getContext());
                         } else if (capability.getRichDocumentsMimeTypeList().contains(file.getMimeType()) &&
                             capability.getRichDocumentsDirectEditing().isTrue() && !file.isEncrypted()) {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -109,7 +109,7 @@ import com.owncloud.android.ui.events.FileLockEvent;
 import com.owncloud.android.ui.events.SearchEvent;
 import com.owncloud.android.ui.helpers.FileOperationsHelper;
 import com.owncloud.android.ui.interfaces.OCFileListFragmentInterface;
-import com.owncloud.android.ui.preview.PreviewImageFragment;
+import com.owncloud.android.ui.preview.PreviewImageActivity;
 import com.owncloud.android.ui.preview.PreviewMediaFragment;
 import com.owncloud.android.ui.preview.PreviewTextFileFragment;
 import com.owncloud.android.utils.DisplayUtils;
@@ -1038,18 +1038,22 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     getActivity().finish();
                 } else if (!mOnlyFoldersClickable) {
                     // Click on a file
-                    if (PreviewImageFragment.canBePreviewed(file) || PreviewMediaFragment.canBePreviewed(file)) {
-                        // media preview - it handles the download, if needed
+                    if (PreviewImageActivity.canBePreviewed(file)) {
+                        // media preview - it handles the download, if necessary
                         if (searchFragment) {
                             VirtualFolderType type = switch (currentSearchType) {
                                 case FAVORITE_SEARCH -> VirtualFolderType.FAVORITE;
                                 case GALLERY_SEARCH -> VirtualFolderType.GALLERY;
                                 default -> VirtualFolderType.NONE;
                             };
-                            ((FileDisplayActivity) mContainerActivity).startImagePreview(file, type, !file.isDown());
+                            ((FileDisplayActivity) mContainerActivity).startMediaPreview(file, type, !file.isDown());
                         } else {
-                            ((FileDisplayActivity) mContainerActivity).startImagePreview(file, !file.isDown());
+                            ((FileDisplayActivity) mContainerActivity).startMediaPreview(file, !file.isDown());
                         }
+                    } else if (PreviewMediaFragment.canBePreviewed(file)) {
+                        // standalone audio playback (no viewpager)
+                        setFabVisible(false);
+                        ((FileDisplayActivity) mContainerActivity).startMediaPreview(file, 0, true, true, false);
                     } else if (file.isDown() && MimeTypeUtil.isVCard(file)) {
                         ((FileDisplayActivity) mContainerActivity).startContactListFragment(file);
                     } else if (file.isDown() && MimeTypeUtil.isPDF(file)) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -242,7 +242,7 @@ public class PreviewImageActivity extends FileActivity implements
             if (file == null) {
                 throw new IllegalStateException("Instanced with a NULL OCFile");
             }
-            if (!MimeTypeUtil.isImage(file) && !MimeTypeUtil.isVideo(file)) {
+            if (!canBePreviewed(file)) {
                 throw new IllegalArgumentException("Non-media file passed as argument");
             }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -242,8 +242,8 @@ public class PreviewImageActivity extends FileActivity implements
             if (file == null) {
                 throw new IllegalStateException("Instanced with a NULL OCFile");
             }
-            if (!MimeTypeUtil.isImage(file)) {
-                throw new IllegalArgumentException("Non-image file passed as argument");
+            if (!MimeTypeUtil.isImage(file) && !MimeTypeUtil.isVideo(file)) {
+                throw new IllegalArgumentException("Non-media file passed as argument");
             }
 
             // Update file according to DB file, if it is possible

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -502,6 +502,10 @@ public class PreviewImageActivity extends FileActivity implements
         }
     }
 
+    public static boolean canBePreviewed(OCFile file) {
+        return PreviewImageFragment.canBePreviewed(file) || MimeTypeUtil.isVideo(file);
+    }
+
     private void previewNewImage(Intent intent) {
         String accountName = intent.getStringExtra(FileDownloader.ACCOUNT_NAME);
         String downloadedRemotePath = intent.getStringExtra(FileDownloader.EXTRA_REMOTE_PATH);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -71,7 +71,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
                                     FileDataStorageManager storageManager,
                                     boolean onlyOnDevice,
                                     AppPreferences preferences) {
-        super(fragmentManager);
+        super(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
         if (parentFolder == null) {
             throw new IllegalArgumentException("NULL parent folder");
         }
@@ -105,7 +105,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
                                     VirtualFolderType type,
                                     User user,
                                     FileDataStorageManager storageManager) {
-        super(fragmentManager);
+        super(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
 
         if (type == null) {
             throw new IllegalArgumentException("NULL parent folder");
@@ -158,22 +158,19 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
 
         if (file == null) {
             fragment = PreviewImageErrorFragment.newInstance();
+        } else if (file.isEncrypted() && !file.isDown()) {
+            fragment = FileDownloadFragment.newInstance(file, user, mObsoletePositions.contains(i));
+        } else if (PreviewMediaFragment.canBePreviewed(file)) {
+            fragment = PreviewMediaFragment.newInstance(file, user, 0, false, file.livePhotoVideo != null);
         } else if (file.isDown()) {
             fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), false);
         } else {
             addVideoOfLivePhoto(file);
-
             if (mDownloadErrors.remove(i)) {
                 fragment = FileDownloadFragment.newInstance(file, user, true);
                 ((FileDownloadFragment) fragment).setError(true);
             } else {
-                if (file.isEncrypted()) {
-                    fragment = FileDownloadFragment.newInstance(file, user, mObsoletePositions.contains(i));
-                } else if (PreviewMediaFragment.canBePreviewed(file)) {
-                    fragment = PreviewMediaFragment.newInstance(file, user, 0, false, file.livePhotoVideo != null);
-                } else {
-                    fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), true);
-                }
+                fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), true);
             }
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -48,7 +48,7 @@ import androidx.fragment.app.FragmentStatePagerAdapter;
 public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
 
     private OCFile selectedFile;
-    private List<OCFile> mImageFiles;
+    private List<OCFile> mMediaFiles;
     private User user;
     private Set<Object> mObsoleteFragments;
     private Set<Integer> mObsoletePositions;
@@ -82,10 +82,10 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         this.user = user;
         this.selectedFile = selectedFile;
         mStorageManager = storageManager;
-        mImageFiles = mStorageManager.getFolderImages(parentFolder, onlyOnDevice);
+        mMediaFiles = mStorageManager.getFolderMedia(parentFolder, onlyOnDevice);
 
         FileSortOrder sortOrder = preferences.getSortOrderByFolder(parentFolder);
-        mImageFiles = sortOrder.sortCloudFiles(mImageFiles);
+        mMediaFiles = sortOrder.sortCloudFiles(mMediaFiles);
 
         mObsoleteFragments = new HashSet<>();
         mObsoletePositions = new HashSet<>();
@@ -107,9 +107,6 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
                                     FileDataStorageManager storageManager) {
         super(fragmentManager);
 
-        if (fragmentManager == null) {
-            throw new IllegalArgumentException("NULL FragmentManager instance");
-        }
         if (type == null) {
             throw new IllegalArgumentException("NULL parent folder");
         }
@@ -124,10 +121,10 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
         mStorageManager = storageManager;
 
         if (type == VirtualFolderType.GALLERY) {
-            mImageFiles = mStorageManager.getAllGalleryItems();
-            mImageFiles = FileStorageUtils.sortOcFolderDescDateModifiedWithoutFavoritesFirst(mImageFiles);
+            mMediaFiles = mStorageManager.getAllGalleryItems();
+            mMediaFiles = FileStorageUtils.sortOcFolderDescDateModifiedWithoutFavoritesFirst(mMediaFiles);
         } else {
-            mImageFiles = mStorageManager.getVirtualFolderContent(type, true);
+            mMediaFiles = mStorageManager.getVirtualFolderContent(type, true);
         }
 
         mObsoleteFragments = new HashSet<>();
@@ -144,7 +141,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
     @Nullable
     public OCFile getFileAt(int position) {
         try {
-            return mImageFiles.get(position);
+            return mMediaFiles.get(position);
         } catch (IndexOutOfBoundsException exception) {
             return null;
         }
@@ -185,12 +182,12 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
     }
 
     public int getFilePosition(OCFile file) {
-        return mImageFiles.indexOf(file);
+        return mMediaFiles.indexOf(file);
     }
 
     @Override
     public int getCount() {
-        return mImageFiles.size();
+        return mMediaFiles.size();
     }
 
     @Override
@@ -211,7 +208,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
             mObsoleteFragments.add(fragmentToUpdate);
         }
         mObsoletePositions.add(position);
-        mImageFiles.set(position, file);
+        mMediaFiles.set(position, file);
     }
 
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -612,8 +612,9 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
 
     @Override
     public void onPause() {
-        Log_OC.v(TAG, "onPause");
         super.onPause();
+        Log_OC.v(TAG, "onPause");
+        stopPreview(true);
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -614,7 +614,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     public void onPause() {
         super.onPause();
         Log_OC.v(TAG, "onPause");
-        stopPreview(true);
+        stopPreview(false);
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -345,6 +345,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
         if (file != null) {
             // bind to any existing player
             mediaPlayerServiceConnection.bind();
+            stopPreview(true);
 
             if (MimeTypeUtil.isAudio(file)) {
                 binding.mediaController.setMediaPlayer(mediaPlayerServiceConnection);
@@ -353,10 +354,6 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
                 binding.emptyView.emptyListView.setVisibility(View.GONE);
                 binding.progress.setVisibility(View.GONE);
             } else if (MimeTypeUtil.isVideo(file)) {
-                if (mediaPlayerServiceConnection.isConnected()) {
-                    // always stop player
-                    mediaPlayerServiceConnection.stop();
-                }
                 if (exoPlayer != null) {
                     playVideo();
                 } else {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -27,7 +27,6 @@ package com.owncloud.android.ui.preview;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -627,19 +626,6 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     }
 
     @Override
-    public void onDestroy() {
-        Log_OC.v(TAG, "onDestroy");
-        super.onDestroy();
-    }
-
-    @Override
-    public void onDestroyView() {
-        Log_OC.v(TAG, "onDestroyView");
-        super.onDestroyView();
-        binding = null;
-    }
-
-    @Override
     public void onStop() {
         Log_OC.v(TAG, "onStop");
         stopPreview(true);
@@ -666,12 +652,6 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
         if (activity != null) {
             new PreviewVideoFullscreenDialog(activity, nextcloudClient, exoPlayer, binding.exoplayerView).show();
         }
-    }
-
-    @Override
-    public void onConfigurationChanged(@NonNull Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Log_OC.v(TAG, "onConfigurationChanged " + this);
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -641,13 +641,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     @Override
     public void onStop() {
         Log_OC.v(TAG, "onStop");
-        final OCFile file = getFile();
-        if (MimeTypeUtil.isAudio(file) && !mediaPlayerServiceConnection.isPlaying()) {
-            stopAudio();
-        } else if (MimeTypeUtil.isVideo(file) && exoPlayer != null && exoPlayer.isPlaying()) {
-            savedPlaybackPosition = exoPlayer.getCurrentPosition();
-            exoPlayer.pause();
-        }
+        stopPreview(true);
 
         mediaPlayerServiceConnection.unbind();
         toggleDrawerLockMode(containerActivity, DrawerLayout.LOCK_MODE_UNLOCKED);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -355,7 +355,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
             } else if (MimeTypeUtil.isVideo(file)) {
                 if (mediaPlayerServiceConnection.isConnected()) {
                     // always stop player
-                    stopAudio();
+                    mediaPlayerServiceConnection.stop();
                 }
                 if (exoPlayer != null) {
                     playVideo();
@@ -420,10 +420,6 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
             linearLayout.addView(fullScreenButton);
             linearLayout.invalidate();
         }
-    }
-
-    private void stopAudio() {
-        mediaPlayerServiceConnection.stop();
     }
 
     @Override
@@ -628,7 +624,7 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
     @Override
     public void onStop() {
         Log_OC.v(TAG, "onStop");
-        stopPreview(true);
+        stopPreview(!mediaPlayerServiceConnection.isPlaying());
 
         mediaPlayerServiceConnection.unbind();
         toggleDrawerLockMode(containerActivity, DrawerLayout.LOCK_MODE_UNLOCKED);


### PR DESCRIPTION
This change improves the user experience when previewing media. Video files and images are now displayed in a combined viewpager by default. This allows users to easily switch between multiple files within the same folder, while extending the functionality of the *Media* tab.

To test this functionality, select any media (video or image) file and swipe to the next/previous file in the folder. Audio files should be excluded and video/audio playback should stop automatically, when switching to another file. The same applies to the *Media* tab, which now combines video files and images into a single view.

Previously, video files would open in a separate fragment, requiring users to exit the preview to view the next file. There were also some inconsistencies, when previewing a set of files containing offline and online media.

---

- [ ] Tests written, or not not needed
