### PR TITLE
Fix screenshot test

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -452,7 +452,6 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
      * before reading database.
      */
     public void refreshSharesFromDB() {
-        file = fileDataStorageManager.getFileById(file.getFileId());
         ShareeListAdapter adapter = (ShareeListAdapter) binding.sharesList.getAdapter();
 
         if (adapter == null) {


### PR DESCRIPTION
This change fixes screenshot tests failing because the following trace:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.owncloud.android.datamodel.OCFile.getRemotePath()' on a null object reference

at com.owncloud.android.ui.fragment.FileDetailSharingFragment.refreshSharesFromDB(FileDetailSharingFragment.java:465)

at com.owncloud.android.ui.fragment.FileDetailSharingFragment.onActivityCreated(FileDetailSharingFragment.java:159)

at androidx.fragment.app.Fragment.performActivityCreated(Fragment.java:3156)
...
```

- [x] Tests written, or not not needed