### PR TITLE
Workaround (or fix maybe) for NEW_NOTIFICATION messages

### DIFF
--- a/app/src/gplay/java/com/owncloud/android/services/firebase/NCFirebaseMessagingService.java
+++ b/app/src/gplay/java/com/owncloud/android/services/firebase/NCFirebaseMessagingService.java
@@ -20,8 +20,10 @@
  */
 package com.owncloud.android.services.firebase;
 
+import android.content.Intent;
 import android.text.TextUtils;
 
+import com.google.firebase.messaging.Constants.MessageNotificationKeys;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.nextcloud.client.account.UserAccountManager;
@@ -29,6 +31,7 @@ import com.nextcloud.client.jobs.BackgroundJobManager;
 import com.nextcloud.client.jobs.NotificationWork;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.R;
+import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.PushUtils;
 
 import java.util.Map;
@@ -43,6 +46,20 @@ public class NCFirebaseMessagingService extends FirebaseMessagingService {
     @Inject UserAccountManager accountManager;
     @Inject BackgroundJobManager backgroundJobManager;
 
+    static final String TAG = "NCFirebaseMessagingService";
+
+    // Firebase Messaging may apparently use two intent extras to specify a notification message.
+    //
+    // See the following fragments in https://github.com/firebase/firebase-android-sdk/blob/releases/m144_1.release/
+    //  firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java#L223
+    //  firebase-messaging/src/main/java/com/google/firebase/messaging/NotificationParams.java#L419
+    //  firebase-messaging/src/main/java/com/google/firebase/messaging/Constants.java#L158
+    //
+    // The "old" key is not exposed in com.google.firebase.messaging.Constants.MessageNotificationKeys,
+    // so we need to define it ourselves.
+    static final String ENABLE_NOTIFICATION_OLD = MessageNotificationKeys.NOTIFICATION_PREFIX_OLD + "e";
+    static final String ENABLE_NOTIFICATION_NEW = MessageNotificationKeys.ENABLE_NOTIFICATION;
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -50,7 +67,34 @@ public class NCFirebaseMessagingService extends FirebaseMessagingService {
     }
 
     @Override
+    public void handleIntent(Intent intent) {
+        Log_OC.d(TAG, "handleIntent - extras: " +
+            ENABLE_NOTIFICATION_NEW + ": " + intent.getExtras().getString(ENABLE_NOTIFICATION_NEW) + ", " +
+            ENABLE_NOTIFICATION_OLD + ": " + intent.getExtras().getString(ENABLE_NOTIFICATION_OLD));
+
+        // When the app is in background and one of the ENABLE_NOTIFICATION or ENABLE_NOTIFICATION_OLD extras is set
+        // to "1" in the intent sent from the FCM system code to the FirebaseMessagingService in the application,
+        // the FCM library code that handles the intent DOES NOT invoke the onMessageReceived method.
+        // It just displays the notification by itself.
+        //
+        // In our case the original FCM message contains dummy values "NEW_NOTIFICATION" and we need to get the
+        // message in onMessageReceived to decrypt it.
+        //
+        // So we cheat here a little, by telling the FCM library that the notification flag is not set.
+        //
+        // Code below depends on implementation details of the firebase-messaging library (Firebase Android SDK).
+        // https://github.com/firebase/firebase-android-sdk/tree/master/firebase-messaging
+
+        intent.removeExtra(ENABLE_NOTIFICATION_OLD);
+        intent.removeExtra(ENABLE_NOTIFICATION_NEW);
+        intent.putExtra(ENABLE_NOTIFICATION_NEW, "0");
+
+        super.handleIntent(intent);
+    }
+
+    @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        Log_OC.d(TAG, "onMessageReceived");
         final Map<String, String> data = remoteMessage.getData();
         final String subject = data.get(NotificationWork.KEY_NOTIFICATION_SUBJECT);
         final String signature = data.get(NotificationWork.KEY_NOTIFICATION_SIGNATURE);
@@ -61,6 +105,7 @@ public class NCFirebaseMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onNewToken(@NonNull String newToken) {
+        Log_OC.d(TAG, "onNewToken");
         super.onNewToken(newToken);
 
         if (!TextUtils.isEmpty(getResources().getString(R.string.push_server_url))) {


### PR DESCRIPTION
This is an attempt of a workaround (or fix) for #1964.

**TL;DR**

Incoming notifications are initially handled by system-level FCM code. Then an intent is passed to the application, that is partially handled by Firebase SDK code and partially by the application code in the `onMessageReceived` method.

Sometimes (I have not been able to find when), the intent contains an additional flag that causes the Firebase SDK code to handle (display) the notification without invoking  **at all** the `onMessageReceived` method defined in application code.

As the unencrypted body of the notification message contains just the **NEW_NOTIFICATION** text, this is what gets shown to the user.

Code in this PR "intercepts" the incoming intent before the SDK code and clears the _notification_ flag, so the SDK code always invokes the `onMessageReceived` method. The application code can then handle the message as usual - i.e. decrypt it and display proper notification to the user.

**More detailed description below**

[Firebase documentation](https://firebase.google.com/docs/cloud-messaging/android/receive) is quite clear that notification messages are delivered to the application code only when the application is in foreground.

> `onMessageReceived` is provided for most message types, with the following exceptions:
> 
> - **Notification messages delivered when your app is in the background.** In this case, the notification is delivered to the device’s system tray. A user tap on a notification opens the app launcher by default.
> 
> - **Messages with both notification and data payload, when received in the background.** In this case, the notification is delivered to the device’s system tray, and the data payload is delivered in the extras of the intent of your launcher Activity.

So it seems that notification messages should not work at all. But they do. :wink:

I have not been able to find out, why in some cases incoming messages are treated as combined notification/data messages and in other cases as just data messages. This would probably need insight into inner working of the `push-notifications.nextcloud.com` server.

I did find out however, that even in cases when the message is treated as a combined notification/data message, the application code **is** involved in handling of the message.

After some investigation of the [Firebase Android SDK](https://github.com/firebase/firebase-android-sdk), I have found that the decision to show notification or invoke the `onMessageReceived` method is made by the `FirebaseMessagingService` class, in the [`dispatchMessage`](https://github.com/firebase/firebase-android-sdk/blob/df84f5f5ed209aaddd5a74bf911ad15df6b8e0c5/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java#L223) method.

Then, I found that the [`NotificationParams.isNotification`](https://github.com/firebase/firebase-android-sdk/blob/1a13dff2a28176ca1b72e59842c6c6b289d0aeb4/firebase-messaging/src/main/java/com/google/firebase/messaging/NotificationParams.java#L419C25-L419C39) method just checks for values of two extras in the intent sent by the FCM system code.

So in this PR, I propose to override the `handleIntent` method and clear these two extras from the incoming intent before letting the Firebase SDK code process it. This means that the notifications will be always delivered to the `onMessageReceived` method - as expected.

I have been able to get the **NEW_NOTIFICATION** messages on the emulator - although I am not sure if I can provide a repeatable scenario.

With the additional debug code from this PR, but without clearing the extras in `handleIntent`, I get the wrong notification and the following sequence in the logs.

````
03-12 22:13:34.752 12640 12782 D NCFirebaseMessagingService: handleIntent - extras: gcm.n.e: null, gcm.notification.e: 1
03-12 22:13:34.753 12640 12782 W FirebaseMessaging: Unable to log event: analytics library is missing
03-12 22:13:34.756 12640 12782 W FirebaseMessaging: Missing Default Notification Channel metadata in AndroidManifest. Default value will be used.
````

When I clear the extras in `handleIntent`, I get the correct notification and the following logs.

````
03-12 22:15:18.645 12832 12942 D NCFirebaseMessagingService: handleIntent - extras: gcm.n.e: null, gcm.notification.e: 1
03-12 22:15:18.646 12832 12942 W FirebaseMessaging: Unable to log event: analytics library is missing
03-12 22:15:18.646 12832 12942 D NCFirebaseMessagingService: onMessageReceived
03-12 22:15:18.662 12832 12946 D NotificationJob: doWork started
03-12 22:15:18.670 12832 12946 D OwnCloudClient #0: REQUEST GET /ocs/v2.php/apps/notifications/api/v2/notifications/7284
03-12 22:15:18.671 12832 12946 D AdvancedSslSocketFactory: Creating SSL Socket with remote ***SERVER NAME REDACTED***:443, local null:0, params: org.apache.commons.httpclient.params.HttpConnectionParams@bf36ecc
03-12 22:15:18.671 12832 12946 D AdvancedSslSocketFactory:  ... with connection timeout 60000 and socket timeout 60000
03-12 22:15:18.672 12832 12946 I ServerNameIndicator: SSLSocket implementation: com.google.android.gms.org.conscrypt.Java8FileDescriptorSocket
03-12 22:15:18.672 12832 12946 I ServerNameIndicator: SNI done, hostname: ***SERVER NAME REDACTED***
03-12 22:15:18.754 12832 12946 D GetNotificationRemoteOperation: Successful response: {"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":{"notification_id":7284,"app":"admin_notifications","user":"darek","datetime":"2024-03-12T21:15:18+00:00","object_type":"admin_notifications","object_id":"65f0c5e6","subject":"Testing push notifications","message":"","link":"","subjectRich":"","subjectRichParameters":[],"messageRich":"","messageRichParameters":[],"icon":"https:\/\/***SERVER NAME REDACTED***\/apps\/notifications\/img\/notifications-dark.svg","shouldNotify":true,"actions":[]}}}
03-12 22:15:18.758 12832 12946 D skia    : --- Failed to create image decoder with message 'unimplemented'
03-12 22:15:18.759 12832 12946 D skia    : --- Failed to create image decoder with message 'unimplemented'
03-12 22:15:18.763 12832 12871 I WM-WorkerWrapper: Worker result SUCCESS for Work [ id=be3ca944-2897-4657-812c-3878caf82aaa, tags={ com.nextcloud.client.jobs.NotificationWork, *, name:notification, timestamp:1710278118647, class:NotificationWork } ]
````