### PR TITLE
Remove unnecessary checks and calls from restartFailedUploads

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -182,7 +182,7 @@ class FilesSyncWork(
         } else {
             // Check every file in synced folder for changes and update
             // filesystemDataProvider database (potentially needs a long time)
-            FilesSyncHelper.insertAllDBEntries(syncedFolder, powerManagementService)
+            FilesSyncHelper.insertAllDBEntriesForSyncedFolder(syncedFolder)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -12,9 +12,11 @@ import android.content.Context
 import android.content.Intent
 import com.nextcloud.client.account.User
 import com.nextcloud.client.account.UserAccountManager
+import com.nextcloud.client.device.BatteryStatus
 import com.nextcloud.client.device.PowerManagementService
 import com.nextcloud.client.jobs.BackgroundJobManager
 import com.nextcloud.client.jobs.upload.FileUploadWorker.Companion.currentUploadFileOperation
+import com.nextcloud.client.network.Connectivity
 import com.nextcloud.client.network.ConnectivityService
 import com.owncloud.android.MainApp
 import com.owncloud.android.datamodel.OCFile
@@ -28,9 +30,9 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation
 import com.owncloud.android.lib.resources.files.model.RemoteFile
+import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.utils.FileUtil
 import java.io.File
-import java.util.Optional
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -117,33 +119,41 @@ class FileUploadHelper {
         failedUploads: Array<OCUpload>
     ): Boolean {
         var showNotExistMessage = false
-        val (gotNetwork, _, gotWifi) = connectivityService.connectivity
-        val batteryStatus = powerManagementService.battery
-        val charging = batteryStatus.isCharging || batteryStatus.isFull
-        val isPowerSaving = powerManagementService.isPowerSavingEnabled
-        var uploadUser = Optional.empty<User>()
+        val hasGeneralConnection = checkConnectivity(connectivityService)
+        val connectivity = connectivityService.connectivity
+        val battery = powerManagementService.battery
+        val accountNames = accountManager.accounts.filter {
+            accountManager.getUser(it.name).isPresent
+        }.map { it.name }.toHashSet()
 
         for (failedUpload in failedUploads) {
-            val isDeleted = !File(failedUpload.localPath).exists()
-            if (isDeleted) {
-                showNotExistMessage = true
 
-                // 2A. for deleted files, mark as permanently failed
-                if (failedUpload.lastResult != UploadResult.FILE_NOT_FOUND) {
-                    failedUpload.lastResult = UploadResult.FILE_NOT_FOUND
+            if (!accountNames.contains(failedUpload.accountName)) {
+                uploadsStorageManager.removeUpload(failedUpload)
+                continue
+            }
+
+            val conditions =
+                checkUploadConditions(failedUpload, connectivity, battery, powerManagementService, hasGeneralConnection)
+
+            if (conditions != UploadResult.UPLOADED) {
+                if (failedUpload.lastResult != conditions){
+                    failedUpload.lastResult = conditions
                     uploadsStorageManager.updateUpload(failedUpload)
                 }
-            } else if (!isPowerSaving && gotNetwork &&
-                canUploadBeRetried(failedUpload, gotWifi, charging) && !connectivityService.isInternetWalled
-            ) {
-                // 2B. for existing local files, try restarting it if possible
-                failedUpload.uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS
-                uploadsStorageManager.updateUpload(failedUpload)
+                if (conditions == UploadResult.FILE_NOT_FOUND) {
+                    showNotExistMessage = true
+                }
+                continue
             }
+
+            failedUpload.uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS
+            uploadsStorageManager.updateUpload(failedUpload)
+
         }
 
-        accountManager.accounts.forEach {
-            val user = accountManager.getUser(it.name)
+        accountNames.forEach {
+            val user = accountManager.getUser(it)
             if (user.isPresent) backgroundJobManager.startFilesUploadJob(user.get())
         }
 
@@ -216,11 +226,52 @@ class FileUploadHelper {
         return upload.uploadStatus == UploadStatus.UPLOAD_IN_PROGRESS
     }
 
-    private fun canUploadBeRetried(upload: OCUpload, gotWifi: Boolean, isCharging: Boolean): Boolean {
-        val file = File(upload.localPath)
-        val needsWifi = upload.isUseWifiOnly
-        val needsCharging = upload.isWhileChargingOnly
-        return file.exists() && (!needsWifi || gotWifi) && (!needsCharging || isCharging)
+    private fun checkConnectivity(connectivityService: ConnectivityService): Boolean {
+        // check that internet is not behind walled garden
+        return connectivityService.getConnectivity().isConnected && !connectivityService.isInternetWalled()
+
+    }
+
+    /**
+     * Dupe of [UploadFileOperation.checkConditions], needed to check if the upload should even be scheduled
+     * @return [UploadResult.UPLOADED] if the upload should be scheduled, otherwise the reason why it shouldn't
+     */
+    private fun checkUploadConditions(
+        upload: OCUpload,
+        connectivity: Connectivity,
+        battery: BatteryStatus,
+        powerManagementService: PowerManagementService,
+        hasGeneralConnection: Boolean
+    ): UploadResult {
+
+        var conditions = UploadResult.UPLOADED
+
+        // check that internet is available
+        if (!hasGeneralConnection) {
+            conditions = UploadResult.NETWORK_CONNECTION
+        }
+
+        // check that local file exists and skip the upload otherwise
+        if (!File(upload.localPath).exists()){
+            conditions = UploadResult.FILE_NOT_FOUND
+        }
+
+        // check that connectivity conditions are met and skip the upload otherwise
+        if (upload.isUseWifiOnly && (!connectivity.isWifi || connectivity.isMetered)) {
+            conditions = UploadResult.DELAYED_FOR_WIFI
+        }
+
+        // check if charging conditions are met and delays the upload otherwise
+        if (upload.isWhileChargingOnly && (!battery.isCharging || !battery.isFull)){
+            conditions = UploadResult.DELAYED_FOR_CHARGING
+        }
+
+        // check that device is not in power save mode
+        if (powerManagementService.isPowerSavingEnabled) {
+            conditions = UploadResult.DELAYED_IN_POWER_SAVE_MODE
+        }
+
+        return conditions
     }
 
     @Suppress("ReturnCount")

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -262,7 +262,7 @@ class FileUploadHelper {
         }
 
         // check if charging conditions are met and delays the upload otherwise
-        if (upload.isWhileChargingOnly && (!battery.isCharging || !battery.isFull)){
+        if (upload.isWhileChargingOnly && !battery.isCharging && !battery.isFull){
             conditions = UploadResult.DELAYED_FOR_CHARGING
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -127,7 +127,6 @@ class FileUploadHelper {
         }.map { it.name }.toHashSet()
 
         for (failedUpload in failedUploads) {
-
             if (!accountNames.contains(failedUpload.accountName)) {
                 uploadsStorageManager.removeUpload(failedUpload)
                 continue
@@ -137,7 +136,7 @@ class FileUploadHelper {
                 checkUploadConditions(failedUpload, connectivity, battery, powerManagementService, hasGeneralConnection)
 
             if (conditions != UploadResult.UPLOADED) {
-                if (failedUpload.lastResult != conditions){
+                if (failedUpload.lastResult != conditions) {
                     failedUpload.lastResult = conditions
                     uploadsStorageManager.updateUpload(failedUpload)
                 }
@@ -149,7 +148,6 @@ class FileUploadHelper {
 
             failedUpload.uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS
             uploadsStorageManager.updateUpload(failedUpload)
-
         }
 
         accountNames.forEach {
@@ -229,7 +227,6 @@ class FileUploadHelper {
     private fun checkConnectivity(connectivityService: ConnectivityService): Boolean {
         // check that internet is not behind walled garden
         return connectivityService.getConnectivity().isConnected && !connectivityService.isInternetWalled()
-
     }
 
     /**
@@ -243,7 +240,6 @@ class FileUploadHelper {
         powerManagementService: PowerManagementService,
         hasGeneralConnection: Boolean
     ): UploadResult {
-
         var conditions = UploadResult.UPLOADED
 
         // check that internet is available
@@ -252,7 +248,7 @@ class FileUploadHelper {
         }
 
         // check that local file exists and skip the upload otherwise
-        if (!File(upload.localPath).exists()){
+        if (!File(upload.localPath).exists()) {
             conditions = UploadResult.FILE_NOT_FOUND
         }
 
@@ -262,7 +258,7 @@ class FileUploadHelper {
         }
 
         // check if charging conditions are met and delays the upload otherwise
-        if (upload.isWhileChargingOnly && !battery.isCharging && !battery.isFull){
+        if (upload.isWhileChargingOnly && !battery.isCharging && !battery.isFull) {
             conditions = UploadResult.DELAYED_FOR_CHARGING
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -130,7 +130,7 @@ class FileUploadWorker(
     @Suppress("ReturnCount")
     private fun retrievePagesBySortingUploadsByID(): Result {
         val accountName = inputData.getString(ACCOUNT) ?: return Result.failure()
-        var uploadsPerPage = uploadsStorageManager.getCurrentAndPendingUploadsForAccountPageAscById(-1, accountName)
+        var uploadsPerPage = uploadsStorageManager.getCurrentUploadsForAccountPageAscById(-1, accountName)
         val totalUploadSize = uploadsStorageManager.getTotalUploadSize(accountName)
 
         Log_OC.d(TAG, "Total upload size: $totalUploadSize")
@@ -148,7 +148,7 @@ class FileUploadWorker(
             val lastId = uploadsPerPage.last().uploadId
             uploadFiles(totalUploadSize, uploadsPerPage, accountName)
             uploadsPerPage =
-                uploadsStorageManager.getCurrentAndPendingUploadsForAccountPageAscById(lastId, accountName)
+                uploadsStorageManager.getCurrentUploadsForAccountPageAscById(lastId, accountName)
         }
 
         if (isStopped) {

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -471,7 +471,7 @@ public class UploadsStorageManager extends Observable {
         return getUploadPage(QUERY_PAGE_SIZE, afterId, true, selection, selectionArgs);
     }
 
-    private String getInProgressUploadsSelection() {
+    private String getInProgressAndDelayedUploadsSelection() {
         return "( " + ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value +
             OR + ProviderTableMeta.UPLOADS_LAST_RESULT +
             EQUAL + UploadResult.DELAYED_FOR_WIFI.getValue() +
@@ -485,7 +485,7 @@ public class UploadsStorageManager extends Observable {
     }
 
     public int getTotalUploadSize(@Nullable String... selectionArgs) {
-        final String selection = getInProgressUploadsSelection();
+        final String selection = getInProgressAndDelayedUploadsSelection();
         int totalSize = 0;
 
         Cursor cursor = getDB().query(
@@ -605,8 +605,13 @@ public class UploadsStorageManager extends Observable {
     }
 
     public OCUpload[] getCurrentAndPendingUploadsForAccount(final @NonNull String accountName) {
-        String inProgressUploadsSelection = getInProgressUploadsSelection();
+        String inProgressUploadsSelection = getInProgressAndDelayedUploadsSelection();
         return getUploads(inProgressUploadsSelection, accountName);
+    }
+
+    public OCUpload[] getCurrentUploadsForAccount(final @NonNull String accountName) {
+        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value + AND +
+                              ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, accountName);
     }
 
     /**
@@ -615,7 +620,7 @@ public class UploadsStorageManager extends Observable {
      * If <code>afterId</code> is -1, returns the first page
      */
     public List<OCUpload> getCurrentAndPendingUploadsForAccountPageAscById(final long afterId, final @NonNull String accountName) {
-        final String selection = getInProgressUploadsSelection();
+        final String selection = getInProgressAndDelayedUploadsSelection();
         return getUploadPage(QUERY_PAGE_SIZE, afterId, false, selection, accountName);
     }
 

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -485,7 +485,8 @@ public class UploadsStorageManager extends Observable {
     }
 
     public int getTotalUploadSize(@Nullable String... selectionArgs) {
-        final String selection = getInProgressAndDelayedUploadsSelection();
+        final String selection = ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value +
+            AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL;
         int totalSize = 0;
 
         Cursor cursor = getDB().query(
@@ -613,6 +614,13 @@ public class UploadsStorageManager extends Observable {
         return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value + AND +
                               ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, accountName);
     }
+
+    public List<OCUpload> getCurrentUploadsForAccountPageAscById(final long afterId, final @NonNull String accountName) {
+        final String selection = ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value +
+            AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL;
+        return getUploadPage(QUERY_PAGE_SIZE, afterId, false, selection, accountName);
+    }
+
 
     /**
      * Gets a page of uploads after <code>afterId</code>, where uploads are sorted by ascending upload id.


### PR DESCRIPTION
The main idea of this PR was to fix double-checking upload conditions first in FileSyncHelper and then in FilesUploadHelper.

I noticed that currently these checks are in my opinion useless. The checks should only schedule those uploads that make sense to do at that moment (e.g. if upload is Wi-Fi only and user is not connected to Wi-Fi upload should not be scheduled and display an info message). Those delayed uploads have the state "failed" and last result e.g. "Delayed_for_wifi". This makes sense to me. The problem is that currently the worker not only tries to upload the scheduled Files but also the delayed files every time. 

This makes no sense to me. 
I guess there are 2 options:
1. Remove all the checks before scheduling, schedule all failed uploads, and let the FileUploadWorker decide which to start and which to skip. -> Basically the same behavior as we have currently, but more consistent and less unnecessary double-checks.
2. Make the Worker only try to upload scheduled uploads. This changes the current behavior, since it would only try to upload delayed Uploads when "retryFailedUploads" is called. Currently, they are retried every time the upload worker runs (so e.g. also when uploading a new file etc.). Would be more performant and also more consistent than currently.

@tobiasKaminsky @ZetaTom @alperozturk96 What do you think is the best approach here? Do you think this changed behavior would be ok? 

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed
