### PR TITLE
Fix: ImageActivity crash after options menu selected

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -205,7 +205,7 @@ public class PreviewImageActivity extends FileActivity implements
             }
             return true;
         } else {
-            return onOptionsItemSelected(item);
+            return super.onOptionsItemSelected(item);
         }
     }
 


### PR DESCRIPTION
### Before

https://github.com/nextcloud/android/assets/111801812/2d34bb9f-9d56-441e-9f7c-70976aec89ec

### After


https://github.com/nextcloud/android/assets/111801812/23d22995-283a-46bc-ac82-dc90f1a36f67


- [x] Tests written, or not not needed
