### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -178,7 +178,7 @@ public abstract class AbstractIT {
         String darkModeParameter = arguments.getString("DARKMODE");
 
         if (darkModeParameter != null) {
-            if (darkModeParameter.equalsIgnoreCase("dark")) {
+            if ("dark".equalsIgnoreCase(darkModeParameter)) {
                 DARK_MODE = "dark";
                 AppPreferencesImpl.fromContext(targetContext).setDarkThemeMode(DarkMode.DARK);
                 MainApp.setAppTheme(DarkMode.DARK);
@@ -187,7 +187,7 @@ public abstract class AbstractIT {
             }
         }
 
-        if (DARK_MODE.equalsIgnoreCase("light") && COLOR.equalsIgnoreCase("blue")) {
+        if ("light".equalsIgnoreCase(DARK_MODE) && "blue".equalsIgnoreCase(COLOR)) {
             // use already existing names
             DARK_MODE = "";
             COLOR = "";

--- a/app/src/androidTest/java/com/owncloud/android/UploadIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/UploadIT.java
@@ -512,7 +512,7 @@ public class UploadIT extends AbstractOnServerIT {
 
         OCFile ocFile = null;
         for (OCFile f : files) {
-            if (f.getFileName().equals("metadata.jpg")) {
+            if ("metadata.jpg".equals(f.getFileName())) {
                 ocFile = f;
                 break;
             }

--- a/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
@@ -136,7 +136,7 @@ public class CreateShareWithShareeOperation extends SyncOperation {
             try {
                 String publicKey = EncryptionUtils.getPublicKey(user, shareeName, arbitraryDataProvider);
 
-                if (publicKey.equals("")) {
+                if ("".equals(publicKey)) {
                     NextcloudClient nextcloudClient = new ClientFactoryImpl(context).createNextcloudClient(user);
                     RemoteOperationResult<String> result = new GetPublicKeyRemoteOperation(shareeName).execute(nextcloudClient);
                     if (result.isSuccess()) {

--- a/app/src/main/java/third_parties/sufficientlysecure/CalendarSource.java
+++ b/app/src/main/java/third_parties/sufficientlysecure/CalendarSource.java
@@ -65,13 +65,13 @@ public class CalendarSource {
             String protocol = mUrl.getProtocol();
             String userPass = mUsername + ":" + mPassword;
 
-            if (protocol.equalsIgnoreCase("ftp") || protocol.equalsIgnoreCase("ftps")) {
+            if ("ftp".equalsIgnoreCase(protocol) || "ftps".equalsIgnoreCase(protocol)) {
                 String external = mUrl.toExternalForm();
                 String end = external.substring(protocol.length() + HTTP_SEP.length());
                 return new URL(protocol + HTTP_SEP + userPass + "@" + end).openConnection();
             }
 
-            if (protocol.equalsIgnoreCase("http") || protocol.equalsIgnoreCase("https")) {
+            if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
                 String encoded = new String(new Base64().encode(userPass.getBytes("UTF-8")));
                 URLConnection connection = mUrl.openConnection();
                 connection.setRequestProperty("Authorization", "Basic " + encoded);

--- a/app/src/main/java/third_parties/sufficientlysecure/ProcessVEvent.java
+++ b/app/src/main/java/third_parties/sufficientlysecure/ProcessVEvent.java
@@ -578,7 +578,7 @@ public class ProcessVEvent {
         String expected = parts.length > 1 ? parts[1] : "";
         String got = c.getAsString(key);
 
-        if (expected.equals("<non-null>") && got != null) {
+        if ("<non-null>".equals(expected) && got != null) {
             got = "<non-null>"; // Sentinel for testing present and non-null
         }
         if (got == null) {

--- a/app/src/main/java/third_parties/sufficientlysecure/SaveCalendar.java
+++ b/app/src/main/java/third_parties/sufficientlysecure/SaveCalendar.java
@@ -504,7 +504,7 @@ public class SaveCalendar {
             return true;
         }
         final String utz = tz.toUpperCase(Locale.US);
-        return utz.equals("UTC") || utz.equals("UTC-0") || utz.equals("UTC+0") || utz.endsWith("/UTC");
+        return "UTC".equals(utz) || "UTC-0".equals(utz) || "UTC+0".equals(utz) || utz.endsWith("/UTC");
     }
 
     private Date getDateTime(Cursor cur, String dbName, String dbTzName, Calendar cal) {


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FNasdaqCloudDataService-SDK-Java%7C877a73b30acafa1dfb5d75972ad11937267a958a)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->


- [x] Tests written, or not not needed
