### PR TITLE
Try to only process changed files for auto upload

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/jobs/BackgroundJobManagerTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/jobs/BackgroundJobManagerTest.kt
@@ -214,7 +214,7 @@ class BackgroundJobManagerTest {
         fun job_is_unique_and_replaces_previous_job() {
             verify(workManager).enqueueUniqueWork(
                 eq(BackgroundJobManagerImpl.JOB_CONTENT_OBSERVER),
-                eq(ExistingWorkPolicy.REPLACE),
+                eq(ExistingWorkPolicy.APPEND),
                 argThat(IsOneTimeWorkRequest())
             )
         }

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -133,7 +133,12 @@ interface BackgroundJobManager {
     fun startImmediateFilesExportJob(files: Collection<OCFile>): LiveData<JobInfo?>
 
     fun schedulePeriodicFilesSyncJob()
-    fun startImmediateFilesSyncJob(skipCustomFolders: Boolean = false, overridePowerSaving: Boolean = false)
+
+    fun startImmediateFilesSyncJob(
+        overridePowerSaving: Boolean = false,
+        changedFiles: Array<String> = arrayOf<String>()
+    )
+
     fun scheduleOfflineSync()
 
     fun scheduleMediaFoldersDetectionJob()

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -277,7 +277,7 @@ internal class BackgroundJobManagerImpl(
             .setConstraints(constrains)
             .build()
 
-        workManager.enqueueUniqueWork(JOB_CONTENT_OBSERVER, ExistingWorkPolicy.REPLACE, request)
+        workManager.enqueueUniqueWork(JOB_CONTENT_OBSERVER, ExistingWorkPolicy.APPEND, request)
     }
 
     override fun schedulePeriodicContactsBackup(user: User) {
@@ -441,7 +441,7 @@ internal class BackgroundJobManagerImpl(
             .setInputData(arguments)
             .build()
 
-        workManager.enqueueUniqueWork(JOB_IMMEDIATE_FILES_SYNC, ExistingWorkPolicy.KEEP, request)
+        workManager.enqueueUniqueWork(JOB_IMMEDIATE_FILES_SYNC, ExistingWorkPolicy.APPEND, request)
     }
 
     override fun scheduleOfflineSync() {

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -425,10 +425,13 @@ internal class BackgroundJobManagerImpl(
         workManager.enqueueUniquePeriodicWork(JOB_PERIODIC_FILES_SYNC, ExistingPeriodicWorkPolicy.REPLACE, request)
     }
 
-    override fun startImmediateFilesSyncJob(skipCustomFolders: Boolean, overridePowerSaving: Boolean) {
+    override fun startImmediateFilesSyncJob(
+        overridePowerSaving: Boolean,
+        changedFiles: Array<String>
+    ) {
         val arguments = Data.Builder()
-            .putBoolean(FilesSyncWork.SKIP_CUSTOM, skipCustomFolders)
             .putBoolean(FilesSyncWork.OVERRIDE_POWER_SAVING, overridePowerSaving)
+            .putStringArray(FilesSyncWork.CHANGED_FILES, changedFiles)
             .build()
 
         val request = oneTimeRequestBuilder(

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -98,7 +98,7 @@ internal class BackgroundJobManagerImpl(
 
         const val JOB_TEST = "test_job"
 
-        const val MAX_CONTENT_TRIGGER_DELAY_MS = 1500L
+        const val MAX_CONTENT_TRIGGER_DELAY_MS = 10000L
 
         const val TAG_PREFIX_NAME = "name"
         const val TAG_PREFIX_USER = "user"

--- a/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
@@ -61,7 +61,11 @@ class ContentObserverWork(
     private fun checkAndStartFileSyncJob() {
         val syncFolders = syncerFolderProvider.countEnabledSyncedFolders() > 0
         if (!powerManagementService.isPowerSavingEnabled && syncFolders) {
-            backgroundJobManager.startImmediateFilesSyncJob(true, false)
+            val changedFiles = mutableListOf<String>();
+            for (uri in params.triggeredContentUris){
+                changedFiles.add(uri.toString())
+            }
+            backgroundJobManager.startImmediateFilesSyncJob(false, changedFiles.toTypedArray())
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
@@ -61,8 +61,8 @@ class ContentObserverWork(
     private fun checkAndStartFileSyncJob() {
         val syncFolders = syncerFolderProvider.countEnabledSyncedFolders() > 0
         if (!powerManagementService.isPowerSavingEnabled && syncFolders) {
-            val changedFiles = mutableListOf<String>();
-            for (uri in params.triggeredContentUris){
+            val changedFiles = mutableListOf<String>()
+            for (uri in params.triggeredContentUris) {
                 changedFiles.add(uri.toString())
             }
             backgroundJobManager.startImmediateFilesSyncJob(false, changedFiles.toTypedArray())

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -122,6 +122,7 @@ class FilesSyncWork(
             powerManagementService
         )
         setForeground(createForegroundInfo(5))
+        // Check every file in every synced folder for changes and update filesystemDataProvider database (expensive)
         FilesSyncHelper.insertAllDBEntries(skipCustom, syncedFolderProvider)
         setForeground(createForegroundInfo(50))
         // Create all the providers we'll need
@@ -130,6 +131,7 @@ class FilesSyncWork(
         val dateFormat = SimpleDateFormat("yyyy:MM:dd HH:mm:ss", currentLocale)
         dateFormat.timeZone = TimeZone.getTimeZone(TimeZone.getDefault().id)
 
+        // start upload of changed / new files
         val syncedFolders = syncedFolderProvider.syncedFolders
         for ((index, syncedFolder) in syncedFolders.withIndex()) {
             setForeground(createForegroundInfo((50 + (index.toDouble() / syncedFolders.size.toDouble()) * 50).toInt()))

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -143,7 +143,11 @@ class FilesSyncWork(
                 (50 + (index.toDouble() / syncedFolders.size.toDouble()) * 50).toInt(),
                 changedFiles.isNullOrEmpty()
             )
-            if (syncedFolder.isEnabled && (changedFiles.isNullOrEmpty() || MediaFolderType.CUSTOM != syncedFolder.type)) {
+            if (syncedFolder.isEnabled && (
+                    changedFiles.isNullOrEmpty() ||
+                        MediaFolderType.CUSTOM != syncedFolder.type
+                    )
+            ) {
                 syncFolder(
                     context,
                     resources,
@@ -160,12 +164,13 @@ class FilesSyncWork(
         return result
     }
 
-    private fun collectChangedFiles(changedFiles: Array<String>?){
+    @Suppress("MagicNumber")
+    private fun collectChangedFiles(changedFiles: Array<String>?) {
         if (!changedFiles.isNullOrEmpty()) {
-            FilesSyncHelper.insertChangedEntries(syncedFolderProvider,changedFiles)
+            FilesSyncHelper.insertChangedEntries(syncedFolderProvider, changedFiles)
         } else {
-            // Check every file in every synced folder for changes and update filesystemDataProvider database (expensive)
-            // Potentially needs a long time so use foreground worker
+            // Check every file in every synced folder for changes and update
+            // filesystemDataProvider database (potentially needs a long time so use foreground worker)
             updateForegroundWorker(5, true)
             FilesSyncHelper.insertAllDBEntries(syncedFolderProvider)
             updateForegroundWorker(50, true)

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -556,7 +556,7 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
         }
 
         if (!preferences.isAutoUploadInitialized()) {
-            backgroundJobManager.startImmediateFilesSyncJob(false, false);
+            backgroundJobManager.startImmediateFilesSyncJob(false, new String[]{});
             preferences.setAutoUploadInit(true);
         }
 

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
@@ -278,4 +278,8 @@ public class SyncedFolder implements Serializable, Cloneable {
     public void setExcludeHidden(boolean excludeHidden) {
         this.excludeHidden = excludeHidden;
     }
+
+    public boolean containsFile(String filePath){
+        return filePath.contains(localPath);
+    }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -40,7 +40,6 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.device.PowerManagementService
 import com.nextcloud.client.di.Injectable
-import com.nextcloud.client.jobs.BackgroundJobManager
 import com.nextcloud.client.jobs.MediaFoldersDetectionWork
 import com.nextcloud.client.jobs.NotificationWork
 import com.nextcloud.client.jobs.upload.FileUploadWorker

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -157,9 +157,6 @@ class SyncedFoldersActivity :
     lateinit var clock: Clock
 
     @Inject
-    lateinit var backgroundJobManager: BackgroundJobManager
-
-    @Inject
     lateinit var viewThemeUtils: ViewThemeUtils
 
     @Inject
@@ -584,7 +581,7 @@ class SyncedFoldersActivity :
             }
         }
         if (syncedFolderDisplayItem.isEnabled) {
-            backgroundJobManager.startImmediateFilesSyncJob(skipCustomFolders = false, overridePowerSaving = false)
+            backgroundJobManager.startImmediateFilesSyncJob(overridePowerSaving = false)
             showBatteryOptimizationInfo()
         }
     }
@@ -714,7 +711,7 @@ class SyncedFoldersActivity :
             // existing synced folder setup to be updated
             syncedFolderProvider.updateSyncFolder(item)
             if (item.isEnabled) {
-                backgroundJobManager.startImmediateFilesSyncJob(skipCustomFolders = false, overridePowerSaving = false)
+                backgroundJobManager.startImmediateFilesSyncJob(overridePowerSaving = false)
             } else {
                 val syncedFolderInitiatedKey = KEY_SYNCED_FOLDER_INITIATED_PREFIX + item.id
                 val arbitraryDataProvider =
@@ -731,7 +728,7 @@ class SyncedFoldersActivity :
         if (storedId != -1L) {
             item.id = storedId
             if (item.isEnabled) {
-                backgroundJobManager.startImmediateFilesSyncJob(skipCustomFolders = false, overridePowerSaving = false)
+                backgroundJobManager.startImmediateFilesSyncJob(overridePowerSaving = false)
             } else {
                 val syncedFolderInitiatedKey = KEY_SYNCED_FOLDER_INITIATED_PREFIX + item.id
                 arbitraryDataProvider.deleteKeyForAccount("global", syncedFolderInitiatedKey)

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -208,7 +208,7 @@ public class UploadListActivity extends FileActivity {
     }
 
     private void refresh() {
-        backgroundJobManager.startImmediateFilesSyncJob(false, true);
+        backgroundJobManager.startImmediateFilesSyncJob(true,new String[]{});
 
         if (uploadsStorageManager.getFailedUploads().length > 0) {
             new Thread(() -> {

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -139,6 +139,16 @@ public final class FilesSyncHelper {
         }
     }
 
+    public static void insertChangedEntries(boolean skipCustom,
+                                            SyncedFolderProvider syncedFolderProvider,
+                                            String[] changedFiles) {
+        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+            if (syncedFolder.isEnabled() && (!skipCustom || syncedFolder.getType() != MediaFolderType.CUSTOM)) {
+                insertAllDBEntriesForSyncedFolder(syncedFolder);
+            }
+        }
+    }
+
     private static void insertContentIntoDB(Uri uri, SyncedFolder syncedFolder) {
         final Context context = MainApp.getAppContext();
         final ContentResolver contentResolver = context.getContentResolver();


### PR DESCRIPTION
Initiated by https://github.com/nextcloud/android/issues/12596 the idea was to reduce the times the full file system scan for changed files for auto upload is needed. This PR adds that when ever ContentObserverWorker detects media files (so only images and videos) change, the FilesSyncWorker does not go through every file in the corresponding folders. Now it only checks which sync folder (if any) the file belongs to and only enqueues this file for upload.   

## Test this PR
To test this functionality, one can set up the camera folder as an auto upload folder and take pictures. The upload of the file should start after about at most 15s automatically in the background. 

This behavior is the same as before, but it now should take less time for especially large media folders, and it does not use a foreground worker for the sync worker. 

## Known Issues
Sometimes some changes are not detected when too many changes happen one after another and the upload of those files stops until the app is opened. So sometime files are missing from upload. Though this is not optimal, it seems like this is an issue with the content observer worker. As we not really rely on this functionality (a full file system scan is still scheduled every 15 min) I think this is still better than the functionality before. So this functionality should rather be seen as a bonus that uploads files faster if it works but if not there is still a fallback.    

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
