### PR TITLE
Bugfix for unspecific errors when renaming files from different session 

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -523,6 +523,7 @@ public class FileOperationsHelper {
                 showShareFile(file);
             }
         }
+
         fileActivity.refreshList();
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -523,6 +523,7 @@ public class FileOperationsHelper {
                 showShareFile(file);
             }
         }
+        fileActivity.refreshList();
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
+++ b/app/src/main/java/com/owncloud/android/utils/ErrorMessageAdapter.java
@@ -423,7 +423,7 @@ public final class ErrorMessageAdapter {
                 message = res.getString(R.string.auth_not_configured_title);
 
             } else if (result.getCode() == ResultCode.FILE_NOT_FOUND) {
-                message = res.getString(R.string.auth_incorrect_path_title);
+                message = res.getString(R.string.file_not_found);
 
             } else if (result.getCode() == ResultCode.OAUTH2_ERROR) {
                 message = res.getString(R.string.auth_oauth_error);


### PR DESCRIPTION
### Issue
- Create file A
- Rename file A to B from another session, e.g. web browser 
- Without manual reload on the client side, try renaming, share by link

Error for Renaming: "Server not found"
Issue for share by link: "Server not found" + No reload after error → File A gets not updated

### New behavior
Error for Renaming: "File not found"
Behavior for share by link: "File not found" + Reload after error → File A gets updated to file B

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
