### PR TITLE
Added SHA256 & SHA1 application certificate fingerprints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ height="80">](https://play.google.com/store/apps/details?id=com.nextcloud.client
 alt="Get it on F-Droid"
 height="80">](https://f-droid.org/packages/com.nextcloud.client/)
 
+Signing certificate fingerprint to [verify](https://developer.android.com/studio/command-line/apksigner#usage-verify) the APK:
+```
+SHA-256: fb009522f65e25802261b67b10a45fd70e610031976f40b28a649e152ded0373   
+```
+
 **The Android client for [Nextcloud](https://nextcloud.com). Easily work with your data on your Nextcloud.**
 
 ![App screenshots](/doc/Nextcloud_Android_Screenshots.png "App screenshots")

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ height="80">](https://f-droid.org/packages/com.nextcloud.client/)
 Signing certificate fingerprint to [verify](https://developer.android.com/studio/command-line/apksigner#usage-verify) the APK:
 ```
 SHA-256: fb009522f65e25802261b67b10a45fd70e610031976f40b28a649e152ded0373   
+SHA-1: adc205b0487e68e221cc4b511083aa78ffadc751
 ```
 
 **The Android client for [Nextcloud](https://nextcloud.com). Easily work with your data on your Nextcloud.**


### PR DESCRIPTION
Add the app certificate fingerprint to the README file, enabling apps and users to check the integrity of apk installed from github.

The main purpose is to enable subsequent verification of the app through [AppVerifier](https://github.com/soupslurpr/AppVerifier), including adding the fingerprint to its internal database.

- [x] Tests written, or not not needed
