### PR TITLE
Use Only Work Manager For File Upload

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/files/services/FileUploaderIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/files/services/FileUploaderIT.kt
@@ -139,12 +139,10 @@ abstract class FileUploaderIT : AbstractOnServerIT() {
         val file = getDummyFile("chunkedFile.txt")
 
         FileUploader.uploadNewFile(
-            targetContext,
             user,
             file.absolutePath,
             "/testFile.txt",
             FileUploader.LOCAL_BEHAVIOUR_COPY,
-            null,
             true,
             UploadFileOperation.CREATED_BY_USER,
             false,
@@ -258,12 +256,10 @@ abstract class FileUploaderIT : AbstractOnServerIT() {
         val file = getDummyFile("nonEmpty.txt")
 
         FileUploader.uploadNewFile(
-            targetContext,
             user,
             file.absolutePath,
             "/testFile.txt",
             FileUploader.LOCAL_BEHAVIOUR_COPY,
-            null,
             true,
             UploadFileOperation.CREATED_BY_USER,
             false,
@@ -369,12 +365,10 @@ abstract class FileUploaderIT : AbstractOnServerIT() {
         val file = getDummyFile("chunkedFile.txt")
 
         FileUploader.uploadNewFile(
-            targetContext,
             user,
             file.absolutePath,
             "/testFile.txt",
             FileUploader.LOCAL_BEHAVIOUR_COPY,
-            null,
             true,
             UploadFileOperation.CREATED_BY_USER,
             false,
@@ -476,12 +470,10 @@ abstract class FileUploaderIT : AbstractOnServerIT() {
         val file = getDummyFile("chunkedFile.txt")
 
         FileUploader.uploadNewFile(
-            targetContext,
             user,
             file.absolutePath,
             "/testFile.txt",
             FileUploader.LOCAL_BEHAVIOUR_COPY,
-            null,
             true,
             UploadFileOperation.CREATED_BY_USER,
             false,

--- a/app/src/main/java/com/nextcloud/client/documentscan/DocumentScanViewModel.kt
+++ b/app/src/main/java/com/nextcloud/client/documentscan/DocumentScanViewModel.kt
@@ -36,7 +36,6 @@ import com.owncloud.android.files.services.FileUploader
 import com.owncloud.android.files.services.NameCollisionPolicy
 import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.helpers.FileOperationsHelper
-import com.owncloud.android.utils.MimeType
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/nextcloud/client/documentscan/DocumentScanViewModel.kt
+++ b/app/src/main/java/com/nextcloud/client/documentscan/DocumentScanViewModel.kt
@@ -184,16 +184,10 @@ class DocumentScanViewModel @Inject constructor(
             uploadFolder + OCFile.PATH_SEPARATOR + File(it).name
         }.toTypedArray()
 
-        val mimetypes = pageList.map {
-            MimeType.JPEG
-        }.toTypedArray()
-
         FileUploader.uploadNewFile(
-            getApplication(),
             currentAccountProvider.user,
             pageList.toTypedArray(),
             uploadPaths,
-            mimetypes,
             FileUploader.LOCAL_BEHAVIOUR_DELETE,
             true,
             UploadFileOperation.CREATED_BY_USER,

--- a/app/src/main/java/com/nextcloud/client/documentscan/GeneratePdfFromImagesWork.kt
+++ b/app/src/main/java/com/nextcloud/client/documentscan/GeneratePdfFromImagesWork.kt
@@ -39,7 +39,6 @@ import com.owncloud.android.files.services.FileUploader
 import com.owncloud.android.files.services.NameCollisionPolicy
 import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.notifications.NotificationUtils
-import com.owncloud.android.utils.MimeType
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.io.File
 import java.security.SecureRandom

--- a/app/src/main/java/com/nextcloud/client/documentscan/GeneratePdfFromImagesWork.kt
+++ b/app/src/main/java/com/nextcloud/client/documentscan/GeneratePdfFromImagesWork.kt
@@ -124,12 +124,10 @@ class GeneratePdfFromImagesWork(
         val uploadPath = uploadFolder + OCFile.PATH_SEPARATOR + File(pdfPath).name
 
         FileUploader.uploadNewFile(
-            appContext,
             user,
             pdfPath,
             uploadPath,
             FileUploader.LOCAL_BEHAVIOUR_DELETE, // MIME type will be detected from file name
-            MimeType.PDF,
             true,
             UploadFileOperation.CREATED_BY_USER,
             false,

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -162,7 +162,6 @@ class FilesSyncWork(
         }
         val localPaths = pathsAndMimes.map { it.first }.toTypedArray()
         val remotePaths = pathsAndMimes.map { it.second }.toTypedArray()
-        val mimetypes = pathsAndMimes.map { it.third }.toTypedArray()
 
         if (lightVersion) {
             needsCharging = resources.getBoolean(R.bool.syncedFolder_light_on_charging)
@@ -177,12 +176,11 @@ class FilesSyncWork(
             needsWifi = syncedFolder.isWifiOnly
             uploadAction = syncedFolder.uploadAction
         }
+
         FileUploader.uploadNewFile(
-            context,
             user,
             localPaths,
             remotePaths,
-            mimetypes,
             uploadAction!!,
             true, // create parent folder if not existent
             UploadFileOperation.CREATED_AS_INSTANT_PICTURE,

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -977,8 +977,7 @@ public class FileUploader extends Service
         OCFile existingFile,
         Integer behaviour,
         NameCollisionPolicy nameCollisionPolicy,
-        boolean disableRetries
-                                       ) {
+        boolean disableRetries) {
         uploadUpdateFile(context,
                          user,
                          new OCFile[]{existingFile},

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1099,6 +1099,7 @@ public class FileUploader extends Service
      * It provides by itself the available operations.
      */
     public class FileUploaderBinder extends Binder implements OnDatatransferProgressListener {
+
         /**
          * Map of listeners that will be reported about progress of uploads from a {@link FileUploaderBinder} instance
          */

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -1099,7 +1099,6 @@ public class FileUploader extends Service
      * It provides by itself the available operations.
      */
     public class FileUploaderBinder extends Binder implements OnDatatransferProgressListener {
-
         /**
          * Map of listeners that will be reported about progress of uploads from a {@link FileUploaderBinder} instance
          */

--- a/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/app/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -79,6 +79,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCode;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.FileUtils;
+import com.owncloud.android.lib.resources.files.model.ServerFileInterface;
 import com.owncloud.android.operations.UploadFileOperation;
 import com.owncloud.android.ui.activity.ConflictsResolveActivity;
 import com.owncloud.android.ui.activity.UploadListActivity;
@@ -1110,7 +1111,7 @@ public class FileUploader extends Service
          * @param account ownCloud account where the remote file will be stored.
          * @param file    A file in the queue of pending uploads
          */
-        public void cancel(Account account, OCFile file) {
+        public void cancel(Account account, ServerFileInterface file) {
             cancel(account.name, file.getRemotePath(), null);
         }
 
@@ -1206,7 +1207,7 @@ public class FileUploader extends Service
         public void addDatatransferProgressListener(
             OnDatatransferProgressListener listener,
             User user,
-            OCFile file
+            ServerFileInterface file
                                                    ) {
             if (user == null || file == null || listener == null) {
                 return;
@@ -1244,7 +1245,7 @@ public class FileUploader extends Service
         public void removeDatatransferProgressListener(
             OnDatatransferProgressListener listener,
             User user,
-            OCFile file
+            ServerFileInterface file
                                                       ) {
             if (user == null || file == null || listener == null) {
                 return;

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -906,8 +906,15 @@ public class FileDisplayActivity extends FileActivity implements FileFragment.Co
                 default -> FileUploader.LOCAL_BEHAVIOUR_FORGET;
             };
 
-            FileUploader.uploadNewFile(this, getUser().orElseThrow(RuntimeException::new), filePaths, remotePaths, null,           // MIME type will be detected from file name
-                                       behaviour, true, UploadFileOperation.CREATED_BY_USER, false, false, NameCollisionPolicy.ASK_USER);
+            FileUploader.uploadNewFile(getUser().orElseThrow(RuntimeException::new),
+                                       filePaths,
+                                       remotePaths,
+                                       behaviour,
+                                       true,
+                                       UploadFileOperation.CREATED_BY_USER,
+                                       false,
+                                       false,
+                                       NameCollisionPolicy.ASK_USER);
 
         } else {
             Log_OC.d(TAG, "User clicked on 'Update' with no selection");

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -885,12 +885,10 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     public void uploadFile(String tmpName, String filename) {
         FileUploader.uploadNewFile(
-            getBaseContext(),
             getUser().orElseThrow(RuntimeException::new),
             tmpName,
             mFile.getRemotePath() + filename,
             FileUploader.LOCAL_BEHAVIOUR_COPY,
-            null,
             true,
             UploadFileOperation.CREATED_BY_USER,
             false,

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -192,8 +192,7 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                     user,
                     fullTempPath,
                     currentRemotePath,
-                    behaviour,
-                    leakedContentResolver.getType(currentUri)
+                    behaviour
                 );
                 fullTempPath = null;
             }
@@ -247,14 +246,12 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
         return result;
     }
 
-    private void requestUpload(User user, String localPath, String remotePath, int behaviour, String mimeType) {
+    private void requestUpload(User user, String localPath, String remotePath, int behaviour) {
         FileUploader.uploadNewFile(
-            mAppContext,
             user,
             localPath,
             remotePath,
             behaviour,
-            mimeType,
             false,      // do not create parent folder if not existent
             UploadFileOperation.CREATED_BY_USER,
             false,

--- a/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
@@ -126,12 +126,10 @@ class UriUploader(
      */
     private fun requestUpload(localPath: String?, remotePath: String) {
         FileUploader.uploadNewFile(
-            mActivity,
             user,
             localPath,
             remotePath,
             mBehaviour,
-            null, // MIME type will be detected from file name
             false, // do not create parent folder if not existent
             UploadFileOperation.CREATED_BY_USER,
             false,


### PR DESCRIPTION
FileUploader service still exists. This implementation only uses worker. In next PR FileUploader service will be removed.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
