### PR TITLE
Fix auto upload not working when "Also upload existing files" not checked

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -148,7 +148,7 @@ class FilesSyncWork(
 
     private fun setSyncedFolder(syncedFolderID: Long): Boolean {
         val syncedFolderTmp = syncedFolderProvider.getSyncedFolderByID(syncedFolderID)
-        if (syncedFolderTmp == null || !syncedFolderTmp.isEnabled || !syncedFolderTmp.isExisting) {
+        if (syncedFolderTmp == null || !syncedFolderTmp.isEnabled) {
             return false
         }
         syncedFolder = syncedFolderTmp


### PR DESCRIPTION
Don't exit early from sync background worker for a folder with "Also upload existing files" unchecked.

Fix #13251

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
