### PR TITLE
Fix crash when restoring contacts

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.kt
@@ -693,9 +693,7 @@ class BackupFragment : FileFragment(), OnDateSetListener, Injectable {
             )
         } else {
             val user = contactsPreferenceActivity.user.orElseThrow { RuntimeException() }
-            val files: Array<OCFile?> = arrayOfNulls(backupToRestore.size)
-
-            val contactListFragment = BackupListFragment.newInstance(files, user)
+            val contactListFragment = BackupListFragment.newInstance(backupToRestore.toTypedArray(), user)
 
             contactsPreferenceActivity.supportFragmentManager.beginTransaction()
                 .replace(R.id.frame_container, contactListFragment, BackupListFragment.TAG)
@@ -705,7 +703,7 @@ class BackupFragment : FileFragment(), OnDateSetListener, Injectable {
     }
 
     companion object {
-        val TAG = BackupFragment::class.java.simpleName
+        val TAG: String = BackupFragment::class.java.simpleName
         private const val ARG_SHOW_SIDEBAR = "SHOW_SIDEBAR"
         private const val KEY_CALENDAR_PICKER_OPEN = "IS_CALENDAR_PICKER_OPEN"
         private const val KEY_CALENDAR_DAY = "CALENDAR_DAY"

--- a/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/contactsbackup/BackupFragment.kt
@@ -493,7 +493,8 @@ class BackupFragment : FileFragment(), OnDateSetListener, Injectable {
     private fun checkCalendarBackupPermission(context: Context): Boolean {
         return checkSelfPermission(context, Manifest.permission.READ_CALENDAR) && checkSelfPermission(
             context,
-            Manifest.permission.WRITE_CALENDAR)
+            Manifest.permission.WRITE_CALENDAR
+        )
     }
 
     private fun checkContactBackupPermission(): Boolean {
@@ -529,7 +530,7 @@ class BackupFragment : FileFragment(), OnDateSetListener, Injectable {
             datePickerDialog = DatePickerDialog(
                 contactsPreferenceActivity,
                 this,
-                cal.get(Calendar.YEAR) - 1900,
+                cal.get(Calendar.YEAR),
                 cal.get(Calendar.MONTH),
                 cal.get(Calendar.DAY_OF_MONTH)
             )


### PR DESCRIPTION
Due to a small error in #12087, `BackupListFragment.newInstance()` would always be called with an array of nulls instead of the expected backup file(s). This would cause the app to crash when attempting to restore any backup.

---

- [ ] Tests written, or not not needed
