### PR TITLE
Handle restoring fab icon from drawer view

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1471,6 +1471,7 @@ public class FileDisplayActivity extends FileActivity implements FileFragment.Co
             setFile(listOfFiles.getCurrentFile());
             startSyncFolderOperation(root, false);
         }
+        binding.fabMain.setImageResource(R.drawable.ic_plus);
         resetTitleBarAndScrolling();
     }
 


### PR DESCRIPTION
From: [comment](https://github.com/nextcloud/android/pull/12298#pullrequestreview-1786104428) 

### Before

https://github.com/nextcloud/android/assets/111801812/7617b0ad-6f9a-4a8f-8820-2647f48b0146

### After

https://github.com/nextcloud/android/assets/111801812/e3ca610a-dbdc-4518-ab56-53df81e629c2

- [x] Tests written, or not not needed
