### PR TITLE
Fix MaterialToolbar Crash

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -35,6 +35,7 @@ import android.graphics.drawable.Drawable
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.AsyncTask
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -143,6 +144,11 @@ class PreviewMediaActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O) {
+            setTheme(R.style.Theme_ownCloud_Toolbar)
+        }
+
         binding = ActivityPreviewMediaBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Nextcloud Android client application
+
+    @author Alper Ozturk
+    Copyright (C) 2024 Alper Ozturk
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+
+    <style name="BaseTheme.ownCloud.Toolbar" parent="Theme.Material3.Dark">
+        <item name="alertDialogTheme">@style/ownCloud.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/Theme.ownCloud.Dialog</item>
+        <item name="android:colorBackground">@color/bg_default</item>
+        <item name="android:windowBackground">@color/bg_default</item>
+        <item name="colorAccent">@color/color_accent</item>
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primary</item>
+        <item name="searchViewStyle">@style/ownCloud.SearchView</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="windowNoTitle">true</item>
+        <item name="textInputStyle">@style/Widget.App.TextInputLayout</item>
+        <item name="popupMenuStyle">@style/Nextcloud.Widget.PopupMenu</item>
+        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
+        <item name="actionModeStyle">@style/App.ActionMode</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -36,6 +36,5 @@
         <item name="popupMenuStyle">@style/Nextcloud.Widget.PopupMenu</item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
         <item name="actionModeStyle">@style/App.ActionMode</item>
-        <item name="android:windowLightNavigationBar">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -23,10 +23,6 @@
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
-    <style name="Theme.ownCloud.Toolbar" parent="Theme.ownCloud.ToolbarBase">
-        <item name="android:windowLightNavigationBar">true</item>
-    </style>
-
     <style name="Theme.ownCloud" parent="BaseTheme.ownCloud">
         <item name="android:windowLightNavigationBar">true</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -107,7 +107,7 @@
     </style>
 
     <!-- separate action bar style for activities without an action bar -->
-    <style name="BaseTheme.ownCloud.Toolbar" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="BaseTheme.ownCloud.Toolbar" parent="Theme.AppCompat">
         <item name="alertDialogTheme">@style/ownCloud.AlertDialog</item>
         <item name="android:alertDialogTheme">@style/Theme.ownCloud.Dialog</item>
         <item name="android:colorBackground">@color/bg_default</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -106,25 +106,6 @@
         <item name="android:textColor">@color/text_color</item>
     </style>
 
-    <!-- separate action bar style for activities without an action bar -->
-    <style name="BaseTheme.ownCloud.Toolbar" parent="Theme.AppCompat">
-        <item name="alertDialogTheme">@style/ownCloud.AlertDialog</item>
-        <item name="android:alertDialogTheme">@style/Theme.ownCloud.Dialog</item>
-        <item name="android:colorBackground">@color/bg_default</item>
-        <item name="android:windowBackground">@color/bg_default</item>
-        <item name="colorAccent">@color/color_accent</item>
-        <item name="colorPrimary">@color/primary</item>
-        <item name="colorPrimaryDark">@color/primary</item>
-        <item name="searchViewStyle">@style/ownCloud.SearchView</item>
-        <item name="windowActionBar">false</item>
-        <item name="windowActionModeOverlay">true</item>
-        <item name="windowNoTitle">true</item>
-        <item name="textInputStyle">@style/Widget.App.TextInputLayout</item>
-        <item name="popupMenuStyle">@style/Nextcloud.Widget.PopupMenu</item>
-        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
-        <item name="actionModeStyle">@style/App.ActionMode</item>
-    </style>
-
     <style name="Theme.ownCloud.ToolbarBase" parent="BaseTheme.ownCloud.Toolbar">
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:navigationBarColor">@color/bg_default</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,6 +22,24 @@
 
 <resources>
 
+    <style name="BaseTheme.ownCloud.Toolbar" parent="Theme.Material3.Light">
+        <item name="alertDialogTheme">@style/ownCloud.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/Theme.ownCloud.Dialog</item>
+        <item name="android:colorBackground">@color/bg_default</item>
+        <item name="android:windowBackground">@color/bg_default</item>
+        <item name="colorAccent">@color/color_accent</item>
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primary</item>
+        <item name="searchViewStyle">@style/ownCloud.SearchView</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="windowNoTitle">true</item>
+        <item name="textInputStyle">@style/Widget.App.TextInputLayout</item>
+        <item name="popupMenuStyle">@style/Nextcloud.Widget.PopupMenu</item>
+        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
+        <item name="actionModeStyle">@style/App.ActionMode</item>
+    </style>
+
     <style name="Theme.ownCloud.Toolbar.AppWidgetContainerParent" parent="@android:style/Theme.DeviceDefault">
         <!-- Radius of the outer bound of widgets to make the rounded corners -->
         <item name="appWidgetRadius">16dp</item>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**How to Test (Updated)**

Since normal login not available for outdated WebView. We can use qr code. Simply we can put one line of code to the AuthenticatorActivity.startQRScan() and disable previous logic.

e.g

```
private void startQRScanner() {
    parseAndLoginFromWebView("nc://login/user:admin&password:admin&server:10.0.2.2:55000");

    // Intent intent = new Intent(this, QrCodeActivity.class);
    // startActivityForResult(intent, REQUEST_CODE_QR_SCAN);
}
```


com.google.android.material.appbar.MaterialToolbar crashes on Android 8 due to misusage of main app theme

**Reproducing the Issue:**

It's difficult to test the app on an emulator because login functionality doesn't work on older Android versions 7 and 8. This is due to our login process relying on a WebView, and older Android versions use WebView versions like 55.x.x.x, which causes compatibility issues.

If you have a real device running Android 7 or 8, you can reproduce the crash because WebView updates automatically via the Play Store.

**Why WebView Can't be Updated on Emulators?**

For Mac OS Apple Silicon users, there's no option to install an Android Emulator with Google Play services for Android versions 7 and 8; only AOSP image versions are available. Consequently, you cannot update WebView with AOSP 7 and 8.

There's a workaround: making all AVD instances writable, then using adb commands to push a new WebView version. You can find a guide [here](https://gist.github.com/ppoffice/9ce9790708eeabbec1281467e25139e4).

Alternative emulators on MacOS still have issues because they don't provide Android 7 and 8 images with Google Services.

For Windows users, testing is also challenging because [Intel HAXM](https://github.com/intel/haxm), which is deprecated, is required for older OS versions. While you can still install Intel HAXM, it doesn't work smoothly on all systems and can be error-prone. Virtualization for the CPU must be enabled, and Windows Hyper-V services must be functioning properly to run Android 7 and 8 Google Play images.