### PR TITLE
Set content length to -1 for InputStream request bodies from the nextcloud/Android-SingleSignOn library

### DIFF
--- a/app/src/main/java/com/nextcloud/android/sso/InputStreamBinder.java
+++ b/app/src/main/java/com/nextcloud/android/sso/InputStreamBinder.java
@@ -237,7 +237,7 @@ public class InputStreamBinder extends IInputStreamService.Stub {
             case "POST":
                 method = new PostMethod(requestUrl);
                 if (requestBodyInputStream != null) {
-                    RequestEntity requestEntity = new InputStreamRequestEntity(requestBodyInputStream);
+                    RequestEntity requestEntity = new InputStreamRequestEntity(requestBodyInputStream, -1);
                     ((PostMethod) method).setRequestEntity(requestEntity);
                 } else if (request.getRequestBody() != null) {
                     StringRequestEntity requestEntity = new StringRequestEntity(
@@ -251,7 +251,7 @@ public class InputStreamBinder extends IInputStreamService.Stub {
             case "PATCH":
                 method = new PatchMethod(requestUrl);
                 if (requestBodyInputStream != null) {
-                    RequestEntity requestEntity = new InputStreamRequestEntity(requestBodyInputStream);
+                    RequestEntity requestEntity = new InputStreamRequestEntity(requestBodyInputStream, -1);
                     ((PatchMethod) method).setRequestEntity(requestEntity);
                 } else if (request.getRequestBody() != null) {
                     StringRequestEntity requestEntity = new StringRequestEntity(
@@ -265,7 +265,7 @@ public class InputStreamBinder extends IInputStreamService.Stub {
             case "PUT":
                 method = new PutMethod(requestUrl);
                 if (requestBodyInputStream != null) {
-                    RequestEntity requestEntity = new InputStreamRequestEntity(requestBodyInputStream);
+                    RequestEntity requestEntity = new InputStreamRequestEntity(requestBodyInputStream, -1);
                     ((PutMethod) method).setRequestEntity(requestEntity);
                 } else if (request.getRequestBody() != null) {
                     StringRequestEntity requestEntity = new StringRequestEntity(


### PR DESCRIPTION
This prevents large request bodies submitted through the nextcloud/Android-SingleSignOn library from crashing the app, fixing issue #13222

### Details:
The Apache HTTP Library used will buffer the entire request body if the content length is not defined in the InputStreamRequestEntity. This causes the app to run out of memory for large uploads as it tries to buffer an arbitrarily large byte array. 

Setting the content length to -1 tells the library that the InputStream is of arbitrary size and it should not try to determine the content length itself.

### Other problems:
- A better solution would be allowing the content length to be specified in the NextcloudRequest object
- Uploading large files can take the server a while to finish writing, and there seems to be no way to specify a read timeout in the NextcloudRequest object, leading to a socket timeout that can't be avoided

Unfortunately, due to the usage of object streams, doing any of these would require `performNextcloudRequestAndBodyStreamV3()`. If such a method were to be made, I think it would be wise to try and serialize/de-serialize the NextcloudRequest in a way that's more forwards/backwards compatible.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed

I don't know how to make the unit tests here since testing requires a server. Here is what I used to test the fix from my own app, if it helps:

```java
    private static class RandomStream extends InputStream {
        private long remaining;
        private final Random random;

        public RandomStream(long length) {
            random = new Random();
            remaining = length;
        }

        @Override
        public int read() {
            return  remaining-- > 0 ? random.nextInt(8) : -1;
        }

        @Override
        public int available() {
            return remaining > 0 ? (int) Math.min(65535, remaining) : -1;
        }
    }

    @Test
    public void testLargeUpload() throws Exception {
        NextcloudAPI nextcloudAPI = getTestNcApi();
        InputStream is = new RandomStream(1000000000); // 1GB
        NextcloudRequest request = new NextcloudRequest.Builder()
                .setMethod("PUT")
                .setUrl("/remote.php/dav/files/user/testing/large%20file%201.bin")
                .setRequestBodyAsStream(is)
                .build();

        Response response = nextcloudAPI.performNetworkRequestV2(request);
        response.getBody().close();
        Log.i(TAG, "Request completed");
        assert is.available() == -1;
    }
```
