### PR TITLE
Bugfix Handle Temp Encrypted File Correctly

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
@@ -836,7 +836,7 @@ public class EncryptionTestIT extends AbstractIT {
 
         // Encryption
         Cipher encryptorCipher = EncryptionUtils.getCipher(Cipher.ENCRYPT_MODE, key, iv);
-        EncryptionUtils.encryptFile(file, encryptorCipher);
+        EncryptionUtils.encryptFile(targetContext, file, encryptorCipher);
         String encryptorCipherAuthTag = EncryptionUtils.getAuthenticationTag(encryptorCipher);
 
         // Decryption

--- a/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
@@ -836,7 +836,7 @@ public class EncryptionTestIT extends AbstractIT {
 
         // Encryption
         Cipher encryptorCipher = EncryptionUtils.getCipher(Cipher.ENCRYPT_MODE, key, iv);
-        EncryptionUtils.encryptFile(targetContext, file, encryptorCipher);
+        EncryptionUtils.encryptFile(user.getAccountName(), file, encryptorCipher);
         String encryptorCipherAuthTag = EncryptionUtils.getAuthenticationTag(encryptorCipher);
 
         // Decryption

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -75,8 +75,10 @@ class FileUploadHelper {
     ) {
         val failedUploads = uploadsStorageManager.failedUploads
         if (failedUploads == null || failedUploads.isEmpty()) {
+            Log_OC.d(TAG, "Failed uploads are empty or null")
             return
         }
+
         retryUploads(
             uploadsStorageManager,
             connectivityService,
@@ -120,6 +122,7 @@ class FileUploadHelper {
         val charging = batteryStatus.isCharging || batteryStatus.isFull
         val isPowerSaving = powerManagementService.isPowerSavingEnabled
         var uploadUser = Optional.empty<User>()
+
         for (failedUpload in failedUploads) {
             // 1. extract failed upload owner account and cache it between loops (expensive query)
             if (!uploadUser.isPresent || !uploadUser.get().nameEquals(failedUpload.accountName)) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -210,7 +210,7 @@ class FileUploadWorker(
 
         notificationManager.prepareForStart(
             uploadFileOperation,
-            intents.startIntent(uploadFileOperation),
+            cancelPendingIntent = intents.startIntent(uploadFileOperation),
             intents.notificationStartIntent(uploadFileOperation)
         )
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -165,16 +165,16 @@ class FileUploadWorker(
             }
 
             if (user.isPresent) {
-                val operation = createUploadFileOperation(upload, user.get())
+                val uploadFileOperation = createUploadFileOperation(upload, user.get())
 
-                currentUploadFileOperation = operation
-                val result = upload(operation, user.get())
+                currentUploadFileOperation = uploadFileOperation
+                val result = upload(uploadFileOperation, user.get())
                 currentUploadFileOperation = null
 
                 fileUploaderDelegate.sendBroadcastUploadFinished(
-                    operation,
+                    uploadFileOperation,
                     result,
-                    operation.oldFile?.storagePath,
+                    uploadFileOperation.oldFile?.storagePath,
                     context,
                     localBroadcastManager
                 )
@@ -205,39 +205,39 @@ class FileUploadWorker(
     }
 
     @Suppress("TooGenericExceptionCaught", "DEPRECATION")
-    private fun upload(operation: UploadFileOperation, user: User): RemoteOperationResult<Any?> {
+    private fun upload(uploadFileOperation: UploadFileOperation, user: User): RemoteOperationResult<Any?> {
         lateinit var result: RemoteOperationResult<Any?>
 
         notificationManager.prepareForStart(
-            operation,
-            intents.startIntent(operation),
-            intents.notificationStartIntent(operation)
+            uploadFileOperation,
+            intents.startIntent(uploadFileOperation),
+            intents.notificationStartIntent(uploadFileOperation)
         )
 
         try {
-            val storageManager = operation.storageManager
+            val storageManager = uploadFileOperation.storageManager
             val ocAccount = OwnCloudAccount(user.toPlatformAccount(), context)
             val uploadClient = OwnCloudClientManagerFactory.getDefaultSingleton().getClientFor(ocAccount, context)
-            result = operation.execute(uploadClient)
+            result = uploadFileOperation.execute(uploadClient)
 
             val task = ThumbnailsCacheManager.ThumbnailGenerationTask(storageManager, user)
-            val file = File(operation.originalStoragePath)
-            val remoteId: String? = operation.file.remoteId
+            val file = File(uploadFileOperation.originalStoragePath)
+            val remoteId: String? = uploadFileOperation.file.remoteId
             task.execute(ThumbnailsCacheManager.ThumbnailGenerationTaskObject(file, remoteId))
         } catch (e: Exception) {
             Log_OC.e(TAG, "Error uploading", e)
             result = RemoteOperationResult<Any?>(e)
         } finally {
-            cleanupUploadProcess(result, operation)
+            cleanupUploadProcess(result, uploadFileOperation)
         }
 
         return result
     }
 
-    private fun cleanupUploadProcess(result: RemoteOperationResult<Any?>, operation: UploadFileOperation) {
+    private fun cleanupUploadProcess(result: RemoteOperationResult<Any?>, uploadFileOperation: UploadFileOperation) {
         if (!isStopped || !result.isCancelled) {
-            uploadsStorageManager.updateDatabaseUploadResult(result, operation)
-            notifyUploadResult(operation, result)
+            uploadsStorageManager.updateDatabaseUploadResult(result, uploadFileOperation)
+            notifyUploadResult(uploadFileOperation, result)
             notificationManager.dismissWorkerNotifications()
         }
     }
@@ -315,10 +315,11 @@ class FileUploadWorker(
 
         if (percent != lastPercent) {
             notificationManager.run {
-                updateUploadProgress(fileAbsoluteName, percent, currentUploadFileOperation)
-
                 val accountName = currentUploadFileOperation?.user?.accountName
                 val remotePath = currentUploadFileOperation?.remotePath
+                val filename = currentUploadFileOperation?.fileName ?: ""
+
+                updateUploadProgress(filename, percent, currentUploadFileOperation)
 
                 if (accountName != null && remotePath != null) {
                     val key: String =
@@ -329,7 +330,7 @@ class FileUploadWorker(
                         progressRate,
                         totalTransferredSoFar,
                         totalToTransfer,
-                        fileAbsoluteName
+                        filename
                     )
                 }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -45,7 +45,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     @Suppress("MagicNumber")
     fun prepareForStart(
         uploadFileOperation: UploadFileOperation,
-        pendingIntent: PendingIntent,
+        cancelPendingIntent: PendingIntent,
         startIntent: PendingIntent
     ) {
         notificationBuilder.run {
@@ -65,7 +65,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             addAction(
                 R.drawable.ic_action_cancel_grey,
                 context.getString(R.string.common_cancel),
-                pendingIntent
+                cancelPendingIntent
             )
 
             setContentIntent(startIntent)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -16,7 +16,6 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
-import com.owncloud.android.lib.resources.files.FileUtils
 import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
@@ -44,14 +43,14 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     }
 
     @Suppress("MagicNumber")
-    fun prepareForStart(upload: UploadFileOperation, pendingIntent: PendingIntent, startIntent: PendingIntent) {
+    fun prepareForStart(uploadFileOperation: UploadFileOperation, pendingIntent: PendingIntent, startIntent: PendingIntent) {
         notificationBuilder.run {
             setContentTitle(context.getString(R.string.uploader_upload_in_progress_ticker))
             setContentText(
                 String.format(
                     context.getString(R.string.uploader_upload_in_progress),
                     0,
-                    upload.fileName
+                    uploadFileOperation.fileName
                 )
             )
             setTicker(context.getString(R.string.foreground_service_upload))
@@ -68,7 +67,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             setContentIntent(startIntent)
         }
 
-        if (!upload.isInstantPicture && !upload.isInstantVideo) {
+        if (!uploadFileOperation.isInstantPicture && !uploadFileOperation.isInstantVideo) {
             showNotification()
         }
     }
@@ -138,11 +137,10 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     }
 
     @Suppress("MagicNumber")
-    fun updateUploadProgress(filePath: String, percent: Int, currentOperation: UploadFileOperation?) {
+    fun updateUploadProgress(filename: String, percent: Int, currentOperation: UploadFileOperation?) {
         notificationBuilder.run {
             setProgress(100, percent, false)
-            val fileName = filePath.substring(filePath.lastIndexOf(FileUtils.PATH_SEPARATOR) + 1)
-            val text = String.format(context.getString(R.string.uploader_upload_in_progress), percent, fileName)
+            val text = String.format(context.getString(R.string.uploader_upload_in_progress), percent, filename)
             setContentText(text)
 
             showNotification()

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -43,7 +43,11 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     }
 
     @Suppress("MagicNumber")
-    fun prepareForStart(uploadFileOperation: UploadFileOperation, pendingIntent: PendingIntent, startIntent: PendingIntent) {
+    fun prepareForStart(
+        uploadFileOperation: UploadFileOperation,
+        pendingIntent: PendingIntent,
+        startIntent: PendingIntent
+    ) {
         notificationBuilder.run {
             setContentTitle(context.getString(R.string.uploader_upload_in_progress_ticker))
             setContentText(

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -341,10 +341,8 @@ public class FileDataStorageManager {
         return ocFile;
     }
 
-    private static final String tempEncryptedFolderPath = "temp_encrypted_folder";
-
-    public static void clearTempEncryptedFolder(Context context) {
-        File tempEncryptedFolder = getTempEncryptedFolder(context);
+    public static void clearTempEncryptedFolder(String accountName) {
+        File tempEncryptedFolder =  new File(FileStorageUtils.getTemporalEncryptedFolderPath(accountName));
 
         if (!tempEncryptedFolder.exists()) {
             Log_OC.d(TAG,"tempEncryptedFolder not exists");
@@ -360,13 +358,8 @@ public class FileDataStorageManager {
         }
     }
 
-    public static File getTempEncryptedFolder(Context context) {
-        String dirPath = context.getFilesDir().getAbsolutePath() + File.separator + tempEncryptedFolderPath;
-        return new File(dirPath);
-    }
-
-    public static File createTempEncryptedFolder(Context context) {
-        File tempEncryptedFolder = getTempEncryptedFolder(context);
+    public static File createTempEncryptedFolder(String accountName) {
+        File tempEncryptedFolder = new File(FileStorageUtils.getTemporalEncryptedFolderPath(accountName));
 
         if (!tempEncryptedFolder.exists()) {
             boolean isTempEncryptedFolderCreated = tempEncryptedFolder.mkdirs();

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -56,7 +56,10 @@ import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimeType;
 import com.owncloud.android.utils.MimeTypeUtil;
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -336,6 +339,43 @@ public class FileDataStorageManager {
         }
 
         return ocFile;
+    }
+
+    private static final String tempEncryptedFolderPath = "temp_encrypted_folder";
+
+    public static void clearTempEncryptedFolder(Context context) {
+        File tempEncryptedFolder = getTempEncryptedFolder(context);
+
+        if (!tempEncryptedFolder.exists()) {
+            Log_OC.d(TAG,"tempEncryptedFolder not exists");
+            return;
+        }
+
+        try {
+            FileUtils.cleanDirectory(tempEncryptedFolder);
+
+            Log_OC.d(TAG,"tempEncryptedFolder cleared");
+        } catch (IOException exception) {
+            Log_OC.d(TAG,"Error caught at clearTempEncryptedFolder: " + exception);
+        }
+    }
+
+    public static File getTempEncryptedFolder(Context context) {
+        String dirPath = context.getFilesDir().getAbsolutePath() + File.separator + tempEncryptedFolderPath;
+        return new File(dirPath);
+    }
+
+    public static File createTempEncryptedFolder(Context context) {
+        File tempEncryptedFolder = getTempEncryptedFolder(context);
+
+        if (!tempEncryptedFolder.exists()) {
+            boolean isTempEncryptedFolderCreated = tempEncryptedFolder.mkdirs();
+            Log_OC.d(TAG, "tempEncryptedFolder created" + isTempEncryptedFolderCreated);
+        } else {
+            Log_OC.d(TAG, "tempEncryptedFolder already exists");
+        }
+
+        return tempEncryptedFolder;
     }
 
     public void saveNewFile(OCFile newFile) {

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -272,11 +272,7 @@ public class UploadFileOperation extends SyncOperation {
     }
 
     public String getFileName() {
-        if (mFile == null) {
-            return null;
-        }
-
-        return mFile.getFileName();
+        return (mFile != null) ? mFile.getFileName() : null;
     }
 
     public OCFile getFile() {

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -753,9 +753,12 @@ public class UploadFileOperation extends SyncOperation {
                 result = unlockFolderResult;
             }
 
-            boolean isTempEncryptedFileDeleted = encryptedTempFile.delete();
-            Log_OC.e(TAG, "isTempEncryptedFileDeleted: " + isTempEncryptedFileDeleted);
-
+            if (encryptedTempFile != null) {
+                boolean isTempEncryptedFileDeleted = encryptedTempFile.delete();
+                Log_OC.e(TAG, "isTempEncryptedFileDeleted: " + isTempEncryptedFileDeleted);
+            } else {
+                Log_OC.e(TAG, "Encrypted temp file cannot be found");
+            }
         }
 
         if (result.isSuccess()) {

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -272,7 +272,11 @@ public class UploadFileOperation extends SyncOperation {
     }
 
     public String getFileName() {
-        return (mFile != null) ? mFile.getFileName() : null;
+        if (mFile == null) {
+            return null;
+        }
+
+        return mFile.getFileName();
     }
 
     public OCFile getFile() {

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -442,6 +442,7 @@ public class UploadFileOperation extends SyncOperation {
         File temporalFile = null;
         File originalFile = new File(mOriginalStoragePath);
         File expectedFile = null;
+        File encryptedTempFile = null;
         FileLock fileLock = null;
         long size;
 
@@ -552,7 +553,7 @@ public class UploadFileOperation extends SyncOperation {
             byte[] iv = EncryptionUtils.randomBytes(EncryptionUtils.ivLength);
             Cipher cipher = EncryptionUtils.getCipher(Cipher.ENCRYPT_MODE, key, iv);
             File file = new File(mFile.getStoragePath());
-            EncryptedFile encryptedFile = EncryptionUtils.encryptFile(file, cipher);
+            EncryptedFile encryptedFile = EncryptionUtils.encryptFile(getContext(), file, cipher);
 
             // new random file name, check if it exists in metadata
             String encryptedFileName = EncryptionUtils.generateUid();
@@ -567,9 +568,7 @@ public class UploadFileOperation extends SyncOperation {
                 }
             }
 
-            File encryptedTempFile = encryptedFile.getEncryptedFile();
-
-            /***** E2E *****/
+            encryptedTempFile = encryptedFile.getEncryptedFile();
 
             FileChannel channel = null;
             try {
@@ -712,8 +711,6 @@ public class UploadFileOperation extends SyncOperation {
                                                                  user,
                                                                  getStorageManager());
                 }
-
-                encryptedTempFile.delete();
             }
         } catch (FileNotFoundException e) {
             Log_OC.d(TAG, mFile.getStoragePath() + " not exists anymore");
@@ -755,6 +752,10 @@ public class UploadFileOperation extends SyncOperation {
             if (unlockFolderResult != null && !unlockFolderResult.isSuccess()) {
                 result = unlockFolderResult;
             }
+
+            boolean isTempEncryptedFileDeleted = encryptedTempFile.delete();
+            Log_OC.e(TAG, "isTempEncryptedFileDeleted: " + isTempEncryptedFileDeleted);
+
         }
 
         if (result.isSuccess()) {

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -439,7 +439,6 @@ public class UploadFileOperation extends SyncOperation {
     @SuppressLint("AndroidLintUseSparseArrays") // gson cannot handle sparse arrays easily, therefore use hashmap
     private RemoteOperationResult encryptedUpload(OwnCloudClient client, OCFile parentFile) {
         RemoteOperationResult result = null;
-        File temporalFile = null;
         File originalFile = new File(mOriginalStoragePath);
         File expectedFile = null;
         File encryptedTempFile = null;
@@ -580,14 +579,14 @@ public class UploadFileOperation extends SyncOperation {
                 String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) +
                     mFile.getRemotePath();
                 mFile.setStoragePath(temporalPath);
-                temporalFile = new File(temporalPath);
+                encryptedTempFile = new File(temporalPath);
 
                 Files.deleteIfExists(Paths.get(temporalPath));
-                result = copy(originalFile, temporalFile);
+                result = copy(originalFile, encryptedTempFile);
 
                 if (result.isSuccess()) {
-                    if (temporalFile.length() == originalFile.length()) {
-                        channel = new RandomAccessFile(temporalFile.getAbsolutePath(), "rw").getChannel();
+                    if (encryptedTempFile.length() == originalFile.length()) {
+                        channel = new RandomAccessFile(encryptedTempFile.getAbsolutePath(), "rw").getChannel();
                         fileLock = channel.tryLock();
                     } else {
                         result = new RemoteOperationResult(ResultCode.LOCK_FAILED);
@@ -732,9 +731,6 @@ public class UploadFileOperation extends SyncOperation {
                 }
             }
 
-            if (temporalFile != null && !originalFile.equals(temporalFile)) {
-                temporalFile.delete();
-            }
             if (result == null) {
                 result = new RemoteOperationResult(ResultCode.UNKNOWN_ERROR);
             }
@@ -753,23 +749,18 @@ public class UploadFileOperation extends SyncOperation {
                 result = unlockFolderResult;
             }
 
+            if (result.isSuccess()) {
+                handleSuccessfulUpload(encryptedTempFile, expectedFile, originalFile, client);
+            } else if (result.getCode() == ResultCode.SYNC_CONFLICT) {
+                getStorageManager().saveConflict(mFile, mFile.getEtagInConflict());
+            }
+
             if (encryptedTempFile != null) {
                 boolean isTempEncryptedFileDeleted = encryptedTempFile.delete();
                 Log_OC.e(TAG, "isTempEncryptedFileDeleted: " + isTempEncryptedFileDeleted);
             } else {
                 Log_OC.e(TAG, "Encrypted temp file cannot be found");
             }
-        }
-
-        if (result.isSuccess()) {
-            handleSuccessfulUpload(temporalFile, expectedFile, originalFile, client);
-        } else if (result.getCode() == ResultCode.SYNC_CONFLICT) {
-            getStorageManager().saveConflict(mFile, mFile.getEtagInConflict());
-        }
-
-        // delete temporal file
-        if (temporalFile != null && temporalFile.exists() && !temporalFile.delete()) {
-            Log_OC.e(TAG, "Could not delete temporal file " + temporalFile.getAbsolutePath());
         }
 
         return result;

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -553,7 +553,7 @@ public class UploadFileOperation extends SyncOperation {
             byte[] iv = EncryptionUtils.randomBytes(EncryptionUtils.ivLength);
             Cipher cipher = EncryptionUtils.getCipher(Cipher.ENCRYPT_MODE, key, iv);
             File file = new File(mFile.getStoragePath());
-            EncryptedFile encryptedFile = EncryptionUtils.encryptFile(getContext(), file, cipher);
+            EncryptedFile encryptedFile = EncryptionUtils.encryptFile(user.getAccountName(), file, cipher);
 
             // new random file name, check if it exists in metadata
             String encryptedFileName = EncryptionUtils.generateUid();

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -54,8 +54,6 @@ import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
-import org.apache.commons.io.FileUtils;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
@@ -143,7 +141,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
             if (itemId == R.id.action_upload_list_failed_clear) {
                 uploadsStorageManager.clearFailedButNotDelayedUploads();
-                FileDataStorageManager.clearTempEncryptedFolder(MainApp.getAppContext());
+                clearTempEncryptedFolder();
                 loadUploadItemsFromDb();
             } else if (itemId == R.id.action_upload_list_failed_retry) {
 
@@ -174,8 +172,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             if (itemId == R.id.action_upload_list_cancelled_clear) {
                 uploadsStorageManager.clearCancelledUploadsForCurrentAccount();
                 loadUploadItemsFromDb();
-
-                FileDataStorageManager.clearTempEncryptedFolder(parentActivity);
+                clearTempEncryptedFolder();
             } else if (itemId == R.id.action_upload_list_cancelled_resume) {
                 retryCancelledUploads();
             }
@@ -184,6 +181,11 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         });
 
         popup.show();
+    }
+
+    private void clearTempEncryptedFolder() {
+        Optional<User> user = parentActivity.getUser();
+        user.ifPresent(value -> FileDataStorageManager.clearTempEncryptedFolder(value.getAccountName()));
     }
 
     // FIXME For e2e resume is not working

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -145,8 +145,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 uploadsStorageManager.clearFailedButNotDelayedUploads();
                 FileDataStorageManager.clearTempEncryptedFolder(MainApp.getAppContext());
                 loadUploadItemsFromDb();
-            } else {
-
+            } else if (itemId == R.id.action_upload_list_failed_retry) {
                 new Thread(() -> {
                     FileUploadHelper.Companion.instance().retryFailedUploads(
                         uploadsStorageManager,
@@ -155,8 +154,8 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                         powerManagementService);
                     parentActivity.runOnUiThread(this::loadUploadItemsFromDb);
                 }).start();
-
             }
+
             return true;
         });
         failedPopup.show();

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -146,6 +146,8 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 FileDataStorageManager.clearTempEncryptedFolder(MainApp.getAppContext());
                 loadUploadItemsFromDb();
             } else if (itemId == R.id.action_upload_list_failed_retry) {
+
+                // FIXME For e2e resume is not working
                 new Thread(() -> {
                     FileUploadHelper.Companion.instance().retryFailedUploads(
                         uploadsStorageManager,
@@ -158,6 +160,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
             return true;
         });
+
         failedPopup.show();
     }
 
@@ -183,6 +186,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         popup.show();
     }
 
+    // FIXME For e2e resume is not working
     private void retryCancelledUploads() {
         new Thread(() -> {
             boolean showNotExistMessage = FileUploadHelper.Companion.instance().retryCancelledUploads(

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -143,6 +143,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
             if (itemId == R.id.action_upload_list_failed_clear) {
                 uploadsStorageManager.clearFailedButNotDelayedUploads();
+                FileDataStorageManager.clearTempEncryptedFolder(MainApp.getAppContext());
                 loadUploadItemsFromDb();
             } else {
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -54,6 +54,8 @@ import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
@@ -169,6 +171,8 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             if (itemId == R.id.action_upload_list_cancelled_clear) {
                 uploadsStorageManager.clearCancelledUploadsForCurrentAccount();
                 loadUploadItemsFromDb();
+
+                FileDataStorageManager.clearTempEncryptedFolder(parentActivity);
             } else if (itemId == R.id.action_upload_list_cancelled_resume) {
                 retryCancelledUploads();
             }

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -548,7 +548,7 @@ public final class EncryptionUtils {
     }
 
     public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        File tempEncryptedFile = File.createTempFile(file.getName(), "", context.getCacheDir());
+        File tempEncryptedFile = File.createTempFile(file.getName(), ".", context.getCacheDir());
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);
         return new EncryptedFile(tempEncryptedFile, authenticationTagString);

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -548,7 +548,17 @@ public final class EncryptionUtils {
     }
 
     public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        File tempEncryptedFile = File.createTempFile(file.getName(), null, context.getFilesDir());
+        String dirPath = context.getFilesDir().getAbsolutePath() + File.separator + "temp_encrypted_folder";
+        File tempEncryptedFolder = new File(dirPath);
+
+        if (!tempEncryptedFolder.exists()) {
+            boolean isTempEncryptedFolderCreated = tempEncryptedFolder.mkdirs();
+            Log_OC.d(TAG, "tempEncryptedFolder created" + isTempEncryptedFolderCreated);
+        } else {
+            Log_OC.d(TAG, "tempEncryptedFolder already exists");
+        }
+
+        File tempEncryptedFile = File.createTempFile(file.getName(), null, tempEncryptedFolder);
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);
         return new EncryptedFile(tempEncryptedFile, authenticationTagString);
@@ -568,7 +578,7 @@ public final class EncryptionUtils {
     }
 
     public static void encryptFileWithGivenCipher(File inputFile, File encryptedFile, Cipher cipher) {
-        try( FileInputStream inputStream = new FileInputStream(inputFile);
+        try (FileInputStream inputStream = new FileInputStream(inputFile);
              FileOutputStream fileOutputStream = new FileOutputStream(encryptedFile);
              CipherOutputStream outputStream = new CipherOutputStream(fileOutputStream, cipher)) {
             byte[] buffer = new byte[4096];

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -548,7 +548,7 @@ public final class EncryptionUtils {
     }
 
     public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        File tempEncryptedFile = File.createTempFile(file.getName(), ".", context.getCacheDir());
+        File tempEncryptedFile = File.createTempFile(file.getName(), null, context.getCacheDir());
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);
         return new EncryptedFile(tempEncryptedFile, authenticationTagString);

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -547,8 +547,8 @@ public final class EncryptionUtils {
         return Base64.decode(string, Base64.NO_WRAP);
     }
 
-    public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        File tempEncryptedFolder = FileDataStorageManager.createTempEncryptedFolder(context);
+    public static EncryptedFile encryptFile(String accountName, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
+        File tempEncryptedFolder = FileDataStorageManager.createTempEncryptedFolder(accountName);
         File tempEncryptedFile = File.createTempFile(file.getName(), null, tempEncryptedFolder);
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -547,8 +547,7 @@ public final class EncryptionUtils {
         return Base64.decode(string, Base64.NO_WRAP);
     }
 
-    public static EncryptedFile encryptFile(File file, Cipher cipher) throws InvalidParameterSpecException {
-        // FIXME this won't work on low or write-protected storage
+    public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException {
         File encryptedFile = new File(file.getAbsolutePath() + ".enc.jpg");
         encryptFileWithGivenCipher(file, encryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -548,16 +548,7 @@ public final class EncryptionUtils {
     }
 
     public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        String dirPath = context.getFilesDir().getAbsolutePath() + File.separator + "temp_encrypted_folder";
-        File tempEncryptedFolder = new File(dirPath);
-
-        if (!tempEncryptedFolder.exists()) {
-            boolean isTempEncryptedFolderCreated = tempEncryptedFolder.mkdirs();
-            Log_OC.d(TAG, "tempEncryptedFolder created" + isTempEncryptedFolderCreated);
-        } else {
-            Log_OC.d(TAG, "tempEncryptedFolder already exists");
-        }
-
+        File tempEncryptedFolder = FileDataStorageManager.createTempEncryptedFolder(context);
         File tempEncryptedFile = File.createTempFile(file.getName(), null, tempEncryptedFolder);
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -547,11 +547,11 @@ public final class EncryptionUtils {
         return Base64.decode(string, Base64.NO_WRAP);
     }
 
-    public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException {
-        File encryptedFile = new File(file.getAbsolutePath() + ".enc.jpg");
-        encryptFileWithGivenCipher(file, encryptedFile, cipher);
+    public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
+        File tempEncryptedFile = File.createTempFile(file.getName(), "", context.getCacheDir());
+        encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);
-        return new EncryptedFile(encryptedFile, authenticationTagString);
+        return new EncryptedFile(tempEncryptedFile, authenticationTagString);
     }
 
     public static String getAuthenticationTag(Cipher cipher) throws InvalidParameterSpecException {

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -548,7 +548,7 @@ public final class EncryptionUtils {
     }
 
     public static EncryptedFile encryptFile(Context context, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        File tempEncryptedFile = File.createTempFile(file.getName(), null, context.getCacheDir());
+        File tempEncryptedFile = File.createTempFile(file.getName(), null, context.getFilesDir());
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
         String authenticationTagString = getAuthenticationTag(cipher);
         return new EncryptedFile(tempEncryptedFile, authenticationTagString);

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -106,6 +106,17 @@ public final class FileStorageUtils {
         // that can be in the accountName since 0.1.190B
     }
 
+    public static String getTemporalEncryptedFolderPath(String accountName) {
+        return MainApp
+            .getAppContext()
+            .getFilesDir()
+            .getAbsolutePath()
+            + File.separator
+            + accountName
+            + File.separator
+            + "temp_encrypted_folder";
+    }
+
     /**
      * Get absolute path to tmp folder inside app folder for given accountName.
      */


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

1. An encrypted file is temporarily generated in the application directory instead of being stored directly on the device.
2. The temporarily encrypted file is automatically deleted under any circumstances during the uploading process.
3. The filename is correctly displayed in the notification.
4. When user clear failed uploads or clear cancelled uploads, temp_encrypted directory will be deleted as well.

**Note**

cacheDir can be used as well for this operation application directory chosen instead cacheDir just in case to cover edge case such as upload very big file can be failed due to cache directory

java.io.tmpdir doesn't have automatically remove mechanism or provide different solution to than File.createTempFile(). It's just a default temporary-file directory. For deletion on when virtual machine killed, **deleteOnExit()** method must be used. And you can use deleteOnExit() with any file created via createTempFile().

In our case, it will not save us from crash during upload scenario as well. 

Please read [documentation](https://docs.oracle.com/javase/8/docs/api/java/io/File.html) before PR Review. @ZetaTom @JonasMayerDev 


**Known Issues and Scope of PR**

Resuming or retrying cancelled uploads done via OCUpload therefore even our deleted temp encrypted files are not affect to the retry or resume scenario because we can get fully encrypted or decrypted path from OCUpload for retry or resume operation.

However during my tests e2e uploads and normal uploads for retry scenario worked but not always so for this PR it's out of scope. Please understand the general purpose of this PR, then review.
