### PR TITLE
Bugfix Fix Rare lateinit Crash on File Download Worker

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -556,7 +556,6 @@ internal class BackgroundJobManagerImpl(
         val tag = startFileDownloadJobTag(user, file.fileId)
 
         val data = workDataOf(
-            FileDownloadWorker.WORKER_ID to file.fileId.toInt(),
             FileDownloadWorker.ACCOUNT_NAME to user.accountName,
             FileDownloadWorker.FILE_REMOTE_PATH to file.remotePath,
             FileDownloadWorker.BEHAVIOUR to behaviour,

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -43,7 +43,7 @@ import java.util.Vector
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class FileDownloadWorker(
-    private val viewThemeUtils: ViewThemeUtils,
+    viewThemeUtils: ViewThemeUtils,
     private val accountManager: UserAccountManager,
     private var localBroadcastManager: LocalBroadcastManager,
     private val context: Context,
@@ -94,7 +94,7 @@ class FileDownloadWorker(
     private var lastPercent = 0
 
     private val intents = FileDownloadIntents(context)
-    private lateinit var notificationManager: DownloadNotificationManager
+    private var notificationManager: DownloadNotificationManager
     private var downloadProgressListener = FileDownloadProgressListener()
 
     private var user: User? = null
@@ -106,17 +106,20 @@ class FileDownloadWorker(
     private var workerId: Int? = null
     private var downloadError: FileDownloadError? = null
 
+    init {
+        workerId = inputData.keyValueMap[WORKER_ID] as Int
+        notificationManager =
+            DownloadNotificationManager(
+                workerId ?: SecureRandom().nextInt(),
+                context,
+                viewThemeUtils
+            )
+    }
+
     @Suppress("TooGenericExceptionCaught")
     override fun doWork(): Result {
         return try {
             val requestDownloads = getRequestDownloads()
-
-            notificationManager =
-                DownloadNotificationManager(
-                    workerId ?: SecureRandom().nextInt(),
-                    context,
-                    viewThemeUtils
-                )
             addAccountUpdateListener()
 
             val foregroundInfo = ForegroundServiceHelper.createWorkerForegroundInfo(
@@ -170,7 +173,6 @@ class FileDownloadWorker(
     }
 
     private fun getRequestDownloads(): AbstractList<String> {
-        workerId = inputData.keyValueMap[WORKER_ID] as Int
         Log_OC.e(TAG, "FilesDownloadWorker started for $workerId")
 
         setUser()

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -65,7 +65,6 @@ class FileDownloadWorker(
             return pendingDownloads.all.any { it.value?.payload?.isMatching(accountName, fileId) == true }
         }
 
-        const val WORKER_ID = "WORKER_ID"
         const val FILE_REMOTE_PATH = "FILE_REMOTE_PATH"
         const val ACCOUNT_NAME = "ACCOUNT_NAME"
         const val BEHAVIOUR = "BEHAVIOUR"
@@ -94,7 +93,12 @@ class FileDownloadWorker(
     private var lastPercent = 0
 
     private val intents = FileDownloadIntents(context)
-    private var notificationManager: DownloadNotificationManager
+    private var notificationManager = DownloadNotificationManager(
+        SecureRandom().nextInt(),
+        context,
+        viewThemeUtils
+    )
+
     private var downloadProgressListener = FileDownloadProgressListener()
 
     private var user: User? = null
@@ -103,18 +107,7 @@ class FileDownloadWorker(
     private var currentUserFileStorageManager: FileDataStorageManager? = null
     private var fileDataStorageManager: FileDataStorageManager? = null
 
-    private var workerId: Int? = null
     private var downloadError: FileDownloadError? = null
-
-    init {
-        workerId = inputData.keyValueMap[WORKER_ID] as Int
-        notificationManager =
-            DownloadNotificationManager(
-                workerId ?: SecureRandom().nextInt(),
-                context,
-                viewThemeUtils
-            )
-    }
 
     @Suppress("TooGenericExceptionCaught")
     override fun doWork(): Result {
@@ -173,8 +166,6 @@ class FileDownloadWorker(
     }
 
     private fun getRequestDownloads(): AbstractList<String> {
-        Log_OC.e(TAG, "FilesDownloadWorker started for $workerId")
-
         setUser()
         val files = getFiles()
         val downloadType = getDownloadType()


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Our crash reports indicate that the `DownloadNotificationManager` occasionally fails to initialize correctly. Previously, `DownloadNotificationManager` was initialized within the `doWork` function, which sometimes led to attempts to use it before it was fully initialized.

This pull request addresses the issue by initializing `DownloadNotificationManager` before calling `doWork`. Additionally, it removes the use of `workerId`, as it is unnecessary; users can still stop the worker using `fileId`, making `workerId` redundant.
