### PR TITLE
BugFix - Unnecessary Sync

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -129,7 +130,6 @@ public class SynchronizeFolderOperation extends SyncOperation {
             if (result.isSuccess()) {
                 if (mRemoteFolderChanged) {
                     result = fetchAndSyncRemoteFolder(client);
-
                 } else {
                     prepareOpsFromLocalKnowledge();
                 }
@@ -419,7 +419,6 @@ public class SynchronizeFolderOperation extends SyncOperation {
             if (!child.isFolder()) {
                 if (!child.isDown()) {
                     mFilesForDirectDownload.add(child);
-
                 } else {
                     /// this should result in direct upload of files that were locally modified
                     SynchronizeFileOperation operation = new SynchronizeFileOperation(
@@ -431,7 +430,6 @@ public class SynchronizeFolderOperation extends SyncOperation {
                         getStorageManager()
                     );
                     mFilesToSyncContents.add(operation);
-
                 }
             }
         }
@@ -442,9 +440,8 @@ public class SynchronizeFolderOperation extends SyncOperation {
         startContentSynchronizations(mFilesToSyncContents);
     }
 
-
     private void startDirectDownloads() {
-        FileDownloadHelper.Companion.instance().downloadFile(user, mLocalFolder);
+        mFilesForDirectDownload.forEach(file -> FileDownloadHelper.Companion.instance().downloadFile(user, file));
     }
 
     /**


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

This regression occurred during the[ conversion from service to worker.](https://github.com/nextcloud/android/commit/3b2824e80e8febff9370a5b906204b51c4831472) Previously, while using the service, [we triggered FileDownloader in a loop](https://github.com/nextcloud/android/blob/54c6d519ff9ac02aced1dd6eb2188c9642ab4c93/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java#L448) for mFilesForDirectDownload. Now, [since FileDownloadWorker supports both folder and file sync](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt#L225), we can directly use the mFilesForDirectDownload list with the worker.

**How to Test?**

1. Sync Folder
2. Only necessary files will be synchronized
