### PR TITLE
Unify Notifications

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -70,7 +70,10 @@ class DownloadNotificationManager(
 
     @Suppress("MagicNumber")
     fun updateDownloadProgress(percent: Int, totalToTransfer: Long) {
-        val progressText = String.format(context.getString(R.string.upload_notification_manager_upload_in_progress_text), percent)
+        val progressText = String.format(
+            context.getString(R.string.upload_notification_manager_upload_in_progress_text),
+            percent
+        )
 
         notificationBuilder.run {
             setProgress(100, percent, totalToTransfer < 0)

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -10,8 +10,6 @@ package com.nextcloud.client.jobs.download
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Handler
-import android.os.Looper
 import com.nextcloud.client.jobs.notification.WorkerNotificationManager
 import com.owncloud.android.R
 import com.owncloud.android.operations.DownloadFileOperation
@@ -59,9 +57,7 @@ class DownloadNotificationManager(
 
     @Suppress("MagicNumber")
     fun dismissNotification() {
-        Handler(Looper.getMainLooper()).postDelayed({
-            notificationManager.cancel(id)
-        }, 2000)
+        dismissNotification(2000)
     }
 
     fun showNewNotification(text: String) {

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -8,18 +8,15 @@
 package com.nextcloud.client.jobs.download
 
 import android.app.Notification
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.graphics.BitmapFactory
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.core.app.NotificationCompat
+import com.nextcloud.client.jobs.notification.WorkerNotificationManager
 import com.owncloud.android.R
 import com.owncloud.android.operations.DownloadFileOperation
-import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.io.File
 import java.security.SecureRandom
@@ -29,19 +26,8 @@ class DownloadNotificationManager(
     private val id: Int,
     private val context: Context,
     viewThemeUtils: ViewThemeUtils
-) {
-    private var currentOperationTitle: String? = null
-    private var notificationBuilder: NotificationCompat.Builder =
-        NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
-            setTicker(context.getString(R.string.downloader_download_in_progress_ticker))
-            setSmallIcon(R.drawable.notification_icon)
-            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD)
-            }
-        }
-    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+): WorkerNotificationManager(context, viewThemeUtils) {
+    private var notificationBuilder: NotificationCompat.Builder = getNotificationBuilder(R.string.downloader_download_in_progress_ticker)
 
     @Suppress("MagicNumber")
     fun prepareForStart(operation: DownloadFileOperation, currentDownloadIndex: Int, totalDownloadSize: Int) {

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -19,19 +19,23 @@ import java.security.SecureRandom
 
 @Suppress("TooManyFunctions")
 class DownloadNotificationManager(
-    private val id: Int,
+    id: Int,
     private val context: Context,
     viewThemeUtils: ViewThemeUtils
 ) : WorkerNotificationManager(id, context, viewThemeUtils, R.string.downloader_download_in_progress_ticker) {
 
     @Suppress("MagicNumber")
     fun prepareForStart(operation: DownloadFileOperation, currentDownloadIndex: Int, totalDownloadSize: Int) {
-        currentOperationTitle = String.format(
-            context.getString(R.string.downloader_notification_manager_download_text),
-            currentDownloadIndex,
-            totalDownloadSize,
+        currentOperationTitle = if (totalDownloadSize > 1) {
+            String.format(
+                context.getString(R.string.downloader_notification_manager_download_text),
+                currentDownloadIndex,
+                totalDownloadSize,
+                File(operation.savePath).name
+            )
+        } else {
             File(operation.savePath).name
-        )
+        }
 
         notificationBuilder.run {
             setContentTitle(currentOperationTitle)

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -7,13 +7,11 @@
  */
 package com.nextcloud.client.jobs.download
 
-import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
-import androidx.core.app.NotificationCompat
 import com.nextcloud.client.jobs.notification.WorkerNotificationManager
 import com.owncloud.android.R
 import com.owncloud.android.operations.DownloadFileOperation
@@ -26,8 +24,7 @@ class DownloadNotificationManager(
     private val id: Int,
     private val context: Context,
     viewThemeUtils: ViewThemeUtils
-): WorkerNotificationManager(context, viewThemeUtils) {
-    private var notificationBuilder: NotificationCompat.Builder = getNotificationBuilder(R.string.downloader_download_in_progress_ticker)
+): WorkerNotificationManager(id, context, viewThemeUtils, R.string.downloader_download_in_progress_ticker) {
 
     @Suppress("MagicNumber")
     fun prepareForStart(operation: DownloadFileOperation, currentDownloadIndex: Int, totalDownloadSize: Int) {
@@ -97,17 +94,5 @@ class DownloadNotificationManager(
                 flag
             )
         )
-    }
-
-    private fun showNotification() {
-        notificationManager.notify(id, notificationBuilder.build())
-    }
-
-    fun getId(): Int {
-        return id
-    }
-
-    fun getNotification(): Notification {
-        return notificationBuilder.build()
     }
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -71,7 +71,7 @@ class DownloadNotificationManager(
     @Suppress("MagicNumber")
     fun updateDownloadProgress(percent: Int, totalToTransfer: Long) {
         val progressText = String.format(
-            context.getString(R.string.upload_notification_manager_upload_in_progress_text),
+            context.getString(R.string.downloader_notification_manager_in_progress_text),
             percent
         )
 

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -24,7 +24,7 @@ class DownloadNotificationManager(
     private val id: Int,
     private val context: Context,
     viewThemeUtils: ViewThemeUtils
-): WorkerNotificationManager(id, context, viewThemeUtils, R.string.downloader_download_in_progress_ticker) {
+) : WorkerNotificationManager(id, context, viewThemeUtils, R.string.downloader_download_in_progress_ticker) {
 
     @Suppress("MagicNumber")
     fun prepareForStart(operation: DownloadFileOperation, currentDownloadIndex: Int, totalDownloadSize: Int) {
@@ -53,17 +53,7 @@ class DownloadNotificationManager(
 
     @Suppress("MagicNumber")
     fun updateDownloadProgress(percent: Int, totalToTransfer: Long) {
-        val progressText = String.format(
-            context.getString(R.string.downloader_notification_manager_in_progress_text),
-            percent
-        )
-
-        notificationBuilder.run {
-            setProgress(100, percent, totalToTransfer < 0)
-            setContentTitle(currentOperationTitle)
-            setContentText(progressText)
-        }
-
+        setProgress(percent, R.string.downloader_notification_manager_in_progress_text, totalToTransfer < 0)
         showNotification()
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -273,7 +273,7 @@ class FileDownloadWorker(
         lastPercent = 0
 
         notificationManager.run {
-            prepareForStart(currentDownload!!, currentDownloadIndex, totalDownloadSize)
+            prepareForStart(currentDownload!!, currentDownloadIndex + 1, totalDownloadSize)
             setContentIntent(intents.detailsIntent(currentDownload!!), PendingIntent.FLAG_IMMUTABLE)
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -406,6 +406,9 @@ class FileDownloadWorker(
         }
     }
 
+    private val minProgressUpdateInterval = 750
+    private var lastUpdateTime = 0L
+
     @Suppress("MagicNumber")
     override fun onTransferProgress(
         progressRate: Long,
@@ -414,15 +417,18 @@ class FileDownloadWorker(
         filePath: String
     ) {
         val percent: Int = (100.0 * totalTransferredSoFar.toDouble() / totalToTransfer.toDouble()).toInt()
+        val currentTime = System.currentTimeMillis()
 
-        if (percent != lastPercent) {
+        if (percent != lastPercent && (currentTime - lastUpdateTime) >= minProgressUpdateInterval) {
             notificationManager.run {
                 updateDownloadProgress(percent, totalToTransfer)
             }
+            lastUpdateTime = currentTime
         }
 
         lastPercent = percent
     }
+
 
     inner class FileDownloadProgressListener : OnDatatransferProgressListener {
         private val boundListeners: MutableMap<Long, OnDatatransferProgressListener> = HashMap()

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -406,6 +406,7 @@ class FileDownloadWorker(
         }
     }
 
+    @Suppress("MagicNumber")
     private val minProgressUpdateInterval = 750
     private var lastUpdateTime = 0L
 
@@ -428,7 +429,6 @@ class FileDownloadWorker(
 
         lastPercent = percent
     }
-
 
     inner class FileDownloadProgressListener : OnDatatransferProgressListener {
         private val boundListeners: MutableMap<Long, OnDatatransferProgressListener> = HashMap()

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -46,6 +46,7 @@ open class WorkerNotificationManager(
         notificationManager.notify(id, notificationBuilder.build())
     }
 
+    @Suppress("MagicNumber")
     fun setProgress(percent: Int, progressTextId: Int, indeterminate: Boolean) {
         val progressText = String.format(
             context.getString(progressTextId),

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -29,21 +29,24 @@ open class WorkerNotificationManager(
 
     val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    var notificationBuilder: NotificationCompat.Builder = NotificationUtils.newNotificationBuilder(context, "WorkerNotificationManager", viewThemeUtils).apply {
-        setTicker(context.getString(tickerId))
-        setSmallIcon(R.drawable.notification_icon)
-        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
+    var notificationBuilder: NotificationCompat.Builder =
+        NotificationUtils.newNotificationBuilder(context, "WorkerNotificationManager", viewThemeUtils).apply {
+            setTicker(context.getString(tickerId))
+            setSmallIcon(R.drawable.notification_icon)
+            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
+            setStyle(NotificationCompat.BigTextStyle())
+            setPriority(NotificationCompat.PRIORITY_LOW)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD)
+            }
         }
-    }
 
     fun showNotification() {
         notificationManager.notify(id, notificationBuilder.build())
     }
 
-    fun setProgress(percent: Int, progressTextId: Int ,indeterminate: Boolean) {
+    fun setProgress(percent: Int, progressTextId: Int, indeterminate: Boolean) {
         val progressText = String.format(
             context.getString(progressTextId),
             percent

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -7,6 +7,7 @@
 
 package com.nextcloud.client.jobs.notification
 
+import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
 import android.graphics.BitmapFactory
@@ -17,22 +18,38 @@ import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
 open class WorkerNotificationManager(
+    private val id: Int,
     private val context: Context,
-    private val viewThemeUtils: ViewThemeUtils
+    viewThemeUtils: ViewThemeUtils,
+    private val tickerId: Int
 ) {
     var currentOperationTitle: String? = null
 
     val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    fun getNotificationBuilder(tickerId: Int): NotificationCompat.Builder {
-        return NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
-            setTicker(context.getString(tickerId))
-            setSmallIcon(R.drawable.notification_icon)
-            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
+    var notificationBuilder: NotificationCompat.Builder = NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+        setTicker(context.getString(tickerId))
+        setSmallIcon(R.drawable.notification_icon)
+        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD)
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD)
         }
+    }
+
+    fun showNotification() {
+        notificationManager.notify(id, notificationBuilder.build())
+    }
+
+    fun dismissWorkerNotifications() {
+        notificationManager.cancel(id)
+    }
+
+    fun getId(): Int {
+        return id
+    }
+
+    fun getNotification(): Notification {
+        return notificationBuilder.build()
     }
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -27,7 +27,7 @@ open class WorkerNotificationManager(
 
     val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    var notificationBuilder: NotificationCompat.Builder = NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+    var notificationBuilder: NotificationCompat.Builder = NotificationUtils.newNotificationBuilder(context, "WorkerNotificationManager", viewThemeUtils).apply {
         setTicker(context.getString(tickerId))
         setSmallIcon(R.drawable.notification_icon)
         setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -41,6 +41,19 @@ open class WorkerNotificationManager(
         notificationManager.notify(id, notificationBuilder.build())
     }
 
+    fun setProgress(percent: Int, progressTextId: Int ,indeterminate: Boolean) {
+        val progressText = String.format(
+            context.getString(progressTextId),
+            percent
+        )
+
+        notificationBuilder.run {
+            setProgress(100, percent, indeterminate)
+            setContentTitle(currentOperationTitle)
+            setContentText(progressText)
+        }
+    }
+
     fun dismissWorkerNotifications() {
         notificationManager.cancel(id)
     }

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -12,6 +12,8 @@ import android.app.NotificationManager
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import androidx.core.app.NotificationCompat
 import com.owncloud.android.R
 import com.owncloud.android.ui.notifications.NotificationUtils
@@ -54,8 +56,10 @@ open class WorkerNotificationManager(
         }
     }
 
-    fun dismissWorkerNotifications() {
-        notificationManager.cancel(id)
+    fun dismissNotification(delay: Long = 0) {
+        Handler(Looper.getMainLooper()).postDelayed({
+            notificationManager.cancel(id)
+        }, delay)
     }
 
     fun getId(): Int {

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -1,0 +1,38 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.jobs.notification
+
+import android.app.NotificationManager
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.owncloud.android.R
+import com.owncloud.android.ui.notifications.NotificationUtils
+import com.owncloud.android.utils.theme.ViewThemeUtils
+
+open class WorkerNotificationManager(
+    private val context: Context,
+    private val viewThemeUtils: ViewThemeUtils
+) {
+    var currentOperationTitle: String? = null
+
+    val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    fun getNotificationBuilder(tickerId: Int): NotificationCompat.Builder {
+        return NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+            setTicker(context.getString(tickerId))
+            setSmallIcon(R.drawable.notification_icon)
+            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_DOWNLOAD)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -113,7 +113,7 @@ class FileUploadWorker(
 
         setIdleWorkerState()
         currentUploadFileOperation?.cancel(null)
-        notificationManager.dismissWorkerNotifications()
+        notificationManager.dismissNotification()
 
         super.onStopped()
     }
@@ -249,7 +249,7 @@ class FileUploadWorker(
         if (!isStopped || !result.isCancelled) {
             uploadsStorageManager.updateDatabaseUploadResult(result, uploadFileOperation)
             notifyUploadResult(uploadFileOperation, result)
-            notificationManager.dismissWorkerNotifications()
+            notificationManager.dismissNotification()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -321,9 +321,11 @@ class FileUploadWorker(
         }
     }
 
+    @Suppress("MagicNumber")
     private val minProgressUpdateInterval = 750
     private var lastUpdateTime = 0L
 
+    @Suppress("MagicNumber")
     override fun onTransferProgress(
         progressRate: Long,
         totalTransferredSoFar: Long,
@@ -360,5 +362,4 @@ class FileUploadWorker(
 
         lastPercent = percent
     }
-
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -100,6 +100,7 @@ class FileUploadWorker(
             backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class))
             val result = retrievePagesBySortingUploadsByID()
             backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
+            notificationManager.dismissNotification()
             result
         } catch (t: Throwable) {
             Log_OC.e(TAG, "Error caught at FileUploadWorker $t")
@@ -246,7 +247,6 @@ class FileUploadWorker(
         if (!isStopped || !result.isCancelled) {
             uploadsStorageManager.updateDatabaseUploadResult(result, uploadFileOperation)
             notifyUploadResult(uploadFileOperation, result)
-            notificationManager.dismissNotification()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -161,14 +161,13 @@ class FileUploadWorker(
         val user = userAccountManager.getUser(accountName)
         setWorkerState(user.get(), uploads)
 
-        run uploads@ {
+        run uploads@{
             uploads.forEachIndexed { currentUploadIndex, upload ->
                 if (isStopped) {
                     return@uploads
                 }
 
                 if (user.isPresent) {
-
                     val uploadFileOperation = createUploadFileOperation(upload, user.get())
 
                     currentUploadFileOperation = uploadFileOperation

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -311,8 +311,13 @@ class FileUploadWorker(
                 null
             }
 
-            notifyForFailedResult(uploadResult.code, conflictResolveIntent, credentialIntent, errorMessage)
-            showNewNotification(uploadFileOperation)
+            notifyForFailedResult(
+                uploadFileOperation,
+                uploadResult.code,
+                conflictResolveIntent,
+                credentialIntent,
+                errorMessage
+            )
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -168,11 +168,10 @@ class FileUploadWorker(
                 }
 
                 if (user.isPresent) {
+
                     val uploadFileOperation = createUploadFileOperation(upload, user.get())
 
                     currentUploadFileOperation = uploadFileOperation
-
-                    val result = upload(uploadFileOperation, user.get())
 
                     notificationManager.prepareForStart(
                         uploadFileOperation,
@@ -181,6 +180,8 @@ class FileUploadWorker(
                         currentUploadIndex = currentUploadIndex + 1,
                         totalUploadSize = uploads.size
                     )
+
+                    val result = upload(uploadFileOperation, user.get())
 
                     currentUploadFileOperation = null
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -134,7 +134,7 @@ class FileUploadWorker(
 
         Log_OC.d(TAG, "Total upload size: $totalUploadSize")
 
-        notificationManager.dismissWorkerNotifications()
+        // notificationManager.dismissWorkerNotifications()
 
         while (uploadsPerPage.isNotEmpty() && !isStopped) {
             if (preferences.isGlobalUploadPaused) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -133,8 +133,6 @@ class FileUploadWorker(
 
         Log_OC.d(TAG, "Total upload size: $totalUploadSize")
 
-        // notificationManager.dismissWorkerNotifications()
-
         while (uploadsPerPage.isNotEmpty() && !isStopped) {
             if (preferences.isGlobalUploadPaused) {
                 Log_OC.d(TAG, "Upload is paused, skip uploading files!")

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -194,8 +194,6 @@ class FileUploadWorker(
                 } else {
                     uploadsStorageManager.removeUpload(upload.uploadId)
                 }
-
-                notificationManager.dismissWorkerNotifications()
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -7,36 +7,22 @@
  */
 package com.nextcloud.client.jobs.upload
 
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
-import android.graphics.BitmapFactory
-import android.os.Build
 import androidx.core.app.NotificationCompat
+import com.nextcloud.client.jobs.notification.WorkerNotificationManager
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
-class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils) {
+class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils): WorkerNotificationManager(context, viewThemeUtils) {
     companion object {
         private const val ID = 411
     }
 
-    private var notificationBuilder: NotificationCompat.Builder =
-        NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
-            setTicker(context.getString(R.string.foreground_service_upload))
-            setSmallIcon(R.drawable.notification_icon)
-            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_UPLOAD)
-            }
-        }
-
-    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    private var currentOperationTitle: String? = null
+    private var notificationBuilder: NotificationCompat.Builder = getNotificationBuilder(R.string.foreground_service_upload)
 
     @Suppress("MagicNumber")
     fun prepareForStart(

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -31,12 +31,16 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         currentUploadIndex: Int,
         totalUploadSize: Int
     ) {
-        currentOperationTitle = String.format(
-            context.getString(R.string.upload_notification_manager_start_text),
-            currentUploadIndex,
-            totalUploadSize,
+        currentOperationTitle = if (totalUploadSize > 1) {
+            String.format(
+                context.getString(R.string.upload_notification_manager_start_text),
+                currentUploadIndex,
+                totalUploadSize,
+                uploadFileOperation.fileName
+            )
+        } else {
             uploadFileOperation.fileName
-        )
+        }
 
         val progressText = String.format(
             context.getString(R.string.upload_notification_manager_upload_in_progress_text),

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -51,7 +51,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             uploadFileOperation.fileName
         )
 
-        notificationBuilder.apply {
+        notificationBuilder.run {
             setContentTitle(title)
             setTicker(context.getString(R.string.foreground_service_upload))
             setOngoing(false)
@@ -64,7 +64,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             )
 
             setContentIntent(startIntent)
-        }.build()
+        }
 
         if (!uploadFileOperation.isInstantPicture && !uploadFileOperation.isInstantVideo) {
             showNotification()
@@ -174,7 +174,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     }
 
     fun notifyPaused(intent: PendingIntent) {
-        notificationBuilder.apply {
+        notificationBuilder.run {
             setContentTitle(context.getString(R.string.upload_global_pause_title))
             setTicker(context.getString(R.string.upload_global_pause_title))
             setOngoing(false)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -84,6 +84,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     }
 
     fun notifyForFailedResult(
+        uploadFileOperation: UploadFileOperation,
         resultCode: RemoteOperationResult.ResultCode,
         conflictsResolveIntent: PendingIntent?,
         credentialIntent: PendingIntent?,
@@ -113,6 +114,8 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
             setContentText(errorMessage)
         }
+
+        showNewNotification(uploadFileOperation)
     }
 
     private fun getFailedResultTitleId(resultCode: RemoteOperationResult.ResultCode): Int {
@@ -135,7 +138,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         )
     }
 
-    fun showNewNotification(operation: UploadFileOperation) {
+    private fun showNewNotification(operation: UploadFileOperation) {
         notificationManager.notify(
             NotificationUtils.createUploadNotificationTag(operation.file),
             FileUploadWorker.NOTIFICATION_ERROR_ID,

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -26,6 +26,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
     private var notificationBuilder: NotificationCompat.Builder =
         NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
+            setTicker(context.getString(R.string.foreground_service_upload))
             setSmallIcon(R.drawable.notification_icon)
             setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.notification_icon))
 
@@ -57,7 +58,6 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             setProgress(100, 0, false)
             setContentTitle(currentOperationTitle)
             setContentText(progressText)
-            setTicker(context.getString(R.string.foreground_service_upload))
             setOngoing(false)
             clearActions()
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -59,7 +59,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             )
             setTicker(context.getString(R.string.foreground_service_upload))
             setProgress(100, 0, false)
-            setOngoing(true)
+            setOngoing(false)
             clearActions()
 
             addAction(
@@ -179,7 +179,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         notificationBuilder.apply {
             setContentTitle(context.getString(R.string.upload_global_pause_title))
             setTicker(context.getString(R.string.upload_global_pause_title))
-            setOngoing(true)
+            setOngoing(false)
             setAutoCancel(false)
             setProgress(0, 0, false)
             clearActions()

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -77,7 +77,10 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
     @Suppress("MagicNumber")
     fun updateUploadProgress(percent: Int, currentOperation: UploadFileOperation?) {
-        val progressText = String.format(context.getString(R.string.upload_notification_manager_upload_in_progress_text), percent)
+        val progressText = String.format(
+            context.getString(R.string.upload_notification_manager_upload_in_progress_text),
+            percent
+        )
 
         notificationBuilder.run {
             setProgress(100, percent, false)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -52,7 +52,10 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             totalUploadSize,
             uploadFileOperation.fileName
         )
-        val progressText = String.format(context.getString(R.string.uploader_upload_in_progress), 0)
+        val progressText = String.format(
+            context.getString(R.string.upload_notification_manager_upload_in_progress_text),
+            0
+        )
 
         notificationBuilder.run {
             setProgress(100, 0, false)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -9,7 +9,6 @@ package com.nextcloud.client.jobs.upload
 
 import android.app.PendingIntent
 import android.content.Context
-import androidx.core.app.NotificationCompat
 import com.nextcloud.client.jobs.notification.WorkerNotificationManager
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
@@ -17,12 +16,12 @@ import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
-class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils): WorkerNotificationManager(context, viewThemeUtils) {
+class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils) :
+    WorkerNotificationManager(ID, context, viewThemeUtils, R.string.foreground_service_upload) {
+
     companion object {
         private const val ID = 411
     }
-
-    private var notificationBuilder: NotificationCompat.Builder = getNotificationBuilder(R.string.foreground_service_upload)
 
     @Suppress("MagicNumber")
     fun prepareForStart(
@@ -38,6 +37,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             totalUploadSize,
             uploadFileOperation.fileName
         )
+
         val progressText = String.format(
             context.getString(R.string.upload_notification_manager_upload_in_progress_text),
             0
@@ -144,10 +144,6 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         )
     }
 
-    private fun showNotification() {
-        notificationManager.notify(ID, notificationBuilder.build())
-    }
-
     fun dismissOldErrorNotification(operation: UploadFileOperation?) {
         if (operation == null) {
             return
@@ -165,10 +161,6 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             NotificationUtils.createUploadNotificationTag(remotePath, localPath),
             FileUploadWorker.NOTIFICATION_ERROR_ID
         )
-    }
-
-    fun dismissWorkerNotifications() {
-        notificationManager.cancel(ID)
     }
 
     fun notifyPaused(intent: PendingIntent) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -7,7 +7,6 @@
  */
 package com.nextcloud.client.jobs.upload
 
-import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
@@ -25,7 +24,6 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         private const val ID = 411
     }
 
-    private var notification: Notification? = null
     private var notificationBuilder: NotificationCompat.Builder =
         NotificationUtils.newNotificationBuilder(context, viewThemeUtils).apply {
             setSmallIcon(R.drawable.notification_icon)
@@ -37,10 +35,6 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         }
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-    init {
-        notification = notificationBuilder.build()
-    }
 
     @Suppress("MagicNumber")
     fun prepareForStart(
@@ -57,7 +51,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             uploadFileOperation.fileName
         )
 
-        notificationBuilder.run {
+        notificationBuilder.apply {
             setContentTitle(title)
             setTicker(context.getString(R.string.foreground_service_upload))
             setOngoing(false)
@@ -70,7 +64,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             )
 
             setContentIntent(startIntent)
-        }
+        }.build()
 
         if (!uploadFileOperation.isInstantPicture && !uploadFileOperation.isInstantVideo) {
             showNotification()

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -66,19 +66,9 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
     @Suppress("MagicNumber")
     fun updateUploadProgress(percent: Int, currentOperation: UploadFileOperation?) {
-        val progressText = String.format(
-            context.getString(R.string.upload_notification_manager_upload_in_progress_text),
-            percent
-        )
-
-        notificationBuilder.run {
-            setProgress(100, percent, false)
-            setContentTitle(currentOperationTitle)
-            setContentText(progressText)
-
-            showNotification()
-            dismissOldErrorNotification(currentOperation)
-        }
+        setProgress(percent, R.string.upload_notification_manager_upload_in_progress_text, false)
+        showNotification()
+        dismissOldErrorNotification(currentOperation)
     }
 
     fun notifyForFailedResult(

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -36,7 +36,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         }
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    private var currentOperationTitle: String? = "null"
+    private var currentOperationTitle: String? = null
 
     @Suppress("MagicNumber")
     fun prepareForStart(

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -35,6 +35,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         }
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    private var currentOperationTitle: String? = "null"
 
     @Suppress("MagicNumber")
     fun prepareForStart(
@@ -44,15 +45,18 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         currentUploadIndex: Int,
         totalUploadSize: Int
     ) {
-        val title = String.format(
+        currentOperationTitle = String.format(
             context.getString(R.string.upload_notification_manager_start_text),
             currentUploadIndex,
             totalUploadSize,
             uploadFileOperation.fileName
         )
+        val progressText = String.format(context.getString(R.string.uploader_upload_in_progress), 0)
 
         notificationBuilder.run {
-            setContentTitle(title)
+            setProgress(100, 0, false)
+            setContentTitle(currentOperationTitle)
+            setContentText(progressText)
             setTicker(context.getString(R.string.foreground_service_upload))
             setOngoing(false)
             clearActions()
@@ -73,10 +77,12 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
     @Suppress("MagicNumber")
     fun updateUploadProgress(percent: Int, currentOperation: UploadFileOperation?) {
+        val progressText = String.format(context.getString(R.string.uploader_upload_in_progress), percent)
+
         notificationBuilder.run {
             setProgress(100, percent, false)
-            val text = String.format(context.getString(R.string.uploader_upload_in_progress), percent)
-            setContentText(text)
+            setContentTitle(currentOperationTitle)
+            setContentText(progressText)
 
             showNotification()
             dismissOldErrorNotification(currentOperation)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -77,7 +77,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
     @Suppress("MagicNumber")
     fun updateUploadProgress(percent: Int, currentOperation: UploadFileOperation?) {
-        val progressText = String.format(context.getString(R.string.uploader_upload_in_progress), percent)
+        val progressText = String.format(context.getString(R.string.upload_notification_manager_upload_in_progress_text), percent)
 
         notificationBuilder.run {
             setProgress(100, percent, false)

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -601,17 +601,8 @@ public class UploadsStorageManager extends Observable {
     }
 
     public OCUpload[] getCurrentAndPendingUploadsForAccount(final @NonNull String accountName) {
-        return getUploads("( " + ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.LOCK_FAILED.getValue() +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
-                              " ) AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
-                          accountName);
+        String inProgressUploadsSelection = getInProgressUploadsSelection();
+        return getUploads(inProgressUploadsSelection, accountName);
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -52,16 +52,16 @@ import androidx.annotation.VisibleForTesting;
  * Database helper for storing list of files to be uploaded, including status information for each file.
  */
 public class UploadsStorageManager extends Observable {
-    private final String TAG = UploadsStorageManager.class.getSimpleName();
+    private static final String TAG = UploadsStorageManager.class.getSimpleName();
 
-    private final String IS_EQUAL =  "== ?";
-    private final String EQUAL =  "==";
-    private final String OR =  " OR ";
-    private final String AND = " AND ";
-    private final String ANGLE_BRACKETS = "<>";
-    private final int SINGLE_RESULT = 1;
+    private static final String IS_EQUAL =  "== ?";
+    private static final String EQUAL =  "==";
+    private static final String OR =  " OR ";
+    private static final String AND = " AND ";
+    private static final String ANGLE_BRACKETS = "<>";
+    private static final int SINGLE_RESULT = 1;
 
-    private final long QUERY_PAGE_SIZE = 100;
+    private static final long QUERY_PAGE_SIZE = 100;
 
     private final ContentResolver contentResolver;
     private final CurrentAccountProvider currentAccountProvider;

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -52,12 +52,16 @@ import androidx.annotation.VisibleForTesting;
  * Database helper for storing list of files to be uploaded, including status information for each file.
  */
 public class UploadsStorageManager extends Observable {
-    private static final String TAG = UploadsStorageManager.class.getSimpleName();
+    private final String TAG = UploadsStorageManager.class.getSimpleName();
 
-    private static final String AND = " AND ";
-    private static final int SINGLE_RESULT = 1;
+    private final String IS_EQUAL =  "== ?";
+    private final String EQUAL =  "==";
+    private final String OR =  " OR ";
+    private final String AND = " AND ";
+    private final String ANGLE_BRACKETS = "<>";
+    private final int SINGLE_RESULT = 1;
 
-    private static final long QUERY_PAGE_SIZE = 100;
+    private final long QUERY_PAGE_SIZE = 100;
 
     private final ContentResolver contentResolver;
     private final CurrentAccountProvider currentAccountProvider;
@@ -468,16 +472,16 @@ public class UploadsStorageManager extends Observable {
     }
 
     private String getInProgressUploadsSelection() {
-        return "( " + ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_IN_PROGRESS.value +
-            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-            "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-            "==" + UploadResult.LOCK_FAILED.getValue() +
-            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-            "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-            " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-            "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
-            " ) AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?";
+        return "( " + ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value +
+            OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+            EQUAL + UploadResult.DELAYED_FOR_WIFI.getValue() +
+            OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+            EQUAL + UploadResult.LOCK_FAILED.getValue() +
+            OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+            EQUAL + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+            OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+            EQUAL + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
+            " ) AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL;
     }
 
     public int getTotalUploadSize(@Nullable String... selectionArgs) {
@@ -619,58 +623,58 @@ public class UploadsStorageManager extends Observable {
      * Get all failed uploads.
      */
     public OCUpload[] getFailedUploads() {
-        return getUploads("(" + ProviderTableMeta.UPLOADS_STATUS + "== ?" +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.LOCK_FAILED.getValue() +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                              " OR " + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "==" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
+        return getUploads("(" + ProviderTableMeta.UPLOADS_STATUS + IS_EQUAL +
+                              OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                              EQUAL + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                              OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                              EQUAL + UploadResult.LOCK_FAILED.getValue() +
+                              OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                              EQUAL + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                              OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
+                              EQUAL + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
                               " ) AND " + ProviderTableMeta.UPLOADS_LAST_RESULT +
                               "!= " + UploadResult.VIRUS_DETECTED.getValue()
             , String.valueOf(UploadStatus.UPLOAD_FAILED.value));
     }
 
     public OCUpload[] getUploadsForAccount(final @NonNull String accountName) {
-        return getUploads(ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", accountName);
+        return getUploads(ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, accountName);
     }
 
     public OCUpload[] getFinishedUploadsForCurrentAccount() {
         User user = currentAccountProvider.getUser();
 
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
-                              ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", user.getAccountName());
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
+                              ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, user.getAccountName());
     }
 
     public OCUpload[] getCancelledUploadsForCurrentAccount() {
         User user = currentAccountProvider.getUser();
 
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_CANCELLED.value + AND +
-                              ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", user.getAccountName());
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_CANCELLED.value + AND +
+                              ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, user.getAccountName());
     }
 
     /**
      * Get all uploads which where successfully completed.
      */
     public OCUpload[] getFinishedUploads() {
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value, (String[]) null);
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_SUCCEEDED.value, (String[]) null);
     }
 
     public OCUpload[] getFailedButNotDelayedUploadsForCurrentAccount() {
         User user = currentAccountProvider.getUser();
 
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value +
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_FAILED.value +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                              ANGLE_BRACKETS + UploadResult.DELAYED_FOR_WIFI.getValue() +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.LOCK_FAILED.getValue() +
+                              ANGLE_BRACKETS + UploadResult.LOCK_FAILED.getValue() +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                              ANGLE_BRACKETS + UploadResult.DELAYED_FOR_CHARGING.getValue() +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
-                              AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
+                              ANGLE_BRACKETS + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
+                              AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL,
                           user.getAccountName());
     }
 
@@ -681,14 +685,14 @@ public class UploadsStorageManager extends Observable {
      */
     public OCUpload[] getFailedButNotDelayedUploads() {
 
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value + AND +
-                              ProviderTableMeta.UPLOADS_LAST_RESULT + "<>" + UploadResult.LOCK_FAILED.getValue() +
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_FAILED.value + AND +
+                              ProviderTableMeta.UPLOADS_LAST_RESULT + ANGLE_BRACKETS + UploadResult.LOCK_FAILED.getValue() +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                              ANGLE_BRACKETS + UploadResult.DELAYED_FOR_WIFI.getValue() +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                              ANGLE_BRACKETS + UploadResult.DELAYED_FOR_CHARGING.getValue() +
                               AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              "<>" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue(),
+                              ANGLE_BRACKETS + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue(),
                           (String[]) null
                          );
     }
@@ -701,16 +705,16 @@ public class UploadsStorageManager extends Observable {
         User user = currentAccountProvider.getUser();
         final long deleted = getDB().delete(
             ProviderTableMeta.CONTENT_URI_UPLOADS,
-            ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_FAILED.value +
+            ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_FAILED.value +
                 AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                "<>" + UploadResult.LOCK_FAILED.getValue() +
+                ANGLE_BRACKETS + UploadResult.LOCK_FAILED.getValue() +
                 AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                "<>" + UploadResult.DELAYED_FOR_WIFI.getValue() +
+                ANGLE_BRACKETS + UploadResult.DELAYED_FOR_WIFI.getValue() +
                 AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                "<>" + UploadResult.DELAYED_FOR_CHARGING.getValue() +
+                ANGLE_BRACKETS + UploadResult.DELAYED_FOR_CHARGING.getValue() +
                 AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                "<>" + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
-                AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?",
+                ANGLE_BRACKETS + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
+                AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL,
             new String[]{user.getAccountName()}
                                            );
         Log_OC.d(TAG, "delete all failed uploads but those delayed for Wifi");
@@ -724,8 +728,8 @@ public class UploadsStorageManager extends Observable {
         User user = currentAccountProvider.getUser();
         final long deleted = getDB().delete(
             ProviderTableMeta.CONTENT_URI_UPLOADS,
-            ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_CANCELLED.value + AND +
-                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", new String[]{user.getAccountName()}
+            ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_CANCELLED.value + AND +
+                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, new String[]{user.getAccountName()}
                                            );
 
         Log_OC.d(TAG, "delete all cancelled uploads");
@@ -738,8 +742,8 @@ public class UploadsStorageManager extends Observable {
         User user = currentAccountProvider.getUser();
         final long deleted = getDB().delete(
             ProviderTableMeta.CONTENT_URI_UPLOADS,
-            ProviderTableMeta.UPLOADS_STATUS + "==" + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
-                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + "== ?", new String[]{user.getAccountName()}
+            ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_SUCCEEDED.value + AND +
+                ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, new String[]{user.getAccountName()}
                                            );
 
         Log_OC.d(TAG, "delete all successful uploads");
@@ -899,17 +903,13 @@ public class UploadsStorageManager extends Observable {
         }
 
         public static UploadStatus fromValue(int value) {
-            switch (value) {
-                case 0:
-                    return UPLOAD_IN_PROGRESS;
-                case 1:
-                    return UPLOAD_FAILED;
-                case 2:
-                    return UPLOAD_SUCCEEDED;
-                case 3:
-                    return UPLOAD_CANCELLED;
-            }
-            return null;
+            return switch (value) {
+                case 0 -> UPLOAD_IN_PROGRESS;
+                case 1 -> UPLOAD_FAILED;
+                case 2 -> UPLOAD_SUCCEEDED;
+                case 3 -> UPLOAD_CANCELLED;
+                default -> null;
+            };
         }
 
         public int getValue() {

--- a/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
+++ b/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.java
@@ -53,8 +53,8 @@ public final class NotificationUtils {
      * @param context       Context that will use the builder to create notifications
      * @return An instance of the regular {@link NotificationCompat.Builder}.
      */
-    public static NotificationCompat.Builder newNotificationBuilder(Context context, final ViewThemeUtils viewThemeUtils) {
-        final NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+    public static NotificationCompat.Builder newNotificationBuilder(Context context, String channelId, final ViewThemeUtils viewThemeUtils) {
+        final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);
         viewThemeUtils.androidx.themeNotificationCompatBuilder(context, builder);
         return builder;
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -977,7 +977,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">الإبقاء على الملف في المجلد الأصلي</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">إحذف الملف من المجلد الأصلي</string>
     <string name="uploader_upload_forbidden_permissions">للرفع إلى هذا المجلد</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% رفع %2$s</string>
     <string name="uploader_upload_in_progress_ticker">يتم الرفع…</string>
     <string name="uploader_upload_succeeded_content_single">تم رفع %1$s</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">فشل التنزيل، قم بتسجيل الدخول مرة أخرى</string>
     <string name="downloader_download_failed_ticker">فشل التحميل</string>
     <string name="downloader_download_file_not_found">الملف غير متوفر في الخادم</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% تحميل  %2$s</string>
     <string name="downloader_download_in_progress_ticker">جارِ التنزيل …</string>
     <string name="downloader_download_succeeded_content">%1$s مُنزَّلَة</string>

--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Download failed, log in again</string>
     <string name="downloader_download_failed_ticker">Download failed</string>
     <string name="downloader_download_file_not_found">The file is no longer available on the server</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>
     <string name="downloader_download_in_progress_ticker">Downloading…</string>
     <string name="downloader_download_succeeded_content">%1$s downloaded</string>

--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Keep file in source folder</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Delete file from source folder</string>
     <string name="uploader_upload_forbidden_permissions">to upload to this folder</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s uploaded</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -236,7 +236,6 @@
     <string name="downloader_download_failed_credentials_error">Stahování se nezdařilo, přihlaste se znovu</string>
     <string name="downloader_download_failed_ticker">Stahování se nezdařilo</string>
     <string name="downloader_download_file_not_found">Tento soubor už není na serveru k dispozici</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Stahuje se %2$s</string>
     <string name="downloader_download_in_progress_ticker">Stahování…</string>
     <string name="downloader_download_succeeded_content">%1$s staženo</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -909,7 +909,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Ponechat soubor ve zdrojové složce</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Vymazat soubor ze zdrojové složky</string>
     <string name="uploader_upload_forbidden_permissions">pro nahrávání do této složky</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Odesílání %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Nahrávání…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s nahráno</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Hochladen und im Quellordner behalten</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Hochladen und Datei im Quellordner löschen</string>
     <string name="uploader_upload_forbidden_permissions">diesen Ordner hochzuladen</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Hochladen %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Lade hoch…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s hochgeladen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Herunterladen fehlgeschlagen, erneute Anmeldung erforderlich</string>
     <string name="downloader_download_failed_ticker">Herunterladen fehlgeschlagen</string>
     <string name="downloader_download_file_not_found">Diese Datei steht auf dem Server nicht mehr zur Verfügung</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Herunterladen %2$s</string>
     <string name="downloader_download_in_progress_ticker">Lade herunter…</string>
     <string name="downloader_download_succeeded_content">%1$s heruntergeladen</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -936,7 +936,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Mantener el archivo en la carpeta de origen</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Borrar el archivo de la carpeta de origen</string>
     <string name="uploader_upload_forbidden_permissions">para cargar a esta carpeta</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Cargando %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Cargando</string>
     <string name="uploader_upload_succeeded_content_single">%1$s cargado</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -238,7 +238,6 @@
     <string name="downloader_download_failed_credentials_error">La descarga falló, inicia sesión de nuevo</string>
     <string name="downloader_download_failed_ticker">Falla en la descarga</string>
     <string name="downloader_download_file_not_found">El archivo ya no se encuentra disponible en el servidor</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Descargando %2$s</string>
     <string name="downloader_download_in_progress_ticker">Descargando…</string>
     <string name="downloader_download_succeeded_content">%1$s descargado</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Mantener el archivo en la carpeta original</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Borrar archivo de la carpeta original</string>
     <string name="uploader_upload_forbidden_permissions">para subir archivos a esta carpeta</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Subiendo %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Subiendo…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s subido</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Descarga fallida, vuelve a iniciar sesión</string>
     <string name="downloader_download_failed_ticker">Fallo al descargar</string>
     <string name="downloader_download_file_not_found">Este archivo ya no se encuentra en el servidor</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Descargado de %2$s</string>
     <string name="downloader_download_in_progress_ticker">Descargando…</string>
     <string name="downloader_download_succeeded_content">%1$s descargado</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Mantendu fitxategia jatorrizko karpetan</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Ezabatu fitxategia jatorrizko karpetatik</string>
     <string name="uploader_upload_forbidden_permissions">kargatzeko karpeta honetara</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Igotzen %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Kargatzen…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s igota</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Deskargak huts egin du, hasi saioa berriz</string>
     <string name="downloader_download_failed_ticker">Deskargak huts egin du</string>
     <string name="downloader_download_file_not_found">Fitxategia jadanik ez dago eskuragarri zerbitzarian</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Deskargatzen %2$s</string>
     <string name="downloader_download_in_progress_ticker">Deskargatzen…</string>
     <string name="downloader_download_succeeded_content">%1$s deskargatuta</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -920,7 +920,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">نگهداری فایل در پوشه منبع</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">حذف فایل از پوشه منبع</string>
     <string name="uploader_upload_forbidden_permissions">برای بارگذاری در این پوشه</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% در حال آپلود%2$s</string>
     <string name="uploader_upload_in_progress_ticker">بارگذاری…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s آپلود شده</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -225,7 +225,6 @@
     <string name="downloader_download_failed_credentials_error">بارگیری شکست خورد. دوباره وارد شوید</string>
     <string name="downloader_download_failed_ticker">دانلود ناموفق</string>
     <string name="downloader_download_file_not_found">این فایل دیگر روی سرور وجود ندارد</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% در حال دانلود %2$s</string>
     <string name="downloader_download_in_progress_ticker">بارگیری…</string>
     <string name="downloader_download_succeeded_content">%1$sدانلود شده </string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -945,7 +945,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Conserver le fichier dans le dossier original</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Supprimer le fichier du dossier original</string>
     <string name="uploader_upload_forbidden_permissions">d\'envoyer dans ce dossier</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">Téléversement de %2$s : %1$d%%</string>
     <string name="uploader_upload_in_progress_ticker">Téléversement en cours…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s envoyé</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -246,7 +246,6 @@
     <string name="downloader_download_failed_credentials_error">Téléchargement échoué, reconnectez-vous</string>
     <string name="downloader_download_failed_ticker">Le téléchargement a échoué</string>
     <string name="downloader_download_file_not_found">Ce fichier n’est plus disponible sur le serveur</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">Téléchargement de %2$s : %1$d%% effectués</string>
     <string name="downloader_download_in_progress_ticker">Réception en cours…</string>
     <string name="downloader_download_succeeded_content">%1$s reçu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -228,7 +228,6 @@
     <string name="downloader_download_failed_credentials_error">Scaricamento non riuscito, effettua nuovamente l\'accesso</string>
     <string name="downloader_download_failed_ticker">Scaricamento non riuscito</string>
     <string name="downloader_download_file_not_found">Il file non è più disponibile sul server</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Scaricamento di %2$s</string>
     <string name="downloader_download_in_progress_ticker">Scaricamento in corso…</string>
     <string name="downloader_download_succeeded_content">%1$s scaricato</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -899,7 +899,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Mantieni il file nella cartella di origine</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Elimina il file dalla cartella di origine</string>
     <string name="uploader_upload_forbidden_permissions">per caricare in questa cartella</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Caricamento di %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Caricamento in corso…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s caricato</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -241,7 +241,6 @@
     <string name="downloader_download_failed_credentials_error">Nedlasting mislyktes, prøv igjen</string>
     <string name="downloader_download_failed_ticker">Nedlasting mislyktes</string>
     <string name="downloader_download_file_not_found">Filen finnes ikke på serveren lenger</string>
-    <string name="downloader_download_in_progress">%1$d %% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Laster ned %2$s</string>
     <string name="downloader_download_in_progress_ticker">Laster ned…</string>
     <string name="downloader_download_succeeded_content">%1$s lastet ned</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -940,7 +940,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Behold filen i kildemappe</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Slett filen fra kildemappen</string>
     <string name="uploader_upload_forbidden_permissions">å laste opp i denne mappen</string>
-    <string name="uploader_upload_in_progress">%1$d %% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Laster opp %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Laster opp…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s lastet opp</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -881,7 +881,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Bewaar het bestand in de bronmap</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Verwijder bestand uit bronmap</string>
     <string name="uploader_upload_forbidden_permissions">om dit bestand in deze map te uploaden</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploaden van %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Uploaden…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s geüpload</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -233,7 +233,6 @@
     <string name="downloader_download_failed_credentials_error">Downloaden mislukt, je moet opnieuw inloggen</string>
     <string name="downloader_download_failed_ticker">Downloaden mislukt</string>
     <string name="downloader_download_file_not_found">Dit bestand is niet langer beschikbaar op de server</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloaden van %2$s</string>
     <string name="downloader_download_in_progress_ticker">Downloaden…</string>
     <string name="downloader_download_succeeded_content">%1$s gedownload.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -949,7 +949,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Manter arquivo na pasta de origem</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Excluir arquivo da pasta de origem</string>
     <string name="uploader_upload_forbidden_permissions">para enviar a esta pasta</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% enviando %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Enviando…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s enviado</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Download falhou, logue-se novamente</string>
     <string name="downloader_download_failed_ticker">Download falhou</string>
     <string name="downloader_download_file_not_found">Este arquivo não está mais disponível neste servidor</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Baixando %2$s</string>
     <string name="downloader_download_in_progress_ticker">Baixando…</string>
     <string name="downloader_download_succeeded_content">%1$s baixado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -241,7 +241,6 @@
     <string name="downloader_download_failed_credentials_error">Ошибка скачивания, необходимо авторизоваться</string>
     <string name="downloader_download_failed_ticker">Сбой при скачивании</string>
     <string name="downloader_download_file_not_found">Этот файл больше недоступен на сервере</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Скачивается %2$s</string>
     <string name="downloader_download_in_progress_ticker">Скачивается…</string>
     <string name="downloader_download_succeeded_content">%1$s скачано</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -941,7 +941,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Оставить файл в исходной папке</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Удалить файл из исходной папки</string>
     <string name="uploader_upload_forbidden_permissions">для передачи в эту папку</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% «%2$s»</string>
     <string name="uploader_upload_in_progress_ticker">Передача…</string>
     <string name="uploader_upload_succeeded_content_single">Передача файла «%1$s» завершена</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -944,7 +944,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Ponechaj súbor v pôvodnom priečinku</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Odstráň súbor z pôvodného priečinka</string>
     <string name="uploader_upload_forbidden_permissions">nahrávať do tohto priečinka</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Odosielam %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Nahrávanie…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s odoslané</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -245,7 +245,6 @@
     <string name="downloader_download_failed_credentials_error">Sťahovanie neúspešné, je potrebné sa znovu prihlásiť</string>
     <string name="downloader_download_failed_ticker">Stiahnutie zlyhalo</string>
     <string name="downloader_download_file_not_found">Súbor už na serveri nie je dostupný</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Sťahovanie %2$s</string>
     <string name="downloader_download_in_progress_ticker">Sťahujem…</string>
     <string name="downloader_download_succeeded_content">%1$s stiahnuté</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Остави фајл у изворној фасцикли</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Избриши фајл из изворне фасцикле</string>
     <string name="uploader_upload_forbidden_permissions">да отпремите ову фасциклу</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Отпремање %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Отпремам…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s отпремљено</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Неуспешно преузимање. Поново се пријавите</string>
     <string name="downloader_download_failed_ticker">Преузимање није успело</string>
     <string name="downloader_download_file_not_found">Фајл није више доступан на серверу</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% преузимам %2$s</string>
     <string name="downloader_download_in_progress_ticker">Преузимам…</string>
     <string name="downloader_download_succeeded_content">%1$s преузето</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">Hämtningen misslyckades, logga in igen</string>
     <string name="downloader_download_failed_ticker">Hämtning misslyckades</string>
     <string name="downloader_download_file_not_found">Filen är inte längre tillgänglig på servern</string>
-    <string name="downloader_download_in_progress">%1$d%%%2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Hämtar %2$s</string>
     <string name="downloader_download_in_progress_ticker">Hämtar…</string>
     <string name="downloader_download_succeeded_content">%1$s hämtad</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -951,7 +951,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Behåll fil i källmappen</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Ta bort fil från källmappen</string>
     <string name="uploader_upload_forbidden_permissions">att ladda upp denna mapp</string>
-    <string name="uploader_upload_in_progress">%1$d%%%2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Laddar upp %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Laddar upp…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s uppladdad</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -246,7 +246,6 @@
     <string name="downloader_download_failed_credentials_error">İndirilemedi, yeniden oturum açmalısınız</string>
     <string name="downloader_download_failed_ticker">İndirilemedi</string>
     <string name="downloader_download_file_not_found">Bu dosya artık sunucuda yok</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%%%1$d İndirilen: %2$s</string>
     <string name="downloader_download_in_progress_ticker">İndiriliyor …</string>
     <string name="downloader_download_succeeded_content">%1$s indirildi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -947,7 +947,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Kaynak klasördeki dosya tutulsun</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Dosya kaynak klasörden silinsin</string>
     <string name="uploader_upload_forbidden_permissions">bu klasöre yükleyemezsiniz</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%%%1$d Yüklenen: %2$s</string>
     <string name="uploader_upload_in_progress_ticker">Yükleniyor …</string>
     <string name="uploader_upload_succeeded_content_single">%1$s yüklendi</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -963,7 +963,6 @@ Nextcloud 是一个私有文件同步、共享和通信服务器。它是自由�
     <string name="uploader_upload_files_behaviour_only_upload">在原文件夹中保留文件</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">从原文件夹中删除文件</string>
     <string name="uploader_upload_forbidden_permissions">上传到此文件夹</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% 正在上传 %2$s</string>
     <string name="uploader_upload_in_progress_ticker">正在上传…</string>
     <string name="uploader_upload_succeeded_content_single">已上传了 %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -239,7 +239,6 @@
     <string name="downloader_download_failed_credentials_error">下载失败，请重新登录</string>
     <string name="downloader_download_failed_ticker">下载失败</string>
     <string name="downloader_download_file_not_found">该文件在服务器上不可用</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% 正在下载 %2$s</string>
     <string name="downloader_download_in_progress_ticker">正在下载…</string>
     <string name="downloader_download_succeeded_content">已下载了 %1$s</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">下載失敗，再重新登入</string>
     <string name="downloader_download_failed_ticker">下載失敗</string>
     <string name="downloader_download_file_not_found">這個檔案已經不存在於伺服器中</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% 下載中 %2$s</string>
     <string name="downloader_download_in_progress_ticker">下載中…</string>
     <string name="downloader_download_succeeded_content">%1$s 已下載</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">在來源資料夾保留檔案</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">刪除來源資料夾中的檔案</string>
     <string name="uploader_upload_forbidden_permissions">上傳至此資料夾</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% 上傳 %2$s 中</string>
     <string name="uploader_upload_in_progress_ticker">上傳中…</string>
     <string name="uploader_upload_succeeded_content_single">%1$s 已上傳</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -247,7 +247,6 @@
     <string name="downloader_download_failed_credentials_error">下載失敗，再重新登入</string>
     <string name="downloader_download_failed_ticker">下載失敗</string>
     <string name="downloader_download_file_not_found">這個檔案已經不存在於伺服器中</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% 下載中 %2$s</string>
     <string name="downloader_download_in_progress_ticker">正在下載……</string>
     <string name="downloader_download_succeeded_content">%1$s 已下載</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -950,7 +950,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">在來源資料夾保留檔案</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">刪除來源資料夾中的檔案</string>
     <string name="uploader_upload_forbidden_permissions">上傳至此資料夾</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
     <string name="uploader_upload_in_progress_content">%1$d%% 上傳 %2$s 中</string>
     <string name="uploader_upload_in_progress_ticker">正在上傳……</string>
     <string name="uploader_upload_succeeded_content_single">%1$s 已上傳</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,11 +187,10 @@
     <string name="upload_chooser_title">Upload from…</string>
     <string name="uploader_info_dirname">Folder name</string>
 
-    <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
-    <string name="upload_notification_manager_upload_in_progress_text">%1$d%%</string>
+    <string name="upload_notification_manager_start_text" translatable="false">%1$d / %2$d - %3$s</string>
+    <string name="upload_notification_manager_upload_in_progress_text" translatable="false">%1$d%%</string>
 
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
-    <string name="uploader_upload_in_progress">%1$d%%</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>
     <string name="uploader_upload_succeeded_content_single">%1$s uploaded</string>
     <string name="uploader_upload_failed_ticker">Upload failed</string>
@@ -221,8 +220,8 @@
     <string name="uploads_view_later_waiting_to_upload">Waiting to upload</string>
     <string name="uploads_view_group_header" translatable="false">%1$s (%2$d)</string>
 
-    <string name="downloader_notification_manager_download_text">%1$d / %2$d - %3$s</string>
-    <string name="downloader_notification_manager_in_progress_text">%1$d%%</string>
+    <string name="downloader_notification_manager_download_text" translatable="false">%1$d / %2$d - %3$s</string>
+    <string name="downloader_notification_manager_in_progress_text" translatable="false">%1$d%%</string>
 
     <string name="downloader_download_in_progress_ticker">Downloading…</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,7 +225,6 @@
     <string name="downloader_notification_manager_in_progress_text">%1$d%%</string>
 
     <string name="downloader_download_in_progress_ticker">Downloading…</string>
-    <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>
     <string name="downloader_download_succeeded_ticker">Downloaded</string>
     <string name="downloader_download_succeeded_content">%1$s downloaded</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,7 +189,6 @@
 
     <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
 
-
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
     <string name="uploader_upload_in_progress">%1$d%%</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="upload_chooser_title">Upload from…</string>
     <string name="uploader_info_dirname">Folder name</string>
 
-    <string name="upload_notification_manager_start_text" translatable="false">%1$d / %2$d - %3$s</string>
+    <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
     <string name="upload_notification_manager_upload_in_progress_text" translatable="false">%1$d%%</string>
 
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="uploader_info_dirname">Folder name</string>
 
     <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
+    <string name="upload_notification_manager_upload_in_progress_text">%1$d%%</string>
 
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
     <string name="uploader_upload_in_progress">%1$d%%</string>
@@ -219,6 +220,10 @@
     <string name="uploads_view_upload_status_fetching_server_version">Fetching server version…</string>
     <string name="uploads_view_later_waiting_to_upload">Waiting to upload</string>
     <string name="uploads_view_group_header" translatable="false">%1$s (%2$d)</string>
+
+    <string name="downloader_notification_manager_download_text">%1$d / %2$d - %3$s</string>
+    <string name="downloader_notification_manager_in_progress_text">%1$d%%</string>
+
     <string name="downloader_download_in_progress_ticker">Downloading…</string>
     <string name="downloader_download_in_progress">%1$d%% %2$s</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,8 +186,12 @@
     <string name="active_user">Active user</string>
     <string name="upload_chooser_title">Upload from…</string>
     <string name="uploader_info_dirname">Folder name</string>
+
+    <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
+
+
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
-    <string name="uploader_upload_in_progress">%1$d%% %2$s</string>
+    <string name="uploader_upload_in_progress">%1$d%%</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>
     <string name="uploader_upload_succeeded_content_single">%1$s uploaded</string>
     <string name="uploader_upload_failed_ticker">Upload failed</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### What does this PR?

- Unify notifications for downloads and uploads to display all progress in a single notification rather than multiple notifications.
- Make download and upload notifications dismissible to prevent stuck notifications on some devices.
- Prevent unnecessary notification updates by adding debounce for the progress updates of downloads and uploads.
- Use a parent class for Upload and Download Notification Manager to prevent code duplication.
- Remove unnecessary usage of notification dismiss.
- Add BigTextStyle for upload and download notifications to provide better visibility
- Fix notification blinking for uploads

**Before**

https://github.com/nextcloud/android/assets/67455295/80e673c5-8e9c-4136-9b52-07a3ce403637

**After**

https://github.com/nextcloud/android/assets/67455295/0d4c1137-d86d-40b8-a025-6afe5b12e46e

**How to Test**

+ Test one file download

+ Test one file upload

+ Test multiple file upload

+ Test multiple file download

+ Test all above scenarios for e2e
