### PR TITLE
Bugfix Add ActivityExtensions for Checking Dialog Fragments

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/ActivityExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/app/src/main/java/com/nextcloud/utils/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/ActivityExtensions.kt
@@ -1,0 +1,15 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+
+fun AppCompatActivity.isDialogFragmentReady(fragment: Fragment): Boolean = isActive() && !fragment.isStateSaved()
+
+fun AppCompatActivity.isActive(): Boolean = !isFinishing && !isDestroyed

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -528,8 +528,8 @@ public abstract class FileActivity extends DrawerActivity
             Log_OC.d(TAG, "show loading dialog");
             LoadingDialog loadingDialogFragment = LoadingDialog.newInstance(message);
             FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-            boolean isFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
-            if (isFragmentReady) {
+            boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
+            if (isDialogFragmentReady) {
                 loadingDialogFragment.show(fragmentTransaction, DIALOG_WAIT_TAG);
             }
         }
@@ -543,8 +543,8 @@ public abstract class FileActivity extends DrawerActivity
         if (frag != null) {
             Log_OC.d(TAG, "dismiss loading dialog");
             LoadingDialog loadingDialogFragment = (LoadingDialog) frag;
-            boolean isFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
-            if (isFragmentReady) {
+            boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
+            if (isDialogFragmentReady) {
                 loadingDialogFragment.dismiss();
             }
         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -37,6 +37,7 @@ import com.nextcloud.client.jobs.download.FileDownloadWorker;
 import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.utils.EditorUtils;
+import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.owncloud.android.MainApp;
@@ -525,11 +526,12 @@ public abstract class FileActivity extends DrawerActivity
         Fragment frag = getSupportFragmentManager().findFragmentByTag(DIALOG_WAIT_TAG);
         if (frag == null) {
             Log_OC.d(TAG, "show loading dialog");
-            LoadingDialog loading = LoadingDialog.newInstance(message);
-            FragmentManager fm = getSupportFragmentManager();
-            FragmentTransaction ft = fm.beginTransaction();
-            ft.add(loading, DIALOG_WAIT_TAG);
-            ft.commitAllowingStateLoss();
+            LoadingDialog loadingDialogFragment = LoadingDialog.newInstance(message);
+            FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+            boolean isFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
+            if (isFragmentReady) {
+                loadingDialogFragment.show(fragmentTransaction, DIALOG_WAIT_TAG);
+            }
         }
     }
 
@@ -540,8 +542,11 @@ public abstract class FileActivity extends DrawerActivity
         Fragment frag = getSupportFragmentManager().findFragmentByTag(DIALOG_WAIT_TAG);
         if (frag != null) {
             Log_OC.d(TAG, "dismiss loading dialog");
-            LoadingDialog loading = (LoadingDialog) frag;
-            loading.dismissAllowingStateLoss();
+            LoadingDialog loadingDialogFragment = (LoadingDialog) frag;
+            boolean isFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
+            if (isFragmentReady) {
+                loadingDialogFragment.dismiss();
+            }
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -61,6 +61,7 @@ import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.utils.IntentUtil;
 import com.nextcloud.model.WorkerState;
 import com.nextcloud.model.WorkerStateLiveData;
+import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.nextcloud.utils.view.FastScrollUtils;
@@ -598,7 +599,7 @@ public class FileDisplayActivity extends FileActivity
         showSortListGroup(showSortListGroup);
 
         FragmentManager fragmentManager = getSupportFragmentManager();
-        if (!isFinishing() && !fragmentManager.isDestroyed()) {
+        if (ActivityExtensionsKt.isActive(this) && !fragmentManager.isDestroyed()) {
             FragmentTransaction transaction = fragmentManager.beginTransaction();
             transaction.addToBackStack(null);
             transaction.replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES);

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -589,11 +589,10 @@ class SyncedFoldersActivity :
 
         dialogFragment?.let {
             if (isDialogFragmentReady(it)) {
+                it.show(fragmentTransaction, SYNCED_FOLDER_PREFERENCES_DIALOG_TAG)
+            } else {
                 Log_OC.d(TAG, "SyncedFolderPreferencesDialogFragment not ready")
-                return
             }
-
-            it.show(fragmentTransaction, SYNCED_FOLDER_PREFERENCES_DIALOG_TAG)
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -33,6 +33,7 @@ import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.client.preferences.SubFolderRule
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.isDialogFragmentReady
 import com.owncloud.android.BuildConfig
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
@@ -577,11 +578,6 @@ class SyncedFoldersActivity :
     }
 
     override fun onSyncFolderSettingsClick(section: Int, syncedFolderDisplayItem: SyncedFolderDisplayItem) {
-        if (isFinishing || isDestroyed) {
-            Log_OC.d(TAG, "Activity destroyed or finished")
-            return
-        }
-
         val fragmentTransaction = supportFragmentManager.beginTransaction().apply {
             addToBackStack(null)
         }
@@ -591,12 +587,14 @@ class SyncedFoldersActivity :
             section
         )
 
-        if (dialogFragment?.isStateSaved == true) {
-            Log_OC.d(TAG, "SyncedFolderPreferencesDialogFragment state is saved cannot be shown")
-            return
-        }
+        dialogFragment?.let {
+            if (isDialogFragmentReady(it)) {
+                Log_OC.d(TAG, "SyncedFolderPreferencesDialogFragment not ready")
+                return
+            }
 
-        dialogFragment?.show(fragmentTransaction, SYNCED_FOLDER_PREFERENCES_DIALOG_TAG)
+            it.show(fragmentTransaction, SYNCED_FOLDER_PREFERENCES_DIALOG_TAG)
+        }
     }
 
     override fun onVisibilityToggleClick(section: Int, syncedFolder: SyncedFolderDisplayItem) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -32,6 +32,7 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.preferences.AppPreferences;
+import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadFilesLayoutBinding;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -479,7 +480,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
      */
     @Override
     public void onCheckAvailableSpaceFinish(boolean hasEnoughSpaceAvailable, String... filesToUpload) {
-        if (mCurrentDialog != null) {
+        if (mCurrentDialog != null && ActivityExtensionsKt.isDialogFragmentReady(this, mCurrentDialog)) {
             mCurrentDialog.dismiss();
             mCurrentDialog = null;
         }
@@ -524,7 +525,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
         } else {
             // show a dialog to query the user if wants to move the selected files
             // to the ownCloud folder instead of copying
-            String[] args = {getString(R.string.app_name)};
+            String[] args = { getString(R.string.app_name) };
             ConfirmationDialogFragment dialog = ConfirmationDialogFragment.newInstance(
                 R.string.upload_query_move_foreign_files, args, 0, R.string.common_yes,  R.string.common_no, -1);
             dialog.setOnConfirmationListener(this);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

We have encountered an issue with dialog fragments where dismissing and showing them without checking their state leads to crashes for users. This PR addresses and resolves this problem.


**Root cause of the problem**

```
Exception java.lang.IllegalStateException: FragmentManager has been destroyed
  at androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1666)
  at androidx.fragment.app.BackStackRecord.commitInternal (BackStackRecord.java:341)
  at androidx.fragment.app.BackStackRecord.commit (BackStackRecord.java:306)
  at androidx.fragment.app.DialogFragment.show (DialogFragment.java:524)
```

DialogFragment.java:524 this throws exception if isStateSaved() is true.