### PR TITLE
Fix back button in trash bin

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinActivity.kt
@@ -86,6 +86,12 @@ class TrashbinActivity :
     private var active = false
     private lateinit var binding: TrashbinActivityBinding
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            trashbinPresenter?.navigateUp()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -181,11 +187,7 @@ class TrashbinActivity :
     private fun handleOnBackPressed() {
         onBackPressedDispatcher.addCallback(
             this,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    trashbinPresenter?.navigateUp()
-                }
-            }
+            onBackPressedCallback
         )
     }
 
@@ -207,7 +209,7 @@ class TrashbinActivity :
         if (itemId == android.R.id.home) {
             if (isDrawerOpen) {
                 closeDrawer()
-            } else if (trashbinPresenter?.isRoot == true) {
+            } else if (trashbinPresenter?.isRoot == false) {
                 trashbinPresenter?.navigateUp()
             } else {
                 openDrawer()
@@ -233,7 +235,6 @@ class TrashbinActivity :
     override fun onItemClicked(file: TrashbinFile) {
         if (file.isFolder) {
             trashbinPresenter?.enterFolder(file.remotePath)
-            mDrawerToggle.isDrawerIndicatorEnabled = false
         }
     }
 
@@ -256,8 +257,9 @@ class TrashbinActivity :
         trashbinPresenter?.navigateUp()
     }
 
-    override fun setDrawerIndicatorEnabled(bool: Boolean) {
-        mDrawerToggle.isDrawerIndicatorEnabled = bool
+    override fun atRoot(isRoot: Boolean) {
+        mDrawerToggle.isDrawerIndicatorEnabled = isRoot
+        onBackPressedCallback.isEnabled = !isRoot
     }
 
     override fun onSortingOrderChosen(sortOrder: FileSortOrder?) {

--- a/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinContract.kt
+++ b/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinContract.kt
@@ -33,7 +33,7 @@ interface TrashbinContract {
         fun removeFile(file: TrashbinFile?)
         fun removeAllFiles()
         fun close()
-        fun setDrawerIndicatorEnabled(bool: Boolean)
+        fun atRoot(isRoot: Boolean)
     }
 
     interface Presenter {

--- a/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinPresenter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/trashbin/TrashbinPresenter.kt
@@ -43,10 +43,10 @@ class TrashbinPresenter(
     }
 
     override val isRoot: Boolean
-        get() = OCFile.ROOT_PATH != currentPath
+        get() = OCFile.ROOT_PATH == currentPath
 
     override fun navigateUp() {
-        if (OCFile.ROOT_PATH == currentPath) {
+        if (isRoot) {
             trashbinView.close()
         } else {
             currentPath?.let {
@@ -54,8 +54,6 @@ class TrashbinPresenter(
                 loadFolder()
             }
         }
-
-        trashbinView.setDrawerIndicatorEnabled(OCFile.ROOT_PATH == currentPath)
     }
 
     override fun loadFolder() {
@@ -71,6 +69,7 @@ class TrashbinPresenter(
                 }
             }
         )
+        trashbinView.atRoot(isRoot)
     }
 
     override fun restoreTrashbinFile(file: TrashbinFile?) {


### PR DESCRIPTION
Pressing back would never actually go back but crashed with a stack exception (`navigateUp` calling itself recursively via `TrashBinActivity.close()` infinitely).

The `OnBackPressedCallback` needs to be disabled, on root path, to allow the back press to be propagated to the activity.
- [ ] Tests written, or not not needed
