### PR TITLE
Add SSO Activity Theme Correctness Test

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/sso/SSOActivityIT.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/sso/SSOActivityIT.kt
@@ -1,0 +1,28 @@
+package com.nextcloud.client.sso
+
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import com.owncloud.android.AbstractIT
+import com.owncloud.android.ui.activity.SsoGrantPermissionActivity
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+
+class SSOActivityIT : AbstractIT() {
+
+    @Suppress("DEPRECATION")
+    @get:Rule
+    var activityRule = IntentsTestRule(SsoGrantPermissionActivity::class.java, true, false)
+
+    @Test
+    fun testActivityStartsWithoutCrash() {
+        val sut = activityRule.launchActivity(null)
+        assert(sut.binding != null)
+
+        try {
+            sut.showDialog()
+            assert(true)
+        } catch (e: Exception) {
+            fail("Wrong theme style applied")
+        }
+    }
+}

--- a/app/src/androidTest/java/com/nextcloud/client/sso/SSOActivityTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/sso/SSOActivityTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 package com.nextcloud.client.sso
 
 import androidx.test.espresso.intent.rule.IntentsTestRule

--- a/app/src/androidTest/java/com/nextcloud/client/sso/SSOActivityTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/sso/SSOActivityTests.kt
@@ -3,26 +3,19 @@ package com.nextcloud.client.sso
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import com.owncloud.android.AbstractIT
 import com.owncloud.android.ui.activity.SsoGrantPermissionActivity
-import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 
-class SSOActivityIT : AbstractIT() {
+class SSOActivityTests : AbstractIT() {
 
     @Suppress("DEPRECATION")
     @get:Rule
     var activityRule = IntentsTestRule(SsoGrantPermissionActivity::class.java, true, false)
 
     @Test
-    fun testActivityStartsWithoutCrash() {
+    fun testActivityTheme() {
         val sut = activityRule.launchActivity(null)
         assert(sut.binding != null)
-
-        try {
-            sut.showDialog()
-            assert(true)
-        } catch (e: Exception) {
-            fail("Wrong theme style applied")
-        }
+        assert(sut.materialAlertDialogBuilder != null)
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
@@ -69,13 +69,19 @@ public class SsoGrantPermissionActivity extends BaseActivity {
 
     private AlertDialog dialog;
 
+    private DialogSsoGrantPermissionBinding binding;
+
+    public DialogSsoGrantPermissionBinding getBinding() {
+        return binding;
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         viewThemeUtils = themeUtilsFactory.withDefaultSchemes();
 
-        DialogSsoGrantPermissionBinding binding = DialogSsoGrantPermissionBinding.inflate(getLayoutInflater());
+        binding = DialogSsoGrantPermissionBinding.inflate(getLayoutInflater());
 
         ComponentName callingActivity = getCallingActivity();
 
@@ -101,16 +107,7 @@ public class SsoGrantPermissionActivity extends BaseActivity {
                 Log_OC.e(TAG, "Error retrieving app icon", e);
             }
 
-            final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this)
-                .setView(binding.getRoot())
-                .setCancelable(false)
-                .setPositiveButton(R.string.permission_allow, (dialog, which) -> grantPermission())
-                .setNegativeButton(R.string.permission_deny, (dialog, which) -> exitFailed());
-
-            viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, builder);
-
-            dialog = builder.create();
-            dialog.show();
+            showDialog();
 
             Log_OC.v(TAG, "TOKEN-REQUEST: Calling Package: " + packageName);
             Log_OC.v(TAG, "TOKEN-REQUEST: App Name: " + appName);
@@ -119,6 +116,19 @@ public class SsoGrantPermissionActivity extends BaseActivity {
             Log_OC.e(TAG, "Calling Package is null");
             setResultAndExit("Request was not executed properly. Use startActivityForResult()");
         }
+    }
+
+    public void showDialog() {
+        final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this)
+            .setView(binding.getRoot())
+            .setCancelable(false)
+            .setPositiveButton(R.string.permission_allow, (dialog, which) -> grantPermission())
+            .setNegativeButton(R.string.permission_deny, (dialog, which) -> exitFailed());
+
+        viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, builder);
+
+        dialog = builder.create();
+        dialog.show();
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SsoGrantPermissionActivity.java
@@ -107,7 +107,18 @@ public class SsoGrantPermissionActivity extends BaseActivity {
                 Log_OC.e(TAG, "Error retrieving app icon", e);
             }
 
-            showDialog();
+            MaterialAlertDialogBuilder builder = getMaterialAlertDialogBuilder();
+
+            builder
+                .setView(binding.getRoot())
+                .setCancelable(false)
+                .setPositiveButton(R.string.permission_allow, (dialog, which) -> grantPermission())
+                .setNegativeButton(R.string.permission_deny, (dialog, which) -> exitFailed());
+
+            viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, builder);
+
+            dialog = builder.create();
+            dialog.show();
 
             Log_OC.v(TAG, "TOKEN-REQUEST: Calling Package: " + packageName);
             Log_OC.v(TAG, "TOKEN-REQUEST: App Name: " + appName);
@@ -118,17 +129,8 @@ public class SsoGrantPermissionActivity extends BaseActivity {
         }
     }
 
-    public void showDialog() {
-        final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this)
-            .setView(binding.getRoot())
-            .setCancelable(false)
-            .setPositiveButton(R.string.permission_allow, (dialog, which) -> grantPermission())
-            .setNegativeButton(R.string.permission_deny, (dialog, which) -> exitFailed());
-
-        viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, builder);
-
-        dialog = builder.create();
-        dialog.show();
+    public MaterialAlertDialogBuilder getMaterialAlertDialogBuilder() {
+        return new MaterialAlertDialogBuilder(this);
     }
 
     @Override


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


**Problem**

SsoGrantPermissionActivity not used in our Files app, however if any other app using Single Sign On e.g. Notes app this activity will be used. If theme for this activity is not correct, app is crashing or dialog is not appearing at all and this causing a huge problem for other apps such as other app can't authenticate the user.

_Android – You need to use a Theme.AppCompat theme (or descendant) with this activity_ error this appears in the logs.

We may change the styles and not aware of the side effects of it. Therefore, we have to be sure are we using correct theme or not.

Writing a screenshot test for this activity is not easy due to usage of the `ComponentName callingActivity = getCallingActivity()`. If we can create MaterialAlertDialogBuilder it means theme is correct. 

**Solution**

Check existence of the MaterialAlertDialogBuilder and binding for this activity.

**How to Test?**

Set wrong theme and test will fail. Set correct theme test will pass.

**How Can I Know Theme Is Correct or Not?**

Check [this](https://www.geeksforgeeks.org/android-you-need-to-use-a-theme-appcompat-theme-or-descendant-with-this-activity/) source for more detailed information.

