### PR TITLE
Bugfix editing folder description 

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
@@ -77,7 +77,7 @@ class TextEditorWebView : EditorWebView() {
 
         webView.setDownloadListener { url, _, _, _, _ -> downloadFile(Uri.parse(url)) }
 
-        loadUrl(null)
+        loadUrl(intent.getStringExtra(EXTRA_URL))
     }
 
     override fun loadUrl(url: String?) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -52,6 +52,8 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
     @Inject UserAccountManager accountManager;
     @Inject ViewThemeUtils viewThemeUtils;
 
+    private boolean isEditorWebviewLaunched = false;
+
     /**
      * Creates an empty fragment for previews.
      */
@@ -107,6 +109,18 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
         return view;
     }
 
+    @Override
+    public void onStart() {
+        if (isEditorWebviewLaunched) {
+            if (containerActivity instanceof FileDisplayActivity fileDisplayActivity) {
+                fileDisplayActivity.getSupportFragmentManager().popBackStack();
+                fileDisplayActivity.onRefresh();
+            }
+        }
+
+        super.onStart();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -146,6 +160,7 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
                 containerActivity.getFileOperationsHelper().openRichWorkspaceWithTextEditor(getFile(),
                                                                                             url,
                                                                                             getContext());
+                isEditorWebviewLaunched = true;
             } else {
                 DisplayUtils.showSnackMessage(getView(), "Error");
             }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -111,11 +111,9 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
 
     @Override
     public void onStart() {
-        if (isEditorWebviewLaunched) {
-            if (containerActivity instanceof FileDisplayActivity fileDisplayActivity) {
-                fileDisplayActivity.getSupportFragmentManager().popBackStack();
-                fileDisplayActivity.onRefresh();
-            }
+        if (isEditorWebviewLaunched && containerActivity instanceof FileDisplayActivity fileDisplayActivity) {
+            fileDisplayActivity.getSupportFragmentManager().popBackStack();
+            fileDisplayActivity.onRefresh();
         }
 
         super.onStart();


### PR DESCRIPTION
Before editing of folder description using readme.md files would lead to error message.
With this PR editing works.

[Screen_recording_20240327_190105.webm](https://github.com/nextcloud/android/assets/43114340/a7bb1435-e9ec-4bf3-b016-e9f7b2c29b5d)

Known Issue:
Folder README will only be updated when manually refreshing. 
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
