### PR TITLE
BugFix - NPE internalFolderSyncTimestamp & File Existence Check

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -47,13 +47,17 @@ class InternalTwoWaySyncWork(
             val folders = fileDataStorageManager.getInternalTwoWaySyncFolders(user)
 
             for (folder in folders) {
-                val freeSpaceLeft = File(folder.storagePath).getFreeSpace()
-                val localFolderSize = FileStorageUtils.getFolderSize(File(folder.storagePath, MainApp.getDataFolder()))
-                val remoteFolderSize = folder.fileLength
+                val file = File(folder.storagePath)
+                if (file.exists()) {
+                    val freeSpaceLeft = file.getFreeSpace()
+                    val localFolder = File(folder.storagePath, MainApp.getDataFolder())
+                    val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
+                    val remoteFolderSize = folder.fileLength
 
-                if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
-                    Log_OC.d(TAG, "Not enough space left!")
-                    result = false
+                    if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
+                        Log_OC.d(TAG, "Not enough space left!")
+                        return Result.failure()
+                    }
                 }
 
                 Log_OC.d(TAG, "Folder ${folder.remotePath}: started!")

--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -83,7 +83,7 @@ class InternalTwoWaySyncWork(
 
     @Suppress("TooGenericExceptionCaught")
     private fun checkFreeSpace(folder: OCFile): Result? {
-        val storagePath = folder.storagePath ?: return null
+        val storagePath = folder.storagePath ?: MainApp.getStoragePath()
         val file = File(storagePath)
 
         if (!file.exists()) return null

--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -21,7 +21,7 @@ import com.owncloud.android.operations.SynchronizeFolderOperation
 import com.owncloud.android.utils.FileStorageUtils
 import java.io.File
 
-@Suppress("Detekt.NestedBlockDepth")
+@Suppress("Detekt.NestedBlockDepth", "ReturnCount")
 class InternalTwoWaySyncWork(
     private val context: Context,
     params: WorkerParameters,
@@ -81,7 +81,7 @@ class InternalTwoWaySyncWork(
         }
     }
 
-    private fun checkFreeSpace(folder:OCFile): Result? {
+    private fun checkFreeSpace(folder: OCFile): Result? {
         folder.storagePath?.let { storagePath ->
             val file = File(storagePath)
             if (file.exists()) {

--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -84,14 +84,16 @@ class InternalTwoWaySyncWork(
     private fun checkFreeSpace(folder: OCFile): Result? {
         folder.storagePath?.let { storagePath ->
             val file = File(storagePath)
-            val freeSpaceLeft = file.getFreeSpace()
-            val localFolder = File(storagePath, MainApp.getDataFolder())
-            val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
-            val remoteFolderSize = folder.fileLength
+            if (file.exists()) {
+                val freeSpaceLeft = file.getFreeSpace()
+                val localFolder = File(storagePath, MainApp.getDataFolder())
+                val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
+                val remoteFolderSize = folder.fileLength
 
-            if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
-                Log_OC.d(TAG, "Not enough space left!")
-                return Result.failure()
+                if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
+                    Log_OC.d(TAG, "Not enough space left!")
+                    return Result.failure()
+                }
             }
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -84,16 +84,14 @@ class InternalTwoWaySyncWork(
     private fun checkFreeSpace(folder: OCFile): Result? {
         folder.storagePath?.let { storagePath ->
             val file = File(storagePath)
-            if (file.exists()) {
-                val freeSpaceLeft = file.getFreeSpace()
-                val localFolder = File(storagePath, MainApp.getDataFolder())
-                val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
-                val remoteFolderSize = folder.fileLength
+            val freeSpaceLeft = file.getFreeSpace()
+            val localFolder = File(storagePath, MainApp.getDataFolder())
+            val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
+            val remoteFolderSize = folder.fileLength
 
-                if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
-                    Log_OC.d(TAG, "Not enough space left!")
-                    return Result.failure()
-                }
+            if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
+                Log_OC.d(TAG, "Not enough space left!")
+                return Result.failure()
             }
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -81,23 +81,29 @@ class InternalTwoWaySyncWork(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun checkFreeSpace(folder: OCFile): Result? {
-        folder.storagePath?.let { storagePath ->
-            val file = File(storagePath)
-            if (file.exists()) {
-                val freeSpaceLeft = file.getFreeSpace()
-                val localFolder = File(storagePath, MainApp.getDataFolder())
-                val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
-                val remoteFolderSize = folder.fileLength
+        val storagePath = folder.storagePath ?: return null
+        val file = File(storagePath)
 
-                if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
-                    Log_OC.d(TAG, "Not enough space left!")
-                    return Result.failure()
-                }
+        if (!file.exists()) return null
+
+        return try {
+            val freeSpaceLeft = file.freeSpace
+            val localFolder = File(storagePath, MainApp.getDataFolder())
+            val localFolderSize = FileStorageUtils.getFolderSize(localFolder)
+            val remoteFolderSize = folder.fileLength
+
+            if (freeSpaceLeft < (remoteFolderSize - localFolderSize)) {
+                Log_OC.d(TAG, "Not enough space left!")
+                Result.failure()
+            } else {
+                null
             }
+        } catch (e: Exception) {
+            Log_OC.d(TAG, "Error caught at checkFreeSpace: $e")
+            null
         }
-
-        return null
     }
 
     companion object {

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1125,7 +1125,7 @@ public class FileDataStorageManager {
         ocFile.setLivePhoto(fileEntity.getMetadataLivePhoto());
         ocFile.setHidden(nullToZero(fileEntity.getHidden()) == 1);
         ocFile.setE2eCounter(fileEntity.getE2eCounter());
-        ocFile.setInternalFolderSyncTimestamp(fileEntity.getInternalTwoWaySync());
+        ocFile.setInternalFolderSyncTimestamp(nullToZero(fileEntity.getInternalTwoWaySync()));
 
         String sharees = fileEntity.getSharees();
         // Surprisingly JSON deserialization causes significant overhead.

--- a/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -1076,11 +1076,15 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
     }
 
     public boolean isInternalFolderSync() {
+        if (internalFolderSyncTimestamp == null) {
+            return false;
+        }
+
         return internalFolderSyncTimestamp >= 0;
     }
     
     public Long getInternalFolderSyncTimestamp() {
-        return internalFolderSyncTimestamp;
+        return Objects.requireNonNullElse(internalFolderSyncTimestamp, -1L);
     }
 
     public void setInternalFolderSyncTimestamp(Long internalFolderSyncTimestamp) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


**Changes**

1.  Fix the NullPointerException (NPE) for internalFolderSyncTimestamp.
2. Check for file existence in the InternalTwoWaySyncWork worker; otherwise, it will throw an exception.


---------------------------------------------------------------------------------------------------------------

During my tests, I wasn’t able to reproduce the issue; however, some users with version 3.30.0 Final have already experienced the crash. It means some OCFile already saved into the internal storage via null value.

**Potential fix could be in this PR:**

Changing following set function, but I’m not sure.

ocFile.setInternalFolderSyncTimestamp(fileEntity.getInternalTwoWaySync()); ->

ocFile.setInternalFolderSyncTimestamp(**nullToZero**(fileEntity.getInternalTwoWaySync()));

To prevent further crashes, I checked nullability of the Long object and return non-null object. Alternative solution can be we can convert the Long object to long primitive type.