### PR TITLE
Create individual workers for every Autoupload Folder

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -119,11 +119,16 @@ interface BackgroundJobManager {
 
     fun startImmediateFilesExportJob(files: Collection<OCFile>): LiveData<JobInfo?>
 
-    fun schedulePeriodicFilesSyncJob()
+    fun schedulePeriodicFilesSyncJob(syncedFolderID: Long)
 
+    /**
+     * Immediately start File Sync job for given syncFolderID if provided. If no syncFolderID is provided, it will start
+     * the syncFolder job for all sync folders.
+     */
     fun startImmediateFilesSyncJob(
+        syncedFolderID: Long,
         overridePowerSaving: Boolean = false,
-        changedFiles: Array<String> = arrayOf<String>()
+        changedFiles: Array<String> = arrayOf<String>(),
     )
 
     fun scheduleOfflineSync()
@@ -163,5 +168,5 @@ interface BackgroundJobManager {
     fun cancelAllJobs()
     fun schedulePeriodicHealthStatus()
     fun startHealthStatus()
-    fun bothFilesSyncJobsRunning(): Boolean
+    fun bothFilesSyncJobsRunning(syncedFolderID: Long): Boolean
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -128,7 +128,7 @@ interface BackgroundJobManager {
     fun startImmediateFilesSyncJob(
         syncedFolderID: Long,
         overridePowerSaving: Boolean = false,
-        changedFiles: Array<String> = arrayOf<String>(),
+        changedFiles: Array<String> = arrayOf<String>()
     )
 
     fun scheduleOfflineSync()

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -122,8 +122,7 @@ interface BackgroundJobManager {
     fun schedulePeriodicFilesSyncJob(syncedFolderID: Long)
 
     /**
-     * Immediately start File Sync job for given syncFolderID if provided. If no syncFolderID is provided, it will start
-     * the syncFolder job for all sync folders.
+     * Immediately start File Sync job for given syncFolderID.
      */
     fun startImmediateFilesSyncJob(
         syncedFolderID: Long,

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -418,12 +418,12 @@ internal class BackgroundJobManagerImpl(
 
         val request = periodicRequestBuilder(
             jobClass = FilesSyncWork::class,
-            jobName = JOB_PERIODIC_FILES_SYNC,
+            jobName = JOB_PERIODIC_FILES_SYNC + "_" + syncedFolderID,
             intervalMins = DEFAULT_PERIODIC_JOB_INTERVAL_MINUTES
         )
             .setInputData(arguments)
             .build()
-        workManager.enqueueUniquePeriodicWork(JOB_PERIODIC_FILES_SYNC, ExistingPeriodicWorkPolicy.REPLACE, request)
+        workManager.enqueueUniquePeriodicWork(JOB_PERIODIC_FILES_SYNC + "_" + syncedFolderID, ExistingPeriodicWorkPolicy.REPLACE, request)
     }
 
     override fun startImmediateFilesSyncJob(
@@ -439,12 +439,12 @@ internal class BackgroundJobManagerImpl(
 
         val request = oneTimeRequestBuilder(
             jobClass = FilesSyncWork::class,
-            jobName = JOB_IMMEDIATE_FILES_SYNC
+            jobName = JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID
         )
             .setInputData(arguments)
             .build()
 
-        workManager.enqueueUniqueWork(JOB_IMMEDIATE_FILES_SYNC, ExistingWorkPolicy.APPEND, request)
+        workManager.enqueueUniqueWork(JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID, ExistingWorkPolicy.APPEND, request)
     }
 
     override fun scheduleOfflineSync() {

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -405,8 +405,8 @@ internal class BackgroundJobManagerImpl(
     }
 
     override fun bothFilesSyncJobsRunning(syncedFolderID: Long): Boolean {
-        return workManager.isWorkRunning(JOB_PERIODIC_FILES_SYNC+"_"+syncedFolderID) &&
-            workManager.isWorkRunning(JOB_IMMEDIATE_FILES_SYNC+"_"+syncedFolderID)
+        return workManager.isWorkRunning(JOB_PERIODIC_FILES_SYNC + "_" + syncedFolderID) &&
+            workManager.isWorkRunning(JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID)
     }
 
     override fun schedulePeriodicFilesSyncJob(
@@ -429,7 +429,7 @@ internal class BackgroundJobManagerImpl(
     override fun startImmediateFilesSyncJob(
         syncedFolderID: Long,
         overridePowerSaving: Boolean,
-        changedFiles: Array<String>,
+        changedFiles: Array<String>
     ) {
         val arguments = Data.Builder()
             .putBoolean(FilesSyncWork.OVERRIDE_POWER_SAVING, overridePowerSaving)

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -423,7 +423,11 @@ internal class BackgroundJobManagerImpl(
         )
             .setInputData(arguments)
             .build()
-        workManager.enqueueUniquePeriodicWork(JOB_PERIODIC_FILES_SYNC + "_" + syncedFolderID, ExistingPeriodicWorkPolicy.REPLACE, request)
+        workManager.enqueueUniquePeriodicWork(
+            JOB_PERIODIC_FILES_SYNC + "_" + syncedFolderID,
+            ExistingPeriodicWorkPolicy.REPLACE,
+            request
+        )
     }
 
     override fun startImmediateFilesSyncJob(
@@ -444,7 +448,11 @@ internal class BackgroundJobManagerImpl(
             .setInputData(arguments)
             .build()
 
-        workManager.enqueueUniqueWork(JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID, ExistingWorkPolicy.APPEND, request)
+        workManager.enqueueUniqueWork(
+            JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID,
+            ExistingWorkPolicy.APPEND,
+            request
+        )
     }
 
     override fun scheduleOfflineSync() {

--- a/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
@@ -48,13 +48,15 @@ class ContentObserverWork(
     }
 
     private fun checkAndStartFileSyncJob() {
-        val syncFolders = syncerFolderProvider.countEnabledSyncedFolders() > 0
-        if (!powerManagementService.isPowerSavingEnabled && syncFolders) {
+        val syncFolders = syncerFolderProvider.syncedFolders
+        if (!powerManagementService.isPowerSavingEnabled && syncerFolderProvider.countEnabledSyncedFolders() > 0) {
             val changedFiles = mutableListOf<String>()
             for (uri in params.triggeredContentUris) {
                 changedFiles.add(uri.toString())
             }
-            backgroundJobManager.startImmediateFilesSyncJob(false, changedFiles.toTypedArray())
+            for (syncFolder in syncFolders){
+                backgroundJobManager.startImmediateFilesSyncJob(syncFolder.id, false, changedFiles.toTypedArray())
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
@@ -54,7 +54,12 @@ class ContentObserverWork(
             for (uri in params.triggeredContentUris) {
                 changedFiles.add(uri.toString())
             }
-            FilesSyncHelper.startFilesSyncForAllFolders(syncedFolderProvider, backgroundJobManager, false, changedFiles.toTypedArray())
+            FilesSyncHelper.startFilesSyncForAllFolders(
+                syncedFolderProvider,
+                backgroundJobManager,
+                false,
+                changedFiles.toTypedArray()
+            )
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/ContentObserverWork.kt
@@ -12,6 +12,7 @@ import androidx.work.WorkerParameters
 import com.nextcloud.client.device.PowerManagementService
 import com.owncloud.android.datamodel.SyncedFolderProvider
 import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.utils.FilesSyncHelper
 
 /**
  * This work is triggered when OS detects change in media folders.
@@ -23,7 +24,7 @@ import com.owncloud.android.lib.common.utils.Log_OC
 class ContentObserverWork(
     appContext: Context,
     private val params: WorkerParameters,
-    private val syncerFolderProvider: SyncedFolderProvider,
+    private val syncedFolderProvider: SyncedFolderProvider,
     private val powerManagementService: PowerManagementService,
     private val backgroundJobManager: BackgroundJobManager
 ) : Worker(appContext, params) {
@@ -48,15 +49,12 @@ class ContentObserverWork(
     }
 
     private fun checkAndStartFileSyncJob() {
-        val syncFolders = syncerFolderProvider.syncedFolders
-        if (!powerManagementService.isPowerSavingEnabled && syncerFolderProvider.countEnabledSyncedFolders() > 0) {
+        if (!powerManagementService.isPowerSavingEnabled && syncedFolderProvider.countEnabledSyncedFolders() > 0) {
             val changedFiles = mutableListOf<String>()
             for (uri in params.triggeredContentUris) {
                 changedFiles.add(uri.toString())
             }
-            for (syncFolder in syncFolders){
-                backgroundJobManager.startImmediateFilesSyncJob(syncFolder.id, false, changedFiles.toTypedArray())
-            }
+            FilesSyncHelper.startFilesSyncForAllFolders(syncedFolderProvider, backgroundJobManager, false, changedFiles.toTypedArray())
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -116,7 +116,7 @@ class FilesSyncWork(
 
         if (canExitEarly(changedFiles, syncFolderId)) {
             val result = Result.success()
-            backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
+            backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class) + "_" + syncFolderId, result)
             return result
         }
 
@@ -156,7 +156,7 @@ class FilesSyncWork(
 
         Log_OC.d(TAG, "File-sync worker (${syncedFolder.remotePath}) finished")
         val result = Result.success()
-        backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
+        backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class) + "_" + syncFolderId, result)
         return result
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -64,7 +64,6 @@ class FilesSyncWork(
 
     private lateinit var syncedFolder: SyncedFolder
 
-
     @Suppress("ReturnCount")
     private fun canExitEarly(changedFiles: Array<String>?, syncedFolderID: Long): Boolean {
         // If we are in power save mode better to postpone scan and upload
@@ -81,17 +80,20 @@ class FilesSyncWork(
         // or sync worker already running and no changed files to be processed
         val alreadyRunning = backgroundJobManager.bothFilesSyncJobsRunning(syncedFolderID)
         if (alreadyRunning && changedFiles.isNullOrEmpty()) {
-            Log_OC.d(TAG, "File-sync kill worker since another instance of the worker ($syncedFolderID) seems to be running already!")
+            Log_OC.d(
+                TAG,
+                "File-sync kill worker since another instance of the worker " +
+                    "($syncedFolderID) seems to be running already!"
+            )
             return true
         }
 
         val syncedFolderTmp = syncedFolderProvider.getSyncedFolderByID(syncedFolderID)
         if (syncedFolderTmp == null || !syncedFolderTmp.isEnabled || !syncedFolderTmp.isExisting) {
-            Log_OC.d(TAG, "File-sync kill worker since syncedFolder (${syncedFolderID}) is not enabled!")
+            Log_OC.d(TAG, "File-sync kill worker since syncedFolder ($syncedFolderID) is not enabled!")
             return true
         }
         syncedFolder = syncedFolderTmp
-
 
         if (syncedFolder.isChargingOnly &&
             !powerManagementService.battery.isCharging &&
@@ -109,7 +111,7 @@ class FilesSyncWork(
         val syncFolderId = inputData.getLong(SYNCED_FOLDER_ID, -1)
         val changedFiles = inputData.getStringArray(CHANGED_FILES)
 
-        backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class)+"_"+syncFolderId)
+        backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class) + "_" + syncFolderId)
         Log_OC.d(TAG, "File-sync worker started for folder ID: $syncFolderId")
 
         if (canExitEarly(changedFiles, syncFolderId)) {
@@ -128,7 +130,11 @@ class FilesSyncWork(
         )
 
         // Get changed files from ContentObserverWork (only images and videos) or by scanning filesystem
-        Log_OC.d(TAG, "File-sync worker (${syncedFolder.remotePath}) changed files from observer: " + changedFiles.contentToString())
+        Log_OC.d(
+            TAG,
+            "File-sync worker (${syncedFolder.remotePath}) changed files from observer: " +
+                changedFiles.contentToString()
+        )
         collectChangedFiles(changedFiles)
         Log_OC.d(TAG, "File-sync worker (${syncedFolder.remotePath}) finished checking files.")
 

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -161,6 +161,9 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
     @Inject
     ConnectivityService connectivityService;
 
+    @Inject
+    SyncedFolderProvider syncedFolderProvider;
+
     @Inject PowerManagementService powerManagementService;
 
     @Inject
@@ -359,7 +362,8 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
                            backgroundJobManager,
                            clock,
                            viewThemeUtils,
-                           walledCheckCache);
+                           walledCheckCache,
+                           syncedFolderProvider);
         initContactsBackup(accountManager, backgroundJobManager);
         notificationChannels();
 
@@ -586,7 +590,8 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
         final BackgroundJobManager backgroundJobManager,
         final Clock clock,
         final ViewThemeUtils viewThemeUtils,
-        final WalledCheckCache walledCheckCache) {
+        final WalledCheckCache walledCheckCache,
+        final SyncedFolderProvider syncedFolderProvider) {
         updateToAutoUpload();
         cleanOldEntries(clock);
         updateAutoUploadEntries(clock);
@@ -600,12 +605,20 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
         }
 
         if (!preferences.isAutoUploadInitialized()) {
-            backgroundJobManager.startImmediateFilesSyncJob(false, new String[]{});
+            for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+                if (syncedFolder.isEnabled()) {
+                    backgroundJobManager.startImmediateFilesSyncJob(syncedFolder.getId() ,false, new String[]{});
+                }
+            }
             preferences.setAutoUploadInit(true);
         }
 
-        FilesSyncHelper.scheduleFilesSyncIfNeeded(mContext, backgroundJobManager);
-        FilesSyncHelper.restartJobsIfNeeded(
+        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+            if (syncedFolder.isEnabled()) {
+                FilesSyncHelper.scheduleFilesSyncIfNeeded(mContext, syncedFolder.getId(), backgroundJobManager);
+            }
+        }
+        FilesSyncHelper.restartUploadsIfNeeded(
             uploadsStorageManager,
             accountManager,
             connectivityService,

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -605,19 +605,11 @@ public class MainApp extends MultiDexApplication implements HasAndroidInjector {
         }
 
         if (!preferences.isAutoUploadInitialized()) {
-            for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
-                if (syncedFolder.isEnabled()) {
-                    backgroundJobManager.startImmediateFilesSyncJob(syncedFolder.getId() ,false, new String[]{});
-                }
-            }
+            FilesSyncHelper.startFilesSyncForAllFolders(syncedFolderProvider, backgroundJobManager,false, new String[]{});
             preferences.setAutoUploadInit(true);
         }
 
-        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
-            if (syncedFolder.isEnabled()) {
-                FilesSyncHelper.scheduleFilesSyncIfNeeded(mContext, syncedFolder.getId(), backgroundJobManager);
-            }
-        }
+        FilesSyncHelper.scheduleFilesSyncForAllFoldersIfNeeded(mContext, syncedFolderProvider, backgroundJobManager);
         FilesSyncHelper.restartUploadsIfNeeded(
             uploadsStorageManager,
             accountManager,

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Observable;
 
+import javax.annotation.Nullable;
+
 import androidx.annotation.NonNull;
 
 import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
@@ -200,6 +202,29 @@ public class SyncedFolderProvider extends Observable {
                 Log_OC.e(TAG, cursor.getCount() + " items for local path=" + localPath
                         + " available in sync folder db. Expected 1. Failed to update sync folder db.");
             }
+        }
+
+        if (cursor != null) {
+            cursor.close();
+        }
+
+        return result;
+
+    }
+
+    @Nullable
+    public SyncedFolder getSyncedFolderByID(Long syncedFolderID) {
+        SyncedFolder result = null;
+        Cursor cursor = mContentResolver.query(
+            ProviderMeta.ProviderTableMeta.CONTENT_URI_SYNCED_FOLDERS,
+            null,
+            ProviderMeta.ProviderTableMeta._ID + " =? ",
+            new String[]{syncedFolderID.toString()},
+            null
+                                              );
+
+        if (cursor != null && cursor.getCount() == 1 && cursor.moveToFirst()) {
+            result = createSyncedFolderFromCursor(cursor);
         }
 
         if (cursor != null) {

--- a/app/src/main/java/com/owncloud/android/files/BootupBroadcastReceiver.java
+++ b/app/src/main/java/com/owncloud/android/files/BootupBroadcastReceiver.java
@@ -23,6 +23,7 @@ import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.client.network.WalledCheckCache;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.owncloud.android.MainApp;
+import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.UploadsStorageManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
@@ -48,6 +49,7 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
     @Inject Clock clock;
     @Inject ViewThemeUtils viewThemeUtils;
     @Inject WalledCheckCache walledCheckCache;
+    @Inject SyncedFolderProvider syncedFolderProvider;
 
     /**
      * Receives broadcast intent reporting that the system was just boot up. *
@@ -68,7 +70,9 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
                                        backgroundJobManager,
                                        clock,
                                        viewThemeUtils,
-                                       walledCheckCache);
+                                       walledCheckCache,
+                                       syncedFolderProvider
+                                       );
             MainApp.initContactsBackup(accountManager, backgroundJobManager);
         } else {
             Log_OC.d(TAG, "Getting wrong intent: " + intent.getAction());

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -571,7 +571,7 @@ class SyncedFoldersActivity :
             }
         }
         if (syncedFolderDisplayItem.isEnabled) {
-            backgroundJobManager.startImmediateFilesSyncJob(overridePowerSaving = false)
+            backgroundJobManager.startImmediateFilesSyncJob(syncedFolderDisplayItem.id ,overridePowerSaving = false)
             showBatteryOptimizationInfo()
         }
     }
@@ -702,7 +702,7 @@ class SyncedFoldersActivity :
             // existing synced folder setup to be updated
             syncedFolderProvider.updateSyncFolder(item)
             if (item.isEnabled) {
-                backgroundJobManager.startImmediateFilesSyncJob(overridePowerSaving = false)
+                backgroundJobManager.startImmediateFilesSyncJob(item.id, overridePowerSaving = false)
             } else {
                 val syncedFolderInitiatedKey = KEY_SYNCED_FOLDER_INITIATED_PREFIX + item.id
                 val arbitraryDataProvider =
@@ -719,7 +719,7 @@ class SyncedFoldersActivity :
         if (storedId != -1L) {
             item.id = storedId
             if (item.isEnabled) {
-                backgroundJobManager.startImmediateFilesSyncJob(overridePowerSaving = false)
+                backgroundJobManager.startImmediateFilesSyncJob(item.id, overridePowerSaving = false)
             } else {
                 val syncedFolderInitiatedKey = KEY_SYNCED_FOLDER_INITIATED_PREFIX + item.id
                 arbitraryDataProvider.deleteKeyForAccount("global", syncedFolderInitiatedKey)

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -571,7 +571,7 @@ class SyncedFoldersActivity :
             }
         }
         if (syncedFolderDisplayItem.isEnabled) {
-            backgroundJobManager.startImmediateFilesSyncJob(syncedFolderDisplayItem.id ,overridePowerSaving = false)
+            backgroundJobManager.startImmediateFilesSyncJob(syncedFolderDisplayItem.id, overridePowerSaving = false)
             showBatteryOptimizationInfo()
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -198,11 +198,10 @@ public class UploadListActivity extends FileActivity {
     }
 
     private void refresh() {
-        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
-            if (syncedFolder.isEnabled()) {
-                backgroundJobManager.startImmediateFilesSyncJob(syncedFolder.getId(), true, new String[]{});
-            }
-        }
+        FilesSyncHelper.startFilesSyncForAllFolders(syncedFolderProvider,
+                                                    backgroundJobManager,
+                                                    true,
+                                                    new String[]{});
 
         if (uploadsStorageManager.getFailedUploads().length > 0) {
             new Thread(() -> {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -34,6 +34,8 @@ import com.nextcloud.model.WorkerStateLiveData;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadListLayoutBinding;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.SyncedFolder;
+import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.UploadsStorageManager;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -83,6 +85,9 @@ public class UploadListActivity extends FileActivity {
 
     @Inject
     BackgroundJobManager backgroundJobManager;
+
+    @Inject
+    SyncedFolderProvider syncedFolderProvider;
 
     @Inject
     LocalBroadcastManager localBroadcastManager;
@@ -193,7 +198,11 @@ public class UploadListActivity extends FileActivity {
     }
 
     private void refresh() {
-        backgroundJobManager.startImmediateFilesSyncJob(true,new String[]{});
+        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+            if (syncedFolder.isEnabled()) {
+                backgroundJobManager.startImmediateFilesSyncJob(syncedFolder.getId(), true, new String[]{});
+            }
+        }
 
         if (uploadsStorageManager.getFailedUploads().length > 0) {
             new Thread(() -> {
@@ -316,10 +325,10 @@ public class UploadListActivity extends FileActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == FileActivity.REQUEST_CODE__UPDATE_CREDENTIALS && resultCode == RESULT_OK) {
-            FilesSyncHelper.restartJobsIfNeeded(uploadsStorageManager,
-                                                userAccountManager,
-                                                connectivityService,
-                                                powerManagementService);
+            FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
+                                                   userAccountManager,
+                                                   connectivityService,
+                                                   powerManagementService);
         }
     }
 
@@ -339,10 +348,10 @@ public class UploadListActivity extends FileActivity {
 
             } else {
                 // already updated -> just retry!
-                FilesSyncHelper.restartJobsIfNeeded(uploadsStorageManager,
-                                                    userAccountManager,
-                                                    connectivityService,
-                                                    powerManagementService);
+                FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
+                                                       userAccountManager,
+                                                       connectivityService,
+                                                       powerManagementService);
             }
 
         } else {

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -311,10 +311,22 @@ public final class FilesSyncHelper {
         }).start();
     }
 
-    public static void scheduleFilesSyncIfNeeded(Context context, Long syncedFolderID, BackgroundJobManager jobManager) {
-        jobManager.schedulePeriodicFilesSyncJob(syncedFolderID);
+    public static void scheduleFilesSyncForAllFoldersIfNeeded(Context context, SyncedFolderProvider syncedFolderProvider, BackgroundJobManager jobManager) {
+        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+            if (syncedFolder.isEnabled()) {
+                jobManager.schedulePeriodicFilesSyncJob(syncedFolder.getId());
+            }
+        }
         if (context != null) {
             jobManager.scheduleContentObserverJob();
+        }
+    }
+
+    public static void startFilesSyncForAllFolders(SyncedFolderProvider syncedFolderProvider, BackgroundJobManager jobManager, boolean overridePowerSaving, String[] changedFiles) {
+        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+            if (syncedFolder.isEnabled()) {
+                jobManager.startImmediateFilesSyncJob(syncedFolder.getId(),overridePowerSaving,changedFiles);
+            }
         }
     }
 }

--- a/app/src/main/java/com/owncloud/android/utils/ReceiversHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/ReceiversHelper.java
@@ -49,10 +49,10 @@ public final class ReceiversHelper {
                 DNSCache.clear();
                 walledCheckCache.clear();
                 if (connectivityService.getConnectivity().isConnected()) {
-                    FilesSyncHelper.restartJobsIfNeeded(uploadsStorageManager,
-                                                        accountManager,
-                                                        connectivityService,
-                                                        powerManagementService);
+                    FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
+                                                           accountManager,
+                                                           connectivityService,
+                                                           powerManagementService);
                 }
             }
         };
@@ -76,10 +76,10 @@ public final class ReceiversHelper {
             @Override
             public void onReceive(Context context, Intent intent) {
                 if (Intent.ACTION_POWER_CONNECTED.equals(intent.getAction())) {
-                    FilesSyncHelper.restartJobsIfNeeded(uploadsStorageManager,
-                                                        accountManager,
-                                                        connectivityService,
-                                                        powerManagementService);
+                    FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
+                                                           accountManager,
+                                                           connectivityService,
+                                                           powerManagementService);
                 }
             }
         };
@@ -102,10 +102,10 @@ public final class ReceiversHelper {
             @Override
             public void onReceive(Context context, Intent intent) {
                 if (!powerManagementService.isPowerSavingEnabled()) {
-                    FilesSyncHelper.restartJobsIfNeeded(uploadsStorageManager,
-                                                        accountManager,
-                                                        connectivityService,
-                                                        powerManagementService);
+                    FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
+                                                           accountManager,
+                                                           connectivityService,
+                                                           powerManagementService);
                 }
             }
         };

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -687,7 +687,6 @@
     <string name="autoupload_hide_folder">Hide folder</string>
     <string name="autoupload_configure">Configure</string>
     <string name="synced_folders_configure_folders">Configure folders</string>
-    <string name="autoupload_worker_foreground_info">Preparing auto upload</string>
 
     <string name="empty" translatable="false" />
     <string name="test_server_button">Test server connection</string>

--- a/app/src/test/java/com/nextcloud/client/jobs/ContentObserverWorkTest.kt
+++ b/app/src/test/java/com/nextcloud/client/jobs/ContentObserverWorkTest.kt
@@ -46,7 +46,7 @@ class ContentObserverWorkTest {
         worker = ContentObserverWork(
             appContext = context,
             params = params,
-            syncerFolderProvider = folderProvider,
+            syncedFolderProvider = folderProvider,
             powerManagementService = powerManagementService,
             backgroundJobManager = backgroundJobManager
         )


### PR DESCRIPTION
This PR finally gets rid of the foreground worker and the corresponding notification by lowering the chance the worker gets killed.

Internally, the app now starts a new worker for every auto upload folder instead of one worker for all folders.
Advantages are:

- Worker finish quicker -> Lower chance of being killed
- Scanning of Folders can happen in parallel
- Better handling in the future

The best way to test is using logcat and filtering for "File sync" since all important log messages start with that term. Like this, you should be able to observe the behavior of the background worker without messing with it. If you want to check something specific, use the debugger, but be aware that that changes behavior (like execution speed).

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
