### PR TITLE
Added direct upload from video camera

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.java
@@ -11,6 +11,7 @@ import android.view.View;
 
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.gson.Gson;
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.device.DeviceInfo;
 import com.nextcloud.client.di.Injectable;
@@ -75,12 +76,12 @@ public class OCFileListBottomSheetDialog extends BottomSheetDialog implements In
         binding = FileListActionsBottomSheetFragmentBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        viewThemeUtils.platform.colorImageView(binding.menuIconUploadFiles);
-        viewThemeUtils.platform.colorImageView(binding.menuIconUploadFromApp);
-        viewThemeUtils.platform.colorImageView(binding.menuIconDirectCameraUpload);
-        viewThemeUtils.platform.colorImageView(binding.menuIconScanDocUpload);
-        viewThemeUtils.platform.colorImageView(binding.menuIconMkdir);
-        viewThemeUtils.platform.colorImageView(binding.menuIconAddFolderInfo);
+        viewThemeUtils.platform.colorImageView(binding.menuIconUploadFiles, ColorRole.PRIMARY);
+        viewThemeUtils.platform.colorImageView(binding.menuIconUploadFromApp, ColorRole.PRIMARY);
+        viewThemeUtils.platform.colorImageView(binding.menuIconDirectCameraUpload, ColorRole.PRIMARY);
+        viewThemeUtils.platform.colorImageView(binding.menuIconScanDocUpload, ColorRole.PRIMARY);
+        viewThemeUtils.platform.colorImageView(binding.menuIconMkdir, ColorRole.PRIMARY);
+        viewThemeUtils.platform.colorImageView(binding.menuIconAddFolderInfo, ColorRole.PRIMARY);
 
         binding.addToCloud.setText(getContext().getResources().getString(R.string.add_to_cloud,
                                                                          themeUtils.getDefaultDisplayNameForRootFolder(getContext())));

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -13,7 +13,6 @@
  */
 package com.owncloud.android.ui.helpers;
 
-import android.Manifest;
 import android.accounts.Account;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -69,7 +68,6 @@ import com.owncloud.android.ui.events.SyncEventFinished;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.EncryptionUtils;
 import com.owncloud.android.utils.FileStorageUtils;
-import com.owncloud.android.utils.PermissionUtil;
 import com.owncloud.android.utils.UriUtils;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
@@ -1058,34 +1056,42 @@ public class FileOperationsHelper {
         fileActivity.showLoadingDialog(fileActivity.getString(R.string.wait_checking_credentials));
     }
 
-    public void uploadFromCamera(Activity activity, int requestCode) {
-        Intent pictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+    public void uploadFromCamera(Activity activity, int requestCode, boolean isVideo) {
+        Intent intent;
+        if (isVideo) {
 
-        File photoFile = createImageFile(activity);
+            // FIXME Not working on Emulator
+            intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
+        } else {
+            intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        }
 
-        Uri photoUri = FileProvider.getUriForFile(activity.getApplicationContext(),
-                                                  activity.getResources().getString(R.string.file_provider_authority), photoFile);
-        pictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoUri);
+        File cameraFile = createCameraFile(activity, isVideo);
 
-        if (pictureIntent.resolveActivity(activity.getPackageManager()) != null) {
-            if (PermissionUtil.checkSelfPermission(activity, Manifest.permission.CAMERA)) {
-                activity.startActivityForResult(pictureIntent, requestCode);
-            } else {
-                PermissionUtil.requestCameraPermission(activity, PermissionUtil.PERMISSIONS_CAMERA);
-            }
+        Uri cameraUri = FileProvider.getUriForFile(activity.getApplicationContext(),
+                                                  activity.getResources().getString(R.string.file_provider_authority), cameraFile);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, cameraUri);
+
+        if (intent.resolveActivity(activity.getPackageManager()) != null) {
+            activity.startActivityForResult(intent, requestCode);
         } else {
             DisplayUtils.showSnackMessage(activity, "No Camera found");
         }
     }
 
-    public static File createImageFile(Activity activity) {
-        File storageDir = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-
-        return new File(storageDir + "/directCameraUpload.jpg");
+    public static File createCameraFile(Activity activity, boolean isVideo) {
+        String directory = isVideo ? Environment.DIRECTORY_MOVIES : Environment.DIRECTORY_PICTURES;
+        File storageDir = activity.getExternalFilesDir(directory);
+        String fileName = isVideo ? "/directCameraUpload.mp4" : "/directCameraUpload.jpg";
+        return new File(storageDir + fileName);
     }
 
     public static String getCapturedImageName() {
         return getTimestampedFileName(".jpg");
+    }
+
+    public static String getCapturedVideoName() {
+        return getTimestampedFileName(".mp4");
     }
 
     /**

--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -904,6 +904,10 @@
     <string name="upload_chooser_title">Upload from…</string>
     <string name="upload_content_from_other_apps">Upload content from other apps</string>
     <string name="upload_direct_camera_upload">Upload from camera</string>
+    <string name="upload_direct_camera_promt">Do you want to take a photo or video?</string>
+    <string name="upload_direct_camera_photo">Photo</string>
+    <string name="upload_direct_camera_video">Video</string>
+    <string name="error_uploading_direct_camera_upload">Failed to upload taken media</string>
     <string name="upload_file_dialog_filename">Filename</string>
     <string name="upload_file_dialog_filetype">Filetype</string>
     <string name="upload_file_dialog_filetype_googlemap_shortcut">Google Maps shortcut file(%s)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -904,6 +904,10 @@
     <string name="upload_chooser_title">Dateien hochladen von…</string>
     <string name="upload_content_from_other_apps">Inhalt anderer Apps hochladen</string>
     <string name="upload_direct_camera_upload">Von Kamera hochladen</string>
+    <string name="upload_direct_camera_promt">Möchten Sie ein Foto oder Video aufnehmen?</string>
+    <string name="upload_direct_camera_photo">Foto</string>
+    <string name="upload_direct_camera_video">Video</string>
+    <string name="error_uploading_direct_camera_upload">Hochladen von Medien fehlgeschlagen</string>
     <string name="upload_file_dialog_filename">Dateiname</string>
     <string name="upload_file_dialog_filetype">Dateityp</string>
     <string name="upload_file_dialog_filetype_googlemap_shortcut">Google Maps Abkürzungs-Datei (%s)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -812,6 +812,10 @@
     <string name="add_to_cloud">Add to %1$s</string>
     <string name="upload_files">Upload files</string>
     <string name="upload_direct_camera_upload">Upload from camera</string>
+    <string name="upload_direct_camera_promt">Do you want to take a photo or video?</string>
+    <string name="upload_direct_camera_photo">Photo</string>
+    <string name="upload_direct_camera_video">Video</string>
+    <string name="error_uploading_direct_camera_upload">Failed to upload taken media</string>
     <string name="upload_scan_doc_upload">Scan document from camera</string>
     <string name="upload_content_from_other_apps">Upload content from other apps</string>
     <string name="create_new_folder">New folder</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
Regarding feature request #7358
- Adding Option to directly upload a video
- If camera permissions are not already granted, it will ask if for video or image after granting (its seems not not to be possible to get the camera-action after the permission request)
-  It seems that the videointent doesn't work on emulator? 
- Tested successfull with a real GooglePixel 6a


- [ ] Tests written, or not not needed

