### PR TITLE
Fix auto upload does not start automatically

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -385,6 +385,12 @@
         </activity>
 
         <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:directBootAware="false"
+            android:enabled="@bool/enable_system_foreground_service_default"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+        <service
             android:name=".services.OperationsService"
             android:exported="false" />
         <service

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -78,8 +78,9 @@ class FilesSyncWork(
         const val FOREGROUND_SERVICE_ID = 414
     }
 
+    @Suppress("MagicNumber")
     private fun createForegroundInfo(progressPercent: Int): ForegroundInfo {
-        //update throughout worker execution to give use feedback how far worker is
+        // update throughout worker execution to give use feedback how far worker is
 
         val notification = NotificationCompat.Builder(context, NotificationUtils.NOTIFICATION_CHANNEL_FILE_SYNC)
             .setTicker(context.getString(R.string.autoupload_worker_foreground_info))
@@ -93,6 +94,7 @@ class FilesSyncWork(
         return ForegroundInfo(FOREGROUND_SERVICE_ID, notification)
     }
 
+    @Suppress("MagicNumber")
     override suspend fun doWork(): Result {
         backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class))
         setForeground(createForegroundInfo(0))
@@ -123,8 +125,8 @@ class FilesSyncWork(
         dateFormat.timeZone = TimeZone.getTimeZone(TimeZone.getDefault().id)
 
         val syncedFolders = syncedFolderProvider.syncedFolders
-        for ((index,syncedFolder) in syncedFolders.withIndex()) {
-            setForeground(createForegroundInfo((50+(index.toDouble()/syncedFolders.size.toDouble())*50).toInt()))
+        for ((index, syncedFolder) in syncedFolders.withIndex()) {
+            setForeground(createForegroundInfo((50 + (index.toDouble() / syncedFolders.size.toDouble()) * 50).toInt()))
             if (syncedFolder.isEnabled && (!skipCustom || MediaFolderType.CUSTOM != syncedFolder.type)) {
                 syncFolder(
                     context,

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -25,6 +25,7 @@ package com.nextcloud.client.jobs
 import android.content.ContentResolver
 import android.content.Context
 import android.content.res.Resources
+import android.os.Build
 import android.text.TextUtils
 import androidx.core.app.NotificationCompat
 import androidx.exifinterface.media.ExifInterface
@@ -39,6 +40,7 @@ import com.owncloud.android.R
 import com.owncloud.android.datamodel.ArbitraryDataProvider
 import com.owncloud.android.datamodel.ArbitraryDataProviderImpl
 import com.owncloud.android.datamodel.FilesystemDataProvider
+import com.owncloud.android.datamodel.ForegroundServiceType
 import com.owncloud.android.datamodel.MediaFolderType
 import com.owncloud.android.datamodel.SyncedFolder
 import com.owncloud.android.datamodel.SyncedFolderProvider
@@ -90,8 +92,11 @@ class FilesSyncWork(
             .setOngoing(true)
             .setProgress(100, progressPercent, false)
             .build()
-
-        return ForegroundInfo(FOREGROUND_SERVICE_ID, notification)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(FOREGROUND_SERVICE_ID, notification, ForegroundServiceType.DataSync.getId())
+        } else {
+            ForegroundInfo(FOREGROUND_SERVICE_ID, notification)
+        }
     }
 
     @Suppress("MagicNumber")

--- a/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
@@ -55,10 +55,10 @@ public class FilesystemDataProvider {
 
     public int deleteAllEntriesForSyncedFolder(String syncedFolderId) {
         return contentResolver.delete(
-                ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
-                new String[]{syncedFolderId}
-        );
+            ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
+            ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
+            new String[]{syncedFolderId}
+                                     );
     }
 
     public void updateFilesystemFileAsSentForUpload(String path, String syncedFolderId) {
@@ -66,12 +66,12 @@ public class FilesystemDataProvider {
         cv.put(ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD, 1);
 
         contentResolver.update(
-                ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
-                cv,
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " = ? and " +
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
-                new String[]{path, syncedFolderId}
-        );
+            ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
+            cv,
+            ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " = ? and " +
+                ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
+            new String[]{path, syncedFolderId}
+                              );
     }
 
     public Set<String> getFilesForUpload(String localPath, String syncedFolderId) {
@@ -80,20 +80,20 @@ public class FilesystemDataProvider {
         String likeParam = localPath + "%";
 
         Cursor cursor = contentResolver.query(
-                ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
-                null,
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " LIKE ? and " +
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ? and " +
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD + " = ? and " +
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER + " = ?",
-                new String[]{likeParam, syncedFolderId, "0", "0"},
-                null);
+            ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
+            null,
+            ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " LIKE ? and " +
+                ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ? and " +
+                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD + " = ? and " +
+                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER + " = ?",
+            new String[]{likeParam, syncedFolderId, "0", "0"},
+            null);
 
         if (cursor != null) {
             if (cursor.moveToFirst()) {
                 do {
                     String value = cursor.getString(cursor.getColumnIndexOrThrow(
-                            ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
+                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
                     if (value == null) {
                         Log_OC.e(TAG, "Cannot get local path");
                     } else {
@@ -159,11 +159,11 @@ public class FilesystemDataProvider {
 
 
             int result = contentResolver.update(
-                    ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
-                    cv,
-                    ProviderMeta.ProviderTableMeta._ID + "=?",
-                    new String[]{String.valueOf(data.getId())}
-            );
+                ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
+                cv,
+                ProviderMeta.ProviderTableMeta._ID + "=?",
+                new String[]{String.valueOf(data.getId())}
+                                               );
 
             if (result == 0) {
                 Log_OC.v(TAG, "Failed to update filesystem data with local path: " + localPath);
@@ -174,33 +174,33 @@ public class FilesystemDataProvider {
     private FileSystemDataSet getFilesystemDataSet(String localPathParam, SyncedFolder syncedFolder) {
 
         Cursor cursor = contentResolver.query(
-                ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
-                null,
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " = ? and " +
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
-                new String[]{localPathParam, Long.toString(syncedFolder.getId())},
-                null
-        );
+            ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
+            null,
+            ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " = ? and " +
+                ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
+            new String[]{localPathParam, Long.toString(syncedFolder.getId())},
+            null
+                                             );
 
         FileSystemDataSet dataSet = null;
         if (cursor != null) {
             if (cursor.moveToFirst()) {
                 int id = cursor.getInt(cursor.getColumnIndexOrThrow(ProviderMeta.ProviderTableMeta._ID));
                 String localPath = cursor.getString(cursor.getColumnIndexOrThrow(
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
+                    ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
                 long modifiedAt = cursor.getLong(cursor.getColumnIndexOrThrow(
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_MODIFIED));
+                    ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_MODIFIED));
                 boolean isFolder = false;
                 if (cursor.getInt(cursor.getColumnIndexOrThrow(
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER)) != 0) {
+                    ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER)) != 0) {
                     isFolder = true;
                 }
                 long foundAt = cursor.getLong(cursor.getColumnIndexOrThrow(ProviderMeta.
-                        ProviderTableMeta.FILESYSTEM_FILE_FOUND_RECENTLY));
+                                                                               ProviderTableMeta.FILESYSTEM_FILE_FOUND_RECENTLY));
 
                 boolean isSentForUpload = false;
                 if (cursor.getInt(cursor.getColumnIndexOrThrow(
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD)) != 0) {
+                    ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD)) != 0) {
                     isSentForUpload = true;
                 }
 
@@ -210,7 +210,7 @@ public class FilesystemDataProvider {
                     Log_OC.e(TAG, "Arbitrary value could not be created from cursor");
                 } else {
                     dataSet = new FileSystemDataSet(id, localPath, modifiedAt, isFolder, isSentForUpload, foundAt,
-                            syncedFolder.getId(), crc32);
+                                                    syncedFolder.getId(), crc32);
                 }
             }
             cursor.close();
@@ -223,12 +223,12 @@ public class FilesystemDataProvider {
 
     private long getFileChecksum(String filepath) {
 
-        try (InputStream inputStream = new BufferedInputStream(new FileInputStream(filepath))){
+        try (InputStream inputStream = new BufferedInputStream(new FileInputStream(filepath))) {
             CRC32 crc = new CRC32();
-            byte[] buf = new byte[1024*64];
+            byte[] buf = new byte[1024 * 64];
             int size;
             while ((size = inputStream.read(buf)) > 0) {
-                crc.update(buf,0,size);
+                crc.update(buf, 0, size);
             }
 
             return crc.getValue();

--- a/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
@@ -225,9 +225,10 @@ public class FilesystemDataProvider {
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(filepath))){
             CRC32 crc = new CRC32();
-            int cnt;
-            while ((cnt = inputStream.read()) != -1) {
-                crc.update(cnt);
+            byte[] buf = new byte[1024*64];
+            int size;
+            while ((size = inputStream.read(buf)) > 0) {
+                crc.update(buf,0,size);
             }
 
             return crc.getValue();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -628,6 +628,7 @@
     <string name="autoupload_hide_folder">Hide folder</string>
     <string name="autoupload_configure">Configure</string>
     <string name="synced_folders_configure_folders">Configure folders</string>
+    <string name="autoupload_worker_foreground_info">Preparing auto upload</string>
 
     <string name="empty" translatable="false" />
     <string name="test_server_button">Test server connection</string>


### PR DESCRIPTION
[Screen_recording_20240103_123529.webm](https://github.com/nextcloud/android/assets/43114340/2a10329f-61bc-452e-abd2-655eec888cdf)
- Add foreground info (also interesting for user) to prevent android killing the worker. (Only visible if worker is active more than ca. 1s -> Use large folder with many files for testing) 

- Make getFileChecksum a lot faster (previously over 1 h for a folder of 6000 Images now only minutes)
![Screenshot_2024-01-02_13-37-46](https://github.com/nextcloud/android/assets/43114340/36ee8696-87c7-4443-89e5-242eb5c4ac73)
Previously 7.5s
![Screenshot_2024-01-02_13-45-05](https://github.com/nextcloud/android/assets/43114340/ffcec165-d28b-4f95-9015-11ad516aed34)
Now 15ms
|_ Should be tested (maybe too good to be true)

For me, it also helps with https://github.com/nextcloud/android/issues/12141
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
