### PR TITLE
Fix AuthenticatorActivity taking over FirstRunActivity

### DIFF
--- a/app/src/main/java/com/nmc/android/ui/LauncherActivity.kt
+++ b/app/src/main/java/com/nmc/android/ui/LauncherActivity.kt
@@ -30,7 +30,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.nextcloud.client.preferences.AppPreferences
 import com.owncloud.android.R
-import com.owncloud.android.authentication.AuthenticatorActivity
 import com.owncloud.android.databinding.ActivitySplashBinding
 import com.owncloud.android.ui.activity.BaseActivity
 import com.owncloud.android.ui.activity.FileDisplayActivity
@@ -76,9 +75,7 @@ class LauncherActivity : BaseActivity() {
 
     private fun scheduleSplashScreen() {
         Handler(Looper.getMainLooper()).postDelayed({
-            if (!user.isPresent) {
-                startActivity(Intent(this, AuthenticatorActivity::class.java))
-            } else {
+            if (user.isPresent) {
                 startActivity(Intent(this, FileDisplayActivity::class.java))
             }
             finish()


### PR DESCRIPTION
When launching the app for the first time, the `FirstRunActivity` prompts the user to either *Log in* to a server directly or to *Sign up with a provider* first.

Due to an oversight during the implementation of the splash screen, the `AuthenticatorActivity` would take over after a few seconds. This behaviour wasn't intended and will be removed by this change.

---

- [x] Tests written, or not not needed
