### PR TITLE
Remove duplicated service tag from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -240,12 +240,6 @@
             android:configChanges="orientation|screenLayout|screenSize|keyboardHidden"
             android:theme="@style/Theme.ownCloud.Media" />
         <service
-            android:name="androidx.work.impl.foreground.SystemForegroundService"
-            android:directBootAware="false"
-            android:enabled="@bool/enable_system_foreground_service_default"
-            android:exported="false"
-            android:foregroundServiceType="dataSync" />
-        <service
             android:name=".authentication.AccountAuthenticatorService"
             android:exported="false">
             <intent-filter android:priority="100">


### PR DESCRIPTION
The exact same service tag already exists in manifest. No need to have it there twice.  
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
