### PR TITLE
Only Download Necessary Files

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -237,7 +237,7 @@ class FileDownloadWorker(
         } else {
             listOf(file)
         }.filterNot {
-            it.isDown && (MimeTypeUtil.isImageOrVideo(it) || MimeTypeUtil.isAudio(it))
+            it.isDown && MimeTypeUtil.isMedia(it.mimeType)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -37,6 +37,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCo
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.operations.DownloadFileOperation
 import com.owncloud.android.operations.DownloadType
+import com.owncloud.android.utils.MimeTypeUtil
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.security.SecureRandom
 import java.util.AbstractList
@@ -115,6 +116,11 @@ class FileDownloadWorker(
     override fun doWork(): Result {
         return try {
             val requestDownloads = getRequestDownloads()
+            if (requestDownloads.isEmpty()) {
+                Log_OC.e(TAG, "FilesDownloadWorker was canceled; no requests or downloads were found")
+                return Result.success()
+            }
+
             addAccountUpdateListener()
 
             val foregroundInfo = ForegroundServiceHelper.createWorkerForegroundInfo(
@@ -230,6 +236,8 @@ class FileDownloadWorker(
             fileDataStorageManager?.getAllFilesRecursivelyInsideFolder(file) ?: listOf()
         } else {
             listOf(file)
+        }.filterNot {
+            it.isDown && (MimeTypeUtil.isImageOrVideo(it) || MimeTypeUtil.isAudio(it))
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem**

Downloaded files are re-downloading, and notifications appear for files that have already been downloaded. The sync should only trigger downloads for new or editable files, as media files cannot be changed. 

The two-way sync triggers the FileDownloadWorker every 15 minutes. If a folder contains multiple files, even if all files are already downloaded, the worker will still show notifications for each file and attempt to re-download them again.

**Note:** Images can be edited, but any edited image will create a copy rather than modifying the original file. Thus, no need to download original image.

**Changes**

- Download only files that haven't been downloaded and aren't media files.
- Return early if requestDownloads is empty.


**Demo**

https://github.com/user-attachments/assets/88505d08-654b-4a4b-821c-0c622970dec8

