### PR TITLE
Fix Crashes When Opening File Details from Media and Other Tabs

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -351,11 +351,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             }
         });
 
-        binding.tabLayout.post(() -> {
-            TabLayout.Tab tab1 = binding.tabLayout.getTabAt(activeTab);
-            if (tab1 == null) return;
-            tab1.select();
-        });
+        // FIXME file detail not opening from Media tab
+        if (binding != null) {
+            TabLayout.Tab tab = binding.tabLayout.getTabAt(activeTab);
+            if (tab == null) return;
+            binding.tabLayout.selectTab(tab);
+        }
     }
 
     @Override
@@ -580,8 +581,9 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         }
 
         setupViewPager();
-
-        getView().invalidate();
+        if (getView() != null) {
+            getView().invalidate();
+        }
     }
 
     private void setFileModificationTimestamp(OCFile file, boolean showDetailedTimestamp) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**How to reproduce?**

Open an image from the Media tab and attempt to navigate to the file details.

**Known Issues:**

File details do not open from the Media tab; the same issue exists on the master branch.

**Changes:**

Fixed crashes when the user tries to open file details from other tabs and the Media tab.
