### PR TITLE
Add Logs For Passed File Sizes

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/ImageDetailFragment.kt
+++ b/app/src/main/java/com/nextcloud/ui/ImageDetailFragment.kt
@@ -25,13 +25,12 @@ import com.nextcloud.client.NominatimClient
 import com.nextcloud.client.account.User
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
 import com.owncloud.android.databinding.PreviewImageDetailsFragmentBinding
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
-import com.owncloud.android.lib.common.utils.Log_OC
-import com.owncloud.android.ui.dialog.ConflictsResolveDialog
 import com.owncloud.android.utils.BitmapUtils
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
@@ -106,8 +105,7 @@ class ImageDetailFragment : Fragment(), Injectable {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        Log_OC.d(tag, "onSaveInstanceState: ${file.fileLength}")
-
+        file.logFileSize(tag)
         outState.putParcelable(ARG_FILE, file)
         outState.putParcelable(ARG_USER, user)
         outState.putParcelable(ARG_METADATA, metadata)

--- a/app/src/main/java/com/nextcloud/ui/ImageDetailFragment.kt
+++ b/app/src/main/java/com/nextcloud/ui/ImageDetailFragment.kt
@@ -30,6 +30,8 @@ import com.owncloud.android.R
 import com.owncloud.android.databinding.PreviewImageDetailsFragmentBinding
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
+import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.ui.dialog.ConflictsResolveDialog
 import com.owncloud.android.utils.BitmapUtils
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
@@ -62,6 +64,8 @@ class ImageDetailFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var viewThemeUtils: ViewThemeUtils
+
+    private val tag = "ImageDetailFragment"
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = PreviewImageDetailsFragmentBinding.inflate(layoutInflater, container, false)
@@ -102,6 +106,8 @@ class ImageDetailFragment : Fragment(), Injectable {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
+        Log_OC.d(tag, "onSaveInstanceState: ${file.fileLength}")
+
         outState.putParcelable(ARG_FILE, file)
         outState.putParcelable(ARG_USER, user)
         outState.putParcelable(ARG_METADATA, metadata)

--- a/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
@@ -14,10 +14,12 @@ import java.io.File
 
 fun OCFile?.logFileSize(tag: String) {
     val size = DisplayUtils.bytesToHumanReadable(this?.fileLength ?: -1)
-    Log_OC.d(tag, "onSaveInstanceState: $size")
+    val rawByte = this?.fileLength ?: -1
+    Log_OC.d(tag, "onSaveInstanceState: $size, raw byte $rawByte")
 }
 
 fun File?.logFileSize(tag: String) {
     val size = DisplayUtils.bytesToHumanReadable(this?.length() ?: -1)
-    Log_OC.d(tag, "onSaveInstanceState: $size")
+    val rawByte = this?.length() ?: -1
+    Log_OC.d(tag, "onSaveInstanceState: $size, raw byte $rawByte")
 }

--- a/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
@@ -9,8 +9,15 @@ package com.nextcloud.utils.extensions
 
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.utils.DisplayUtils
 import java.io.File
 
-fun OCFile?.logFileSize(tag: String) = Log_OC.d(tag, "onSaveInstanceState: ${this?.fileLength}")
+fun OCFile?.logFileSize(tag: String) {
+    val size = DisplayUtils.bytesToHumanReadable(this?.fileLength ?: -1)
+    Log_OC.d(tag, "onSaveInstanceState: $size")
+}
 
-fun File?.logFileSize(tag: String) = Log_OC.d(tag, "onSaveInstanceState: ${this?.length()}")
+fun File?.logFileSize(tag: String) {
+    val size = DisplayUtils.bytesToHumanReadable(this?.length() ?: -1)
+    Log_OC.d(tag, "onSaveInstanceState: $size")
+}

--- a/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
@@ -1,0 +1,16 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.common.utils.Log_OC
+import java.io.File
+
+fun OCFile?.logFileSize(tag: String) = Log_OC.d(tag, "onSaveInstanceState: ${this?.fileLength}")
+
+fun File?.logFileSize(tag: String) = Log_OC.d(tag, "onSaveInstanceState: ${this?.length()}")

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -33,7 +33,6 @@ import com.owncloud.android.lib.resources.files.model.RemoteFile
 import com.owncloud.android.ui.dialog.ConflictsResolveDialog
 import com.owncloud.android.ui.dialog.ConflictsResolveDialog.Decision
 import com.owncloud.android.ui.dialog.ConflictsResolveDialog.OnConflictDecisionMadeListener
-import com.owncloud.android.ui.preview.FileDownloadFragment
 import com.owncloud.android.utils.FileStorageUtils
 import javax.inject.Inject
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -32,6 +32,7 @@ import com.owncloud.android.lib.resources.files.model.RemoteFile
 import com.owncloud.android.ui.dialog.ConflictsResolveDialog
 import com.owncloud.android.ui.dialog.ConflictsResolveDialog.Decision
 import com.owncloud.android.ui.dialog.ConflictsResolveDialog.OnConflictDecisionMadeListener
+import com.owncloud.android.ui.preview.FileDownloadFragment
 import com.owncloud.android.utils.FileStorageUtils
 import javax.inject.Inject
 
@@ -143,6 +144,8 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
+        Log_OC.d(TAG, "onSaveInstanceState: " + existingFile?.fileLength)
+
         outState.putLong(EXTRA_CONFLICT_UPLOAD_ID, conflictUploadId)
         outState.putParcelable(EXTRA_EXISTING_FILE, existingFile)
         outState.putInt(EXTRA_LOCAL_BEHAVIOUR, localBehaviour)

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -20,6 +20,7 @@ import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.jobs.upload.UploadNotificationManager
 import com.nextcloud.model.HTTPStatusCodes
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
@@ -144,8 +145,7 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        Log_OC.d(TAG, "onSaveInstanceState: " + existingFile?.fileLength)
-
+        existingFile.logFileSize(TAG)
         outState.putLong(EXTRA_CONFLICT_UPLOAD_ID, conflictUploadId)
         outState.putParcelable(EXTRA_EXISTING_FILE, existingFile)
         outState.putInt(EXTRA_LOCAL_BEHAVIOUR, localBehaviour)

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -39,6 +39,7 @@ import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.utils.EditorUtils;
 import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -271,7 +272,7 @@ public abstract class FileActivity extends DrawerActivity
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log_OC.d(TAG, "onSaveInstanceState: " + mFile.getFileLength());
+        FileExtensionsKt.logFileSize(mFile, TAG);
         outState.putParcelable(FileActivity.EXTRA_FILE, mFile);
         outState.putBoolean(FileActivity.EXTRA_FROM_NOTIFICATION, mFromNotification);
         outState.putLong(KEY_WAITING_FOR_OP_ID, mFileOperationsHelper.getOpIdWaitingFor());

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -271,6 +271,7 @@ public abstract class FileActivity extends DrawerActivity
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
+        Log_OC.d(TAG, "onSaveInstanceState: " + mFile.getFileLength());
         outState.putParcelable(FileActivity.EXTRA_FILE, mFile);
         outState.putBoolean(FileActivity.EXTRA_FROM_NOTIFICATION, mFromNotification);
         outState.putLong(KEY_WAITING_FOR_OP_ID, mFileOperationsHelper.getOpIdWaitingFor());

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1067,8 +1067,8 @@ public class FileDisplayActivity extends FileActivity
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         // responsibility of restore is preferred in onCreate() before than in
         // onRestoreInstanceState when there are Fragments involved
-        Log_OC.v(TAG, "onSaveInstanceState() start");
         super.onSaveInstanceState(outState);
+        Log_OC.d(TAG, "onSaveInstanceState: " + mWaitingToPreview.getFileLength());
         outState.putParcelable(FileDisplayActivity.KEY_WAITING_TO_PREVIEW, mWaitingToPreview);
         outState.putBoolean(FileDisplayActivity.KEY_SYNC_IN_PROGRESS, mSyncInProgress);
         // outState.putBoolean(FileDisplayActivity.KEY_REFRESH_SHARES_IN_PROGRESS,

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -66,6 +66,7 @@ import com.nextcloud.model.WorkerState;
 import com.nextcloud.model.WorkerStateLiveData;
 import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.nextcloud.utils.view.FastScrollUtils;
 import com.owncloud.android.MainApp;
@@ -1068,7 +1069,7 @@ public class FileDisplayActivity extends FileActivity
         // responsibility of restore is preferred in onCreate() before than in
         // onRestoreInstanceState when there are Fragments involved
         super.onSaveInstanceState(outState);
-        Log_OC.d(TAG, "onSaveInstanceState: " + mWaitingToPreview.getFileLength());
+        FileExtensionsKt.logFileSize(mWaitingToPreview, TAG);
         outState.putParcelable(FileDisplayActivity.KEY_WAITING_TO_PREVIEW, mWaitingToPreview);
         outState.putBoolean(FileDisplayActivity.KEY_SYNC_IN_PROGRESS, mSyncInProgress);
         // outState.putBoolean(FileDisplayActivity.KEY_REFRESH_SHARES_IN_PROGRESS,

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -264,7 +264,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
-        Log_OC.d(TAG, "onSaveInstanceState() start");
+        Log_OC.d(TAG, "onSaveInstanceState " + mFile.getFileLength());
         super.onSaveInstanceState(outState);
         outState.putString(KEY_PARENTS, generatePath(mParents));
         outState.putParcelable(KEY_FILE, mFile);

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -52,6 +52,7 @@ import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -264,7 +265,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
-        Log_OC.d(TAG, "onSaveInstanceState " + mFile.getFileLength());
+        FileExtensionsKt.logFileSize(mFile, TAG);
         super.onSaveInstanceState(outState);
         outState.putString(KEY_PARENTS, generatePath(mParents));
         outState.putParcelable(KEY_FILE, mFile);

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -33,6 +33,7 @@ import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.utils.extensions.ActivityExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadFilesLayoutBinding;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -410,7 +411,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         // responsibility of restore is preferred in onCreate() before than in
         // onRestoreInstanceState when there are Fragments involved
-        Log_OC.d(TAG, "onSaveInstanceState " + mCurrentDir.length());
+        FileExtensionsKt.logFileSize(mCurrentDir, TAG);
         super.onSaveInstanceState(outState);
         outState.putString(UploadFilesActivity.KEY_DIRECTORY_PATH, mCurrentDir.getAbsolutePath());
         if (mOptionsMenu != null && mOptionsMenu.findItem(R.id.action_select_all) != null) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -410,7 +410,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         // responsibility of restore is preferred in onCreate() before than in
         // onRestoreInstanceState when there are Fragments involved
-        Log_OC.d(TAG, "onSaveInstanceState() start");
+        Log_OC.d(TAG, "onSaveInstanceState " + mCurrentDir.length());
         super.onSaveInstanceState(outState);
         outState.putString(UploadFilesActivity.KEY_DIRECTORY_PATH, mCurrentDir.getAbsolutePath());
         if (mOptionsMenu != null && mOptionsMenu.findItem(R.id.action_select_all) != null) {

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
@@ -62,6 +62,7 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
     @Inject ViewThemeUtils viewThemeUtils;
     @Inject SyncedFolderProvider syncedFolderProvider;
 
+    private static final String TAG = "ConflictsResolveDialog";
     private static final String KEY_NEW_FILE = "file";
     private static final String KEY_EXISTING_FILE = "ocfile";
     private static final String KEY_USER = "user";
@@ -78,7 +79,10 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
 
         Bundle args = new Bundle();
         args.putParcelable(KEY_EXISTING_FILE, existingFile);
-        args.putSerializable(KEY_NEW_FILE, new File(newFile.getStoragePath()));
+
+        File file = new File(newFile.getStoragePath());
+        Log_OC.d(TAG,"ConflictsResolveDialog.putSerializable: " + file.getAbsolutePath().length());
+        args.putSerializable(KEY_NEW_FILE, file);
         args.putParcelable(KEY_USER, user);
         dialog.setArguments(args);
 
@@ -135,6 +139,9 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
+
+        Log_OC.d(TAG,"onSaveInstanceState.existingFile: " + existingFile.getFileLength());
+        Log_OC.d(TAG,"onSaveInstanceState.newFile: " + newFile.length());
 
         outState.putParcelable(KEY_EXISTING_FILE, existingFile);
         outState.putSerializable(KEY_NEW_FILE, newFile);

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
@@ -21,6 +21,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.ConflictResolveDialogBinding;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -81,7 +82,7 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
         args.putParcelable(KEY_EXISTING_FILE, existingFile);
 
         File file = new File(newFile.getStoragePath());
-        Log_OC.d(TAG,"ConflictsResolveDialog.putSerializable: " + file.getAbsolutePath().length());
+        FileExtensionsKt.logFileSize(file, TAG);
         args.putSerializable(KEY_NEW_FILE, file);
         args.putParcelable(KEY_USER, user);
         dialog.setArguments(args);
@@ -140,9 +141,8 @@ public class ConflictsResolveDialog extends DialogFragment implements Injectable
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
 
-        Log_OC.d(TAG,"onSaveInstanceState.existingFile: " + existingFile.getFileLength());
-        Log_OC.d(TAG,"onSaveInstanceState.newFile: " + newFile.length());
-
+        FileExtensionsKt.logFileSize(existingFile, TAG);
+        FileExtensionsKt.logFileSize(newFile, TAG);
         outState.putParcelable(KEY_EXISTING_FILE, existingFile);
         outState.putSerializable(KEY_NEW_FILE, newFile);
         outState.putParcelable(KEY_USER, user);

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -23,6 +23,7 @@ import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.network.ClientFactory;
 import com.nextcloud.common.NextcloudClient;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.FileDetailsActivitiesFragmentBinding;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -431,7 +432,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log_OC.d(TAG, "onSaveInstanceState " + file.getFileLength());
+        FileExtensionsKt.logFileSize(file, TAG);
         outState.putParcelable(ARG_FILE, file);
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -431,7 +431,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-
+        Log_OC.d(TAG, "onSaveInstanceState " + file.getFileLength());
         outState.putParcelable(ARG_FILE, file);
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -355,6 +355,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
+        Log_OC.d(TAG, "onSaveInstanceState " + getFile().getFileLength());
         outState.putParcelable(ARG_FILE, getFile());
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -35,6 +35,7 @@ import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.ui.fileactions.FileActionsBottomSheet;
 import com.nextcloud.utils.MenuUtils;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.FileDetailsFragmentBinding;
@@ -355,7 +356,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log_OC.d(TAG, "onSaveInstanceState " + getFile().getFileLength());
+        FileExtensionsKt.logFileSize(getFile(), TAG);
         outState.putParcelable(ARG_FILE, getFile());
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -81,7 +81,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     DisplayUtils.AvatarGenerationListener,
     Injectable, FileDetailsSharingMenuBottomSheetActions, QuickSharingPermissionsBottomSheetDialog.QuickPermissionSharingBottomSheetActions {
 
-    private final String tag = "FileDetailSharingFragment";
+    private static final String TAG = "FileDetailSharingFragment";
     private static final String ARG_FILE = "FILE";
     private static final String ARG_USER = "USER";
 
@@ -543,7 +543,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        FileExtensionsKt.logFileSize(file, tag);
+        FileExtensionsKt.logFileSize(file, TAG);
         outState.putParcelable(ARG_FILE, file);
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -80,6 +80,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     DisplayUtils.AvatarGenerationListener,
     Injectable, FileDetailsSharingMenuBottomSheetActions, QuickSharingPermissionsBottomSheetDialog.QuickPermissionSharingBottomSheetActions {
 
+    private final String tag = "FileDetailSharingFragment";
     private static final String ARG_FILE = "FILE";
     private static final String ARG_USER = "USER";
 
@@ -541,7 +542,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-
+        Log_OC.d(tag, "onSaveInstanceState " + file.getFileLength());
         outState.putParcelable(ARG_FILE, file);
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -36,6 +36,7 @@ import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.network.ClientFactory;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.FileDetailsSharingFragmentBinding;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -542,7 +543,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log_OC.d(tag, "onSaveInstanceState " + file.getFileLength());
+        FileExtensionsKt.logFileSize(file, tag);
         outState.putParcelable(ARG_FILE, file);
         outState.putParcelable(ARG_USER, user);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -67,8 +67,8 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
     private GalleryFragmentBottomSheetDialog galleryFragmentBottomSheetDialog;
 
     @Inject FileDataStorageManager fileDataStorageManager;
-    private final int maxColumnSizeLandscape = 5;
-    private final int maxColumnSizePortrait = 2;
+    private final static int maxColumnSizeLandscape = 5;
+    private final static int maxColumnSizePortrait = 2;
     private int columnSize;
 
     protected void setPhotoSearchQueryRunning(boolean value) {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -57,6 +57,7 @@ import com.nextcloud.ui.fileactions.FileActionsBottomSheet;
 import com.nextcloud.utils.EditorUtils;
 import com.nextcloud.utils.ShortcutUtil;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.nextcloud.utils.view.FastScrollUtils;
 import com.owncloud.android.MainApp;
@@ -850,7 +851,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log_OC.d(TAG, "onSaveInstanceState: " + mFile.getFileLength());
+        FileExtensionsKt.logFileSize(mFile, TAG);
         outState.putParcelable(KEY_FILE, mFile);
         if (searchFragment) {
             outState.putParcelable(KEY_CURRENT_SEARCH_TYPE, currentSearchType);

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -850,7 +850,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-
+        Log_OC.d(TAG, "onSaveInstanceState: " + mFile.getFileLength());
         outState.putParcelable(KEY_FILE, mFile);
         if (searchFragment) {
             outState.putParcelable(KEY_CURRENT_SEARCH_TYPE, currentSearchType);

--- a/app/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -163,6 +163,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
+        Log_OC.d(TAG, "onSaveInstanceState: " + getFile().getFileLength());
         outState.putParcelable(FileDownloadFragment.EXTRA_FILE, getFile());
         outState.putParcelable(FileDownloadFragment.EXTRA_USER, user);
         outState.putBoolean(FileDownloadFragment.EXTRA_ERROR, mError);

--- a/app/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -24,6 +24,7 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.jobs.download.FileDownloadHelper;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.network.OnDatatransferProgressListener;
@@ -163,7 +164,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log_OC.d(TAG, "onSaveInstanceState: " + getFile().getFileLength());
+        FileExtensionsKt.logFileSize(getFile(), TAG);
         outState.putParcelable(FileDownloadFragment.EXTRA_FILE, getFile());
         outState.putParcelable(FileDownloadFragment.EXTRA_USER, user);
         outState.putBoolean(FileDownloadFragment.EXTRA_ERROR, mError);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -65,6 +65,7 @@ import com.nextcloud.common.NextcloudClient
 import com.nextcloud.ui.fileactions.FileActionsBottomSheet.Companion.newInstance
 import com.nextcloud.ui.fileactions.FileActionsBottomSheet.ResultListener
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.R
 import com.owncloud.android.databinding.ActivityPreviewMediaBinding
 import com.owncloud.android.datamodel.OCFile
@@ -327,7 +328,7 @@ class PreviewMediaActivity :
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        Log_OC.d(TAG, "onSaveInstanceState: " + file.fileLength)
+        file.logFileSize(TAG)
         outState.let { bundle ->
             bundle.putParcelable(EXTRA_FILE, file)
             bundle.putParcelable(EXTRA_USER, user)

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -327,7 +327,7 @@ class PreviewMediaActivity :
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        Log_OC.v(TAG, "onSaveInstanceState")
+        Log_OC.d(TAG, "onSaveInstanceState: " + file.fileLength)
         outState.let { bundle ->
             bundle.putParcelable(EXTRA_FILE, file)
             bundle.putParcelable(EXTRA_USER, user)

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -126,6 +126,7 @@ class PreviewMediaFragment : FileFragment(), OnTouchListener, Injectable {
         super.onCreate(savedInstanceState)
 
         arguments?.let { bundle ->
+            file.logFileSize(TAG)
             file = bundle.getParcelableArgument(FILE, OCFile::class.java)
             user = bundle.getParcelableArgument(USER, User::class.java)
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -55,6 +55,7 @@ import com.nextcloud.client.network.ClientFactory.CreationException
 import com.nextcloud.common.NextcloudClient
 import com.nextcloud.ui.fileactions.FileActionsBottomSheet.Companion.newInstance
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
 import com.owncloud.android.databinding.FragmentPreviewMediaBinding
@@ -254,7 +255,7 @@ class PreviewMediaFragment : FileFragment(), OnTouchListener, Injectable {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        Log_OC.v(TAG, "onSaveInstanceState " + file.fileLength)
+        file.logFileSize(TAG)
         toggleDrawerLockMode(containerActivity, DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
 
         outState.run {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -254,7 +254,7 @@ class PreviewMediaFragment : FileFragment(), OnTouchListener, Injectable {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        Log_OC.v(TAG, "onSaveInstanceState")
+        Log_OC.v(TAG, "onSaveInstanceState " + file.fileLength)
         toggleDrawerLockMode(containerActivity, DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
 
         outState.run {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
@@ -21,6 +21,7 @@ import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.ui.fileactions.FileActionsBottomSheet;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -136,7 +137,7 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
      */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        Log_OC.d(TAG, "onSaveInstanceState: " + getFile().getFileLength());
+        FileExtensionsKt.logFileSize(getFile(), TAG);
         outState.putParcelable(PreviewTextFileFragment.EXTRA_FILE, getFile());
         outState.putParcelable(PreviewTextFileFragment.EXTRA_USER, user);
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
@@ -136,6 +136,7 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
      */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
+        Log_OC.d(TAG, "onSaveInstanceState: " + getFile().getFileLength());
         outState.putParcelable(PreviewTextFileFragment.EXTRA_FILE, getFile());
         outState.putParcelable(PreviewTextFileFragment.EXTRA_USER, user);
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -21,6 +21,7 @@ import com.nextcloud.android.lib.richWorkspace.RichWorkspaceDirectEditingRemoteO
 import com.nextcloud.client.account.UserAccountManager;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
+import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
@@ -37,6 +38,7 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
     @Inject UserAccountManager accountManager;
     @Inject ViewThemeUtils viewThemeUtils;
 
+    private final String tag = "PreviewTextStringFragment";
     private boolean isEditorWebviewLaunched = false;
 
     /**
@@ -70,6 +72,7 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
      */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
+        Log_OC.d(tag, "onSaveInstanceState: " + getFile().getFileLength());
         outState.putParcelable(PreviewTextStringFragment.EXTRA_FILE, getFile());
 
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -22,7 +22,6 @@ import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
-import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
@@ -39,7 +38,7 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
     @Inject UserAccountManager accountManager;
     @Inject ViewThemeUtils viewThemeUtils;
 
-    private final String tag = "PreviewTextStringFragment";
+    private final static String TAG = "PreviewTextStringFragment";
     private boolean isEditorWebviewLaunched = false;
 
     /**
@@ -73,7 +72,7 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
      */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        FileExtensionsKt.logFileSize(getFile(), tag);
+        FileExtensionsKt.logFileSize(getFile(), TAG);
         outState.putParcelable(PreviewTextStringFragment.EXTRA_FILE, getFile());
 
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextStringFragment.java
@@ -19,6 +19,7 @@ import android.view.ViewGroup;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.lib.richWorkspace.RichWorkspaceDirectEditingRemoteOperation;
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -72,7 +73,7 @@ public class PreviewTextStringFragment extends PreviewTextFragment {
      */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        Log_OC.d(tag, "onSaveInstanceState: " + getFile().getFileLength());
+        FileExtensionsKt.logFileSize(getFile(), tag);
         outState.putParcelable(PreviewTextStringFragment.EXTRA_FILE, getFile());
 
         super.onSaveInstanceState(outState);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**What is the Problem?**

App sometimes throws **TransactionTooLargeException**. Back trace not helping too much.

e.g. Backtrace

```
Exception java.lang.RuntimeException:
  at android.app.servertransaction.PendingTransactionActions$StopInfo.run (PendingTransactionActions.java:146)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8893)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
Caused by android.os.TransactionTooLargeException: data parcel size 594696 bytes
  at android.os.BinderProxy.transactNative
  at android.os.BinderProxy.transact (BinderProxy.java:662)
  at android.app.IActivityClientController$Stub$Proxy.activityStopped (IActivityClientController.java:1507)
  at android.app.ActivityClient.activityStopped (ActivityClient.java:100)
  at android.app.servertransaction.PendingTransactionActions$StopInfo.run (PendingTransactionActions.java:135)
```

The `TransactionTooLargeException` can be thrown due to the following reasons:

1. Including large objects in Bundles or Intents.
2. Using `onSaveInstanceState` to save the UI state with large data.

**What this PR does?**

Add logs to print file size so that we can check passed file sizes.