### PR TITLE
Ensure every file is scanned even when Worker is killed

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -73,8 +73,6 @@ class FilesSyncWork(
         backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class) + "_" + syncFolderId)
         Log_OC.d(TAG, "File-sync worker started for folder ID: $syncFolderId")
 
-
-
         // Create all the providers we'll need
         val resources = context.resources
         val lightVersion = resources.getBoolean(R.bool.syncedFolder_light)
@@ -94,7 +92,6 @@ class FilesSyncWork(
             syncedFolder
         )
 
-
         if (canExitEarly(changedFiles, syncFolderId)) {
             val result = Result.success()
             backgroundJobManager.logEndOfWorker(
@@ -105,9 +102,8 @@ class FilesSyncWork(
             return result
         }
 
-
         val user = userAccountManager.getUser(syncedFolder.account)
-        if (user.isPresent){
+        if (user.isPresent) {
             backgroundJobManager.startFilesUploadJob(user.get())
         }
 
@@ -184,12 +180,17 @@ class FilesSyncWork(
             return true
         }
 
-        val passedScanInterval = (syncedFolder.lastScanTimestampMs +
-            FilesSyncHelper.calculateScanInterval(syncedFolder, connectivityService, powerManagementService)) <= System.currentTimeMillis()
+        val passedScanInterval = (
+            syncedFolder.lastScanTimestampMs +
+                FilesSyncHelper.calculateScanInterval(syncedFolder, connectivityService, powerManagementService)
+            ) <= System.currentTimeMillis()
 
-        if (!passedScanInterval && changedFiles.isNullOrEmpty() && !overridePowerSaving){
-            Log_OC.d(TAG, "File-sync kill worker since started before scan " +
-                "Interval and nothing todo (${syncedFolder.localPath})!")
+        if (!passedScanInterval && changedFiles.isNullOrEmpty() && !overridePowerSaving) {
+            Log_OC.d(
+                TAG,
+                "File-sync kill worker since started before scan " +
+                    "Interval and nothing todo (${syncedFolder.localPath})!"
+            )
             return true
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -93,13 +93,7 @@ class FilesSyncWork(
         )
 
         if (canExitEarly(changedFiles, syncFolderId)) {
-            val result = Result.success()
-            backgroundJobManager.logEndOfWorker(
-                BackgroundJobManagerImpl.formatClassTag(this::class) +
-                    "_" + syncFolderId,
-                result
-            )
-            return result
+            return logEndOfWorker(syncFolderId)
         }
 
         val user = userAccountManager.getUser(syncedFolder.account)
@@ -133,6 +127,10 @@ class FilesSyncWork(
             powerManagementService
         )
 
+        return logEndOfWorker(syncFolderId)
+    }
+
+    private fun logEndOfWorker(syncFolderId: Long): Result {
         Log_OC.d(TAG, "File-sync worker (${syncedFolder.remotePath}) finished")
         val result = Result.success()
         backgroundJobManager.logEndOfWorker(

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -65,7 +65,7 @@ class FilesSyncWork(
 
     private lateinit var syncedFolder: SyncedFolder
 
-    @Suppress("MagicNumber")
+    @Suppress("MagicNumber", "ReturnCount")
     override fun doWork(): Result {
         val syncFolderId = inputData.getLong(SYNCED_FOLDER_ID, -1)
         val changedFiles = inputData.getStringArray(CHANGED_FILES)

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -95,8 +95,7 @@ public final class FilesSyncHelper {
     private static void insertCustomFolderIntoDB(Path path,
                                                  SyncedFolder syncedFolder,
                                                  FilesystemDataProvider filesystemDataProvider,
-                                                 long lastCheck,
-                                                 long thisCheck) {
+                                                 long lastCheck) {
 
         final long enabledTimestampMs = syncedFolder.getEnabledTimestampMs();
 
@@ -140,7 +139,6 @@ public final class FilesSyncHelper {
                     return FileVisitResult.CONTINUE;
                 }
             });
-            syncedFolder.setLastScanTimestampMs(thisCheck);
         } catch (IOException e) {
             Log_OC.e(TAG, "Something went wrong while indexing files for auto upload", e);
         }
@@ -155,7 +153,6 @@ public final class FilesSyncHelper {
         if (syncedFolder.isEnabled() && (syncedFolder.isExisting() || enabledTimestampMs >= 0)) {
             MediaFolderType mediaType = syncedFolder.getType();
             final long lastCheckTimestampMs = syncedFolder.getLastScanTimestampMs();
-            final long thisCheckTimestampMs = System.currentTimeMillis();
 
             Log_OC.d(TAG,"File-sync start check folder "+syncedFolder.getLocalPath());
             long startTime = System.nanoTime();
@@ -163,21 +160,21 @@ public final class FilesSyncHelper {
             if (mediaType == MediaFolderType.IMAGE) {
                 FilesSyncHelper.insertContentIntoDB(MediaStore.Images.Media.INTERNAL_CONTENT_URI,
                                                     syncedFolder,
-                                                    lastCheckTimestampMs, thisCheckTimestampMs);
+                                                    lastCheckTimestampMs);
                 FilesSyncHelper.insertContentIntoDB(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                                                     syncedFolder,
-                                                    lastCheckTimestampMs, thisCheckTimestampMs);
+                                                    lastCheckTimestampMs);
             } else if (mediaType == MediaFolderType.VIDEO) {
                 FilesSyncHelper.insertContentIntoDB(MediaStore.Video.Media.INTERNAL_CONTENT_URI,
                                                     syncedFolder,
-                                                    lastCheckTimestampMs, thisCheckTimestampMs);
+                                                    lastCheckTimestampMs);
                 FilesSyncHelper.insertContentIntoDB(MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
                                                     syncedFolder,
-                                                    lastCheckTimestampMs, thisCheckTimestampMs);
+                                                    lastCheckTimestampMs);
             } else {
                     FilesystemDataProvider filesystemDataProvider = new FilesystemDataProvider(contentResolver);
                     Path path = Paths.get(syncedFolder.getLocalPath());
-                    FilesSyncHelper.insertCustomFolderIntoDB(path, syncedFolder, filesystemDataProvider, lastCheckTimestampMs, thisCheckTimestampMs);
+                    FilesSyncHelper.insertCustomFolderIntoDB(path, syncedFolder, filesystemDataProvider, lastCheckTimestampMs);
             }
 
             Log_OC.d(TAG,"File-sync finished full check for custom folder "+syncedFolder.getLocalPath()+" within "+(System.nanoTime() - startTime)+ "ns");
@@ -219,7 +216,7 @@ public final class FilesSyncHelper {
     }
 
     private static void insertContentIntoDB(Uri uri, SyncedFolder syncedFolder,
-                                            long lastCheckTimestampMs, long thisCheckTimestampMs) {
+                                            long lastCheckTimestampMs) {
         final Context context = MainApp.getAppContext();
         final ContentResolver contentResolver = context.getContentResolver();
 
@@ -266,7 +263,6 @@ public final class FilesSyncHelper {
                 }
             }
             cursor.close();
-            syncedFolder.setLastScanTimestampMs(thisCheckTimestampMs);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -325,7 +325,7 @@ public final class FilesSyncHelper {
             return defaultInterval * 4;
         }
 
-        if (powerManagementService.getBattery().getLevel() < 15){
+        if (powerManagementService.getBattery().getLevel() < 20){
             return defaultInterval * 8;
         }
 


### PR DESCRIPTION
As [this](https://github.com/nextcloud/android/pull/13217) PR failed because it produces too much overhead, a new approach consists of just shuffling the files before scanning to prevent a bias where files "further at the back" get not scanned in large folders. It is probably not the prettiest solution but since this problem is only theoretical (no known issues) and an edge case with the new improvements to auto upload this should be enough to prevent bias.  

Also Fixes https://github.com/nextcloud/android/issues/13008 and fixes https://github.com/nextcloud/android/issues/13078
Finally finishes https://github.com/nextcloud/android/issues/12954

Additionally, this PR includes:
1. Fixes a bug where the lastScannedTimestamp is not saved to the database -> Gaining a lot of performance
2. Make sure the files are not only scanned but also uploaded
3. Increase the FileSyncWorker execution interval if battery is low or conditions are not met (no internet)

To test, please test the whole auto upload feature, since there are a lot of small changes done that could affect the whole feature.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
