### PR TITLE
fix for media tab not showing thumbnails when image not in cache manager

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -1426,6 +1426,7 @@ public final class ThumbnailsCacheManager {
             // resized dimensions and set update thumbnail needed to false to prevent rendering loop
             if (thumbnail != null) {
                 file.setImageDimension(new ImageDimension(thumbnail.getWidth(), thumbnail.getHeight()));
+                file.setUpdateThumbnailNeeded(false);
                 storageManager.saveFile(file);
             }
         }

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -289,7 +289,7 @@ public final class ThumbnailsCacheManager {
             file = (OCFile) params[0];
 
 
-            if (file.getRemoteId() != null && file.isPreviewAvailable()) {
+            if (file.getRemoteId() != null || file.isPreviewAvailable()) {
                 // Thumbnail in cache?
                 thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
                     ThumbnailsCacheManager.PREFIX_RESIZED_IMAGE + file.getRemoteId()
@@ -1423,7 +1423,7 @@ public final class ThumbnailsCacheManager {
                 }
             }
 
-            // resized dimensions
+            // resized dimensions and set update thumbnail needed to false to prevent rendering loop
             if (thumbnail != null) {
                 file.setImageDimension(new ImageDimension(thumbnail.getWidth(), thumbnail.getHeight()));
                 storageManager.saveFile(file);

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -286,8 +286,12 @@ public final class ThumbnailsCacheManager {
         protected Bitmap doInBackground(Object... params) {
             Bitmap thumbnail;
 
-            file = (OCFile) params[0];
+            if (params == null || params.length == 0 || !(params[0] instanceof OCFile)) {
+                Log_OC.d(TAG, "Downloaded file is null or is not an instance of OCFile");
+                return null;
+            }
 
+            file = (OCFile) params[0];
 
             if (file.getRemoteId() != null || file.isPreviewAvailable()) {
                 // Thumbnail in cache?
@@ -335,6 +339,7 @@ public final class ThumbnailsCacheManager {
                 }
             }
 
+            Log_OC.d(TAG, "File cannot be previewed");
             return null;
         }
 


### PR DESCRIPTION
- [x] Tests written, or not not needed

Hello i've had this issue for a long time and wanted to fix it.

The problem i found was that the cache manager never requested the server for a thumbnail because the condition to do so was never true. This caused that all my remote photos thumbnails were the default thumbnail image.

From what i understand if there is not a preview but there is a remote id it should ask the server for a thumbnail.

This never happened because of an && instead of an ||.

I also had to set updateThumbnailNeeded to false when it finished otherwise it entered a loop because it kept passing the validation: if (thumbnail == null || file.isUpdateThumbnailNeeded()).

Regarding test i didn't really understand where and how to test this functionality because, in case of an integration test, i need a server to call.

I would be more than happy to add a test if some kind soul could give me a little help xD <3
