### PR TITLE
Bugfix Fix NPE FileDataStorageManager

### DIFF
--- a/app/src/main/java/com/nextcloud/client/account/CurrentAccountProvider.java
+++ b/app/src/main/java/com/nextcloud/client/account/CurrentAccountProvider.java
@@ -24,7 +24,7 @@ public interface CurrentAccountProvider {
      * @return Currently selected {@link Account} or first valid {@link Account} registered in OS or null, if not available at all.
      */
     @Deprecated
-    @Nullable
+    @NonNull
     Account getCurrentAccount();
 
     /**

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -18,14 +18,12 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AuthenticatorActivity;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
-import com.owncloud.android.datamodel.ArbitraryDataProviderImpl;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
@@ -42,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import javax.inject.Inject;
 

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -24,6 +24,7 @@ import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AuthenticatorActivity;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
+import com.owncloud.android.datamodel.ArbitraryDataProviderImpl;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
@@ -50,7 +51,6 @@ public class UserAccountManagerImpl implements UserAccountManager {
 
     private static final String TAG = UserAccountManagerImpl.class.getSimpleName();
     private static final String PREF_SELECT_OC_ACCOUNT = "select_oc_account";
-    @Inject ArbitraryDataProvider arbitraryDataProvider;
 
     private Context context;
     private final AccountManager accountManager;
@@ -136,6 +136,7 @@ public class UserAccountManagerImpl implements UserAccountManager {
     public Account getCurrentAccount() {
         Account[] ocAccounts = getAccounts();
 
+        ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProviderImpl(context);
         SharedPreferences appPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         String accountName = appPreferences.getString(PREF_SELECT_OC_ACCOUNT, null);
 

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -20,6 +20,7 @@ import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
 import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.utils.extensions.AccountExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AuthenticatorActivity;
@@ -154,10 +155,18 @@ public class UserAccountManagerImpl implements UserAccountManager {
         }
 
         if (defaultAccount == null) {
-            defaultAccount = ocAccounts[0];
+            if (ocAccounts.length > 0) {
+                defaultAccount = ocAccounts[0];
+            } else {
+                defaultAccount = getAnonymousAccount();
+            }
         }
 
         return defaultAccount;
+    }
+
+    private Account getAnonymousAccount() {
+        return new Account("Anonymous", context.getString(R.string.anonymous_account_type));
     }
 
     /**
@@ -169,8 +178,8 @@ public class UserAccountManagerImpl implements UserAccountManager {
      * @return User instance or null, if conversion failed
      */
     @Nullable
-    private User createUserFromAccount(@Nullable Account account) {
-        if (account == null) {
+    private User createUserFromAccount(@NonNull Account account) {
+        if (AccountExtensionsKt.isAnonymous(account, context)) {
             return null;
         }
 
@@ -252,7 +261,7 @@ public class UserAccountManagerImpl implements UserAccountManager {
     }
 
     @Override
-    @Nullable
+    @NonNull
     public Account getAccountByName(String name) {
         for (Account account : getAccounts()) {
             if (account.name.equals(name)) {
@@ -260,7 +269,7 @@ public class UserAccountManagerImpl implements UserAccountManager {
             }
         }
 
-        return null;
+        return getAnonymousAccount();
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/client/di/AppModule.java
+++ b/app/src/main/java/com/nextcloud/client/di/AppModule.java
@@ -100,8 +100,7 @@ class AppModule {
     @Provides
     UserAccountManager userAccountManager(
         Context context,
-        AccountManager accountManager
-                                         ) {
+        AccountManager accountManager) {
         return new UserAccountManagerImpl(context, accountManager);
     }
 

--- a/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
+++ b/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
@@ -60,10 +60,7 @@ class SessionMixin(
      * If no valid ownCloud [Account] exists, then the user is requested
      * to create a new ownCloud [Account].
      */
-    private fun getDefaultAccount(): Account {
-        // default to the most recently used account
-        return accountManager.currentAccount
-    }
+    private fun getDefaultAccount(): Account = accountManager.currentAccount
 
     /**
      * Launches the account creation activity.

--- a/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
+++ b/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
@@ -13,6 +13,7 @@ import android.content.Intent
 import android.os.Bundle
 import com.nextcloud.client.account.User
 import com.nextcloud.client.account.UserAccountManager
+import com.nextcloud.utils.extensions.isAnonymous
 import com.owncloud.android.lib.resources.status.OCCapability
 import com.owncloud.android.utils.theme.CapabilityUtils
 import java.util.Optional
@@ -50,8 +51,12 @@ class SessionMixin(
         setAccount(user.toPlatformAccount())
     }
 
-    fun getUser(): Optional<User> = when (val it = this.currentAccount) {
-        else -> accountManager.getUser(it.name)
+    fun getUser(): Optional<User> {
+        return if (currentAccount.isAnonymous(activity)) {
+            Optional.empty()
+        } else {
+            accountManager.getUser(currentAccount.name)
+        }
     }
 
     /**
@@ -60,7 +65,15 @@ class SessionMixin(
      * If no valid ownCloud [Account] exists, then the user is requested
      * to create a new ownCloud [Account].
      */
-    private fun getDefaultAccount(): Account = accountManager.currentAccount
+    private fun getDefaultAccount(): Account {
+        val defaultAccount = accountManager.currentAccount
+
+        if (defaultAccount.isAnonymous(activity)) {
+            startAccountCreation()
+        }
+
+        return defaultAccount
+    }
 
     /**
      * Launches the account creation activity.

--- a/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
+++ b/app/src/main/java/com/nextcloud/client/mixins/SessionMixin.kt
@@ -9,7 +9,6 @@ package com.nextcloud.client.mixins
 
 import android.accounts.Account
 import android.app.Activity
-import android.content.ContentResolver
 import android.content.Intent
 import android.os.Bundle
 import com.nextcloud.client.account.User
@@ -27,7 +26,6 @@ import java.util.Optional
  */
 class SessionMixin(
     private val activity: Activity,
-    private val contentResolver: ContentResolver,
     private val accountManager: UserAccountManager
 ) : ActivityMixin {
     var currentAccount: Account? = null

--- a/app/src/main/java/com/nextcloud/utils/extensions/AccountExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/AccountExtensions.kt
@@ -1,0 +1,14 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import android.accounts.Account
+import android.content.Context
+import com.owncloud.android.R
+
+fun Account.isAnonymous(context: Context): Boolean = type.equals(context.getString(R.string.anonymous_account_type))

--- a/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -175,10 +175,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     }
 
     public FileDataStorageManager getStorageManager() {
-        FileDataStorageManager result = sessionMixin.getStorageManager();
-        if (result == null) {
-            result = fileDataStorageManager;
-        }
-        return result;
+        return fileDataStorageManager;
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -48,6 +48,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
 
     @Inject UserAccountManager accountManager;
     @Inject AppPreferences preferences;
+    @Inject FileDataStorageManager fileDataStorageManager;
 
     private AppPreferences.Listener onPreferencesChanged = new AppPreferences.Listener() {
         @Override
@@ -174,6 +175,10 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     }
 
     public FileDataStorageManager getStorageManager() {
-        return sessionMixin.getStorageManager();
+        FileDataStorageManager result = sessionMixin.getStorageManager();
+        if (result == null) {
+            result = fileDataStorageManager;
+        }
+        return result;
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -64,9 +64,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        sessionMixin = new SessionMixin(this,
-                                        getContentResolver(),
-                                        accountManager);
+        sessionMixin = new SessionMixin(this, accountManager);
         mixinRegistry.add(sessionMixin);
 
         if (enableAccountHandling) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="app_config_proxy_host_title">Proxy Host Name</string>
     <string name="app_config_proxy_port_title">Proxy Port</string>
 
+    <string name="anonymous_account_type" translatable="false">AnonymousAccountType</string>
+
     <string name="assistant_screen_task_types_error_state_message">Unable to fetch task types, please check your internet connection.</string>
     <string name="assistant_screen_task_list_error_state_message">Unable to fetch task list, please check your internet connection.</string>
 

--- a/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
+++ b/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
@@ -8,7 +8,6 @@
 package com.nextcloud.client.mixins
 
 import android.app.Activity
-import android.content.ContentResolver
 import com.nextcloud.client.account.UserAccountManager
 import junit.framework.Assert.assertNull
 import org.junit.Before
@@ -25,9 +24,6 @@ class SessionMixinTest {
     private lateinit var activity: Activity
 
     @Mock
-    private lateinit var contentResolver: ContentResolver
-
-    @Mock
     private lateinit var userAccountManager: UserAccountManager
 
     private lateinit var session: SessionMixin
@@ -38,7 +34,6 @@ class SessionMixinTest {
         session = spy(
             SessionMixin(
                 activity,
-                contentResolver,
                 userAccountManager
             )
         )

--- a/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
+++ b/app/src/test/java/com/nextcloud/client/mixins/SessionMixinTest.kt
@@ -9,7 +9,6 @@ package com.nextcloud.client.mixins
 
 import android.app.Activity
 import com.nextcloud.client.account.UserAccountManager
-import junit.framework.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -49,16 +48,5 @@ class SessionMixinTest {
         //      start is delegated to account manager
         //      account manager receives parent activity
         verify(userAccountManager).startAccountCreation(same(activity))
-    }
-
-    @Test
-    fun `trigger accountCreation on resume when currentAccount is null`() {
-        // WHEN
-        //      start onResume and currentAccount is null
-        assertNull(session.currentAccount)
-        session.onResume()
-        // THEN
-        //      accountCreation flow is started
-        verify(session).startAccountCreation()
     }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**What this PR Does?**

- Get FileDataStorageManager only from DI, remove creation from SessionMix. Both are same no need to have both of it.
- Make account non nullable

**How to Test?**

1. Have 2 account in the app, switch accounts and check files for each account.
2. Delete app and make fresh install
3. Have 2 account in app and switch accounts and check FileDataStorageManager and DefaultAccount those variable must contain selected account from ManageAccount Dialog

