### PR TITLE
Restore delete functionality for E2EE - fixes #11387

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/files/FileMenuFilterIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/files/FileMenuFilterIT.kt
@@ -189,6 +189,10 @@ class FileMenuFilterIT : AbstractIT() {
             mimeType = MimeType.DIRECTORY
         }
 
+        val encryptedFile = OCFile("/foo.md").apply {
+            isEncrypted = true
+        }
+
         configureCapability(capability)
 
         launchActivity<TestActivity>().use {
@@ -226,6 +230,16 @@ class FileMenuFilterIT : AbstractIT() {
 
                 assertTrue(toHide.contains(R.id.action_unset_encrypted))
                 assertFalse(toHide.contains(R.id.action_encrypted))
+                assertFalse(toHide.contains(R.id.action_remove_file))
+
+                // encrypted file
+                sut = filterFactory.newInstance(encryptedFile, mockComponentsGetter, true, user)
+                toHide = sut.getToHide(false)
+
+                assertTrue(toHide.contains(R.id.action_unset_encrypted))
+                assertTrue(toHide.contains(R.id.action_encrypted))
+                assertTrue(toHide.contains(R.id.action_move_or_copy))
+                assertTrue(toHide.contains(R.id.action_rename_file))
                 assertFalse(toHide.contains(R.id.action_remove_file))
             }
         }

--- a/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -339,8 +339,7 @@ public class FileMenuFilter {
     }
 
     private void filterRemove(List<Integer> toHide, boolean synchronizing) {
-        if (files.isEmpty() || synchronizing || containsLockedFile()
-            || containsEncryptedFolder() || containsEncryptedFile()) {
+        if (files.isEmpty() || synchronizing || containsLockedFile() || isEncryptedRoot()) {
             toHide.add(R.id.action_remove_file);
         }
     }
@@ -564,5 +563,9 @@ public class FileMenuFilter {
             }
         }
         return false;
+    }
+
+    private boolean isEncryptedRoot() {
+        return isEncryptedFolder() && !hasEncryptedParent();
     }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Test added ~~modified, they distinguish between the root encrypted folder (which cannot be deleted) and subfolders (which can).~~

EDIT: I was not able to implement a test for subfolders, I was not able to figure out how to change properties of the parent directory (in particular, I need to flag the parent as encrypted).
I opted to instead introduce a test that checks that an encrypted file *can* be deleted, while it *cannot* be moved/copied or renamed.