### PR TITLE
Fix check if share already exists and give feedback

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -880,7 +880,7 @@ public abstract class FileActivity extends DrawerActivity
             String shareWith = dataString.substring(dataString.lastIndexOf('/') + 1);
 
             ArrayList<String> existingSharees = new ArrayList<>();
-            for (OCShare share : getStorageManager().getSharesWithForAFile(getFile().getRemotePath(),
+            for (OCShare share : getStorageManager().getSharesWithForAFile(getFileFromDetailFragment().getRemotePath(),
                                                                            getAccount().name)) {
                 existingSharees.add(share.getShareType() + "_" + share.getShareWith());
             }
@@ -890,8 +890,21 @@ public abstract class FileActivity extends DrawerActivity
 
             if (!existingSharees.contains(shareType + "_" + shareWith)) {
                 doShareWith(shareWith, shareType);
+            } else {
+                DisplayUtils.showSnackMessage(this, getString(R.string.sharee_already_added_to_file));
             }
         }
+    }
+
+    /**
+     * returns the file that is selected for sharing, getFile() only returns the containing folder
+     */
+    private OCFile getFileFromDetailFragment() {
+        FileDetailFragment fragment = getFileDetailFragment();
+        if (fragment != null) {
+            return fragment.getFile();
+        }
+        return getFile();
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -786,6 +786,7 @@
     <string name="uploads_view_upload_status_virus_detected">Virus detected. Upload cannot be completed!</string>
     <string name="tags">Tags</string>
     <string name="sharee_add_failed">Adding sharee failed</string>
+    <string name="sharee_already_added_to_file">Adding share failed. This file or folder has already been shared with this person or group.</string>
     <string name="unsharing_failed">Unsharing failed</string>
     <string name="updating_share_failed">Updating share failed</string>
     <string name="prefs_e2e_mnemonic">E2E mnemonic</string>


### PR DESCRIPTION
When adding a sharee for a Folder the check if that sharee already exists was broken and gave no feedback if it already exists.

This leads to the behavior in the video (no feedback when adding same sharee twice, when renaming adding same sharee multible times).
 
[Screen_recording_20240314_165058.webm](https://github.com/nextcloud/android/assets/43114340/c3fa42c3-86c4-423a-9b92-5e83b7b794b8)

With my PR it checks before adding new sharee and displays an error toast if it already exists.

[Screen_recording_20240314_165229.webm](https://github.com/nextcloud/android/assets/43114340/482cce3f-6d50-4d64-896f-fce9349959fb)


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
