### PR TITLE
Bugfix: Change database query to only return uploads for right account

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -569,7 +569,7 @@ public class UploadsStorageManager extends Observable {
     }
 
     public OCUpload[] getCurrentAndPendingUploadsForAccount(final @NonNull String accountName) {
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
+        return getUploads("( " + ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
                               " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
                               "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
                               " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
@@ -578,7 +578,7 @@ public class UploadsStorageManager extends Observable {
                               "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
                               " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
                               "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
-                              " AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
+                              " ) AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
                           accountName);
     }
 
@@ -588,7 +588,7 @@ public class UploadsStorageManager extends Observable {
      * If <code>afterId</code> is -1, returns the first page
      */
     public List<OCUpload> getCurrentAndPendingUploadsForAccountPageAscById(final long afterId, final @NonNull String accountName) {
-        final String selection = ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
+        final String selection = "( " + ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
             " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
             "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
             " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
@@ -597,7 +597,7 @@ public class UploadsStorageManager extends Observable {
             "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
             " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
             "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
-            " AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?";
+            " ) AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?";
         return getUploadPage(afterId, false, selection, accountName);
     }
 


### PR DESCRIPTION
Before:
![Screenshot_2024-02-06_14-18-36](https://github.com/nextcloud/android/assets/43114340/67bfad87-7304-4e33-9a61-4ff0db2c2ac4)

After:
![Screenshot_2024-02-06_14-20-33](https://github.com/nextcloud/android/assets/43114340/003a132c-7659-47fe-bd99-b36d47b129bd)
![Screenshot_2024-02-06_14-21-10](https://github.com/nextcloud/android/assets/43114340/9a78d303-c87f-43bb-b828-7257f2076768)

Fixes: 
Upload Worker queries uploads for wrong account and uploads it in wrong account.
-> Also leads to upload conflicts, so maybe also causes: https://github.com/nextcloud/android/issues/11974
Multiple other inconsistencies.
Fixes #11088

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
