### PR TITLE
Limit Max File Upload Count

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -64,6 +64,9 @@ class FileUploadHelper {
     companion object {
         private val TAG = FileUploadWorker::class.java.simpleName
 
+        @Suppress("MagicNumber")
+        const val MAX_FILE_COUNT = 500
+
         val mBoundListeners = HashMap<String, OnDatatransferProgressListener>()
 
         private var instance: FileUploadHelper? = null

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -880,7 +880,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private boolean somethingToUpload() {
-        return (mStreamsToUpload != null && mStreamsToUpload.size() > 0 && mStreamsToUpload.get(0) != null ||
+        return (mStreamsToUpload != null && !mStreamsToUpload.isEmpty() && mStreamsToUpload.get(0) != null ||
             mUploadFromTmpFile);
     }
 
@@ -901,6 +901,11 @@ public class ReceiveExternalFilesActivity extends FileActivity
     public void uploadFiles() {
         if (mStreamsToUpload == null) {
             DisplayUtils.showSnackMessage(this, R.string.receive_external_files_activity_unable_to_find_file_to_upload);
+            return;
+        }
+
+        if (mStreamsToUpload.size() > FileUploadHelper.MAX_FILE_COUNT) {
+            DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
             return;
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -487,7 +487,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             mCurrentDialog = null;
         }
 
-        if (!hasEnoughSpaceAvailable) {
+        if (hasEnoughSpaceAvailable) {
             // return the list of files (success)
             Intent data = new Intent();
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -30,6 +30,7 @@ import android.widget.TextView;
 
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
+import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.utils.extensions.ActivityExtensionsKt;
@@ -486,7 +487,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             mCurrentDialog = null;
         }
 
-        if (hasEnoughSpaceAvailable) {
+        if (!hasEnoughSpaceAvailable) {
             // return the list of files (success)
             Intent data = new Intent();
 
@@ -653,6 +654,11 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     @Override
     public void onConfirmation(String callerTag) {
         Log_OC.d(TAG, "Positive button in dialog was clicked; dialog tag is " + callerTag);
+        if (mFileListFragment.getCheckedFilePaths().length > FileUploadHelper.MAX_FILE_COUNT) {
+            DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+            return;
+        }
+
         if (QUERY_TO_MOVE_DIALOG_TAG.equals(callerTag)) {
             // return the list of selected files to the caller activity (success),
             // signaling that they should be moved to the ownCloud folder, instead of copied

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="uploader_error_message_source_file_not_found">File selected for upload not found. Please check whether the file exists.</string>
     <string name="uploader_error_message_source_file_not_copied">Could not copy file to a temporary folder. Try to resend it.</string>
     <string name="uploader_upload_files_behaviour">Upload option:</string>
+    <string name="max_file_count_warning_message">You have reached the maximum file upload limit. Please upload fewer than 500 files at a time.</string>
     <string name="uploader_upload_files_behaviour_move_to_nextcloud_folder">Move file to %1$s folder</string>
     <string name="uploader_upload_files_behaviour_only_upload">Keep file in source folder</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Delete file from source folder</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem?**

We are using String array to pass file paths then upload those files. Some users trying to upload more than 5000 files at one time and when we put that String array inside the Intent we are exceeding the max limit then app is crashing, **Transaction Too Large**

**Solution**

We can store all file paths in the database and later use the table ID to retrieve and upload the files. Once the upload is complete, we will clean the database. Alternatively, we can limit the maximum file size. This PR implements a maximum file size limit.

**Example**

<img width="502" alt="example_ss" src="https://github.com/user-attachments/assets/dbc1655e-abdc-4f14-b15f-028b1044aa56">