### PR TITLE
Bugfix Unified Search Load More

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
@@ -103,14 +103,16 @@ class UnifiedSearchListAdapter(
     }
 
     override fun onBindHeaderViewHolder(holder: SectionedViewHolder, section: Int, expanded: Boolean) {
-        val headerViewHolder = holder as UnifiedSearchHeaderViewHolder
-        headerViewHolder.bind(sections[section])
+        (holder as UnifiedSearchHeaderViewHolder).run {
+            bind(sections[section])
+        }
     }
 
     override fun onBindFooterViewHolder(holder: SectionedViewHolder, section: Int) {
         if (sections[section].hasMoreResults) {
-            val footerViewHolder = holder as UnifiedSearchFooterViewHolder
-            footerViewHolder.bind(sections[section])
+            (holder as UnifiedSearchFooterViewHolder).run {
+                bind(sections[section])
+            }
         }
     }
 
@@ -126,17 +128,19 @@ class UnifiedSearchListAdapter(
         absolutePosition: Int
     ) {
         // TODO different binding (and also maybe diff UI) for non-file results
-        val itemViewHolder = holder as UnifiedSearchItemViewHolder
-        val entry = sections[section].entries[relativePosition]
-        itemViewHolder.bind(entry)
+        (holder as UnifiedSearchItemViewHolder).run {
+            val entry = sections[section].entries[relativePosition]
+            bind(entry)
+        }
     }
 
     override fun onViewAttachedToWindow(holder: SectionedViewHolder) {
         if (holder is UnifiedSearchItemViewHolder) {
-            val thumbnailShimmer = holder.binding.thumbnailShimmer
-            if (thumbnailShimmer.visibility == View.VISIBLE) {
-                thumbnailShimmer.setImageResource(R.drawable.background)
-                thumbnailShimmer.resetLoader()
+            holder.binding.thumbnailShimmer.run {
+                if (visibility == View.VISIBLE) {
+                    setImageResource(R.drawable.background)
+                    resetLoader()
+                }
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/SearchOnProviderTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/SearchOnProviderTask.kt
@@ -16,7 +16,7 @@ class SearchOnProviderTask(
     private val provider: String,
     private val client: NextcloudClient,
     private val cursor: Int? = null,
-    private val limit: Int = 5
+    private val limit: Int = 6
 ) : () -> SearchOnProviderTask.Result {
     companion object {
         private const val TAG = "SearchOnProviderTask"

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/SearchOnProviderTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/SearchOnProviderTask.kt
@@ -16,7 +16,7 @@ class SearchOnProviderTask(
     private val provider: String,
     private val client: NextcloudClient,
     private val cursor: Int? = null,
-    private val limit: Int = 6
+    private val limit: Int = 5
 ) : () -> SearchOnProviderTask.Result {
     companion object {
         private const val TAG = "SearchOnProviderTask"

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -36,7 +36,13 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
     private data class UnifiedSearchMetadata(
         var results: MutableList<SearchResult> = mutableListOf()
     ) {
-        fun nextCursor(): Int? = results.lastOrNull()?.cursor?.toInt()
+        fun nextCursor(): Int? {
+            return try {
+                results.lastOrNull()?.cursor?.toInt()
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
         fun name(): String? = results.lastOrNull()?.name
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -94,14 +94,6 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
         )
     }
 
-    open fun startLoading(query: String) {
-        if (!loadingStarted) {
-            loadingStarted = true
-            this.query.value = query
-            initialQuery()
-        }
-    }
-
     /**
      * Clears data and queries all available providers
      */
@@ -183,10 +175,6 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
             )
             runner.postQuickTask(task, onResult = this::onFileRequestResult)
         }
-    }
-
-    open fun clearError() {
-        error.value = ""
     }
 
     fun onError(error: Throwable) {

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -43,7 +43,6 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
                 null
             }
         }
-
         fun name(): String? = results.lastOrNull()?.name
     }
 
@@ -197,11 +196,13 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
         searchResults.value = results
             .filter { it.value.results.isNotEmpty() }
             .map { (key, value) ->
+                val isLastEntryHaveValue = results[key]?.results?.last()?.entries?.isEmpty() != true
+
                 UnifiedSearchSection(
                     providerID = key,
                     name = value.name()!!,
                     entries = value.results.flatMap { it.entries },
-                    hasMoreResults = results.isNotEmpty() && results[key]?.nextCursor() != null
+                    hasMoreResults = isLastEntryHaveValue && results[key]?.nextCursor() != null
                 )
             }
             .sortedWith { o1, o2 ->

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -43,6 +43,7 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
                 null
             }
         }
+
         fun name(): String? = results.lastOrNull()?.name
     }
 
@@ -131,6 +132,7 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
                     isLoading.value = false
                 }
             }
+
             else -> block()
         }
     }
@@ -151,6 +153,7 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
                 val fullUrl = serverUrl + result.resourceUrl
                 Uri.parse(fullUrl)
             }
+
             else -> uri
         }
     }
@@ -194,13 +197,11 @@ class UnifiedSearchViewModel(application: Application) : AndroidViewModel(applic
         searchResults.value = results
             .filter { it.value.results.isNotEmpty() }
             .map { (key, value) ->
-                val hasMoreResults = results.isNotEmpty() && results[key]?.nextCursor() != null
-
                 UnifiedSearchSection(
                     providerID = key,
                     name = value.name()!!,
                     entries = value.results.flatMap { it.entries },
-                    hasMoreResults = hasMoreResults
+                    hasMoreResults = results.isNotEmpty() && results[key]?.nextCursor() != null
                 )
             }
             .sortedWith { o1, o2 ->


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


In certain scenarios even user have more data, "Load More Data" not visible.

e.g. 

User have F1, F2, F3, F4, f 5, f 6, f7, f 8 folders when user make search via "f" user only sees last 4 item without "load more data"