### PR TITLE
Fix media tab not loading Thumbnails for images on server only 

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -289,7 +289,7 @@ public final class ThumbnailsCacheManager {
             file = (OCFile) params[0];
 
 
-            if (file.getRemoteId() != null && file.isPreviewAvailable()) {
+            if (file.getRemoteId() != null || file.isPreviewAvailable()) {
                 // Thumbnail in cache?
                 thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
                     ThumbnailsCacheManager.PREFIX_RESIZED_IMAGE + file.getRemoteId()
@@ -1423,9 +1423,10 @@ public final class ThumbnailsCacheManager {
                 }
             }
 
-            // resized dimensions
+            // resized dimensions && set update thumbnail needed to false to prevent rendering loop
             if (thumbnail != null) {
                 file.setImageDimension(new ImageDimension(thumbnail.getWidth(), thumbnail.getHeight()));
+                file.setUpdateThumbnailNeeded(false);
                 storageManager.saveFile(file);
             }
         }

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -1423,7 +1423,7 @@ public final class ThumbnailsCacheManager {
                 }
             }
 
-            // resized dimensions && set update thumbnail needed to false to prevent rendering loop
+            // resized dimensions and set update thumbnail needed to false to prevent rendering loop
             if (thumbnail != null) {
                 file.setImageDimension(new ImageDimension(thumbnail.getWidth(), thumbnail.getHeight()));
                 file.setUpdateThumbnailNeeded(false);


### PR DESCRIPTION

- [x ] Tests written, or not not needed

Hello i've had this issue for a long time and wanted to fix it. 

The problem i found was that the cache manager never requested the server for a thumbnail because the condition to do so was never true. This caused that all my remote photos thumbnails were the default thumbnail image.

From what i understand if there is not a preview but there is a remote id it should ask the server for a thumbnail. 

This never happened because of an && instead of an ||.

I also had to set  updateThumbnailNeeded to false when it finished otherwise it entered a loop because it kept passing the validation: `if (thumbnail == null || file.isUpdateThumbnailNeeded())`.

Regarding test i didn't really understand where and how to test this functionality because, in case of an integration test, i need a server to call.

I would be more than happy to add a test if some kind soul could give me a little help xD <3 