### PR TITLE
Fix File Download Indicator/UI Problems

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -115,8 +115,12 @@ class OfflineSyncWork constructor(
      * @return new etag if changed, `null` otherwise
      */
     private fun checkEtagChanged(folderName: String, storageManager: FileDataStorageManager, user: User): String? {
-        val ocFolder = storageManager.getFileByPath(folderName)
-        Log_OC.d(TAG, folderName + ": currentEtag: " + ocFolder.etag)
+        val ocFolder = storageManager.getFileByPath(folderName) ?: return null
+
+        ocFolder.etag?.let {
+            Log_OC.d(TAG, "$folderName: currentEtag: $it")
+        }
+
         // check for etag change, if false, skip
         val checkEtagOperation = CheckEtagRemoteOperation(
             ocFolder.remotePath,

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadHelper.kt
@@ -67,7 +67,8 @@ class FileDownloadHelper {
             backgroundJobManager.isStartFileDownloadJobScheduled(user, file.fileId) ||
                 backgroundJobManager.isStartFileDownloadJobScheduled(user, topParentId)
         } else {
-            FileDownloadWorker.isDownloading(user.accountName, file.fileId)
+            backgroundJobManager.isStartFileDownloadJobScheduled(user, file.fileId) ||
+                FileDownloadWorker.isDownloading(user.accountName, file.fileId)
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -251,6 +251,25 @@ public class FileDataStorageManager {
         return imageList;
     }
 
+    public boolean isFileExists(OCFile ocFile) {
+        final ContentValues cv = createContentValuesForFile(ocFile);
+        Uri contentUri = ProviderTableMeta.CONTENT_URI;
+        String selection = ProviderTableMeta._ID + "=?";
+        String[] selectionArgs = new String[]{String.valueOf(ocFile.getFileId())};
+
+        boolean result = false;
+        Cursor cursor = contentResolver.query(contentUri, null, selection, selectionArgs, null);
+        if (cursor != null && cursor.moveToFirst()) {
+            result = true;
+        }
+
+        if (cursor != null) {
+            cursor.close();
+        }
+
+        return result;
+    }
+
     public boolean saveFile(OCFile ocFile) {
         boolean overridden = false;
         final ContentValues cv = createContentValuesForFile(ocFile);

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -251,25 +251,6 @@ public class FileDataStorageManager {
         return imageList;
     }
 
-    public boolean isFileExists(OCFile ocFile) {
-        final ContentValues cv = createContentValuesForFile(ocFile);
-        Uri contentUri = ProviderTableMeta.CONTENT_URI;
-        String selection = ProviderTableMeta._ID + "=?";
-        String[] selectionArgs = new String[]{String.valueOf(ocFile.getFileId())};
-
-        boolean result = false;
-        Cursor cursor = contentResolver.query(contentUri, null, selection, selectionArgs, null);
-        if (cursor != null && cursor.moveToFirst()) {
-            result = true;
-        }
-
-        if (cursor != null) {
-            cursor.close();
-        }
-
-        return result;
-    }
-
     public boolean saveFile(OCFile ocFile) {
         boolean overridden = false;
         final ContentValues cv = createContentValuesForFile(ocFile);

--- a/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -361,15 +361,6 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
         return false;
     }
 
-    public String getFileNameWithoutExtension(String fileName) {
-        int dotIndex = fileName.lastIndexOf('.');
-        if (dotIndex > 0) {
-            return fileName.substring(0, dotIndex);
-        } else {
-            return fileName;
-        }
-    }
-
     /**
      * The path, where the file is stored locally
      *

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -344,6 +344,7 @@ class OCFileListDelegate(
                 R.drawable.ic_synchronizing_error
             }
 
+            // FIXME delete keep showing deleted snackbar, tick always visible, delete local file not available
             file.isDown -> {
                 R.drawable.ic_synced
             }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -344,7 +344,7 @@ class OCFileListDelegate(
                 R.drawable.ic_synchronizing_error
             }
 
-            // FIXME delete keep showing deleted snackbar, tick always visible, delete local file not available
+            // FIXME delete keep showing deleted snackbar, tick not visible, delete local file not available
             file.isDown -> {
                 R.drawable.ic_synced
             }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -344,7 +344,7 @@ class OCFileListDelegate(
                 R.drawable.ic_synchronizing_error
             }
 
-            // FIXME delete keep showing deleted snackbar, tick not visible, delete local file not available
+            // FIXME tick not visible for downloaded files also delete local file not available
             file.isDown -> {
                 R.drawable.ic_synced
             }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.java
@@ -106,11 +106,9 @@ public class RemoveFilesDialogFragment extends ConfirmationDialogFragment implem
 
         if (containsFolder || containsDown) {
             args.putInt(ARG_NEGATIVE_BTN_RES, R.string.confirmation_remove_local);
-            args.putInt(ARG_NEUTRAL_BTN_RES, R.string.file_keep);
-        } else {
-            args.putInt(ARG_NEGATIVE_BTN_RES, R.string.file_keep);
         }
 
+        args.putInt(ARG_NEUTRAL_BTN_RES, R.string.file_keep);
         args.putParcelableArrayList(ARG_TARGET_FILES, files);
         frag.setArguments(args);
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

This PR Fixes Problems Related to Each Other

1. Sync icon visibility during download
2. Accessing after download attempt to etag throws null point exception
3. Remove file dialog actions order is wrong for downloaded and normal file

Known issues are added as FIXME comment. Will be handled in different PR.