### PR TITLE
Bugfix Audio File Preview

### DIFF
--- a/app/src/main/java/com/nextcloud/client/media/PlayerService.kt
+++ b/app/src/main/java/com/nextcloud/client/media/PlayerService.kt
@@ -60,7 +60,7 @@ class PlayerService : Service() {
 
     private val playerListener = object : Player.Listener {
         override fun onRunning(file: OCFile) {
-            Log_OC.d(TAG,"PlayerService.onRunning()")
+            Log_OC.d(TAG, "PlayerService.onRunning()")
             val intent = Intent(PreviewMediaActivity.MEDIA_CONTROL_READY_RECEIVER).apply {
                 putExtra(IS_MEDIA_CONTROL_LAYOUT_READY, false)
             }
@@ -69,7 +69,7 @@ class PlayerService : Service() {
         }
 
         override fun onStart() {
-            Log_OC.d(TAG,"PlayerService.onStart()")
+            Log_OC.d(TAG, "PlayerService.onStart()")
             val intent = Intent(PreviewMediaActivity.MEDIA_CONTROL_READY_RECEIVER).apply {
                 putExtra(IS_MEDIA_CONTROL_LAYOUT_READY, true)
             }
@@ -77,16 +77,16 @@ class PlayerService : Service() {
         }
 
         override fun onPause() {
-            Log_OC.d(TAG,"PlayerService.onPause()")
+            Log_OC.d(TAG, "PlayerService.onPause()")
         }
 
         override fun onStop() {
-            Log_OC.d(TAG,"PlayerService.onStop()")
+            Log_OC.d(TAG, "PlayerService.onStop()")
             stopServiceAndRemoveNotification(null)
         }
 
         override fun onError(error: PlayerError) {
-            Log_OC.d(TAG,"PlayerService.onError()")
+            Log_OC.d(TAG, "PlayerService.onError()")
             Toast.makeText(this@PlayerService, error.message, Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/com/nextcloud/client/media/PlayerService.kt
+++ b/app/src/main/java/com/nextcloud/client/media/PlayerService.kt
@@ -16,6 +16,7 @@ import android.os.IBinder
 import android.widget.MediaController
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.nextcloud.client.account.User
 import com.nextcloud.client.network.ClientFactory
 import com.nextcloud.utils.ForegroundServiceHelper
@@ -23,7 +24,9 @@ import com.nextcloud.utils.extensions.getParcelableArgument
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.ForegroundServiceType
 import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.notifications.NotificationUtils
+import com.owncloud.android.ui.preview.PreviewMediaActivity
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import dagger.android.AndroidInjection
 import java.util.Locale
@@ -32,6 +35,8 @@ import javax.inject.Inject
 class PlayerService : Service() {
 
     companion object {
+        private const val TAG = "PlayerService"
+
         const val EXTRA_USER = "USER"
         const val EXTRA_FILE = "FILE"
         const val EXTRA_AUTO_PLAY = "EXTRA_AUTO_PLAY"
@@ -40,6 +45,8 @@ class PlayerService : Service() {
         const val ACTION_STOP = "STOP"
         const val ACTION_TOGGLE = "TOGGLE"
         const val ACTION_STOP_FILE = "STOP_FILE"
+
+        const val IS_MEDIA_CONTROL_LAYOUT_READY = "IS_MEDIA_CONTROL_LAYOUT_READY"
     }
 
     class Binder(val service: PlayerService) : android.os.Binder() {
@@ -52,24 +59,34 @@ class PlayerService : Service() {
     }
 
     private val playerListener = object : Player.Listener {
-
         override fun onRunning(file: OCFile) {
+            Log_OC.d(TAG,"PlayerService.onRunning()")
+            val intent = Intent(PreviewMediaActivity.MEDIA_CONTROL_READY_RECEIVER).apply {
+                putExtra(IS_MEDIA_CONTROL_LAYOUT_READY, false)
+            }
+            LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
             startForeground(file)
         }
 
         override fun onStart() {
-            // empty
+            Log_OC.d(TAG,"PlayerService.onStart()")
+            val intent = Intent(PreviewMediaActivity.MEDIA_CONTROL_READY_RECEIVER).apply {
+                putExtra(IS_MEDIA_CONTROL_LAYOUT_READY, true)
+            }
+            LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
         }
 
         override fun onPause() {
-            // empty
+            Log_OC.d(TAG,"PlayerService.onPause()")
         }
 
         override fun onStop() {
+            Log_OC.d(TAG,"PlayerService.onStop()")
             stopServiceAndRemoveNotification(null)
         }
 
         override fun onError(error: PlayerError) {
+            Log_OC.d(TAG,"PlayerService.onError()")
             Toast.makeText(this@PlayerService, error.message, Toast.LENGTH_SHORT).show()
         }
     }
@@ -89,18 +106,23 @@ class PlayerService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+
         AndroidInjection.inject(this)
         player = Player(applicationContext, clientFactory, playerListener, audioManager)
         notificationBuilder = NotificationCompat.Builder(this)
         viewThemeUtils.androidx.themeNotificationCompatBuilder(this, notificationBuilder)
 
-        val stop = Intent(this, PlayerService::class.java)
-        stop.action = ACTION_STOP
+        val stop = Intent(this, PlayerService::class.java).apply {
+            action = ACTION_STOP
+        }
+
         val pendingStop = PendingIntent.getService(this, 0, stop, PendingIntent.FLAG_IMMUTABLE)
         notificationBuilder.addAction(0, getString(R.string.player_stop).toUpperCase(Locale.getDefault()), pendingStop)
 
-        val toggle = Intent(this, PlayerService::class.java)
-        toggle.action = ACTION_TOGGLE
+        val toggle = Intent(this, PlayerService::class.java).apply {
+            action = ACTION_TOGGLE
+        }
+
         val pendingToggle = PendingIntent.getService(this, 0, toggle, PendingIntent.FLAG_IMMUTABLE)
         notificationBuilder.addAction(
             0,
@@ -124,10 +146,12 @@ class PlayerService : Service() {
     }
 
     private fun onActionToggle() {
-        if (player.isPlaying) {
-            player.pause()
-        } else {
-            player.start()
+        player.run {
+            if (isPlaying) {
+                pause()
+            } else {
+                start()
+            }
         }
     }
 
@@ -153,14 +177,17 @@ class PlayerService : Service() {
     private fun startForeground(currentFile: OCFile) {
         val ticker = String.format(getString(R.string.media_notif_ticker), getString(R.string.app_name))
         val content = getString(R.string.media_state_playing, currentFile.getFileName())
-        notificationBuilder.setSmallIcon(R.drawable.ic_play_arrow)
-        notificationBuilder.setWhen(System.currentTimeMillis())
-        notificationBuilder.setOngoing(true)
-        notificationBuilder.setContentTitle(ticker)
-        notificationBuilder.setContentText(content)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            notificationBuilder.setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_MEDIA)
+        notificationBuilder.run {
+            setSmallIcon(R.drawable.ic_play_arrow)
+            setWhen(System.currentTimeMillis())
+            setOngoing(true)
+            setContentTitle(ticker)
+            setContentText(content)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_MEDIA)
+            }
         }
 
         ForegroundServiceHelper.startService(

--- a/app/src/main/java/com/nextcloud/client/media/PlayerServiceConnection.kt
+++ b/app/src/main/java/com/nextcloud/client/media/PlayerServiceConnection.kt
@@ -38,12 +38,14 @@ class PlayerServiceConnection(private val context: Context) : MediaController.Me
     }
 
     fun start(user: User, file: OCFile, playImmediately: Boolean, position: Long) {
-        val i = Intent(context, PlayerService::class.java)
-        i.putExtra(PlayerService.EXTRA_USER, user)
-        i.putExtra(PlayerService.EXTRA_FILE, file)
-        i.putExtra(PlayerService.EXTRA_AUTO_PLAY, playImmediately)
-        i.putExtra(PlayerService.EXTRA_START_POSITION_MS, position)
-        i.action = PlayerService.ACTION_PLAY
+        val i = Intent(context, PlayerService::class.java).apply {
+            putExtra(PlayerService.EXTRA_USER, user)
+            putExtra(PlayerService.EXTRA_FILE, file)
+            putExtra(PlayerService.EXTRA_AUTO_PLAY, playImmediately)
+            putExtra(PlayerService.EXTRA_START_POSITION_MS, position)
+            action = PlayerService.ACTION_PLAY
+        }
+
         startForegroundService(i)
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -164,7 +164,8 @@ class PreviewMediaActivity :
             intent.getBooleanExtra(PlayerService.IS_MEDIA_CONTROL_LAYOUT_READY, false).run {
                 if (this) {
                     hideProgressLayout()
-                    recreate()
+                    mediaPlayerServiceConnection?.bind()
+                    setupAudioPlayerServiceConnection()
                 } else {
                     showProgressLayout()
                 }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -172,7 +172,6 @@ class PreviewMediaActivity :
         }
     }
 
-
     private fun initArguments(savedInstanceState: Bundle?) {
         intent?.let {
             initWithIntent(it)

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -311,21 +311,23 @@ class PreviewMediaActivity :
 
         Log_OC.v(TAG, "onStart")
 
-        if (file != null) {
-            mediaPlayerServiceConnection?.bind()
+        if (file == null) {
+            return
+        }
 
-            if (MimeTypeUtil.isAudio(file)) {
-                setupAudioPlayerServiceConnection()
-            } else if (MimeTypeUtil.isVideo(file)) {
-                if (mediaPlayerServiceConnection?.isConnected == true) {
-                    stopAudio()
-                }
+        mediaPlayerServiceConnection?.bind()
 
-                if (exoPlayer != null) {
-                    playVideo()
-                } else {
-                    initNextcloudExoPlayer()
-                }
+        if (MimeTypeUtil.isAudio(file)) {
+            setupAudioPlayerServiceConnection()
+        } else if (MimeTypeUtil.isVideo(file)) {
+            if (mediaPlayerServiceConnection?.isConnected == true) {
+                stopAudio()
+            }
+
+            if (exoPlayer != null) {
+                playVideo()
+            } else {
+                initNextcloudExoPlayer()
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -185,9 +185,18 @@ class PreviewMediaActivity :
         }
 
         if (MimeTypeUtil.isAudio(file)) {
-            registerMediaControlReceiver()
-            requestForDownload(file)
+            preparePreviewForAudioFile()
         }
+    }
+
+    private fun preparePreviewForAudioFile() {
+        registerMediaControlReceiver()
+
+        if (file.isDown) {
+            return
+        }
+
+        requestForDownload(file)
     }
 
     private fun initWithIntent(intent: Intent) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -177,12 +177,14 @@ public class PreviewMediaFragment extends FileFragment implements OnTouchListene
 
         Bundle bundle = getArguments();
 
-        setFile(BundleExtensionsKt.getParcelableArgument(bundle, FILE, OCFile.class));
-        user = BundleExtensionsKt.getParcelableArgument(bundle, USER, User.class);
+        if (bundle != null) {
+            setFile(BundleExtensionsKt.getParcelableArgument(bundle, FILE, OCFile.class));
+            user = BundleExtensionsKt.getParcelableArgument(bundle, USER, User.class);
 
-        savedPlaybackPosition = bundle.getLong(PLAYBACK_POSITION);
-        autoplay = bundle.getBoolean(AUTOPLAY);
-        isLivePhoto = bundle.getBoolean(IS_LIVE_PHOTO);
+            savedPlaybackPosition = bundle.getLong(PLAYBACK_POSITION);
+            autoplay = bundle.getBoolean(AUTOPLAY);
+            isLivePhoto = bundle.getBoolean(IS_LIVE_PHOTO);
+        }
 
         mediaPlayerServiceConnection = new PlayerServiceConnection(requireContext());
     }

--- a/app/src/main/res/layout/activity_preview_media.xml
+++ b/app/src/main/res/layout/activity_preview_media.xml
@@ -51,24 +51,16 @@
 
     <FrameLayout
         android:id="@+id/progress"
+        android:background="@color/color_dark_transparent"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.elyeproj.loaderviewlibrary.LoaderImageView
-            android:layout_width="@dimen/empty_list_icon_layout_width"
-            android:layout_height="@dimen/empty_list_icon_layout_width"
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:layout_width="wrap_content"
             android:layout_gravity="center"
-            android:contentDescription="@null"
-            app:corners="24" />
+            android:layout_height="wrap_content"
+            android:indeterminate="true" />
 
-        <ImageView
-            android:layout_width="@dimen/empty_list_icon_layout_width"
-            android:layout_height="@dimen/empty_list_icon_layout_height"
-            android:layout_gravity="center"
-            android:contentDescription="@null"
-            android:padding="@dimen/standard_half_padding"
-            android:src="@drawable/file_movie"
-            app:tint="@color/bg_default" />
     </FrameLayout>
 
     <FrameLayout


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Demo**

https://github.com/nextcloud/android/assets/67455295/1dc3c99b-e700-4871-a196-8ed1823dd6da


**What this PR does?**

- During file download, it displays the progress dialog and checks if the media control layout is ready
- Removes com.elyeproj.loaderviewlibrary.LoaderImageView and replaces it via Material 3 loading progress dialog
- Check nullable bundle

**How to Test?**

- Have audio file.
- Try to open audio file
- Loading dialog must be shown and user cannot be able to click any button if media is not ready
- Reopen same file, file shouldn't trigger download again
