### PR TITLE
Dismiss notification of successful downloads

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -353,6 +353,7 @@ class FileDownloadWorker(
 
     private fun checkDownloadError(result: RemoteOperationResult<*>) {
         if (result.isSuccess || downloadError != null) {
+            notificationManager.dismissNotification()
             return
         }
 


### PR DESCRIPTION
Sometimes download notifications could be stuck at 100% and not be dismissed automatically. In a previous pull request these notifications were made dismissible by the end user as a workaround. This pull request aims to minimise the edge cases where notifications become stuck.

#### Test Procedure
1. Set breakpoint on `FileActivity.java:524` and `FileActivity.java:542`
2. Start app in debug mode
3. Open overflow menu of any file
4. Select *Download*
5. Wait until the breakpoint is hit
6. Close the app and continue running
7. Wait for some amount of time
8. re-open the app

Without this patch the *Downloading...* notification is displayed but not automatically dismissed. IT should now be dismissed automatically.

---

- [ ] Tests written, or not not needed
