### PR TITLE
Reload rich document edition on reload event from webview (triggered on session expiration)

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -31,6 +31,7 @@ import com.owncloud.android.databinding.RichdocumentsWebviewBinding;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
+import com.owncloud.android.ui.asynctasks.TextEditorLoadUrlTask;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.WebViewUtil;
@@ -97,6 +98,23 @@ public abstract class EditorWebView extends ExternalSiteWebView {
     public void closeView() {
         getWebView().destroy();
         finish();
+    }
+
+    public void reload() {
+        if (getWebView().getVisibility() != View.VISIBLE) {
+            return;
+        }
+
+        Optional<User> user = getUser();
+        if (!user.isPresent()) {
+            return;
+        }
+
+        OCFile file = getFile();
+        if (file != null) {
+            TextEditorLoadUrlTask task = new TextEditorLoadUrlTask(this, user.get(), file, editorUtils);
+            task.execute();
+        }
     }
 
     @Override
@@ -280,6 +298,11 @@ public abstract class EditorWebView extends ExternalSiteWebView {
         @JavascriptInterface
         public void loaded() {
             runOnUiThread(EditorWebView.this::hideLoading);
+        }
+
+        @JavascriptInterface
+        public void reload() {
+            EditorWebView.this.reload();
         }
     }
 


### PR DESCRIPTION
This fixes the android part of https://github.com/nextcloud/android/issues/12138.
The webview part needs some tweaking but can already be used with this PR for testing: https://github.com/nicofrand/nextcloud-text/commits/fixReconnect/.

I am quite new to android development and brand new to this app (thanks @juliushaertl for all the help already). I don't know if tests should be added or how to put them. I am open to discussion ofc.

To test (see https://github.com/nextcloud/android/issues/12138):

* Use this version of the Text app that will trigger a reload event when a 403 error is caught: https://github.com/nicofrand/nextcloud-text/commits/fixReconnect/
* Open a markdown file in the android app
* Put the app in background and wait a few minutes (so the session expires due to lack of sync requests sent while in background)
* Go back to app: the app should reload

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
