### PR TITLE
Fix suggestion

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -73,7 +73,6 @@ import com.nextcloud.client.utils.IntentUtil;
 import com.nextcloud.java.util.Optional;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
-import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.view.FastScrollUtils;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -1086,7 +1085,6 @@ public class FileDisplayActivity extends FileActivity implements FileFragment.Co
                 startFile = fileArgs;
                 setFile(startFile);
             }
-            setFile(startFile);
         }
 
         // refresh list of files


### PR DESCRIPTION
This change fixes several problems introduced by a suggestion from #12287. The suggestion was missing a line, which meant that `setFile()` could be called with a null argument under certain circumstances.

See cb329b1e37de4da3e140bc5c6549206a05419e2b.

---

- [x] Tests written, or not not needed
