### PR TITLE
Fix Path Traversal To Internal File ExFiltration

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/helpers/UriUploaderIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/helpers/UriUploaderIT.kt
@@ -5,10 +5,13 @@ import androidx.test.core.app.launchActivity
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.test.TestActivity
 import com.owncloud.android.AbstractIT
+import com.owncloud.android.lib.common.utils.Log_OC
 import org.junit.Assert
 import org.junit.Test
 
 class UriUploaderIT : AbstractIT() {
+
+    private val tag = "UriUploaderIT"
 
     @Test
     fun testUploadPrivatePathSharedPreferences() {
@@ -43,6 +46,9 @@ class UriUploaderIT : AbstractIT() {
             null
         )
         val uploadResult = sut.uploadUris()
+
+        Log_OC.d(tag, "Upload Result: ${uploadResult.name}")
+
         Assert.assertEquals(
             "Wrong result code",
             UriUploader.UriUploaderResultCode.ERROR_SENSITIVE_PATH,

--- a/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
@@ -115,7 +115,7 @@ class UriUploader(
 
     private fun belongsToCurrentApplication(ctx: Context, uri: Uri): Boolean {
         val authority: String = uri.authority.toString()
-        val info: ProviderInfo = ctx.packageManager.resolveContentProvider(authority, 0) ?: return false
+        val info: ProviderInfo = ctx.packageManager.resolveContentProvider(authority, 0) ?: return true
         return ctx.packageName.equals(info.packageName)
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
@@ -20,6 +20,8 @@
 package com.owncloud.android.ui.helpers
 
 import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.ProviderInfo
 import android.net.Uri
 import android.os.Parcelable
 import com.nextcloud.client.account.User
@@ -70,7 +72,7 @@ class UriUploader(
         try {
             val anySensitiveUri = mUrisToUpload
                 .filterNotNull()
-                .any { isSensitiveUri((it as Uri)) }
+                .any { belongsToCurrentApplication(mActivity, it as Uri) }
             if (anySensitiveUri) {
                 Log_OC.e(TAG, "Sensitive URI detected, aborting upload.")
                 code = UriUploaderResultCode.ERROR_SENSITIVE_PATH
@@ -111,7 +113,11 @@ class UriUploader(
         return mUploadPath + displayName
     }
 
-    private fun isSensitiveUri(uri: Uri): Boolean = uri.toString().contains(mActivity.packageName)
+    private fun belongsToCurrentApplication(ctx: Context, uri: Uri): Boolean {
+        val authority: String = uri.authority.toString()
+        val info: ProviderInfo = ctx.packageManager.resolveContentProvider(authority, 0) ?: return false
+        return ctx.packageName.equals(info.packageName)
+    }
 
     /**
      * Requests the upload of a file in the local file system to [FileUploadHelper] service.


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

How come old implementation, check sensitivity of uri? @tobiasKaminsky  As far as I understood from code we are only accepting files from other apps.

**Test After Change**

https://github.com/nextcloud/android/assets/67455295/0baec58f-f51f-4c20-b514-9da3189d6851
