### PR TITLE
BugFix - Use Activity When Fragment Added

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/FragmentExtensions.kt
@@ -1,0 +1,18 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import androidx.fragment.app.Fragment
+
+inline fun <reified T : Any> Fragment.typedActivity(): T? {
+    return if (isAdded && activity != null && activity is T) {
+        activity as T
+    } else {
+        null
+    }
+}

--- a/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
@@ -27,6 +27,7 @@ import com.nextcloud.client.account.CurrentAccountProvider
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.network.ConnectivityService
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.typedActivity
 import com.nextcloud.utils.fileNameValidator.FileNameValidator
 import com.owncloud.android.R
 import com.owncloud.android.databinding.EditBoxDialogBinding
@@ -185,7 +186,7 @@ class CreateFolderDialogFragment : DialogFragment(), DialogInterface.OnClickList
             val path = parentFolder?.decryptedRemotePath + newFolderName + OCFile.PATH_SEPARATOR
             lifecycleScope.launch(Dispatchers.IO) {
                 if (connectivityService.isNetworkAndServerAvailable()) {
-                    (requireActivity() as ComponentsGetter).fileOperationsHelper.createFolder(path)
+                    typedActivity<ComponentsGetter>()?.fileOperationsHelper?.createFolder(path)
                 } else {
                     Log_OC.d(TAG, "Network not available, creating offline operation")
                     fileDataStorageManager.addCreateFolderOfflineOperation(
@@ -196,8 +197,7 @@ class CreateFolderDialogFragment : DialogFragment(), DialogInterface.OnClickList
                     )
 
                     launch(Dispatchers.Main) {
-                        val fileDisplayActivity = requireActivity() as? FileDisplayActivity
-                        fileDisplayActivity?.syncAndUpdateFolder(true)
+                        (requireActivity() as? FileDisplayActivity)?.syncAndUpdateFolder(true)
                     }
                 }
             }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem?**

Fragments are not always immediately attached to an activity. Even if activity is not null, accessing it before the fragment is properly added to the activity can lead to unexpected behavior or crashes.

**Solution**

This PR ensures fragment added, activity is not null and it is expected activity.

