### PR TITLE
Fix - Edit, Delete Behaviors on PreviewImageActivity

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -159,7 +159,7 @@ class FileDownloadWorker(
     }
 
     private fun setIdleWorkerState() {
-        WorkerStateLiveData.instance().setWorkState(WorkerState.Idle)
+        WorkerStateLiveData.instance().setWorkState(WorkerState.Idle(getCurrentFile()))
     }
 
     private fun removePendingDownload(accountName: String?) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -124,7 +124,7 @@ class FileUploadWorker(
     }
 
     private fun setIdleWorkerState() {
-        WorkerStateLiveData.instance().setWorkState(WorkerState.Idle)
+        WorkerStateLiveData.instance().setWorkState(WorkerState.Idle(currentUploadFileOperation?.file))
     }
 
     @Suppress("ReturnCount")

--- a/app/src/main/java/com/nextcloud/model/WorkerState.kt
+++ b/app/src/main/java/com/nextcloud/model/WorkerState.kt
@@ -8,11 +8,12 @@
 package com.nextcloud.model
 
 import com.nextcloud.client.account.User
+import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.db.OCUpload
 import com.owncloud.android.operations.DownloadFileOperation
 
 sealed class WorkerState {
-    object Idle : WorkerState()
-    class Download(var user: User?, var currentDownload: DownloadFileOperation?) : WorkerState()
-    class Upload(var user: User?, var uploads: List<OCUpload>) : WorkerState()
+    data class Idle(var currentFile: OCFile?) : WorkerState()
+    data class Download(var user: User?, var currentDownload: DownloadFileOperation?) : WorkerState()
+    data class Upload(var user: User?, var uploads: List<OCUpload>) : WorkerState()
 }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -1,15 +1,8 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2020-2024 Andy Scherzinger <info@andy-scherzinger.de>
- * SPDX-FileCopyrightText: 2023 Alper Ozturk <alper.ozturk@nextcloud.com>
- * SPDX-FileCopyrightText: 2022 Álvaro Brey <alvaro@alvarobrey.com>
- * SPDX-FileCopyrightText: 2019 Tobias Kaminsky <tobias@kaminsky.me>
- * SPDX-FileCopyrightText: 2019 Chris Narkiewicz <hello@ezaquarii.com>
- * SPDX-FileCopyrightText: 2016 ownCloud Inc.
- * SPDX-FileCopyrightText: 2015 María Asensio Valverde <masensio@solidgear.es>
- * SPDX-FileCopyrightText: 2013 David A. Velasco <dvelasco@solidgear.es>
- * SPDX-License-Identifier: GPL-2.0-only AND (AGPL-3.0-or-later OR GPL-2.0-only)
+ * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 package com.owncloud.android.ui.preview
 
@@ -56,6 +49,7 @@ import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.fragment.GalleryFragment
 import com.owncloud.android.ui.fragment.OCFileListFragment
+import com.owncloud.android.ui.preview.model.PreviewImageActivityState
 import com.owncloud.android.utils.MimeTypeUtil
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import java.io.Serializable
@@ -65,16 +59,18 @@ import kotlin.math.max
 /**
  * Holds a swiping gallery where image files contained in an Nextcloud directory are shown.
  */
+@Suppress("TooManyFunctions")
 class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnRemoteOperationListener, Injectable {
     private var livePhotoFile: OCFile? = null
     private var viewPager: ViewPager2? = null
     private var previewImagePagerAdapter: PreviewImagePagerAdapter? = null
     private var savedPosition = 0
     private var hasSavedPosition = false
-    private var requestWaitingForBinder = false
     private var downloadFinishReceiver: DownloadFinishReceiver? = null
     private var fullScreenAnchorView: View? = null
+
     private var isDownloadWorkStarted = false
+    private var screenState = PreviewImageActivityState.Idle
 
     @Inject
     lateinit var preferences: AppPreferences
@@ -115,7 +111,10 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
         // to keep our UI controls visibility in line with system bars visibility
         setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
 
-        requestWaitingForBinder = savedInstanceState?.getBoolean(KEY_WAITING_FOR_BINDER) ?: false
+        val requestWaitingForBinder = savedInstanceState?.getBoolean(KEY_WAITING_FOR_BINDER) ?: false
+        if (requestWaitingForBinder) {
+            screenState = PreviewImageActivityState.WaitingForBinder
+        }
 
         observeWorkerState()
     }
@@ -181,7 +180,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
         if (position == 0 && !file.isDown) {
             // this is necessary because mViewPager.setCurrentItem(0) just after setting the
             // adapter does not result in a call to #onPageSelected(0)
-            requestWaitingForBinder = true
+            screenState = PreviewImageActivityState.WaitingForBinder
         }
     }
 
@@ -241,7 +240,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putBoolean(KEY_WAITING_FOR_BINDER, requestWaitingForBinder)
+        outState.putBoolean(KEY_WAITING_FOR_BINDER, screenState == PreviewImageActivityState.WaitingForBinder)
         outState.putBoolean(KEY_SYSTEM_VISIBLE, isSystemUIVisible)
     }
 
@@ -274,24 +273,48 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
 
     private fun observeWorkerState() {
         WorkerStateLiveData.instance().observe(this) { state: WorkerState? ->
-            if (state is WorkerState.Download) {
-                Log_OC.d(TAG, "Download worker started")
-                isDownloadWorkStarted = true
+            when(state) {
+                is WorkerState.Download -> {
+                    Log_OC.d(TAG, "Download worker started")
+                    isDownloadWorkStarted = true
 
-                if (requestWaitingForBinder) {
-                    requestWaitingForBinder = false
-                    Log_OC.d(
-                        TAG,
-                        "Simulating reselection of current page after connection " +
-                            "of download binder"
-                    )
-                    selectPage(viewPager?.currentItem)
+                    if (screenState == PreviewImageActivityState.WaitingForBinder) {
+                        selectPageOnDownload()
+                    }
                 }
-            } else {
-                Log_OC.d(TAG, "Download worker stopped")
-                isDownloadWorkStarted = false
+
+                is WorkerState.Idle -> {
+                    Log_OC.d(TAG, "Download worker stopped")
+                    isDownloadWorkStarted = false
+
+                    if (screenState == PreviewImageActivityState.Edit) {
+                        onImageDownloadComplete(state.currentFile)
+                    }
+                }
+
+                else -> {
+                    Log_OC.d(TAG, "Download worker stopped")
+                    isDownloadWorkStarted = false
+                }
             }
         }
+    }
+
+    private fun selectPageOnDownload() {
+        screenState = PreviewImageActivityState.Idle
+        Log_OC.d(
+            TAG,
+            "Simulating reselection of current page after connection " +
+                "of download binder"
+        )
+        selectPage(viewPager?.currentItem)
+    }
+
+    private fun onImageDownloadComplete(downloadedFile: OCFile?) {
+        dismissLoadingDialog()
+        screenState = PreviewImageActivityState.Idle
+        file = downloadedFile
+        startEditImageActivity()
     }
 
     override fun onResume() {
@@ -356,7 +379,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
         val currentFile = previewImagePagerAdapter?.getFileAt(position)
 
         if (!isDownloadWorkStarted) {
-            requestWaitingForBinder = true
+            screenState = PreviewImageActivityState.WaitingForBinder
         } else {
             if (currentFile != null) {
                 if (currentFile.isEncrypted && !currentFile.isDown &&
@@ -457,12 +480,19 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
 
     fun startImageEditor(file: OCFile) {
         if (file.isDown) {
-            val editImageIntent = Intent(this, EditImageActivity::class.java)
-            editImageIntent.putExtra(EditImageActivity.EXTRA_FILE, file)
-            startActivity(editImageIntent)
+            startEditImageActivity()
         } else {
+            showLoadingDialog(getString(R.string.preview_image_downloading_image_for_edit))
+            screenState = PreviewImageActivityState.Edit
             requestForDownload(file, EditImageActivity.OPEN_IMAGE_EDITOR)
         }
+    }
+
+    private fun startEditImageActivity() {
+        val intent = Intent(this, EditImageActivity::class.java).apply {
+            putExtra(EditImageActivity.EXTRA_FILE, file)
+        }
+        startActivity(intent)
     }
 
     override fun onBrowsedDownTo(folder: OCFile) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -253,7 +253,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
 
             previewImagePagerAdapter?.let {
                 if (it.itemCount <= 1) {
-                    finish()
+                    backToDisplayActivity()
                     return
                 }
             }
@@ -262,8 +262,8 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
                 initViewPager(user.get())
             }
 
-            previewImagePagerAdapter?.delete(deletePosition)
             viewPager?.setCurrentItem(nextPosition, true)
+            previewImagePagerAdapter?.delete(deletePosition)
         } else if (operation is SynchronizeFileOperation) {
             onSynchronizeFileOperationFinish(result)
         }
@@ -343,6 +343,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
     }
 
     private fun backToDisplayActivity() {
+        sendRefreshSearchEventBroadcast()
         finish()
     }
 
@@ -355,7 +356,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
         }
 
         startActivity(intent)
-        finish()
+        backToDisplayActivity()
     }
 
     override fun showDetails(file: OCFile, activeTab: Int) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -273,7 +273,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
 
     private fun observeWorkerState() {
         WorkerStateLiveData.instance().observe(this) { state: WorkerState? ->
-            when(state) {
+            when (state) {
                 is WorkerState.Download -> {
                     Log_OC.d(TAG, "Download worker started")
                     isDownloadWorkStarted = true

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 package com.owncloud.android.ui.preview

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -258,8 +258,12 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
                 }
             }
 
-            viewPager?.setCurrentItem(nextPosition, true)
+            if (user.isPresent) {
+                initViewPager(user.get())
+            }
+
             previewImagePagerAdapter?.delete(deletePosition)
+            viewPager?.setCurrentItem(nextPosition, true)
         } else if (operation is SynchronizeFileOperation) {
             onSynchronizeFileOperationFinish(result)
         }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -50,6 +50,7 @@ import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.fragment.GalleryFragment
 import com.owncloud.android.ui.fragment.OCFileListFragment
 import com.owncloud.android.ui.preview.model.PreviewImageActivityState
+import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.MimeTypeUtil
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import java.io.Serializable
@@ -494,6 +495,16 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
     }
 
     private fun startEditImageActivity() {
+        if (file == null) {
+            DisplayUtils.showSnackMessage(this, R.string.preview_image_file_is_not_exist)
+            return
+        }
+
+        if (!file.isDown) {
+            DisplayUtils.showSnackMessage(this, R.string.preview_image_file_is_not_downloaded)
+            return
+        }
+
         val intent = Intent(this, EditImageActivity::class.java).apply {
             putExtra(EditImageActivity.EXTRA_FILE, file)
         }

--- a/app/src/main/java/com/owncloud/android/ui/preview/model/PreviewImageActivityState.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/model/PreviewImageActivityState.kt
@@ -1,0 +1,12 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.ui.preview.model
+
+enum class PreviewImageActivityState {
+    WaitingForBinder, Edit, Idle
+}

--- a/app/src/main/java/com/owncloud/android/ui/preview/model/PreviewImageActivityState.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/model/PreviewImageActivityState.kt
@@ -8,5 +8,7 @@
 package com.owncloud.android.ui.preview.model
 
 enum class PreviewImageActivityState {
-    WaitingForBinder, Edit, Idle
+    WaitingForBinder,
+    Edit,
+    Idle
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,6 +419,8 @@
     <string name="preview_media_unhandled_http_code_message">File is currently locked by another user or process and therefore not deletable. Please try again later.</string>
 
     <string name="preview_sorry">Sorry</string>
+    <string name="preview_image_file_is_not_exist">File is not exist</string>
+    <string name="preview_image_file_is_not_downloaded">File is not downloaded</string>
     <string name="preview_image_downloading_image_for_edit">Downloading image to start the edit screen, please wait…</string>
     <string name="preview_image_description">Image preview</string>
     <string name="preview_image_error_unknown_format">Unable to show image</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,6 +419,7 @@
     <string name="preview_media_unhandled_http_code_message">File is currently locked by another user or process and therefore not deletable. Please try again later.</string>
 
     <string name="preview_sorry">Sorry</string>
+    <string name="preview_image_downloading_image_for_edit">Downloading image to start the edit screen, please wait…</string>
     <string name="preview_image_description">Image preview</string>
     <string name="preview_image_error_unknown_format">Unable to show image</string>
     <string name="preview_image_error_no_local_file">There is no local file to preview</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problems?**

1. The first time an image is selected for editing, the app flickers for a brief moment and the user have to press the same button again.
2. Does not focus on the next image after deleting from the image detail page.
3. If last image deleted from image detail page, previous screen is not updated, still last image is visible after deletion.


**Steps to Reproduce 1**

1. Open the application
2. Go to Media view
4. Select an image that has never been edited
5. Tap on the three dot menu and tap the edit button

**Steps to Reproduce 2**

1. Open the application
2. Go to Media view
3. Have multiple images
4. Select an image that and delete

**Steps to Reproduce 3**

1. Open the application
2. Go to Media view
4. Have one image in media screen
5. Select the last image and delete


**Fixes**

1. When the user presses the edit button, if the image is not yet downloaded, show a loading dialog. Wait for the download to complete, then start the edit image activity.
2. After deletion update view pager
3. After last image deletion send refresh search event broadcast

**Demo**


https://github.com/user-attachments/assets/634454f1-53b5-4bce-b6b1-5225d32e3e5f


