### PR TITLE
Flag FLAG_SECURE should only be active when in passcode screen

### DIFF
--- a/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
+++ b/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
@@ -37,6 +37,18 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
          * the pass code being requested on screen rotations.
          */
         private const val PASS_CODE_TIMEOUT = 5000
+
+        fun setSecureFlag(activity: Activity, isSet: Boolean) {
+            activity.window?.let { window ->
+                if (isSet) {
+                    println("flag added")
+                    window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                } else {
+                    println("flag cleared")
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                }
+            }
+        }
     }
 
     var canAskPin = true
@@ -49,7 +61,6 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
     fun onActivityResumed(activity: Activity): Boolean {
         var askedForPin = false
         val timestamp = preferences.lockTimestamp
-        setSecureFlag(activity)
 
         if (!isExemptActivity(activity)) {
             val passcodeRequested = passCodeShouldBeRequested(timestamp)
@@ -74,16 +85,6 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
         }
 
         return askedForPin
-    }
-
-    private fun setSecureFlag(activity: Activity) {
-        activity.window?.let { window ->
-            if (isPassCodeEnabled() || deviceCredentialsAreEnabled(activity)) {
-                window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-            } else {
-                window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-            }
-        }
     }
 
     private fun requestPasscode(activity: Activity) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.kt
@@ -79,6 +79,7 @@ class PassCodeActivity : AppCompatActivity(), Injectable {
         binding = PasscodelockBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        PassCodeManager.setSecureFlag(this, true)
         applyTint()
         setupPasscodeEditTexts()
         setSoftInputMode()
@@ -372,6 +373,11 @@ class PassCodeActivity : AppCompatActivity(), Injectable {
             putBoolean(KEY_CONFIRMING_PASSCODE, confirmingPassCode)
             putStringArray(KEY_PASSCODE_DIGITS, passCodeDigits)
         }
+    }
+
+    override fun onDestroy() {
+        PassCodeManager.setSecureFlag(this, false)
+        super.onDestroy()
     }
 
     private inner class PassCodeDigitTextWatcher(index: Int, lastOne: Boolean) : TextWatcher {

--- a/app/src/main/java/com/owncloud/android/ui/activity/RequestCredentialsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/RequestCredentialsActivity.java
@@ -14,14 +14,18 @@ import android.app.Activity;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.os.SystemClock;
 import android.widget.Toast;
 
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.owncloud.android.R;
+import com.owncloud.android.authentication.PassCodeManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.DeviceCredentialUtils;
 import com.owncloud.android.utils.DisplayUtils;
+
+import androidx.annotation.Nullable;
 
 /**
  * Dummy activity that is used to handle the device's default authentication workflow.
@@ -35,6 +39,12 @@ public class RequestCredentialsActivity extends Activity {
     public final static int KEY_CHECK_RESULT_FALSE = 0;
     public final static int KEY_CHECK_RESULT_CANCEL = -1;
     private static final int REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS = 1;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        PassCodeManager.Companion.setSecureFlag(this,true);
+    }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -81,5 +91,11 @@ public class RequestCredentialsActivity extends Activity {
         resultIntent.putExtra(KEY_CHECK_RESULT, success);
         setResult(Activity.RESULT_OK, resultIntent);
         finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        PassCodeManager.Companion.setSecureFlag(this,false);
+        super.onDestroy();
     }
 }


### PR DESCRIPTION
From talk [issue](https://github.com/nextcloud/talk-android/issues/4164#issue-2510459429) 

FLAG_SECURE, should only be active in passcode screen unlike (current) master. This cause user unable to take screenshots or screen recording. If user is using passcode/device-credentials.


