### PR TITLE
Fix misleading toast in uploads tab

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -196,19 +196,22 @@ public class UploadListActivity extends FileActivity {
     private void refresh() {
         backgroundJobManager.startImmediateFilesSyncJob(false, true);
 
-        // retry failed uploads
-        new Thread(() -> FileUploader.retryFailedUploads(
-            this,
-            uploadsStorageManager,
-            connectivityService,
-            userAccountManager,
-            powerManagementService))
-            .start();
+        if(uploadsStorageManager.getFailedUploads().length > 0){
+            // retry failed uploads
+            new Thread(() -> FileUploader.retryFailedUploads(
+                this,
+                uploadsStorageManager,
+                connectivityService,
+                userAccountManager,
+                powerManagementService))
+                .start();
+            DisplayUtils.showSnackMessage(this, R.string.uploader_local_files_uploaded);
+        }
+
 
         // update UI
         uploadListAdapter.loadUploadItemsFromDb();
         swipeListRefreshLayout.setRefreshing(false);
-        DisplayUtils.showSnackMessage(this, R.string.uploader_local_files_uploaded);
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/utils/FilesUploadHelper.kt
+++ b/app/src/main/java/com/owncloud/android/utils/FilesUploadHelper.kt
@@ -151,7 +151,6 @@ class FilesUploadHelper {
             val boundListener = mBoundListeners[key]
 
             boundListener?.onTransferProgress(progressRate, totalTransferredSoFar, totalToTransfer, fileName)
-            Log_OC.d("TAG", "Hello")
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -916,7 +916,7 @@
     <string name="failed_to_start_editor">Failed to start editor</string>
     <string name="create_rich_workspace">Add folder info</string>
     <string name="creates_rich_workspace">creates folder info</string>
-    <string name="uploader_local_files_uploaded">Try to upload local files again</string>
+    <string name="uploader_local_files_uploaded">Retry to upload failed local files</string>
     <string name="uploader_file_not_found_on_server_message">We couldnt locate the file on server. Another user may have deleted the file</string>
     <string name="uploader_file_not_found_message">File not found. Are you sure that this file exists or has a previous conflict not been resolved?</string>
     <string name="uploader_upload_failed_sync_conflict_error">File upload conflict</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
Fix info toast showing every time uploads tab is refreshed, even if no files are actually retried.
- [X] Tests written, or not not needed
