### PR TITLE
(Sonar) Fixed finding: "@Override should be used on overriding and im…

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -210,6 +210,7 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
         showAllGalleryItems();
     }
 
+    @Override
     public int getColumnsCount() {
         return columnSize;
     }


### PR DESCRIPTION
## Remediation

This change fixes "`@Override` should be used on overriding and implementing methods" (id = [java:S1161](https://rules.sonarsource.com/java/RSPEC-1161/)) identified by Sonar.

## Details

This change adds missing `@Override` to known subclasses. Documenting inheritance will help readers and static analysis tools understand the code better, spot bugs easier, and in general lead to more efficient and effective review.

Our changes look something like this:

```diff
  interface AcmeParent {
     void doThing();
  } 

  class AcmeChild implements AcmeParent {

+   @Override
    void doThing() {
      thing();
    }
    
  }
```

<details>
  <summary>More reading</summary>

  * [https://rules.sonarsource.com/java/RSPEC-1161/](https://rules.sonarsource.com/java/RSPEC-1161/)
</details>

🧚🤖Powered by Pixeebot (codemod ID: [sonar:java/add-missing-override-s1161](https://docs.pixee.ai/codemods/java/sonar_java_add-missing-override-s1161)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fandroid%7C8ece1aa93df38da9529fe0d29a6abe0920a65af1)

<!--{"type":"DRIP","codemod":"sonar:java/add-missing-override-s1161"}-->

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
