### PR TITLE
Use custom quota exceeded error message in UploadList

### DIFF
--- a/app/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/app/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -44,7 +44,8 @@ public enum UploadResult {
     OLD_ANDROID_API(18),
     SYNC_CONFLICT(19),
     CANNOT_CREATE_FILE(20),
-    LOCAL_STORAGE_NOT_COPIED(21);
+    LOCAL_STORAGE_NOT_COPIED(21),
+    QUOTA_EXCEEDED(22);
 
     private final int value;
 
@@ -104,6 +105,8 @@ public enum UploadResult {
                 return CANNOT_CREATE_FILE;
             case 21:
                 return LOCAL_STORAGE_NOT_COPIED;
+            case 22:
+                return QUOTA_EXCEEDED;
         }
         return UNKNOWN;
     }
@@ -162,6 +165,8 @@ public enum UploadResult {
                 return VIRUS_DETECTED;
             case CANNOT_CREATE_FILE:
                 return CANNOT_CREATE_FILE;
+            case QUOTA_EXCEEDED:
+                return QUOTA_EXCEEDED;
             default:
                 return UNKNOWN;
         }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -711,6 +711,9 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             case LOCAL_STORAGE_NOT_COPIED:
                 status = parentActivity.getString(R.string.upload_local_storage_not_copied);
                 break;
+            case QUOTA_EXCEEDED:
+                status = parentActivity.getString(R.string.upload_quota_exceeded);
+                break;
             default:
                 status = parentActivity.getString(R.string.upload_unknown_error);
                 break;

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -467,7 +467,7 @@ public class ExtendedListFragment extends Fragment implements
     private void scrollToPosition(int position) {
         LinearLayoutManager linearLayoutManager = (LinearLayoutManager) mRecyclerView.getLayoutManager();
 
-        if (mRecyclerView != null) {
+        if (linearLayoutManager != null) {
             int visibleItemCount = linearLayoutManager.findLastCompletelyVisibleItemPosition() -
                 linearLayoutManager.findFirstCompletelyVisibleItemPosition();
             linearLayoutManager.scrollToPositionWithOffset(position, (visibleItemCount / 2) * mHeightCell);


### PR DESCRIPTION
When a user exceeds the allocated storage quota during an upload, an error message is displayed. Previously this message was not translated and always appeared in English: *Insufficient Storage*.

### Steps to reproduce
1. set up a user account on server with a low storage quota
2. sign in on android app
3. upload large file
4. open *Uploads* tab
5. see message on failed item

---

- [ ] Tests written, or not not needed
