### PR TITLE
Share Link Crash Fix

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -790,11 +790,14 @@ public abstract class FileActivity extends DrawerActivity
             String link = "";
             OCFile file = null;
             for (Object object : result.getData()) {
-                OCShare shareLink = (OCShare) object;
-                if (TAG_PUBLIC_LINK.equalsIgnoreCase(shareLink.getShareType().name())) {
-                    link = shareLink.getShareLink();
-                    file = getStorageManager().getFileByPath(shareLink.getPath());
-                    break;
+                if (object instanceof OCShare shareLink) {
+                    ShareType shareType = shareLink.getShareType();
+
+                    if (shareType != null && TAG_PUBLIC_LINK.equalsIgnoreCase(shareType.name())) {
+                        link = shareLink.getShareLink();
+                        file = getStorageManager().getFileByEncryptedRemotePath(shareLink.getPath());
+                        break;
+                    }
                 }
             }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -808,7 +808,11 @@ public abstract class FileActivity extends DrawerActivity
             }
 
             if (fileListFragment instanceof OCFileListFragment ocFileListFragment && file != null) {
-                ocFileListFragment.updateOCFile(file);
+                if (ocFileListFragment.getAdapterFiles().contains(file)) {
+                    ocFileListFragment.updateOCFile(file);
+                } else {
+                    DisplayUtils.showSnackMessage(this, R.string.file_activity_shared_file_cannot_be_updated);
+                }
             }
         } else {
             // Detect Failure (403) --> maybe needs password

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -807,8 +807,8 @@ public abstract class FileActivity extends DrawerActivity
                 sharingFragment.onUpdateShareInformation(result, file);
             }
 
-            if (fileListFragment instanceof OCFileListFragment && file != null) {
-                ((OCFileListFragment) fileListFragment).updateOCFile(file);
+            if (fileListFragment instanceof OCFileListFragment ocFileListFragment && file != null) {
+                ocFileListFragment.updateOCFile(file);
             }
         } else {
             // Detect Failure (403) --> maybe needs password

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1389,7 +1389,13 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
     public void updateOCFile(OCFile file) {
         List<OCFile> mFiles = mAdapter.getFiles();
-        mFiles.set(mFiles.indexOf(file), file);
+        int index = mFiles.indexOf(file);
+        if (index == -1) {
+            Log_OC.d(TAG, "File cannot be found in adapter's files");
+            return;
+        }
+
+        mFiles.set(index, file);
         mAdapter.notifyItemChanged(file);
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1387,14 +1387,18 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
     }
 
+    public List<OCFile> getAdapterFiles() {
+        return mAdapter.getFiles();
+    }
+
     public void updateOCFile(@NonNull OCFile file) {
         List<OCFile> mFiles = mAdapter.getFiles();
-        if (!mFiles.contains(file)) {
+        int index = mFiles.indexOf(file);
+        if (index == -1) {
             Log_OC.d(TAG, "File cannot be found in adapter's files");
             return;
         }
 
-        int index = mFiles.indexOf(file);
         mFiles.set(index, file);
         mAdapter.notifyItemChanged(file);
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1387,14 +1387,14 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
     }
 
-    public void updateOCFile(OCFile file) {
+    public void updateOCFile(@NonNull OCFile file) {
         List<OCFile> mFiles = mAdapter.getFiles();
-        int index = mFiles.indexOf(file);
-        if (index == -1) {
+        if (!mFiles.contains(file)) {
             Log_OC.d(TAG, "File cannot be found in adapter's files");
             return;
         }
 
+        int index = mFiles.indexOf(file);
         mFiles.set(index, file);
         mAdapter.notifyItemChanged(file);
     }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -530,7 +530,8 @@ class PreviewImageFragment : FileFragment(), Injectable {
 
                         try {
                             bitmapResult = BitmapUtils.decodeSampledBitmapFromFile(
-                                storagePath, minWidth,
+                                storagePath,
+                                minWidth,
                                 minHeight
                             )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1154,6 +1154,7 @@
     <string name="check_back_later_or_reload">Check back later or reload.</string>
     <string name="e2e_not_yet_setup">E2E not yet setup</string>
     <string name="error_file_actions">Error showing file actions</string>
+    <string name="file_activity_shared_file_cannot_be_updated">Shared file cannot be updated</string>
     <string name="pin_home">Pin to Home screen</string>
     <string name="pin_shortcut_label">Open %1$s</string>
     <string name="displays_mnemonic">Displays your 12 word passphrase</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem**

After share file list needs to be updated for the display the share icon on the folder. Sometimes a folder cannot be found after share action.

**Solution**

We can prevent crash via checking file existence and check Share Object instance type. If we cannot find file in the list we can inform the user.



During my tests, share functionality is working as expected. I can't able to reproduce.

https://github.com/nextcloud/android/assets/67455295/b5995237-f4b3-4ac0-b7ec-68f61b8db124