### PR TITLE
[Bug Fix] Attach snackbar only to respective fragment item in viewpager

### DIFF
--- a/app/src/main/res/layout/preview_image_fragment.xml
+++ b/app/src/main/res/layout/preview_image_fragment.xml
@@ -9,7 +9,7 @@
   ~ SPDX-FileCopyrightText: 2013 David A. Velasco <dvelasco@solidgear.es>
   ~ SPDX-License-Identifier: GPL-2.0-only AND (AGPL-3.0-or-later OR GPL-2.0-only)
 -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/top"
@@ -119,4 +119,4 @@
             android:src="@drawable/ic_image_outline" />
 
     </FrameLayout>
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes: 
#8054
#7808

## Before
https://github.com/user-attachments/assets/fe290717-1090-4531-b296-7029e570a6cf

## After
https://github.com/user-attachments/assets/ff1592fb-2686-446d-97aa-09556b9c8e19

- Use `CoordinatorLayout` instead of `FrameLayout`. ` Snackbar` [prioritize](https://developer.android.com/develop/ui/views/notifications/snackbar/showing#coordinator) attaching to that from the view tree. Otherwise, it would attach to the parent view which would show snackbar outside the pager container (unintended).

- Now passing `CoordinatorLayout` to only those snackbar messages that needs to be in context of a particular fragment in the pager.