### PR TITLE
Added application certificate fingerprint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ height="80">](https://f-droid.org/packages/com.nextcloud.client/)
 
 ![App screenshots](/doc/Nextcloud_Android_Screenshots.png "App screenshots")
 
+Signing certificate fingerprint to [verify](https://developer.android.com/studio/command-line/apksigner#usage-verify) the APK:
+```
+SHA-256: fb009522f65e25802261b67b10a45fd70e610031976f40b28a649e152ded0373   
+```
+
 ## Getting help :rescue\_worker\_helmet:
 
 Note: The section *Known Problems / FAQs* below may already document your situation.


### PR DESCRIPTION
Add the app certificate fingerprint to the README file, enabling apps and users to check the integrity of apk installed from github.

The main purpose is to enable subsequent verification of the app through [AppVerifier](https://github.com/soupslurpr/AppVerifier), including adding the fingerprint to its internal database.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
