### PR TITLE
Changing the Documentation from the Toolbar Options

### DIFF
--- a/app/src/main/res/layout/toolbar_standard.xml
+++ b/app/src/main/res/layout/toolbar_standard.xml
@@ -174,7 +174,7 @@
                     app:layout_constraintLeft_toRightOf="@id/menu_button"
                     app:layout_constraintRight_toLeftOf="@id/switch_account_button"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:text="Search in Nextcloud" />
+                    tools:text="Explore in Nextcloud" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/switch_account_button"


### PR DESCRIPTION
A small change in the search bar hint from "Search in NextCloud" to "Explore in NextCloud".
![Screenshot 2024-01-01 104738](https://github.com/nextcloud/android/assets/120440817/e70927a8-ba1b-4afa-8c0b-1ced594cc3b6)

