### PR TITLE
Bug-Fix E2E File Conflict Duplicated Files

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -369,12 +369,7 @@ class FileUploadHelper {
      * @param user Needed for creating client
      * @param onCompleted Gets called when this function completed
      */
-    fun removeDuplicatedFile(
-        newFile: OCFile,
-        clientFactory: ClientFactory,
-        user: User,
-        onCompleted: () -> Unit
-    ) {
+    fun removeDuplicatedFile(newFile: OCFile, clientFactory: ClientFactory, user: User, onCompleted: () -> Unit) {
         val parentFolder: OCFile? = fileStorageManager.getFileById(newFile.parentId)
 
         if (parentFolder == null) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -358,7 +358,7 @@ class FileUploadHelper {
         backgroundJobManager.startFilesUploadJob(user)
     }
 
-    fun removeAnyOtherFileHaveSameName(
+    fun removeDuplicatedFile(
         newFile: OCFile,
         clientFactory: ClientFactory,
         user: User,
@@ -367,15 +367,13 @@ class FileUploadHelper {
         val parentFile: OCFile? = fileStorageManager.getFileById(newFile.parentId)
         val folderContent: List<OCFile> = fileStorageManager.getFolderContent(parentFile, false)
 
-        val replacedFile: OCFile? = folderContent.find { it.fileName == newFile.fileName }
-
-        replacedFile?.let {
+        folderContent.firstOrNull { it.fileName == newFile.fileName }?.let { duplicateFile ->
             val job = CoroutineScope(Dispatchers.IO)
 
             job.launch {
                 val client = clientFactory.create(user)
                 val removeFileOperation = RemoveFileOperation(
-                    it,
+                    duplicateFile,
                     false,
                     user,
                     true,

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -362,7 +362,7 @@ class FileUploadHelper {
      * Removes any existing file in the same directory that has the same name as the provided new file.
      *
      * This function checks the parent directory of the given `newFile` for any file with the same name.
-     * If such a file is found, it is removed using the `fileOperationsHelper`.
+     * If such a file is found, it is removed using the `RemoveFileOperation`.
      *
      * @param newFile The new file that is being added to the directory.
      * @param clientFactory Needed for creating client
@@ -375,8 +375,14 @@ class FileUploadHelper {
         user: User,
         onCompleted: () -> Unit
     ) {
-        val parentFile: OCFile? = fileStorageManager.getFileById(newFile.parentId)
-        val folderContent: List<OCFile> = fileStorageManager.getFolderContent(parentFile, false)
+        val parentFolder: OCFile? = fileStorageManager.getFileById(newFile.parentId)
+
+        if (parentFolder == null) {
+            onCompleted()
+            return
+        }
+
+        val folderContent: List<OCFile> = fileStorageManager.getFolderContent(parentFolder, false)
         val duplicatedFile = folderContent.firstOrNull { it.fileName == newFile.fileName }
 
         if (duplicatedFile == null) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -323,7 +323,7 @@ class FileUploadHelper {
             // For file conflicts check old file remote path
             upload.remotePath == currentUploadFileOperation.remotePath ||
                 upload.remotePath == currentUploadFileOperation.oldFile!!
-                .remotePath
+                    .remotePath
         } else {
             upload.remotePath == currentUploadFileOperation.remotePath
         }
@@ -368,12 +368,7 @@ class FileUploadHelper {
      * @param client Needed for executing RemoveFileOperation
      * @param user Needed for creating client
      */
-    fun removeDuplicatedFile(
-        duplicatedFile: OCFile,
-        client: OwnCloudClient,
-        user: User,
-        onCompleted: () -> Unit
-    ) {
+    fun removeDuplicatedFile(duplicatedFile: OCFile, client: OwnCloudClient, user: User, onCompleted: () -> Unit) {
         val job = CoroutineScope(Dispatchers.IO)
 
         job.launch {

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -228,6 +228,23 @@ public class FileDataStorageManager {
         }
     }
 
+    public OCFile findDuplicatedFile(OCFile parentFolder, OCFile newFile) {
+        List<OCFile> folderContent = getFolderContent(parentFolder, false);
+        if (folderContent == null || folderContent.isEmpty()) {
+            return null;
+        }
+
+        OCFile duplicatedFile = null;
+        for (OCFile file : folderContent) {
+            if (file.getFileName().equals(newFile.getFileName())) {
+                duplicatedFile = file;
+                break;
+            }
+        }
+
+        return duplicatedFile;
+    }
+
     public List<OCFile> getFolderImages(OCFile folder, boolean onlyOnDevice) {
         List<OCFile> imageList = new ArrayList<>();
 

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -45,6 +45,7 @@ import com.owncloud.android.lib.resources.files.model.FileLockType;
 import com.owncloud.android.lib.resources.files.model.GeoLocation;
 import com.owncloud.android.lib.resources.files.model.ImageDimension;
 import com.owncloud.android.lib.resources.files.model.RemoteFile;
+import com.owncloud.android.lib.resources.files.model.ServerFileInterface;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.lib.resources.shares.ShareeUser;
@@ -228,7 +229,7 @@ public class FileDataStorageManager {
         }
     }
 
-    public OCFile findDuplicatedFile(OCFile parentFolder, OCFile newFile) {
+    public OCFile findDuplicatedFile(OCFile parentFolder, ServerFileInterface newFile) {
         List<OCFile> folderContent = getFolderContent(parentFolder, false);
         if (folderContent == null || folderContent.isEmpty()) {
             return null;

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -881,6 +881,10 @@ public class UploadFileOperation extends SyncOperation {
             result = unlockFolderResult;
         }
 
+        if (unlockFolderResult != null && unlockFolderResult.isSuccess()) {
+            Log_OC.d(TAG, "Folder successfully unlocked: " + e2eFiles.getParentFile().getFileName());
+        }
+
         e2eFiles.deleteEncryptedTempFile();
 
         return result;

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -92,7 +92,7 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
 
             newFile?.let {
                 val user = user.orElseThrow { RuntimeException() }
-                FileUploadHelper.instance().removeAnyOtherFileHaveSameName(file, clientFactory, user, onCompleted = {
+                FileUploadHelper.instance().removeDuplicatedFile(file, clientFactory, user, onCompleted = {
                     removeWorkerObserver()
                 })
             }

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -86,7 +86,6 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
     private fun setupOnConflictDecisionMadeListener(upload: OCUpload?) {
         listener = OnConflictDecisionMadeListener { decision: Decision? ->
             val file = newFile // local file got changed, so either upload it or replace it again by server
-            // version
             val user = user.orElseThrow { RuntimeException() }
             when (decision) {
                 Decision.CANCEL -> {}
@@ -94,12 +93,17 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
                     upload?.let {
                         FileUploadHelper.instance().removeFileUpload(it.remotePath, it.accountName)
                     }
+
                     FileUploadHelper.instance().uploadUpdatedFile(
                         user,
                         arrayOf(file),
                         localBehaviour,
                         NameCollisionPolicy.OVERWRITE
                     )
+
+                    file?.let {
+                        FileUploadHelper.instance().removeAnyOtherFileHaveSameName(file, fileOperationsHelper)
+                    }
                 }
 
                 Decision.KEEP_BOTH -> {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -86,6 +86,7 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
     private fun setupOnConflictDecisionMadeListener(upload: OCUpload?) {
         listener = OnConflictDecisionMadeListener { decision: Decision? ->
             val file = newFile // local file got changed, so either upload it or replace it again by server
+            // version
             val user = user.orElseThrow { RuntimeException() }
             when (decision) {
                 Decision.CANCEL -> {}
@@ -93,7 +94,6 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
                     upload?.let {
                         FileUploadHelper.instance().removeFileUpload(it.remotePath, it.accountName)
                     }
-
                     FileUploadHelper.instance().uploadUpdatedFile(
                         user,
                         arrayOf(file),

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -13,15 +13,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
-import androidx.lifecycle.Observer
 import com.nextcloud.client.account.User
 import com.nextcloud.client.jobs.download.FileDownloadHelper
 import com.nextcloud.client.jobs.upload.FileUploadHelper
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.jobs.upload.UploadNotificationManager
 import com.nextcloud.model.HTTPStatusCodes
-import com.nextcloud.model.WorkerState
-import com.nextcloud.model.WorkerStateLiveData
 import com.nextcloud.utils.extensions.getParcelableArgument
 import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.R
@@ -86,24 +83,6 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
         }
     }
 
-    private val workerObserver = Observer<WorkerState> { state ->
-        if (state is WorkerState.Upload) {
-            Log_OC.d(TAG, "Upload observation started")
-
-            newFile?.let {
-                val user = user.orElseThrow { RuntimeException() }
-                FileUploadHelper.instance().removeDuplicatedFile(file, clientFactory, user, onCompleted = {
-                    removeWorkerObserver()
-                })
-            }
-        }
-    }
-
-    private fun removeWorkerObserver() {
-        Log_OC.d(TAG, "Upload observation stopped")
-        WorkerStateLiveData.instance().removeObserver(workerObserver)
-    }
-
     private fun setupOnConflictDecisionMadeListener(upload: OCUpload?) {
         listener = OnConflictDecisionMadeListener { decision: Decision? ->
             val file = newFile // local file got changed, so either upload it or replace it again by server
@@ -121,8 +100,6 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
                         localBehaviour,
                         NameCollisionPolicy.OVERWRITE
                     )
-
-                    WorkerStateLiveData.instance().observe(this, workerObserver)
                 }
 
                 Decision.KEEP_BOTH -> {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem?**

When user try to upload different file with same file name inside encrypted folder, "REPLACE" not working. Instead of replacing two files exists in folder.
 
**How to Reproduce?**

1. Create a new encrypted folder
2. Upload file (a1.png)
3. Upload different file with same name (a1.png)
4. Tap to resolve conflict from notification
5. Select local file
6. Two files will be listed in encrypted folder

**What does this PR?**

- After upload the new encrypted file, find the duplicated encrypted file and delete it.