### PR TITLE
BugFix - Preserve Selected Drawer Tab State When App Returns to Foreground

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -462,6 +462,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                 return true;
             });
 
+
         User account = accountManager.getUser();
         filterDrawerMenu(navigationView.getMenu(), account);
     }
@@ -1050,6 +1051,10 @@ public abstract class DrawerActivity extends ToolbarActivity
         }
         updateExternalLinksInDrawer();
         updateQuotaLink();
+    }
+
+    public int getCheckedMenuItem() {
+        return mCheckedMenuItem;
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1168,7 +1168,12 @@ public class FileDisplayActivity extends FileActivity
             setDrawerMenuItemChecked(R.id.nav_on_device);
             setupToolbar();
         } else {
-            setDrawerMenuItemChecked(R.id.nav_all_files);
+            int lastMenuItem = getCheckedMenuItem();
+            if (lastMenuItem == Menu.NONE) {
+                lastMenuItem = R.id.nav_all_files;
+            }
+
+            setDrawerMenuItemChecked(lastMenuItem);
             setupHomeSearchToolbarWithSortAndListButtons();
         }
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


https://github.com/user-attachments/assets/58929413-e418-48e5-ac78-09d51152c520


