### PR TITLE
Deprecate OwncloudClient - DirectEditing

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -316,8 +316,8 @@ public class RefreshFolderOperation extends RemoteOperation {
     }
 
     private void updateDirectEditing(ArbitraryDataProvider arbitraryDataProvider, String newDirectEditingEtag) {
-        RemoteOperationResult<DirectEditing> result = new DirectEditingObtainRemoteOperation().execute(user,
-                                                                                                       mContext);
+        RemoteOperationResult<DirectEditing> result =
+            new DirectEditingObtainRemoteOperation().executeNextcloudClient(user, mContext);
 
         if (result.isSuccess()) {
             DirectEditing directEditing = result.getResultData();

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/TextEditorLoadUrlTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/TextEditorLoadUrlTask.java
@@ -60,15 +60,15 @@ public class TextEditorLoadUrlTask extends AsyncTask<Void, Void, String> {
             return "";
         }
 
-        RemoteOperationResult result = new DirectEditingOpenFileRemoteOperation(file.getRemotePath(), editor.getId())
-            .execute(user, editorWebViewWeakReference.get());
+        RemoteOperationResult<String> result = new DirectEditingOpenFileRemoteOperation(file.getRemotePath(), editor.getId())
+            .executeNextcloudClient(user, editorWebViewWeakReference.get());
 
 
         if (!result.isSuccess()) {
             return "";
         }
 
-        return (String) result.getData().get(0);
+        return result.getResultData();
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         daggerVersion = "2.47"
         markwonVersion = "4.6.2"
         prismVersion = "2.0.0"
-        androidLibraryVersion = "master-SNAPSHOT"
+        androidLibraryVersion = "depocc/directediting-SNAPSHOT"
         mockitoVersion = "4.11.0"
         mockitoKotlinVersion = "4.1.0"
         mockkVersion = "1.13.3"


### PR DESCRIPTION
This is one of a series of pull requests which aim to replace all instances of `OwnCloudClient` with `NextcloudClient`. The reason for this change is that the newer `NextcloudClient` uses OkHttp, replacing the outdated Jackrabbit methods.

Specifically, this pull request implements the following:
- changes related to direct editing
- see https://github.com/nextcloud/android-library/pull/1272

---

- [ ] Tests written, or not not needed