### PR TITLE
Add global upload pause button

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
@@ -251,6 +251,7 @@ class BackgroundJobFactory @Inject constructor(
             viewThemeUtils.get(),
             localBroadcastManager.get(),
             backgroundJobManager.get(),
+            preferences,
             context,
             params
         )

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -160,7 +160,7 @@ class FileUploadHelper {
         }
     }
 
-    private fun cancelAndRestartUploadJob(user: User) {
+    fun cancelAndRestartUploadJob(user: User) {
         backgroundJobManager.run {
             cancelFilesUploadJob(user)
             startFilesUploadJob(user)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -138,12 +138,13 @@ class FileUploadWorker(
         WorkerStateLiveData.instance().setWorkState(WorkerState.Idle)
     }
 
+    @Suppress("ReturnCount")
     private fun retrievePagesBySortingUploadsByID(): Result {
         val accountName = inputData.getString(ACCOUNT) ?: return Result.failure()
         var currentPage = uploadsStorageManager.getCurrentAndPendingUploadsForAccountPageAscById(-1, accountName)
 
         while (currentPage.isNotEmpty() && !isStopped) {
-            if (preferences.globalUploadPaused){
+            if (preferences.globalUploadPaused) {
                 Log_OC.d(TAG, "Upload is paused, skip uploading files!")
                 notificationManager.notifyPaused(
                     intents.notificationStartIntent(null)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -144,7 +144,7 @@ class FileUploadWorker(
         var currentPage = uploadsStorageManager.getCurrentAndPendingUploadsForAccountPageAscById(-1, accountName)
 
         while (currentPage.isNotEmpty() && !isStopped) {
-            if (preferences.globalUploadPaused) {
+            if (preferences.isGlobalUploadPaused) {
                 Log_OC.d(TAG, "Upload is paused, skip uploading files!")
                 notificationManager.notifyPaused(
                     intents.notificationStartIntent(null)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploaderIntents.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploaderIntents.kt
@@ -97,10 +97,10 @@ class FileUploaderIntents(private val context: Context) {
         )
     }
 
-    fun notificationStartIntent(operation: UploadFileOperation): PendingIntent {
+    fun notificationStartIntent(operation: UploadFileOperation?): PendingIntent {
         val intent = UploadListActivity.createIntent(
-            operation.file,
-            operation.user,
+            operation?.file,
+            operation?.user,
             Intent.FLAG_ACTIVITY_CLEAR_TOP,
             context
         )

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -37,16 +37,12 @@ import com.owncloud.android.utils.theme.ViewThemeUtils
 
 class UploadNotificationManager(private val context: Context, private val viewThemeUtils: ViewThemeUtils) {
     companion object {
-
         private const val ID = 411
     }
 
     private var notification: Notification? = null
-    private var notificationBuilder: NotificationCompat.Builder
-    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-    init {
-        notificationBuilder = NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+    private var notificationBuilder: NotificationCompat.Builder =
+        NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
             setContentTitle(context.getString(R.string.foreground_service_upload))
             setSmallIcon(R.drawable.notification_icon)
             setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
@@ -55,13 +51,15 @@ class UploadNotificationManager(private val context: Context, private val viewTh
                 setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD)
             }
         }
+    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
+    init {
         notification = notificationBuilder.build()
     }
 
     @Suppress("MagicNumber")
     fun prepareForStart(upload: UploadFileOperation, pendingIntent: PendingIntent, startIntent: PendingIntent) {
-        notificationBuilder = NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+        notificationBuilder.run {
             setSmallIcon(R.drawable.notification_icon)
             setOngoing(true)
             setTicker(context.getString(R.string.foreground_service_upload))
@@ -195,12 +193,14 @@ class UploadNotificationManager(private val context: Context, private val viewTh
     }
 
     fun notifyPaused(startIntent: PendingIntent) {
-        notificationBuilder = NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+        notificationBuilder.apply {
             setSmallIcon(R.drawable.notification_icon)
             setOngoing(true)
+            setAutoCancel(false)
             setTicker(context.getString(R.string.upload_global_pause))
             setContentTitle(context.getString(R.string.upload_global_pause_title))
             setContentText(context.getString(R.string.upload_global_pause))
+            setProgress(0, 0, false)
             clearActions()
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -37,6 +37,7 @@ import com.owncloud.android.utils.theme.ViewThemeUtils
 
 class UploadNotificationManager(private val context: Context, private val viewThemeUtils: ViewThemeUtils) {
     companion object {
+
         private const val ID = 411
     }
 
@@ -191,5 +192,25 @@ class UploadNotificationManager(private val context: Context, private val viewTh
 
     fun dismissWorkerNotifications() {
         notificationManager.cancel(ID)
+    }
+
+    fun notifyPaused(startIntent: PendingIntent) {
+        notificationBuilder = NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+            setSmallIcon(R.drawable.notification_icon)
+            setOngoing(true)
+            setTicker(context.getString(R.string.upload_global_pause))
+            setContentTitle(context.getString(R.string.upload_global_pause_title))
+            setContentText(context.getString(R.string.upload_global_pause))
+            clearActions()
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD)
+            }
+
+            setContentIntent(startIntent)
+        }
+
+
+        showNotification()
     }
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -210,7 +210,6 @@ class UploadNotificationManager(private val context: Context, private val viewTh
             setContentIntent(startIntent)
         }
 
-
         showNotification()
     }
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -35,7 +35,7 @@ import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
-class UploadNotificationManager(private val context: Context, private val viewThemeUtils: ViewThemeUtils) {
+class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils) {
     companion object {
         private const val ID = 411
     }
@@ -60,11 +60,7 @@ class UploadNotificationManager(private val context: Context, private val viewTh
     @Suppress("MagicNumber")
     fun prepareForStart(upload: UploadFileOperation, pendingIntent: PendingIntent, startIntent: PendingIntent) {
         notificationBuilder.run {
-            setSmallIcon(R.drawable.notification_icon)
-            setOngoing(true)
-            setTicker(context.getString(R.string.foreground_service_upload))
             setContentTitle(context.getString(R.string.uploader_upload_in_progress_ticker))
-            setProgress(100, 0, false)
             setContentText(
                 String.format(
                     context.getString(R.string.uploader_upload_in_progress),
@@ -72,6 +68,9 @@ class UploadNotificationManager(private val context: Context, private val viewTh
                     upload.fileName
                 )
             )
+            setTicker(context.getString(R.string.foreground_service_upload))
+            setProgress(100, 0, false)
+            setOngoing(true)
             clearActions()
 
             addAction(
@@ -79,10 +78,6 @@ class UploadNotificationManager(private val context: Context, private val viewTh
                 context.getString(R.string.common_cancel),
                 pendingIntent
             )
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD)
-            }
 
             setContentIntent(startIntent)
         }
@@ -192,22 +187,16 @@ class UploadNotificationManager(private val context: Context, private val viewTh
         notificationManager.cancel(ID)
     }
 
-    fun notifyPaused(startIntent: PendingIntent) {
+    fun notifyPaused(intent: PendingIntent) {
         notificationBuilder.apply {
-            setSmallIcon(R.drawable.notification_icon)
-            setOngoing(true)
-            setAutoCancel(false)
-            setTicker(context.getString(R.string.upload_global_pause))
             setContentTitle(context.getString(R.string.upload_global_pause_title))
             setContentText(context.getString(R.string.upload_global_pause))
+            setTicker(context.getString(R.string.upload_global_pause))
+            setOngoing(true)
+            setAutoCancel(false)
             setProgress(0, 0, false)
             clearActions()
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD)
-            }
-
-            setContentIntent(startIntent)
+            setContentIntent(intent)
         }
 
         showNotification()

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -190,8 +190,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     fun notifyPaused(intent: PendingIntent) {
         notificationBuilder.apply {
             setContentTitle(context.getString(R.string.upload_global_pause_title))
-            setContentText(context.getString(R.string.upload_global_pause))
-            setTicker(context.getString(R.string.upload_global_pause))
+            setTicker(context.getString(R.string.upload_global_pause_title))
             setOngoing(true)
             setAutoCancel(false)
             setProgress(0, 0, false)

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -387,7 +387,7 @@ public interface AppPreferences {
 
     void setCalendarLastBackup(long timestamp);
 
-    boolean getGlobalUploadPaused();
+    boolean isGlobalUploadPaused();
 
     void setGlobalUploadPaused(boolean globalPausedState);
 

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -387,6 +387,10 @@ public interface AppPreferences {
 
     void setCalendarLastBackup(long timestamp);
 
+    boolean getGlobalUploadPaused();
+
+    void setGlobalUploadPaused(boolean globalPausedState);
+
     void setPdfZoomTipShownCount(int count);
 
     int getPdfZoomTipShownCount();

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -107,6 +107,8 @@ public final class AppPreferencesImpl implements AppPreferences {
     private static final String PREF__CALENDAR_AUTOMATIC_BACKUP = "calendar_automatic_backup";
     private static final String PREF__CALENDAR_LAST_BACKUP = "calendar_last_backup";
 
+    private static final String PREF__GLOBAL_PAUSE_STATE = "global_pause_state";
+
     private static final String PREF__PDF_ZOOM_TIP_SHOWN = "pdf_zoom_tip_shown";
     private static final String PREF__MEDIA_FOLDER_LAST_PATH = "media_folder_last_path";
 
@@ -739,6 +741,16 @@ public final class AppPreferencesImpl implements AppPreferences {
     @Override
     public void setCalendarLastBackup(long timestamp) {
         preferences.edit().putLong(PREF__CALENDAR_LAST_BACKUP, timestamp).apply();
+    }
+
+    @Override
+    public boolean getGlobalUploadPaused() {
+        return preferences.getBoolean(PREF__GLOBAL_PAUSE_STATE,false);
+    }
+
+    @Override
+    public void setGlobalUploadPaused(boolean globalPausedState) {
+        preferences.edit().putBoolean(PREF__GLOBAL_PAUSE_STATE, globalPausedState).apply();
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -744,7 +744,7 @@ public final class AppPreferencesImpl implements AppPreferences {
     }
 
     @Override
-    public boolean getGlobalUploadPaused() {
+    public boolean isGlobalUploadPaused() {
         return preferences.getBoolean(PREF__GLOBAL_PAUSE_STATE,false);
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1155,6 +1155,10 @@ public abstract class DrawerActivity extends ToolbarActivity
         return true;
     }
 
+    public AppPreferences getAppPreferences(){
+        return preferences;
+    }
+
     @Override
     protected void onStart() {
         super.onStart();

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -267,7 +267,7 @@ public class UploadListActivity extends FileActivity {
     }
 
     @Override
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.activity_upload_list, menu);

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -290,18 +290,12 @@ public class UploadListActivity extends FileActivity {
         int iconId;
         String title;
         if (preferences.getGlobalUploadPaused()) {
-            iconId = R.drawable.ic_play_arrow;
+            iconId = R.drawable.ic_play;
             title = getString(R.string.upload_action_global_upload_resume);
         } else {
             iconId = R.drawable.ic_pause;
             title = getString(R.string.upload_action_global_upload_pause);
         }
-        /*
-        DrawableUtil drawableUtil = new DrawableUtil();
-        Drawable iconDrawable = AppCompatResources.getDrawable(this, iconId);
-        assert iconDrawable != null;
-        iconDrawable = drawableUtil.changeColor(iconDrawable, R.color.dark_background_text_color);
-         */
 
         pauseMenuItem.setIcon(iconId);
         pauseMenuItem.setTitle(title);

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -29,6 +29,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -57,11 +60,16 @@ import com.owncloud.android.operations.CheckCurrentCredentialsOperation;
 import com.owncloud.android.ui.adapter.UploadListAdapter;
 import com.owncloud.android.ui.decoration.MediaGridItemDecoration;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.DrawableUtil;
 import com.owncloud.android.utils.FilesSyncHelper;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -275,20 +283,28 @@ public class UploadListActivity extends FileActivity {
 
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     private void updateGlobalPauseIcon(MenuItem pauseMenuItem) {
-        if (pauseMenuItem.getItemId() == R.id.action_toggle_global_pause) {
-            if (preferences.getGlobalUploadPaused()) {
-                pauseMenuItem.setIcon(android.R.drawable.ic_media_play);
-                pauseMenuItem.setTitle(getApplicationContext().getString(
-                    R.string.upload_action_global_upload_resume
-                                                                        ));
-            } else {
-                pauseMenuItem.setIcon(android.R.drawable.ic_media_pause);
-                pauseMenuItem.setTitle(getApplicationContext().getString(
-                    R.string.upload_action_global_upload_pause
-                                                                        ));
-            }
-
+        if (pauseMenuItem.getItemId() != R.id.action_toggle_global_pause) {
+            return;
         }
+
+        int iconId;
+        String title;
+        if (preferences.getGlobalUploadPaused()) {
+            iconId = R.drawable.ic_play_arrow;
+            title = getString(R.string.upload_action_global_upload_resume);
+        } else {
+            iconId = R.drawable.ic_pause;
+            title = getString(R.string.upload_action_global_upload_pause);
+        }
+        /*
+        DrawableUtil drawableUtil = new DrawableUtil();
+        Drawable iconDrawable = AppCompatResources.getDrawable(this, iconId);
+        assert iconDrawable != null;
+        iconDrawable = drawableUtil.changeColor(iconDrawable, R.color.dark_background_text_color);
+         */
+
+        pauseMenuItem.setIcon(iconId);
+        pauseMenuItem.setTitle(title);
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -320,6 +320,8 @@ public class UploadListActivity extends FileActivity {
             }
         } else if (itemId == R.id.action_toggle_global_pause) {
             toggleGlobalPause(item);
+        } else {
+            return super.onOptionsItemSelected(item);
         }
 
         return true;

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -49,7 +49,6 @@ import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadListLayoutBinding;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.UploadsStorageManager;
-import com.owncloud.android.db.OCUpload;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -270,11 +269,17 @@ public class UploadListActivity extends FileActivity {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.activity_upload_list, menu);
 
-        if (menu.getItem(0).getItemId() == R.id.action_toogle_global_pause){
+        if (menu.getItem(0).getItemId() == R.id.action_toggle_global_pause){
             if (preferences.getGlobalUploadPaused()){
                 menu.getItem(0).setIcon(android.R.drawable.ic_media_play);
+                menu.getItem(0).setTitle(getApplicationContext().getString(
+                    R.string.upload_action_global_upload_resume
+                                                                          ));
             }else{
                 menu.getItem(0).setIcon(android.R.drawable.ic_media_pause);
+                menu.getItem(0).setTitle(getApplicationContext().getString(
+                    R.string.upload_action_global_upload_pause
+                                                                          ));
             }
 
         }
@@ -293,7 +298,7 @@ public class UploadListActivity extends FileActivity {
             } else {
                 openDrawer();
             }
-        } else if (itemId == R.id.action_toogle_global_pause) {
+        } else if (itemId == R.id.action_toggle_global_pause) {
             preferences.setGlobalUploadPaused(!preferences.getGlobalUploadPaused());
             if (preferences.getGlobalUploadPaused()){
                 item.setIcon(android.R.drawable.ic_media_play);

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -65,6 +65,7 @@ import javax.inject.Inject;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Activity listing pending, active, and completed uploads. User can delete
@@ -266,6 +267,7 @@ public class UploadListActivity extends FileActivity {
     }
 
     @Override
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.activity_upload_list, menu);

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -290,8 +290,9 @@ public class UploadListActivity extends FileActivity {
         return true;
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     @Override
+    @SuppressLint("NotifyDataSetChanged")
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     public boolean onOptionsItemSelected(MenuItem item) {
 
         int itemId = item.getItemId();

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -29,9 +29,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.graphics.Canvas;
-import android.graphics.ColorFilter;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -60,16 +57,11 @@ import com.owncloud.android.operations.CheckCurrentCredentialsOperation;
 import com.owncloud.android.ui.adapter.UploadListAdapter;
 import com.owncloud.android.ui.decoration.MediaGridItemDecoration;
 import com.owncloud.android.utils.DisplayUtils;
-import com.owncloud.android.utils.DrawableUtil;
 import com.owncloud.android.utils.FilesSyncHelper;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import javax.inject.Inject;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.content.res.AppCompatResources;
-import androidx.core.content.res.ResourcesCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -289,7 +281,7 @@ public class UploadListActivity extends FileActivity {
 
         int iconId;
         String title;
-        if (preferences.getGlobalUploadPaused()) {
+        if (preferences.isGlobalUploadPaused()) {
             iconId = R.drawable.ic_play;
             title = getString(R.string.upload_action_global_upload_resume);
         } else {
@@ -303,7 +295,7 @@ public class UploadListActivity extends FileActivity {
 
     @SuppressLint("NotifyDataSetChanged")
     private void toggleGlobalPause(MenuItem pauseMenuItem) {
-        preferences.setGlobalUploadPaused(!preferences.getGlobalUploadPaused());
+        preferences.setGlobalUploadPaused(!preferences.isGlobalUploadPaused());
         updateGlobalPauseIcon(pauseMenuItem);
 
         for (User user : accountManager.getAllUsers()) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -24,6 +24,7 @@
 package com.owncloud.android.ui.activity;
 
 import android.accounts.Account;
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -287,6 +288,7 @@ public class UploadListActivity extends FileActivity {
         return true;
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 
@@ -309,6 +311,7 @@ public class UploadListActivity extends FileActivity {
             for (User user: accountManager.getAllUsers()){
                 if (user != null) FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user);
             }
+            uploadListAdapter.notifyDataSetChanged();
         }
 
         return true;

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -644,7 +644,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                     status = parentActivity.getString(R.string.uploader_upload_in_progress_ticker);
                 }
                 if (parentActivity.getAppPreferences().getGlobalUploadPaused()) {
-                    status = parentActivity.getString(R.string.upload_global_pause);
+                    status = parentActivity.getString(R.string.upload_global_pause_title);
                 }
             }
             case UPLOAD_SUCCEEDED -> {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -646,6 +646,8 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 if (uploadHelper.isUploadingNow(upload)) {
                     // really uploading, bind the progress bar to listen for progress updates
                     status = parentActivity.getString(R.string.uploader_upload_in_progress_ticker);
+                } else if (parentActivity.getAppPreferences().getGlobalUploadPaused()) {
+                    status = parentActivity.getString(R.string.upload_global_pause);
                 }
                 break;
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -287,7 +287,6 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         itemViewHolder.binding.uploadRemotePath.setVisibility(View.VISIBLE);
         itemViewHolder.binding.uploadFileSize.setVisibility(View.VISIBLE);
         itemViewHolder.binding.uploadStatus.setVisibility(View.VISIBLE);
-        itemViewHolder.binding.uploadStatus.setTypeface(null, Typeface.NORMAL);
         itemViewHolder.binding.uploadProgressBar.setVisibility(View.GONE);
 
         // Update information depending of upload details
@@ -333,7 +332,6 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         // show status if same file conflict or local file deleted
         if (item.getUploadStatus() == UploadStatus.UPLOAD_SUCCEEDED && item.getLastResult() != UploadResult.UPLOADED){
             itemViewHolder.binding.uploadStatus.setVisibility(View.VISIBLE);
-            itemViewHolder.binding.uploadStatus.setTypeface(null, Typeface.BOLD);
             itemViewHolder.binding.uploadDate.setVisibility(View.GONE);
             itemViewHolder.binding.uploadFileSize.setVisibility(View.GONE);
         }
@@ -641,32 +639,27 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
     private String getStatusText(OCUpload upload) {
         String status;
         switch (upload.getUploadStatus()) {
-            case UPLOAD_IN_PROGRESS:
+            case UPLOAD_IN_PROGRESS -> {
                 status = parentActivity.getString(R.string.uploads_view_later_waiting_to_upload);
                 if (uploadHelper.isUploadingNow(upload)) {
                     // really uploading, bind the progress bar to listen for progress updates
                     status = parentActivity.getString(R.string.uploader_upload_in_progress_ticker);
-                } else if (parentActivity.getAppPreferences().getGlobalUploadPaused()) {
+                }
+                if (parentActivity.getAppPreferences().getGlobalUploadPaused()) {
                     status = parentActivity.getString(R.string.upload_global_pause);
                 }
-                break;
-
-            case UPLOAD_SUCCEEDED:
-                if (upload.getLastResult() == UploadResult.SAME_FILE_CONFLICT){
+            }
+            case UPLOAD_SUCCEEDED -> {
+                if (upload.getLastResult() == UploadResult.SAME_FILE_CONFLICT) {
                     status = parentActivity.getString(R.string.uploads_view_upload_status_succeeded_same_file);
-                }else if (upload.getLastResult() == UploadResult.FILE_NOT_FOUND) {
+                } else if (upload.getLastResult() == UploadResult.FILE_NOT_FOUND) {
                     status = getUploadFailedStatusText(upload.getLastResult());
                 } else {
                     status = parentActivity.getString(R.string.uploads_view_upload_status_succeeded);
                 }
-                break;
-
-            case UPLOAD_FAILED:
-                status = getUploadFailedStatusText(upload.getLastResult());
-                break;
-
-            default:
-                status = "Uncontrolled status: " + upload.getUploadStatus();
+            }
+            case UPLOAD_FAILED -> status = getUploadFailedStatusText(upload.getLastResult());
+            default -> status = "Uncontrolled status: " + upload.getUploadStatus();
         }
         return status;
     }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -29,7 +29,6 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.text.format.DateUtils;
@@ -643,7 +642,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                     // really uploading, bind the progress bar to listen for progress updates
                     status = parentActivity.getString(R.string.uploader_upload_in_progress_ticker);
                 }
-                if (parentActivity.getAppPreferences().getGlobalUploadPaused()) {
+                if (parentActivity.getAppPreferences().isGlobalUploadPaused()) {
                     status = parentActivity.getString(R.string.upload_global_pause_title);
                 }
             }

--- a/app/src/main/res/drawable/ic_pause.xml
+++ b/app/src/main/res/drawable/ic_pause.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="960"
     android:viewportHeight="960">
   <path
-      android:fillColor="#FFEEEEEE"
+      android:fillColor="@color/foreground_highlight"
       android:pathData="M560,760v-560h160v560L560,760ZM240,760v-560h160v560L240,760Z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_pause.xml
+++ b/app/src/main/res/drawable/ic_pause.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FFEEEEEE"
+      android:pathData="M560,760v-560h160v560L560,760ZM240,760v-560h160v560L240,760Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_play.xml
+++ b/app/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Nextcloud Android client application
+  ~
+  ~ @author Alper Ozturk
+  ~ Copyright (C) 2023 Alper Ozturk
+  ~ Copyright (C) 2023 Nextcloud GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@color/foreground_highlight"
+      android:pathData="M320,760v-560l440,280 -440,280Z"/>
+</vector>

--- a/app/src/main/res/menu/activity_upload_list.xml
+++ b/app/src/main/res/menu/activity_upload_list.xml
@@ -16,13 +16,16 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <group
         android:id="@+id/upload_list_actions"
         android:checkableBehavior="none">
 
         <item
-            android:id="@+id/action_clear_failed_uploads"
-            android:title="@string/action_clear_failed_uploads" />
+            android:id="@+id/action_toogle_global_pause"
+            android:icon="@android:drawable/ic_media_pause"
+            android:title="@string/action_clear_failed_uploads"
+            app:showAsAction="always" />
     </group>
 </menu>

--- a/app/src/main/res/menu/activity_upload_list.xml
+++ b/app/src/main/res/menu/activity_upload_list.xml
@@ -23,9 +23,9 @@
         android:checkableBehavior="none">
 
         <item
-            android:id="@+id/action_toogle_global_pause"
+            android:id="@+id/action_toggle_global_pause"
             android:icon="@android:drawable/ic_media_pause"
-            android:title="@string/action_clear_failed_uploads"
+            android:title="@string/upload_action_global_upload_pause"
             app:showAsAction="always" />
     </group>
 </menu>

--- a/app/src/main/res/menu/upload_list_failed_options.xml
+++ b/app/src/main/res/menu/upload_list_failed_options.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Nextcloud Android client application
+
+ @author Jonas Mayer
+ Copyright (C) 2019 Jonas Mayer
+ Copyright (C) 2019 Nextcloud GmbH
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_upload_list_failed_retry"
+        android:icon="@drawable/ic_sync"
+        android:title="@string/upload_action_failed_retry" />
+
+    <item
+        android:id="@+id/action_upload_list_failed_clear"
+        android:title="@string/upload_action_failed_clear"
+        android:icon="@drawable/ic_close" />
+</menu>

--- a/app/src/main/res/menu/upload_list_failed_options.xml
+++ b/app/src/main/res/menu/upload_list_failed_options.xml
@@ -3,8 +3,8 @@
  Nextcloud Android client application
 
  @author Jonas Mayer
- Copyright (C) 2019 Jonas Mayer
- Copyright (C) 2019 Nextcloud GmbH
+ Copyright (C) 2024 Jonas Mayer
+ Copyright (C) 2024 Nextcloud GmbH
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -33,6 +33,7 @@
     <color name="grey_200">#818181</color>
     <color name="nc_grey">#222222</color>
     <color name="icon_on_nc_grey">#ffffff</color>
+    <color name="foreground_highlight">#EAE0E5</color>
 
     <!-- Multiselect backgrounds -->
     <color name="action_mode_background">@color/appbar</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -59,6 +59,7 @@
     <color name="secondary_button_text_color">#000000</color>
     <color name="nc_grey">#ededed</color>
     <color name="icon_on_nc_grey">#000000</color>
+    <color name="foreground_highlight">#1D1B1E</color>
 
     <color name="process_dialog_background">#ffffff</color>
     <color name="indicator_dot_selected">#ffffff</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -843,8 +843,7 @@
     <string name="upload_sync_conflict">Sync conflict, please resolve manually</string>
     <string name="upload_cannot_create_file">Cannot create local file</string>
     <string name="upload_local_storage_not_copied">File could not be copied to local storage</string>
-    <string name="upload_global_pause">Upload for all files is paused</string>
-    <string name="upload_global_pause_title">Upload paused</string>
+    <string name="upload_global_pause_title">All uploads are paused</string>
     <string name="upload_quota_exceeded">Storage quota exceeded</string>
     <string name="host_not_available">Server not available</string>
     <string name="delete_entries">Delete entries</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,8 +522,6 @@
     <string name="share_room_clarification">%1$s (conversation)</string>
     <string name="share_known_remote_on_clarification">on %1$s</string>
 
-    <string name="action_clear_failed_uploads">Clear failed uploads</string>
-
     <string name="action_switch_grid_view">Grid view</string>
     <string name="action_switch_list_view">List view</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -852,6 +852,8 @@
     <string name="delete_entries">Delete entries</string>
     <string name="upload_action_failed_retry">Retry failed uploads</string>
     <string name="upload_action_failed_clear">Clear failed uploads</string>
+    <string name="upload_action_global_upload_pause">Pause all uploads</string>
+    <string name="upload_action_global_upload_resume">Resume all uploads</string>
     <string name="dismiss_notification_description">Dismiss notification</string>
     <string name="action_empty_notifications">Clear all notifications</string>
     <string name="timeout_richDocuments">Loading is taking longer than expected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -845,9 +845,13 @@
     <string name="upload_sync_conflict">Sync conflict, please resolve manually</string>
     <string name="upload_cannot_create_file">Cannot create local file</string>
     <string name="upload_local_storage_not_copied">File could not be copied to local storage</string>
+    <string name="upload_global_pause">Upload for all files is paused</string>
+    <string name="upload_global_pause_title">Upload paused</string>
     <string name="upload_quota_exceeded">Storage quota exceeded</string>
     <string name="host_not_available">Server not available</string>
     <string name="delete_entries">Delete entries</string>
+    <string name="upload_action_failed_retry">Retry failed uploads</string>
+    <string name="upload_action_failed_clear">Clear failed uploads</string>
     <string name="dismiss_notification_description">Dismiss notification</string>
     <string name="action_empty_notifications">Clear all notifications</string>
     <string name="timeout_richDocuments">Loading is taking longer than expected</string>


### PR DESCRIPTION
This PR implements a global pause functionality like described here: https://github.com/nextcloud/android/issues/383
Use case: E.g. In bad Wi-Fi and upload should not happen at this moment to prevent overload.

Added Pause button in uploads tab where previously the "Clear failed uploads" option was. The "Clear failed uploads" is now available in a popup menu in the failed uploads section.

The global pause mode stops all current and future uploads until all uploads are resumed manually. To make sure the user does not forget that uploads are paused, a not dismissible notification is shown that tells the user that uploads are paused. 

[Screen_recording_20240212_110157.webm](https://github.com/nextcloud/android/assets/43114340/9ee08942-f634-49ca-bb60-864c19b8b4fa)

[Screen_recording_20240212_111807.webm](https://github.com/nextcloud/android/assets/43114340/7dc74cf4-ee28-4f20-8323-e674d59457f3)


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
