### PR TITLE
Deprecate OwncloudClient - Helpers

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/extensions/OwnCloudClientExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OwnCloudClientExtensions.kt
@@ -1,0 +1,37 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author ZetaTom
+ * Copyright (C) 2023 ZetaTom
+ * Copyright (C) 2023 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.utils.extensions
+
+import android.content.Context
+import com.nextcloud.common.NextcloudClient
+import com.owncloud.android.lib.common.OwnCloudClient
+import com.owncloud.android.lib.common.OwnCloudClientFactory
+
+fun OwnCloudClient.toNextcloudClient(context: Context): NextcloudClient {
+    return OwnCloudClientFactory.createNextcloudClient(
+        baseUri,
+        userId,
+        credentials.toOkHttpCredentials(),
+        context,
+        isFollowRedirects
+    )
+}


### PR DESCRIPTION
This is one of a series of pull requests which aim to replace all instances of `OwnCloudClient` with `NextcloudClient`. The reason for this change is that the newer `NextcloudClient` uses OkHttp, replacing the outdated Jackrabbit methods.

Specifically, this pull request implements the following:
- helper classes to ease the transition and refactoring
- general changes
- fallback mechanism to convert legacy `OwnCloudClient` to `NextcloudClient` at runtime
- see https://github.com/nextcloud/android-library/pull/1271

---

- [ ] Tests written, or not not needed