### PR TITLE
BugFix - Loading Dialog Must Run On Main Thread 

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -543,35 +543,39 @@ public abstract class FileActivity extends DrawerActivity
     public void showLoadingDialog(String message) {
         dismissLoadingDialog();
 
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
-        if (fragment == null) {
-            Log_OC.d(TAG, "show loading dialog");
-            LoadingDialog loadingDialogFragment = LoadingDialog.newInstance(message);
-            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-            boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
-            if (isDialogFragmentReady) {
-                fragmentTransaction.add(loadingDialogFragment, DIALOG_WAIT_TAG);
-                fragmentTransaction.commitNow();
+        runOnUiThread(() -> {
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
+            if (fragment == null) {
+                Log_OC.d(TAG, "show loading dialog");
+                LoadingDialog loadingDialogFragment = LoadingDialog.newInstance(message);
+                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+                boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
+                if (isDialogFragmentReady) {
+                    fragmentTransaction.add(loadingDialogFragment, DIALOG_WAIT_TAG);
+                    fragmentTransaction.commitNow();
+                }
             }
-        }
+        });
     }
 
     /**
      * Dismiss loading dialog
      */
     public void dismissLoadingDialog() {
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
-        if (fragment != null) {
-            Log_OC.d(TAG, "dismiss loading dialog");
-            LoadingDialog loadingDialogFragment = (LoadingDialog) fragment;
-            boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
-            if (isDialogFragmentReady) {
-                loadingDialogFragment.dismiss();
-                fragmentManager.executePendingTransactions();
+        runOnUiThread(() -> {
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
+            if (fragment != null) {
+                Log_OC.d(TAG, "dismiss loading dialog");
+                LoadingDialog loadingDialogFragment = (LoadingDialog) fragment;
+                boolean isDialogFragmentReady = ActivityExtensionsKt.isDialogFragmentReady(this, loadingDialogFragment);
+                if (isDialogFragmentReady) {
+                    loadingDialogFragment.dismiss();
+                    fragmentManager.executePendingTransactions();
+                }
             }
-        }
+        });
     }
 
     private void doOnResumeAndBound() {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**How to reproduce?**

1. Have encrypted folder in app
2. Set passcode
3. Open web panel reset encryption and select delete all encrypted folder
4. Pull-to-refresh from the app

or

1. Try to create folder multiple times

This bug introduced with https://github.com/nextcloud/android/pull/13551. 

While testing the previous PR, I didn’t encounter any issues. However, when I tried to trigger the loading dialog multiple times in quick succession—such as by attempting to create new folders repeatedly—the following exception occurred.

java.lang.IllegalStateException: Must be called from main thread of fragment host at FileActivity.showLoadingDialog().
