### PR TITLE
Use custom quota exceeded error message

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/app/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -437,6 +437,9 @@ public final class ErrorMessageAdapter {
             } else if (result.getCode() == ResultCode.ACCOUNT_NOT_THE_SAME) {
                 message = res.getString(R.string.auth_account_not_the_same);
 
+            } else if (result.getCode() == ResultCode.QUOTA_EXCEEDED) {
+                message = res.getString(R.string.upload_quota_exceeded);
+
             }
 
             else if (!TextUtils.isEmpty(result.getHttpPhrase())) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -831,6 +831,7 @@
     <string name="upload_sync_conflict">Sync conflict, please resolve manually</string>
     <string name="upload_cannot_create_file">Cannot create local file</string>
     <string name="upload_local_storage_not_copied">File could not be copied to local storage</string>
+    <string name="upload_quota_exceeded">Storage quota exceeded</string>
     <string name="host_not_available">Server not available</string>
     <string name="delete_entries">Delete entries</string>
     <string name="dismiss_notification_description">Dismiss notification</string>


### PR DESCRIPTION
When a user exceeds the allocated storage quota during an upload, an error message is displayed. Previously this message was not translated and always appeared in English: *Insufficient Storage*.

### Steps to reproduce
1. set up a user account on server with a low storage quota
2. sign in on android app
3. upload large file
4. observe error message in notification

---

- [ ] Tests written, or not not needed
