### PR TITLE
Bug-Fix Percentage Value During Download or Upload

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -22,6 +22,7 @@ import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.model.WorkerState
 import com.nextcloud.model.WorkerStateLiveData
 import com.nextcloud.utils.ForegroundServiceHelper
+import com.nextcloud.utils.extensions.getPercent
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.ForegroundServiceType
@@ -410,7 +411,7 @@ class FileDownloadWorker(
         totalToTransfer: Long,
         filePath: String
     ) {
-        val percent: Int = (100.0 * totalTransferredSoFar.toDouble() / totalToTransfer.toDouble()).toInt()
+        val percent: Int = downloadProgressListener.getPercent(totalTransferredSoFar, totalToTransfer)
         val currentTime = System.currentTimeMillis()
 
         if (percent != lastPercent && (currentTime - lastUpdateTime) >= minProgressUpdateInterval) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -21,6 +21,7 @@ import com.nextcloud.client.network.ConnectivityService
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.model.WorkerState
 import com.nextcloud.model.WorkerStateLiveData
+import com.nextcloud.utils.extensions.getPercent
 import com.nextcloud.utils.extensions.showToast
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
@@ -330,7 +331,7 @@ class FileUploadWorker(
         totalToTransfer: Long,
         fileAbsoluteName: String
     ) {
-        val percent = (100.0 * totalTransferredSoFar.toDouble() / totalToTransfer.toDouble()).toInt()
+        val percent = getPercent(totalTransferredSoFar, totalToTransfer)
         val currentTime = System.currentTimeMillis()
 
         if (percent != lastPercent && (currentTime - lastUpdateTime) >= minProgressUpdateInterval) {

--- a/app/src/main/java/com/nextcloud/utils/extensions/AccountExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/AccountExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/app/src/main/java/com/nextcloud/utils/extensions/OnDataTransferProgressListenerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OnDataTransferProgressListenerExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/app/src/main/java/com/nextcloud/utils/extensions/OnDataTransferProgressListenerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OnDataTransferProgressListenerExtensions.kt
@@ -9,6 +9,7 @@ package com.nextcloud.utils.extensions
 
 import com.owncloud.android.lib.common.network.OnDatatransferProgressListener
 
+@Suppress("MagicNumber")
 fun OnDatatransferProgressListener.getPercent(
     totalTransferredSoFar: Long,
     totalToTransfer: Long

--- a/app/src/main/java/com/nextcloud/utils/extensions/OnDataTransferProgressListenerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OnDataTransferProgressListenerExtensions.kt
@@ -1,0 +1,15 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import com.owncloud.android.lib.common.network.OnDatatransferProgressListener
+
+fun OnDatatransferProgressListener.getPercent(
+    totalTransferredSoFar: Long,
+    totalToTransfer: Long
+): Int = ((100.0 * totalTransferredSoFar.toDouble() / totalToTransfer.toDouble()).toInt()).coerceAtMost(100)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Most of the time, the percentage value is correct. However, some users have encountered abnormally large integer values at the end of the upload or download progress. **To suppress** this issue until the root cause is identified, `coerceAtMost` and the `OnDataTransferProgressListener` extension used to prevent incorrect usage.
