### PR TITLE
Fix infinite loading of folders in shared tab

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
@@ -73,6 +73,7 @@ class SharedListFragment : OCFileListFragment(), Injectable {
                 val fileDisplayActivity = activity as FileDisplayActivity
                 fileDisplayActivity.updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_item_shared))
                 fileDisplayActivity.setMainFabVisible(false)
+                fileDisplayActivity.initSyncBroadcastReceiver()
             }
         }
     }


### PR DESCRIPTION
This change fixes an issue where users were left with an infinite *Loading...* message, when attempting to open a folder from the *Shared* tab.

### Steps to reproduce
1. open Nextcloud Android client
2. create empty folder in root directory
3. share said folder with another user on the same instance
4. open *Shared* tab
5. tap on the new folder

Previously the *Loading...* message would be displayed without any further feedback.

Supersedes #11401

---

- [ ] Tests written, or not not needed
