### PR TITLE
handle audio focus and becoming noisy

### DIFF
--- a/app/src/main/java/com/nextcloud/client/media/NextcloudExoPlayer.kt
+++ b/app/src/main/java/com/nextcloud/client/media/NextcloudExoPlayer.kt
@@ -23,6 +23,7 @@ package com.nextcloud.client.media
 
 import android.content.Context
 import androidx.annotation.OptIn
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
@@ -53,6 +54,8 @@ object NextcloudExoPlayer {
         return ExoPlayer
             .Builder(context)
             .setMediaSourceFactory(mediaSourceFactory)
+            .setAudioAttributes(AudioAttributes.DEFAULT, true)
+            .setHandleAudioBecomingNoisy(true)
             .setSeekForwardIncrementMs(FIVE_SECONDS_IN_MILLIS)
             .build()
     }


### PR DESCRIPTION
- [x] Handle Audio focus
- [x] Handle Audio becoming noisy

### Handle audio focus -->

https://github.com/nextcloud/android/assets/111801812/7c2802a5-ccdf-4bd2-87f4-b48e8b477c7d

The player will handle the audio focus shifts. Basically It would:
- Pause the already playing media when this player is started.
- Or If some other media starts this player would pause itself.
This would avoid two media's playing at the same time.

### Handle audio becoming noisy -->


https://github.com/nextcloud/android/assets/111801812/b076620f-a5e4-4eb7-9ec3-ddafa7d65bcd


> When a headset is unplugged or a Bluetooth device disconnected, the audio stream automatically reroutes to the built-in speaker. If you listen to music at a high volume, this can be a noisy surprise.
> 
> Users usually expect apps that include a music player with onscreen playback controls to pause playback in this case. Other apps, like games that don't include controls, should keep playing. The user can adjust the volume with the device's hardware controls.
>
[See More](https://developer.android.com/guide/topics/media/platform/output#becoming-noisy)


You can see here after turning of bluetooth the playback pauses.