### PR TITLE
Show Snackbar If mStreamsToUpload is null on ReceiveExternalFilesActivity

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -899,6 +899,10 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     public void uploadFiles() {
+        if (mStreamsToUpload == null) {
+            DisplayUtils.showSnackMessage(this, R.string.receive_external_files_activity_unable_to_find_file_to_upload);
+            return;
+        }
 
         UriUploader uploader = new UriUploader(
             this,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,7 @@
     <string name="clipboard_label">Text copied from %1$s</string>
 
     <string name="receive_external_files_activity_start_sync_folder_is_not_exists_message">Folder cannot be found, sync operation is cancelled</string>
+    <string name="receive_external_files_activity_unable_to_find_file_to_upload">Unable to find file to upload</string>
 
     <string name="error_cant_bind_to_operations_service">Critical error: Unable to perform operations</string>
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem?**

In some cases mStreamsToUpload not initialized properly, therefore UriUploader usage will cause crash.

**What does this PR?**

If mStreamsToUpload not initialized it shows snackbar and give feedback to the user instead crashing the app.

**How to Test?**

1. Open file manager application
2. Share file with Nextcloud app