### PR TITLE
BugFix - Check Filename Limitation With Correct Server Version and Configuration

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -8,8 +8,9 @@
 package com.nextcloud.utils
 
 import com.nextcloud.utils.fileNameValidator.FileNameValidator
-import com.owncloud.android.AbstractIT
+import com.owncloud.android.AbstractOnServerIT
 import com.owncloud.android.R
+import com.owncloud.android.lib.resources.status.NextcloudVersion
 import com.owncloud.android.lib.resources.status.OCCapability
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,7 +20,7 @@ import org.junit.Before
 import org.junit.Test
 
 @Suppress("TooManyFunctions")
-class FileNameValidatorTests : AbstractIT() {
+class FileNameValidatorTests : AbstractOnServerIT() {
 
     private var capability: OCCapability = fileDataStorageManager.getCapability(account.name)
 
@@ -40,6 +41,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testInvalidCharacter() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val result = FileNameValidator.checkFileName("file<name", capability, targetContext)
         assertEquals(
             String.format(targetContext.getString(R.string.file_name_validator_error_invalid_character), "<"),
@@ -49,12 +52,16 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val result = FileNameValidator.checkFileName("CON", capability, targetContext)
         assertEquals(targetContext.getString(R.string.file_name_validator_error_reserved_names, "CON"), result)
     }
 
     @Test
     fun testForbiddenFilenameExtension() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val result = FileNameValidator.checkFileName("my_fav_file.filepart", capability, targetContext)
         assertEquals(
             targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, "filepart"),
@@ -79,7 +86,7 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testFileAlreadyExists() {
-        val existingFiles = mutableSetOf("existingFile")
+        val existingFiles = setOf("existingFile")
         val result = FileNameValidator.checkFileName("existingFile", capability, targetContext, existingFiles)
         assertEquals(targetContext.getString(R.string.file_already_exists), result)
     }
@@ -98,7 +105,7 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testIsFileNameAlreadyExist() {
-        val existingFiles = mutableSetOf("existingFile")
+        val existingFiles = setOf("existingFile")
         assertTrue(FileNameValidator.isFileNameAlreadyExist("existingFile", existingFiles))
         assertFalse(FileNameValidator.isFileNameAlreadyExist("newFile", existingFiles))
     }
@@ -114,6 +121,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testFolderPathWithReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "CON"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
@@ -123,6 +132,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testFilePathWithReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "validFolder"
         val filePaths = listOf("file1.txt", "PRN.doc", "file3.jpg")
 
@@ -132,6 +143,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testFolderPathWithInvalidCharacter() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "invalid<Folder"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
@@ -141,6 +154,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testFilePathWithInvalidCharacter() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "validFolder"
         val filePaths = listOf("file1.txt", "file|2.doc", "file3.jpg")
 
@@ -168,6 +183,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testFilePathWithNestedFolder() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "validFolder\\secondValidFolder\\CON"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.")
 
@@ -185,6 +202,8 @@ class FileNameValidatorTests : AbstractIT() {
 
     @Test
     fun testOnlyFolderPathWithOneReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "/A1/Aaaww/CON/W/C2/"
 
         val result = FileNameValidator.checkFolderAndFilePaths(folderPath, listOf(), capability, targetContext)

--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -72,10 +72,15 @@ class FileNameValidatorTests : AbstractOnServerIT() {
     @Test
     fun testEndsWithSpaceOrPeriod() {
         val result = FileNameValidator.checkFileName("filename ", capability, targetContext)
-        assertEquals(targetContext.getString(R.string.file_name_validator_error_ends_with_space_period), result)
-
         val result2 = FileNameValidator.checkFileName("filename.", capability, targetContext)
-        assertEquals(targetContext.getString(R.string.file_name_validator_error_ends_with_space_period), result2)
+
+        if (capability.version.isOlderThan(NextcloudVersion.nextcloud_30)) {
+            assertEquals(null, result)
+            assertEquals(null, result2)
+        } else {
+            assertEquals(targetContext.getString(R.string.file_name_validator_error_ends_with_space_period), result)
+            assertEquals(targetContext.getString(R.string.file_name_validator_error_ends_with_space_period), result2)
+        }
     }
 
     @Test
@@ -169,7 +174,7 @@ class FileNameValidatorTests : AbstractOnServerIT() {
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
         val result = FileNameValidator.checkFolderAndFilePaths(folderPath, filePaths, capability, targetContext)
-        assertFalse(result)
+        assertEquals(capability.version.isOlderThan(NextcloudVersion.nextcloud_30), result)
     }
 
     @Test
@@ -178,7 +183,7 @@ class FileNameValidatorTests : AbstractOnServerIT() {
         val filePaths = listOf("file1.txt", "file2.doc", "file3.")
 
         val result = FileNameValidator.checkFolderAndFilePaths(folderPath, filePaths, capability, targetContext)
-        assertFalse(result)
+        assertEquals(capability.version.isOlderThan(NextcloudVersion.nextcloud_30), result)
     }
 
     @Test

--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -41,6 +41,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testInvalidCharacter() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val result = FileNameValidator.checkFileName("file<name", capability, targetContext)
         assertEquals(
             String.format(targetContext.getString(R.string.file_name_validator_error_invalid_character), "<"),
@@ -50,12 +52,16 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val result = FileNameValidator.checkFileName("CON", capability, targetContext)
         assertEquals(targetContext.getString(R.string.file_name_validator_error_reserved_names, "CON"), result)
     }
 
     @Test
     fun testForbiddenFilenameExtension() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val result = FileNameValidator.checkFileName("my_fav_file.filepart", capability, targetContext)
         assertEquals(
             targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, "filepart"),
@@ -120,6 +126,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFolderPathWithReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "CON"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
@@ -129,6 +137,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFilePathWithReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "validFolder"
         val filePaths = listOf("file1.txt", "PRN.doc", "file3.jpg")
 
@@ -138,6 +148,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFolderPathWithInvalidCharacter() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "invalid<Folder"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
@@ -147,6 +159,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFilePathWithInvalidCharacter() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "validFolder"
         val filePaths = listOf("file1.txt", "file|2.doc", "file3.jpg")
 
@@ -174,6 +188,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFilePathWithNestedFolder() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "validFolder\\secondValidFolder\\CON"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.")
 
@@ -191,6 +207,8 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testOnlyFolderPathWithOneReservedName() {
+        testOnlyOnServer(NextcloudVersion.nextcloud_30)
+
         val folderPath = "/A1/Aaaww/CON/W/C2/"
 
         val result = FileNameValidator.checkFolderAndFilePaths(folderPath, listOf(), capability, targetContext)

--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -34,7 +34,7 @@ class FileNameValidatorTests : AbstractOnServerIT() {
                                     "lpt0", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", 
                                     "lpt8", "lpt9", "lpt¹", "lpt²", "lpt³"]
                                     """
-            forbiddenFilenameExtensionJson = """[".filepart",".part"]"""
+            forbiddenFilenameExtensionJson = """[" ",".",".part",".part"]"""
             forbiddenFilenameCharactersJson = """["<", ">", ":", "\\\\", "/", "|", "?", "*", "&"]"""
         }
     }

--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -55,31 +55,39 @@ class FileNameValidatorTests : AbstractOnServerIT() {
         testOnlyOnServer(NextcloudVersion.nextcloud_30)
 
         val result = FileNameValidator.checkFileName("CON", capability, targetContext)
-        assertEquals(targetContext.getString(R.string.file_name_validator_error_reserved_names, "CON"), result)
+        assertEquals(targetContext.getString(R.string.file_name_validator_error_reserved_names, "con"), result)
     }
 
     @Test
     fun testForbiddenFilenameExtension() {
         testOnlyOnServer(NextcloudVersion.nextcloud_30)
 
-        val result = FileNameValidator.checkFileName("my_fav_file.filepart", capability, targetContext)
+        val result = FileNameValidator.checkFileName("my_fav_file.part", capability, targetContext)
         assertEquals(
-            targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, "filepart"),
+            targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, ".part"),
             result
         )
     }
 
     @Test
     fun testEndsWithSpaceOrPeriod() {
-        val result = FileNameValidator.checkFileName("filename ", capability, targetContext)
-        val result2 = FileNameValidator.checkFileName("filename.", capability, targetContext)
+        val firstFilename = "test "
+        val secondFilename = "test."
+        val result = FileNameValidator.checkFileName(firstFilename, capability, targetContext)
+        val result2 = FileNameValidator.checkFileName(secondFilename, capability, targetContext)
 
         if (capability.version.isOlderThan(NextcloudVersion.nextcloud_30)) {
             assertEquals(null, result)
             assertEquals(null, result2)
         } else {
-            assertEquals(targetContext.getString(R.string.file_name_validator_error_ends_with_space_period), result)
-            assertEquals(targetContext.getString(R.string.file_name_validator_error_ends_with_space_period), result2)
+            assertEquals(
+                targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, " "),
+                result
+            )
+            assertEquals(
+                targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, "."),
+                result2
+            )
         }
     }
 

--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -41,8 +41,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testInvalidCharacter() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val result = FileNameValidator.checkFileName("file<name", capability, targetContext)
         assertEquals(
             String.format(targetContext.getString(R.string.file_name_validator_error_invalid_character), "<"),
@@ -52,16 +50,12 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testReservedName() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val result = FileNameValidator.checkFileName("CON", capability, targetContext)
         assertEquals(targetContext.getString(R.string.file_name_validator_error_reserved_names, "CON"), result)
     }
 
     @Test
     fun testForbiddenFilenameExtension() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val result = FileNameValidator.checkFileName("my_fav_file.filepart", capability, targetContext)
         assertEquals(
             targetContext.getString(R.string.file_name_validator_error_forbidden_file_extensions, "filepart"),
@@ -126,8 +120,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFolderPathWithReservedName() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val folderPath = "CON"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
@@ -137,8 +129,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFilePathWithReservedName() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val folderPath = "validFolder"
         val filePaths = listOf("file1.txt", "PRN.doc", "file3.jpg")
 
@@ -148,8 +138,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFolderPathWithInvalidCharacter() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val folderPath = "invalid<Folder"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.jpg")
 
@@ -159,8 +147,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFilePathWithInvalidCharacter() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val folderPath = "validFolder"
         val filePaths = listOf("file1.txt", "file|2.doc", "file3.jpg")
 
@@ -188,8 +174,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testFilePathWithNestedFolder() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val folderPath = "validFolder\\secondValidFolder\\CON"
         val filePaths = listOf("file1.txt", "file2.doc", "file3.")
 
@@ -207,8 +191,6 @@ class FileNameValidatorTests : AbstractOnServerIT() {
 
     @Test
     fun testOnlyFolderPathWithOneReservedName() {
-        testOnlyOnServer(NextcloudVersion.nextcloud_30)
-
         val folderPath = "/A1/Aaaww/CON/W/C2/"
 
         val result = FileNameValidator.checkFolderAndFilePaths(folderPath, listOf(), capability, targetContext)

--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
@@ -60,33 +60,37 @@ object FileNameValidator {
                 forbiddenFilenameBaseNames().let {
                     val forbiddenBaseNames = forbiddenFilenameBaseNames().map { it.lowercase() }
 
-                    if (forbiddenBaseNames.any { it in filenameVariants }) {
-                        return context.getString(
-                            R.string.file_name_validator_error_reserved_names,
-                            filename.substringBefore(StringConstants.DOT)
-                        )
+                    for (forbiddenBaseName in forbiddenBaseNames) {
+                        if (forbiddenBaseName in filenameVariants) {
+                            return context.getString(
+                                R.string.file_name_validator_error_reserved_names,
+                                forbiddenBaseName
+                            )
+                        }
                     }
                 }
 
                 forbiddenFilenamesJson?.let {
                     val forbiddenFilenames = forbiddenFilenames().map { it.lowercase() }
 
-                    if (forbiddenFilenames.any { it in filenameVariants }) {
-                        return context.getString(
-                            R.string.file_name_validator_error_reserved_names,
-                            filename.substringBefore(StringConstants.DOT)
-                        )
+                    for (forbiddenFilename in forbiddenFilenames) {
+                        if (forbiddenFilename in filenameVariants) {
+                            return context.getString(
+                                R.string.file_name_validator_error_reserved_names,
+                                forbiddenFilename
+                            )
+                        }
                     }
                 }
 
                 forbiddenFilenameExtensionJson?.let {
-                    val forbiddenExtensions = forbiddenFilenameExtension()
-
-                    if (forbiddenExtensions.any { filename.endsWith(it, ignoreCase = true) }) {
-                        return context.getString(
-                            R.string.file_name_validator_error_forbidden_file_extensions,
-                            filename.substringAfter(StringConstants.DOT)
-                        )
+                    for (forbiddenExtension in forbiddenFilenameExtension()) {
+                        if (filename.endsWith(forbiddenExtension, ignoreCase = true)) {
+                            return context.getString(
+                                R.string.file_name_validator_error_forbidden_file_extensions,
+                                forbiddenExtension
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
@@ -55,13 +55,12 @@ object FileNameValidator {
             }
 
             capability.run {
-                forbiddenFilenameBaseNames().let {
-                    val forbiddenFilenameBaseNames = capability.forbiddenFilenameBaseNames().map { it.lowercase() }
+                val filenameVariants = setOf(filename.lowercase(), filename.removeFileExtension().lowercase())
 
-                    if (forbiddenFilenameBaseNames.contains(filename.lowercase()) || forbiddenFilenameBaseNames.contains(
-                            filename.removeFileExtension().lowercase()
-                        )
-                    ) {
+                forbiddenFilenameBaseNames().let {
+                    val forbiddenBaseNames = forbiddenFilenameBaseNames().map { it.lowercase() }
+
+                    if (forbiddenBaseNames.any { it in filenameVariants }) {
                         return context.getString(
                             R.string.file_name_validator_error_reserved_names,
                             filename.substringBefore(StringConstants.DOT)
@@ -70,12 +69,9 @@ object FileNameValidator {
                 }
 
                 forbiddenFilenamesJson?.let {
-                    val forbiddenFilenames = capability.forbiddenFilenames().map { it.lowercase() }
+                    val forbiddenFilenames = forbiddenFilenames().map { it.lowercase() }
 
-                    if (forbiddenFilenames.contains(filename.uppercase()) || forbiddenFilenames.contains(
-                            filename.removeFileExtension().uppercase()
-                        )
-                    ) {
+                    if (forbiddenFilenames.any { it in filenameVariants }) {
                         return context.getString(
                             R.string.file_name_validator_error_reserved_names,
                             filename.substringBefore(StringConstants.DOT)
@@ -84,9 +80,9 @@ object FileNameValidator {
                 }
 
                 forbiddenFilenameExtensionJson?.let {
-                    val forbiddenFilenameExtension = capability.forbiddenFilenameExtension()
+                    val forbiddenExtensions = forbiddenFilenameExtension()
 
-                    if (forbiddenFilenameExtension.any { filename.endsWith(it, ignoreCase = true) }) {
+                    if (forbiddenExtensions.any { filename.endsWith(it, ignoreCase = true) }) {
                         return context.getString(
                             R.string.file_name_validator_error_forbidden_file_extensions,
                             filename.substringAfter(StringConstants.DOT)

--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
@@ -49,69 +49,50 @@ object FileNameValidator {
             }
         }
 
-        return if (capability.version.isNewerOrEqual(NextcloudVersion.nextcloud_30)) {
-            validateForNCThirtyOrAbove(filename, capability, context)
-        } else {
-            validateForBelowNCThirty(filename, context)
-        }
-    }
-
-    private fun validateForBelowNCThirty(
-        filename: String,
-        context: Context,
-    ): String? {
-        if (filename.endsWith(StringConstants.SPACE) || filename.endsWith(StringConstants.DOT)) {
-            return context.getString(R.string.file_name_validator_error_ends_with_space_period)
-        }
-
-        return null
-    }
-
-    private fun validateForNCThirtyOrAbove(
-        filename: String,
-        capability: OCCapability,
-        context: Context,
-    ): String? {
-        checkInvalidCharacters(filename, capability, context)?.let {
-            return it
-        }
-
-        capability.forbiddenFilenameBaseNames().let {
-            val forbiddenFilenameBaseNames = capability.forbiddenFilenameBaseNames().map { it.lowercase() }
-
-            if (forbiddenFilenameBaseNames.contains(filename.lowercase()) || forbiddenFilenameBaseNames.contains(
-                    filename.removeFileExtension().lowercase()
-                )
-            ) {
-                return context.getString(
-                    R.string.file_name_validator_error_reserved_names,
-                    filename.substringBefore(StringConstants.DOT)
-                )
+        if (capability.version.isNewerOrEqual(NextcloudVersion.nextcloud_30)) {
+            checkInvalidCharacters(filename, capability, context)?.let {
+                return it
             }
-        }
 
-        capability.forbiddenFilenamesJson?.let {
-            val forbiddenFilenames = capability.forbiddenFilenames().map { it.lowercase() }
+            capability.run {
+                forbiddenFilenameBaseNames().let {
+                    val forbiddenFilenameBaseNames = capability.forbiddenFilenameBaseNames().map { it.lowercase() }
 
-            if (forbiddenFilenames.contains(filename.uppercase()) || forbiddenFilenames.contains(
-                    filename.removeFileExtension().uppercase()
-                )
-            ) {
-                return context.getString(
-                    R.string.file_name_validator_error_reserved_names,
-                    filename.substringBefore(StringConstants.DOT)
-                )
-            }
-        }
+                    if (forbiddenFilenameBaseNames.contains(filename.lowercase()) || forbiddenFilenameBaseNames.contains(
+                            filename.removeFileExtension().lowercase()
+                        )
+                    ) {
+                        return context.getString(
+                            R.string.file_name_validator_error_reserved_names,
+                            filename.substringBefore(StringConstants.DOT)
+                        )
+                    }
+                }
 
-        capability.forbiddenFilenameExtensionJson?.let {
-            val forbiddenFilenameExtension = capability.forbiddenFilenameExtension()
+                forbiddenFilenamesJson?.let {
+                    val forbiddenFilenames = capability.forbiddenFilenames().map { it.lowercase() }
 
-            if (forbiddenFilenameExtension.any { filename.endsWith(it, ignoreCase = true) }) {
-                return context.getString(
-                    R.string.file_name_validator_error_forbidden_file_extensions,
-                    filename.substringAfter(StringConstants.DOT)
-                )
+                    if (forbiddenFilenames.contains(filename.uppercase()) || forbiddenFilenames.contains(
+                            filename.removeFileExtension().uppercase()
+                        )
+                    ) {
+                        return context.getString(
+                            R.string.file_name_validator_error_reserved_names,
+                            filename.substringBefore(StringConstants.DOT)
+                        )
+                    }
+                }
+
+                forbiddenFilenameExtensionJson?.let {
+                    val forbiddenFilenameExtension = capability.forbiddenFilenameExtension()
+
+                    if (forbiddenFilenameExtension.any { filename.endsWith(it, ignoreCase = true) }) {
+                        return context.getString(
+                            R.string.file_name_validator_error_forbidden_file_extensions,
+                            filename.substringAfter(StringConstants.DOT)
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
@@ -133,7 +133,7 @@ class CreateFolderDialogFragment : DialogFragment(), DialogInterface.OnClickList
     private fun getOCCapability(): OCCapability = fileDataStorageManager.getCapability(accountProvider.user.accountName)
 
     private fun checkFileNameAfterEachType(fileNames: MutableSet<String>) {
-        val newFileName = binding.userInput.text?.toString()?.trim() ?: ""
+        val newFileName = binding.userInput.text?.toString() ?: ""
 
         val fileNameValidatorResult: String? =
             FileNameValidator.checkFileName(newFileName, getOCCapability(), requireContext(), fileNames)
@@ -172,7 +172,7 @@ class CreateFolderDialogFragment : DialogFragment(), DialogInterface.OnClickList
     override fun onClick(dialog: DialogInterface, which: Int) {
         if (which == AlertDialog.BUTTON_POSITIVE) {
             val newFolderName = (getDialog()?.findViewById<View>(R.id.user_input) as TextView)
-                .text.toString().trim { it <= ' ' }
+                .text.toString()
 
             val errorMessage: String? =
                 FileNameValidator.checkFileName(newFolderName, getOCCapability(), requireContext())

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.kt
@@ -136,7 +136,7 @@ class RenameFileDialogFragment : DialogFragment(), DialogInterface.OnClickListen
             var newFileName = ""
 
             if (binding.userInput.text != null) {
-                newFileName = binding.userInput.text.toString().trim { it <= ' ' }
+                newFileName = binding.userInput.text.toString()
             }
 
             val errorMessage = checkFileName(newFileName, oCCapability, requireContext(), null)
@@ -166,7 +166,7 @@ class RenameFileDialogFragment : DialogFragment(), DialogInterface.OnClickListen
     override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
         var newFileName = ""
         if (binding.userInput.text != null) {
-            newFileName = binding.userInput.text.toString().trim { it <= ' ' }
+            newFileName = binding.userInput.text.toString()
         }
 
         val errorMessage = checkFileName(newFileName, oCCapability, requireContext(), fileNames)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">بإنتظار مزامنة كاملة…</string>
     <string name="file_name_validator_current_path_is_invalid">اسم المجلد الحالي غير صحيح. قُم رجاءً بتغيير اسم المجلد. إعادة التوجيه إلى المجلد الجذر</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">مسار المجلد يحتوي على أسماء محجوزة أو حروف غير صالحة</string>
-    <string name="file_name_validator_error_ends_with_space_period">اسم ينتهي بفراغ أو نقطة</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s امتداد ملف غير مسموحٍ به</string>
     <string name="file_name_validator_error_invalid_character">اسم يحتوي على حروف غير صالحة: %s</string>
     <string name="file_name_validator_error_reserved_names">%s اسم ممنوع</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">اسم المجلد الحالي غير صحيح. قُم رجاءً بتغيير اسم المجلد. إعادة التوجيه إلى المجلد الجذر</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">مسار المجلد يحتوي على أسماء محجوزة أو حروف غير صالحة</string>
     <string name="file_name_validator_error_ends_with_space_period">اسم ينتهي بفراغ أو نقطة</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s امتداد ملف غير مسموحٍ به</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s امتداد ملف غير مسموحٍ به</string>
     <string name="file_name_validator_error_invalid_character">اسم يحتوي على حروف غير صالحة: %s</string>
     <string name="file_name_validator_error_reserved_names">%s اسم ممنوع</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. قُم رجاءً بتغيير اسم الملف قبل نقله أو نسخه</string>

--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Awaiting full sync…</string>
     <string name="file_name_validator_current_path_is_invalid">Current folder name is invalid, please rename the folder. Redirecting to root</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Folder path contains reserved names or invalid character</string>
-    <string name="file_name_validator_error_ends_with_space_period">Name ends with a space or a period</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s is a forbidden file extension</string>
     <string name="file_name_validator_error_invalid_character">Name contains an invalid character: %s</string>
     <string name="file_name_validator_error_reserved_names">%s is a forbidden name</string>

--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">Current folder name is invalid, please rename the folder. Redirecting to root</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Folder path contains reserved names or invalid character</string>
     <string name="file_name_validator_error_ends_with_space_period">Name ends with a space or a period</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s is a forbidden file extension</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s is a forbidden file extension</string>
     <string name="file_name_validator_error_invalid_character">Name contains an invalid character: %s</string>
     <string name="file_name_validator_error_reserved_names">%s is a forbidden name</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Please rename the file before moving or copying</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">Der aktuelle Ordnername ist unzulässig. Bitte benennen Sie den Ordner um. Weiterleitung zum Stammverzeichnis</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Der Ordnerpfad enthält reservierte Namen oder ungültige Zeichen</string>
     <string name="file_name_validator_error_ends_with_space_period">Der Name endet mit einem Leerzeichen oder einem Punkt</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s ist eine unzulässige Dateierweiterung</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s ist eine unzulässige Dateierweiterung</string>
     <string name="file_name_validator_error_invalid_character">Der Name enthält ein unzulässiges Zeichen: %s</string>
     <string name="file_name_validator_error_reserved_names">%s ist ein unzulässiger Name</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Bitte Datei umbenennen, bevor diese verschoben oder kopiert wird</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Warte auf die Fertigstellung aller Synchronisierungen …</string>
     <string name="file_name_validator_current_path_is_invalid">Der aktuelle Ordnername ist unzulässig. Bitte benennen Sie den Ordner um. Weiterleitung zum Stammverzeichnis</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Der Ordnerpfad enthält reservierte Namen oder ungültige Zeichen</string>
-    <string name="file_name_validator_error_ends_with_space_period">Der Name endet mit einem Leerzeichen oder einem Punkt</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s ist eine unzulässige Dateierweiterung</string>
     <string name="file_name_validator_error_invalid_character">Der Name enthält ein unzulässiges Zeichen: %s</string>
     <string name="file_name_validator_error_reserved_names">%s ist ein unzulässiger Name</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">Uneko karpetaren izena ez da baliozkoa, mesedez izena aldatu karpetari. Errora birbideratzen</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Karpetaren bideak izen erreserbatuak edo karaktere baliogabeak ditu</string>
     <string name="file_name_validator_error_ends_with_space_period">Izena tarte batekin edo puntu batekin amaitzen da</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%sdebekatutako fitxategi-luzapena da</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%sdebekatutako fitxategi-luzapena da</string>
     <string name="file_name_validator_error_invalid_character">Izenak karaktere baliogabe bat dauka: %s</string>
     <string name="file_name_validator_error_reserved_names">%s debekatutako izen bat da</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Aldatu fitxategiaren izena mugitu edo kopiatu aurretik</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Sinkronizazio osoaren zain...</string>
     <string name="file_name_validator_current_path_is_invalid">Uneko karpetaren izena ez da baliozkoa, mesedez izena aldatu karpetari. Errora birbideratzen</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Karpetaren bideak izen erreserbatuak edo karaktere baliogabeak ditu</string>
-    <string name="file_name_validator_error_ends_with_space_period">Izena tarte batekin edo puntu batekin amaitzen da</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%sdebekatutako fitxategi-luzapena da</string>
     <string name="file_name_validator_error_invalid_character">Izenak karaktere baliogabe bat dauka: %s</string>
     <string name="file_name_validator_error_reserved_names">%s debekatutako izen bat da</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -411,7 +411,7 @@
     <string name="file_name_validator_current_path_is_invalid">Le nom actuel du dossier est invalide, veuillez renommer le dossier. Redirection vers la racine</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Le chemin du dossier contient des noms réservés ou des caractères invalides</string>
     <string name="file_name_validator_error_ends_with_space_period">Le nom se termine par un espace ou un point</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s est une extension de fichier interdite</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s est une extension de fichier interdite</string>
     <string name="file_name_validator_error_invalid_character">Le nom contient un caractère invalide : %s</string>
     <string name="file_name_validator_error_reserved_names">%s est un nom interdit</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Veuillez renommer le fichier avant de le déplacer ou de le copier</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -410,7 +410,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">En attente de la synchronisation complète…</string>
     <string name="file_name_validator_current_path_is_invalid">Le nom actuel du dossier est invalide, veuillez renommer le dossier. Redirection vers la racine</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Le chemin du dossier contient des noms réservés ou des caractères invalides</string>
-    <string name="file_name_validator_error_ends_with_space_period">Le nom se termine par un espace ou un point</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s est une extension de fichier interdite</string>
     <string name="file_name_validator_error_invalid_character">Le nom contient un caractère invalide : %s</string>
     <string name="file_name_validator_error_reserved_names">%s est un nom interdit</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Ag feitheamh ar shioncronú iomlán…</string>
     <string name="file_name_validator_current_path_is_invalid">Tá ainm an fhillteáin reatha neamhbhailí, le do thoil athainmnigh an fillteán. Atreorú chuig an fhréamh</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Tá ainmneacha forchoimeádta nó carachtar neamhbhailí i gcosán an fhillteáin</string>
-    <string name="file_name_validator_error_ends_with_space_period">Críochnaíonn an t-ainm le spás nó le peiriad</string>
     <string name="file_name_validator_error_forbidden_file_extensions">Is iarmhír toirmiscthe comhaid é %s</string>
     <string name="file_name_validator_error_invalid_character">Tá carachtar neamhbhailí san ainm: %s</string>
     <string name="file_name_validator_error_reserved_names">Is ainm toirmiscthe é %s</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">O nome actual do cartafol non é válido, cambie o nome do cartafol. Redireccionando á raíz</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">A ruta do cartafol contén nomes reservados ou caracteres non válidos</string>
     <string name="file_name_validator_error_ends_with_space_period">O nome remata cun espazo ou un punto</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s é unha extensión de ficheiro prohibida.</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s é unha extensión de ficheiro prohibida.</string>
     <string name="file_name_validator_error_invalid_character">O nome contén un carácter non válido: %s</string>
     <string name="file_name_validator_error_reserved_names">%s é un nome prohibido.</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Cambie o nome do ficheiro antes de mover ou copiar</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Agardando que rematen as sincronizacións…</string>
     <string name="file_name_validator_current_path_is_invalid">O nome actual do cartafol non é válido, cambie o nome do cartafol. Redireccionando á raíz</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">A ruta do cartafol contén nomes reservados ou caracteres non válidos</string>
-    <string name="file_name_validator_error_ends_with_space_period">O nome remata cun espazo ou un punto</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s é unha extensión de ficheiro prohibida.</string>
     <string name="file_name_validator_error_invalid_character">O nome contén un carácter non válido: %s</string>
     <string name="file_name_validator_error_reserved_names">%s é un nome prohibido.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">모든 동기화가 완료되기를 기다리는 중…</string>
     <string name="file_name_validator_current_path_is_invalid">현재 폴더 이름이 유효하지 않습니다. 폴더 이름을 변경해 주세요. 루트로 리디렉션됩니다.</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">폴더 경로에 예약된 이름 또는 잘못된 문자가 포함되어 있습니다</string>
-    <string name="file_name_validator_error_ends_with_space_period">이름이 공백이나 마침표로 끝납니다</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s은(는) 금지된 파일 확장자입니다</string>
     <string name="file_name_validator_error_invalid_character">이름에 잘못된 문자가 포함되어 있습니다: %s</string>
     <string name="file_not_found">파일을 찾을 수 없음</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">현재 폴더 이름이 유효하지 않습니다. 폴더 이름을 변경해 주세요. 루트로 리디렉션됩니다.</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">폴더 경로에 예약된 이름 또는 잘못된 문자가 포함되어 있습니다</string>
     <string name="file_name_validator_error_ends_with_space_period">이름이 공백이나 마침표로 끝납니다</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s은(는) 금지된 파일 확장자입니다</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s은(는) 금지된 파일 확장자입니다</string>
     <string name="file_name_validator_error_invalid_character">이름에 잘못된 문자가 포함되어 있습니다: %s</string>
     <string name="file_not_found">파일을 찾을 수 없음</string>
     <string name="file_not_synced">파일을 동기화할 수 없습니다. 마지막으로 불러온 버전을 표시합니다.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -412,7 +412,7 @@
     <string name="file_name_validator_current_path_is_invalid">Gjeldende mappenavn er ugyldig, vennligst gi nytt navn til mappen. Omdirigerer til rot</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Mappebanen inneholder reserverte navn eller ugyldige tegn</string>
     <string name="file_name_validator_error_ends_with_space_period">Navn slutter med et mellomrom eller et punktum</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s er en forbudt filtype</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s er en forbudt filtype</string>
     <string name="file_name_validator_error_invalid_character">Navnet inneholder et ugyldig tegn: %s</string>
     <string name="file_name_validator_error_reserved_names">%s er et forbudt navn</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Gi nytt navn til filen før du flytter eller kopierer</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -411,7 +411,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Venter på full synkronisering…</string>
     <string name="file_name_validator_current_path_is_invalid">Gjeldende mappenavn er ugyldig, vennligst gi nytt navn til mappen. Omdirigerer til rot</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Mappebanen inneholder reserverte navn eller ugyldige tegn</string>
-    <string name="file_name_validator_error_ends_with_space_period">Navn slutter med et mellomrom eller et punktum</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s er en forbudt filtype</string>
     <string name="file_name_validator_error_invalid_character">Navnet inneholder et ugyldig tegn: %s</string>
     <string name="file_name_validator_error_reserved_names">%s er et forbudt navn</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -411,7 +411,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Aguardando sincronização completa…</string>
     <string name="file_name_validator_current_path_is_invalid">O nome da pasta atual é inválido, renomeie a pasta. Redirecionando para a raiz</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">O caminho da pasta contém nomes reservados ou caracteres inválidos</string>
-    <string name="file_name_validator_error_ends_with_space_period">O nome termina com um espaço ou um ponto</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s é uma extensão de arquivo proibida</string>
     <string name="file_name_validator_error_invalid_character">O nome contém um caractere inválido:%s</string>
     <string name="file_name_validator_error_reserved_names">%s é um nome proibido</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -412,7 +412,7 @@
     <string name="file_name_validator_current_path_is_invalid">O nome da pasta atual é inválido, renomeie a pasta. Redirecionando para a raiz</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">O caminho da pasta contém nomes reservados ou caracteres inválidos</string>
     <string name="file_name_validator_error_ends_with_space_period">O nome termina com um espaço ou um ponto</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s é uma extensão de arquivo proibida</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s é uma extensão de arquivo proibida</string>
     <string name="file_name_validator_error_invalid_character">O nome contém um caractere inválido:%s</string>
     <string name="file_name_validator_error_reserved_names">%s é um nome proibido</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Renomeie o arquivo antes de mover ou copiar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -414,7 +414,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Ожидание завершения синхронизации…</string>
     <string name="file_name_validator_current_path_is_invalid">Текущее имя папки неверное, пожалуйста, переименуйте папку. Перенаправление в корень</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Путь к папке содержит зарезервированные имена или недопустимый символ</string>
-    <string name="file_name_validator_error_ends_with_space_period">Имя заканчивается пробелом или точкой</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s является запрещенным расширением файла</string>
     <string name="file_name_validator_error_invalid_character">Имя содержит недопустимый символ: %s</string>
     <string name="file_name_validator_error_reserved_names">%s это запрещенное имя</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -415,7 +415,7 @@
     <string name="file_name_validator_current_path_is_invalid">Текущее имя папки неверное, пожалуйста, переименуйте папку. Перенаправление в корень</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Путь к папке содержит зарезервированные имена или недопустимый символ</string>
     <string name="file_name_validator_error_ends_with_space_period">Имя заканчивается пробелом или точкой</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s является запрещенным расширением файла</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s является запрещенным расширением файла</string>
     <string name="file_name_validator_error_invalid_character">Имя содержит недопустимый символ: %s</string>
     <string name="file_name_validator_error_reserved_names">%s это запрещенное имя</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Пожалуйста, переименуйте файл перед перемещением или копированием</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Väntar på fullständig synkronisering…</string>
     <string name="file_name_validator_current_path_is_invalid">Aktuellt mappnamn är ogiltigt. Byt namn på mappen. Omdirigerar till root</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Mappsökvägen innehåller reserverade namn eller ogiltiga tecken</string>
-    <string name="file_name_validator_error_ends_with_space_period">Namnet slutar med ett mellanslag eller en punkt</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s är ett förbjudet filtillägg</string>
     <string name="file_name_validator_error_invalid_character">Namnet innehåller ett ogiltigt tecken: %s</string>
     <string name="file_name_validator_error_reserved_names">%s är ett förbjudet namn</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">Aktuellt mappnamn är ogiltigt. Byt namn på mappen. Omdirigerar till root</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Mappsökvägen innehåller reserverade namn eller ogiltiga tecken</string>
     <string name="file_name_validator_error_ends_with_space_period">Namnet slutar med ett mellanslag eller en punkt</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s är ett förbjudet filtillägg</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s är ett förbjudet filtillägg</string>
     <string name="file_name_validator_error_invalid_character">Namnet innehåller ett ogiltigt tecken: %s</string>
     <string name="file_name_validator_error_reserved_names">%s är ett förbjudet namn</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Byt namn på filen innan du flyttar eller kopierar</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Eşitleme işleminin tamamlanması bekleniyor …</string>
     <string name="file_name_validator_current_path_is_invalid">Geçerli klasör adı geçersiz. Lütfen klasörü yeniden adlandırın. Kök klasöre yönlendiriliyorsunuz.</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Klasör yolunda ayrılmış adlar veya geçersiz karakterler var</string>
-    <string name="file_name_validator_error_ends_with_space_period">Ad bir boşluk ya da nokta ile bitiyor</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s dosya uzantısına izin verilmiyor.</string>
     <string name="file_name_validator_error_invalid_character">Ad içinde geçersiz bir karakter var: %s</string>
     <string name="file_name_validator_error_reserved_names">%s adına izin verilmiyor</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">Geçerli klasör adı geçersiz. Lütfen klasörü yeniden adlandırın. Kök klasöre yönlendiriliyorsunuz.</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Klasör yolunda ayrılmış adlar veya geçersiz karakterler var</string>
     <string name="file_name_validator_error_ends_with_space_period">Ad bir boşluk ya da nokta ile bitiyor</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s dosya uzantısına izin verilmiyor.</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s dosya uzantısına izin verilmiyor.</string>
     <string name="file_name_validator_error_invalid_character">Ad içinde geçersiz bir karakter var: %s</string>
     <string name="file_name_validator_error_reserved_names">%s adına izin verilmiyor</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Kopyalamadan ya da taşımadan önce lütfen dosyayı yeniden adlandırın</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -407,7 +407,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">Очікування повної синхронізації…</string>
     <string name="file_name_validator_current_path_is_invalid">Перейменуйте назву поточого каталогу, оскільки його назва не є дійсною. Переспрямування до кореневого каталогу.</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Шлях до каталогу містить зарезервовані імена або недійсні символи</string>
-    <string name="file_name_validator_error_ends_with_space_period">Ім\'я закінчується на символ пробілу або крапку</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s не є дозволеним розширенням файлу</string>
     <string name="file_name_validator_error_invalid_character">Ім\'я містить недійсний символ: %s</string>
     <string name="file_name_validator_error_reserved_names">%s не є дозволеним ім\'ям</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -408,7 +408,7 @@
     <string name="file_name_validator_current_path_is_invalid">Перейменуйте назву поточого каталогу, оскільки його назва не є дійсною. Переспрямування до кореневого каталогу.</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Шлях до каталогу містить зарезервовані імена або недійсні символи</string>
     <string name="file_name_validator_error_ends_with_space_period">Ім\'я закінчується на символ пробілу або крапку</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s не є дозволеним розширенням файлу</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s не є дозволеним розширенням файлу</string>
     <string name="file_name_validator_error_invalid_character">Ім\'я містить недійсний символ: %s</string>
     <string name="file_name_validator_error_reserved_names">%s не є дозволеним ім\'ям</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Перейменуйте файл перед переміщенням або копіюванням</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">等待完整同步…</string>
     <string name="file_name_validator_current_path_is_invalid">目前資料夾名稱無效，請重新命名該資料夾。重定向到根目錄</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">資料夾途徑包含保留名稱或無效字符</string>
-    <string name="file_name_validator_error_ends_with_space_period">名稱以空格或句點結尾。</string>
     <string name="file_name_validator_error_forbidden_file_extensions">「%s」是禁止使用的副檔名。</string>
     <string name="file_name_validator_error_invalid_character">名字含有無效的字元：「%s」。</string>
     <string name="file_name_validator_error_reserved_names">「%s」是禁止使用的名字。</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">目前資料夾名稱無效，請重新命名該資料夾。重定向到根目錄</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">資料夾途徑包含保留名稱或無效字符</string>
     <string name="file_name_validator_error_ends_with_space_period">名稱以空格或句點結尾。</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">「.%s」是禁止使用的副檔名。</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">「%s」是禁止使用的副檔名。</string>
     <string name="file_name_validator_error_invalid_character">名字含有無效的字元：「%s」。</string>
     <string name="file_name_validator_error_reserved_names">「%s」是禁止使用的名字。</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s。請在移動或複製之前重新命名檔案</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -413,7 +413,6 @@
     <string name="file_migration_waiting_for_unfinished_sync">正在等待完全同步……</string>
     <string name="file_name_validator_current_path_is_invalid">目前資料夾名稱無效，請重新命名資料夾。重新導向至根目錄</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">資料夾路徑包含保留名稱或無效字元</string>
-    <string name="file_name_validator_error_ends_with_space_period">名稱以空格或句點結尾</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s 是禁止使用的副檔名</string>
     <string name="file_name_validator_error_invalid_character">名稱包含無效的字元：%s</string>
     <string name="file_name_validator_error_reserved_names">%s 是禁止的名稱</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -414,7 +414,7 @@
     <string name="file_name_validator_current_path_is_invalid">目前資料夾名稱無效，請重新命名資料夾。重新導向至根目錄</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">資料夾路徑包含保留名稱或無效字元</string>
     <string name="file_name_validator_error_ends_with_space_period">名稱以空格或句點結尾</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s 是禁止使用的副檔名</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s 是禁止使用的副檔名</string>
     <string name="file_name_validator_error_invalid_character">名稱包含無效的字元：%s</string>
     <string name="file_name_validator_error_reserved_names">%s 是禁止的名稱</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s。請在移動或複製前重新命名檔案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1241,7 +1241,7 @@
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Folder path contains reserved names or invalid character</string>
     <string name="file_name_validator_error_invalid_character">Name contains an invalid character: %s</string>
     <string name="file_name_validator_error_reserved_names">%s is a forbidden name</string>
-    <string name="file_name_validator_error_forbidden_file_extensions">.%s is a forbidden file extension</string>
+    <string name="file_name_validator_error_forbidden_file_extensions">%s is a forbidden file extension</string>
     <string name="file_name_validator_error_ends_with_space_period">Name ends with a space or a period</string>
     <string name="sync">Sync</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1242,6 +1242,5 @@
     <string name="file_name_validator_error_invalid_character">Name contains an invalid character: %s</string>
     <string name="file_name_validator_error_reserved_names">%s is a forbidden name</string>
     <string name="file_name_validator_error_forbidden_file_extensions">%s is a forbidden file extension</string>
-    <string name="file_name_validator_error_ends_with_space_period">Name ends with a space or a period</string>
     <string name="sync">Sync</string>
 </resources>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**What does this PR?**

- Allow folder creation/renaming with trailing spaces or periods if no WCF config is present.
- Enforce WCF rules (e.g., forbidden file extensions, reserved file names) when WCF configs exist.
- Improve feedback messages: remove "." from translations and use OCCapability to display forbidden file extensions, eliminating string manipulation.
- Uses lowercase for comparison in any case
- Updates tests according to correct NC versions

**Acceptance Criteria**

- For NC versions below 30, no checks are performed.
- For versions 30 and above with WCF, OC capability checks are applied.
- File emptiness and duplicate filename checks are always enforced, regardless of version or limitations.