### PR TITLE
Do Not Throw An Exception in SyncOperation

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/common/SyncOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/common/SyncOperation.java
@@ -46,8 +46,7 @@ public abstract class SyncOperation extends RemoteOperation {
      */
     public RemoteOperationResult execute(Context context) {
         if (storageManager.getUser().isAnonymous()) {
-            throw new IllegalArgumentException("Trying to execute a sync operation with a " +
-                                                   "storage manager for an anonymous account");
+            return new RemoteOperationResult(RemoteOperationResult.ResultCode.ACCOUNT_EXCEPTION);
         }
         return super.execute(this.storageManager.getUser(), context);
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

I returned an ACCOUNT_EXCEPTION for testing purposes, and as can be seen in the video, only the capabilities cannot be updated.

https://github.com/user-attachments/assets/b279536f-6c9e-4dd5-8a32-30f4728b345a


