### PR TITLE
Fix: To many old notifications  

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
@@ -59,7 +59,6 @@ import com.owncloud.android.utils.ErrorMessageAdapter
 import com.owncloud.android.utils.FilesUploadHelper
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.io.File
-import java.security.SecureRandom
 
 @Suppress("LongParameterList")
 class FilesUploadWorker(
@@ -261,8 +260,14 @@ class FilesUploadWorker(
         uploadResult: RemoteOperationResult<Any?>
     ) {
         Log_OC.d(TAG, "NotifyUploadResult with resultCode: " + uploadResult.code)
+
+        if (uploadResult.isSuccess){
+            cancelOldErrorNotification(uploadFileOperation)
+            return
+        }
+
         // Only notify if the upload fails
-        if (uploadResult.isSuccess || uploadResult.isCancelled) {
+        if (uploadResult.isCancelled) {
             return
         }
 
@@ -312,9 +317,10 @@ class FilesUploadWorker(
                 )
             }
             notificationBuilder.setContentText(content)
-            if (!uploadResult.isSuccess) {
-                notificationManager.notify(SecureRandom().nextInt(), notificationBuilder.build())
-            }
+
+            notificationManager.notify(NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
+                NOTIFICATION_ERROR_ID, notificationBuilder.build())
+
         }
     }
 
@@ -386,8 +392,16 @@ class FilesUploadWorker(
                 totalToTransfer,
                 fileAbsoluteName
             )
+            currentUploadFileOperation?.let { cancelOldErrorNotification(it) }
         }
         lastPercent = percent
+    }
+
+    private fun cancelOldErrorNotification(uploadFileOperation: UploadFileOperation){
+        notificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.oldFile),
+            NOTIFICATION_ERROR_ID)
+        notificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
+            NOTIFICATION_ERROR_ID)
     }
 
     override fun onStopped() {
@@ -399,6 +413,7 @@ class FilesUploadWorker(
     companion object {
         val TAG: String = FilesUploadWorker::class.java.simpleName
         private const val FOREGROUND_SERVICE_ID: Int = 412
+        private const val NOTIFICATION_ERROR_ID: Int = 413
         private const val MAX_PROGRESS: Int = 100
         const val ACCOUNT = "data_account"
         var currentUploadFileOperation: UploadFileOperation? = null

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
@@ -402,10 +402,12 @@ class FilesUploadWorker(
 
     private fun cancelOldErrorNotification(uploadFileOperation: UploadFileOperation) {
         // cancel for old file because of file conflicts
-        notificationManager.cancel(
-            NotificationUtils.createUploadNotificationTag(uploadFileOperation.oldFile),
-            NOTIFICATION_ERROR_ID
-        )
+        if (uploadFileOperation.oldFile != null) {
+            notificationManager.cancel(
+                NotificationUtils.createUploadNotificationTag(uploadFileOperation.oldFile),
+                NOTIFICATION_ERROR_ID
+            )
+        }
         notificationManager.cancel(
             NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
             NOTIFICATION_ERROR_ID

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
@@ -413,7 +413,7 @@ class FilesUploadWorker(
     companion object {
         val TAG: String = FilesUploadWorker::class.java.simpleName
         private const val FOREGROUND_SERVICE_ID: Int = 412
-        private const val NOTIFICATION_ERROR_ID: Int = 413
+        const val NOTIFICATION_ERROR_ID: Int = 413
         private const val MAX_PROGRESS: Int = 100
         const val ACCOUNT = "data_account"
         var currentUploadFileOperation: UploadFileOperation? = null

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
@@ -59,6 +59,7 @@ import com.owncloud.android.utils.ErrorMessageAdapter
 import com.owncloud.android.utils.FilesUploadHelper
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.io.File
+import java.security.SecureRandom
 
 @Suppress("LongParameterList")
 class FilesUploadWorker(
@@ -398,6 +399,7 @@ class FilesUploadWorker(
     }
 
     private fun cancelOldErrorNotification(uploadFileOperation: UploadFileOperation){
+        //cancel for old file because of file conflicts
         notificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.oldFile),
             NOTIFICATION_ERROR_ID)
         notificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesUploadWorker.kt
@@ -262,7 +262,7 @@ class FilesUploadWorker(
     ) {
         Log_OC.d(TAG, "NotifyUploadResult with resultCode: " + uploadResult.code)
 
-        if (uploadResult.isSuccess){
+        if (uploadResult.isSuccess) {
             cancelOldErrorNotification(uploadFileOperation)
             return
         }
@@ -319,9 +319,11 @@ class FilesUploadWorker(
             }
             notificationBuilder.setContentText(content)
 
-            notificationManager.notify(NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
-                NOTIFICATION_ERROR_ID, notificationBuilder.build())
-
+            notificationManager.notify(
+                NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
+                NOTIFICATION_ERROR_ID,
+                notificationBuilder.build()
+            )
         }
     }
 
@@ -398,12 +400,16 @@ class FilesUploadWorker(
         lastPercent = percent
     }
 
-    private fun cancelOldErrorNotification(uploadFileOperation: UploadFileOperation){
-        //cancel for old file because of file conflicts
-        notificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.oldFile),
-            NOTIFICATION_ERROR_ID)
-        notificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
-            NOTIFICATION_ERROR_ID)
+    private fun cancelOldErrorNotification(uploadFileOperation: UploadFileOperation) {
+        // cancel for old file because of file conflicts
+        notificationManager.cancel(
+            NotificationUtils.createUploadNotificationTag(uploadFileOperation.oldFile),
+            NOTIFICATION_ERROR_ID
+        )
+        notificationManager.cancel(
+            NotificationUtils.createUploadNotificationTag(uploadFileOperation.file),
+            NOTIFICATION_ERROR_ID
+        )
     }
 
     override fun onStopped() {

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1447,10 +1447,10 @@ public class FileUploader extends Service
             mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         }
 
-        if (uploadFileOperation == null) return;
+        if (uploadFileOperation == null || uploadFileOperation.getOldFile() == null) return;
         //cancel for old file because of file conflicts
         mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getOldFile()),
-                                   NOTIFICATION_ERROR_ID);
+                                    NOTIFICATION_ERROR_ID);
         mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getFile()),
                                    NOTIFICATION_ERROR_ID);
     }

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1448,6 +1448,7 @@ public class FileUploader extends Service
         }
 
         if (uploadFileOperation == null) return;
+        //cancel for old file because of file conflicts
         mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getOldFile()),
                                    NOTIFICATION_ERROR_ID);
         mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getFile()),

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -135,7 +135,7 @@ public class FileUploader extends Service
     public static final String ACTION_PAUSE_BROADCAST = "PAUSE";
 
     private static final int FOREGROUND_SERVICE_ID = 411;
-    private static final int NOTIFICATION_ERROR_ID = 410;
+    private static final int NOTIFICATION_ERROR_ID = FilesUploadWorker.NOTIFICATION_ERROR_ID;
 
     public static final String KEY_FILE = "FILE";
     public static final String KEY_LOCAL_FILE = "LOCAL_FILE";
@@ -1443,6 +1443,10 @@ public class FileUploader extends Service
     }
 
     private void cancelOldErrorNotification(UploadFileOperation uploadFileOperation){
+        if (mNotificationManager == null) {
+            mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        }
+
         if (uploadFileOperation == null) return;
         mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getOldFile()),
                                    NOTIFICATION_ERROR_ID);

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1447,12 +1447,19 @@ public class FileUploader extends Service
             mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         }
 
-        if (uploadFileOperation == null || uploadFileOperation.getOldFile() == null) return;
-        //cancel for old file because of file conflicts
-        mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getOldFile()),
-                                    NOTIFICATION_ERROR_ID);
+        if (uploadFileOperation == null) return;
+
         mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getFile()),
-                                   NOTIFICATION_ERROR_ID);
+                                    NOTIFICATION_ERROR_ID);
+
+        //cancel for old file because of file conflicts
+        OCFile oldFile = uploadFileOperation.getOldFile();
+        if ( oldFile != null) {
+            mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(oldFile),
+                                        NOTIFICATION_ERROR_ID);
+        }
+
+
     }
 
 

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -135,6 +135,7 @@ public class FileUploader extends Service
     public static final String ACTION_PAUSE_BROADCAST = "PAUSE";
 
     private static final int FOREGROUND_SERVICE_ID = 411;
+    private static final int NOTIFICATION_ERROR_ID = 410;
 
     public static final String KEY_FILE = "FILE";
     public static final String KEY_LOCAL_FILE = "LOCAL_FILE";
@@ -781,6 +782,7 @@ public class FileUploader extends Service
                 mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
             }
             mNotificationManager.notify(FOREGROUND_SERVICE_ID, mNotificationBuilder.build());
+            cancelOldErrorNotification(mCurrentUpload);
         }
         mLastPercent = percent;
     }
@@ -797,6 +799,10 @@ public class FileUploader extends Service
         // cancelled operation or success -> silent removal of progress notification
         if (mNotificationManager == null) {
             mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        }
+
+        if (uploadResult.isSuccess()){
+            cancelOldErrorNotification(upload);
         }
 
         // Only notify if the upload fails
@@ -1434,6 +1440,14 @@ public class FileUploader extends Service
         public static String buildRemoteName(String accountName, String remotePath) {
             return accountName + remotePath;
         }
+    }
+
+    private void cancelOldErrorNotification(UploadFileOperation uploadFileOperation){
+        if (uploadFileOperation == null) return;
+        mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getOldFile()),
+                                   NOTIFICATION_ERROR_ID);
+        mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(uploadFileOperation.getFile()),
+                                   NOTIFICATION_ERROR_ID);
     }
 
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -48,6 +48,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadListLayoutBinding;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.UploadsStorageManager;
+import com.owncloud.android.db.OCUpload;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
@@ -263,6 +264,9 @@ public class UploadListActivity extends FileActivity {
                 openDrawer();
             }
         } else if (itemId == R.id.action_clear_failed_uploads) {
+            for (OCUpload upload : uploadsStorageManager.getFailedButNotDelayedUploadsForCurrentAccount()){
+                uploadListAdapter.cancelOldErrorNotification(upload);
+            }
             uploadsStorageManager.clearFailedButNotDelayedUploads();
             uploadListAdapter.loadUploadItemsFromDb();
         } else {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -24,6 +24,7 @@
 
 package com.owncloud.android.ui.adapter;
 
+import android.app.NotificationManager;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -42,6 +43,7 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.core.Clock;
 import com.nextcloud.client.device.PowerManagementService;
+import com.nextcloud.client.jobs.FilesUploadWorker;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.java.util.Optional;
 import com.owncloud.android.MainApp;
@@ -63,6 +65,7 @@ import com.owncloud.android.operations.RefreshFolderOperation;
 import com.owncloud.android.ui.activity.ConflictsResolveActivity;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
+import com.owncloud.android.ui.notifications.NotificationUtils;
 import com.owncloud.android.ui.preview.PreviewImageFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
@@ -86,6 +89,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
     private ConnectivityService connectivityService;
     private PowerManagementService powerManagementService;
     private UserAccountManager accountManager;
+    private NotificationManager mNotificationManager;
     private Clock clock;
     private UploadGroup[] uploadGroups;
     private boolean showUser;
@@ -556,6 +560,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
     private void removeUpload(OCUpload item) {
         uploadsStorageManager.removeUpload(item);
+        cancelOldErrorNotification(item);
         loadUploadItemsFromDb();
     }
 
@@ -873,4 +878,17 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             return items == null ? 0 : items.length;
         }
     }
+
+    public void cancelOldErrorNotification(OCUpload upload){
+
+        if (mNotificationManager == null) {
+            mNotificationManager = (NotificationManager) parentActivity.getSystemService(parentActivity.NOTIFICATION_SERVICE);
+        }
+
+        if (upload == null) return;
+        mNotificationManager.cancel(NotificationUtils.createUploadNotificationTag(upload.getRemotePath(),upload.getLocalPath()),
+                                    FilesUploadWorker.NOTIFICATION_ERROR_ID);
+
+    }
+
 }

--- a/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
+++ b/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
@@ -84,6 +84,9 @@ public final class NotificationUtils {
     }
 
     public static String createUploadNotificationTag(OCFile file){
-        return file.getRemotePath() + file.getStoragePath();
+        return createUploadNotificationTag(file.getRemotePath(), file.getStoragePath());
+    }
+    public static String createUploadNotificationTag(String remotePath, String localPath){
+        return remotePath + localPath;
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
+++ b/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
@@ -25,6 +25,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Process;
 
+import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import java.security.SecureRandom;
@@ -80,5 +81,9 @@ public final class NotificationUtils {
             notificationManager.cancel(notificationId);
             ((HandlerThread) Thread.currentThread()).getLooper().quit();
         }, delayInMillis);
+    }
+
+    public static String createUploadNotificationTag(OCFile file){
+        return file.getRemotePath() + file.getStoragePath();
     }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

Spawns the upload failed notification with a tag that is unique for every file upload operation to make sure only one error notification (e.g. file conflict) is displayed at a time per file upload. 
Also cancels error notification when upload makes progress or finishes successfully to make sure no old not relevant notifications are displayed.

Fixes issues described in https://github.com/nextcloud/android/issues/11974 where one conflict creates a lot of notifications because of automatic retry in background.

To reproduce the bug:
1. upload file that already exists -> create file conflict
2. retry upload in uploads menu via retry all (or wait till automatic retry in background)
3. You should get a new notification every time the upload is retried
4. Solve conflict
5. The notifications should still exist


- [x] Tests written, or not not needed
