### PR TITLE
Do not allow multiple instances of LoadingDialog

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -543,14 +543,16 @@ public abstract class FileActivity extends DrawerActivity
     public void showLoadingDialog(String message) {
         dismissLoadingDialog();
 
-        Fragment frag = getSupportFragmentManager().findFragmentByTag(DIALOG_WAIT_TAG);
-        if (frag == null) {
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
+        if (fragment == null) {
             Log_OC.d(TAG, "show loading dialog");
             LoadingDialog loadingDialogFragment = LoadingDialog.newInstance(message);
-            FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
             if (isDialogFragmentReady) {
-                loadingDialogFragment.show(fragmentTransaction, DIALOG_WAIT_TAG);
+                fragmentTransaction.add(loadingDialogFragment, DIALOG_WAIT_TAG);
+                fragmentTransaction.commitNow();
             }
         }
     }
@@ -559,13 +561,15 @@ public abstract class FileActivity extends DrawerActivity
      * Dismiss loading dialog
      */
     public void dismissLoadingDialog() {
-        Fragment frag = getSupportFragmentManager().findFragmentByTag(DIALOG_WAIT_TAG);
-        if (frag != null) {
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
+        if (fragment != null) {
             Log_OC.d(TAG, "dismiss loading dialog");
-            LoadingDialog loadingDialogFragment = (LoadingDialog) frag;
+            LoadingDialog loadingDialogFragment = (LoadingDialog) fragment;
             boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
             if (isDialogFragmentReady) {
                 loadingDialogFragment.dismiss();
+                fragmentManager.executePendingTransactions();
             }
         }
     }


### PR DESCRIPTION
This change reintroduces more robust state handling when creating new loading dialogues. Previously it was possible to create multiple instances by issuing successive calls to `showLoadingDialog()`. Because of this one or more instances could end up stuck on screen, requiring a restart of the app.

**Testing these changes:**
1. Open Nextcloud App
2. Select two or more files
3. Download said files
4. Observe the *Wait a moment...* dialogue

With this change, the dialogue should eventually disappear.

---
- [x] Tests written, or not not needed
