### PR TITLE
Fix collabora files not loading

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.kt
@@ -71,9 +71,7 @@ class RichDocumentsEditorWebView : EditorWebView() {
 
         webView.addJavascriptInterface(RichDocumentsMobileInterface(), "RichDocumentsMobileInterface")
 
-        intent.getStringExtra(EXTRA_URL)?.let {
-            loadUrl(it)
-        }
+        loadUrl(intent.getStringExtra(EXTRA_URL))
 
         registerActivityResult()
     }
@@ -150,7 +148,7 @@ class RichDocumentsEditorWebView : EditorWebView() {
         PrintAsyncTask(targetFile, url.toString(), WeakReference(this)).execute()
     }
 
-    public override fun loadUrl(url: String) {
+    public override fun loadUrl(url: String?) {
         if (TextUtils.isEmpty(url)) {
             RichDocumentsLoadUrlTask(this, user.get(), file).execute()
         } else {


### PR DESCRIPTION
Allow loadUrl with extra_url = null to create new document viewer.
Opening a collabora file (eg. docx file) before was not possible (infinite loading screen).
Fixes https://github.com/nextcloud/android/issues/12338 
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
