### PR TITLE
Fix: Launching LauncherActivity & FirstRunActivity properly

### DIFF
--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2023 TSI-mc
+ * SPDX-FileCopyrightText: 2023-2024 TSI-mc <surinder.kumar@t-systems.com>
  * SPDX-FileCopyrightText: 2019 Chris Narkiewicz <hello@ezaquarii.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
@@ -19,8 +19,10 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
+import com.nextcloud.client.onboarding.FirstRunActivity;
 import com.nextcloud.common.NextcloudClient;
 import com.nextcloud.utils.extensions.AccountExtensionsKt;
+import com.nmc.android.ui.LauncherActivity;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AuthenticatorActivity;
@@ -397,6 +399,10 @@ public class UserAccountManagerImpl implements UserAccountManager {
 
     @Override
     public void startAccountCreation(final Activity activity) {
+
+        // skipping AuthenticatorActivity redirection when user is on Launcher or FirstRun Activity
+        if (activity instanceof LauncherActivity || activity instanceof FirstRunActivity) return;
+
         Intent intent = new Intent(context, AuthenticatorActivity.class);
 
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/com/nextcloud/client/onboarding/OnboardingServiceImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/onboarding/OnboardingServiceImpl.kt
@@ -2,6 +2,7 @@
  * Nextcloud - Android Client
  *
  * SPDX-FileCopyrightText: 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * SPDX-FileCopyrightText: 2024 TSI-mc <surinder.kumar@t-systems.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.nextcloud.client.onboarding
@@ -42,7 +43,7 @@ internal class OnboardingServiceImpl constructor(
 
     override val isFirstRun: Boolean
         get() {
-            return accountProvider.currentAccount == null
+            return accountProvider.user.isAnonymous
         }
 
     override fun shouldShowWhatsNew(callingContext: Context): Boolean {

--- a/app/src/main/java/com/nmc/android/ui/LauncherActivity.kt
+++ b/app/src/main/java/com/nmc/android/ui/LauncherActivity.kt
@@ -3,7 +3,7 @@
  *
  * SPDX-FileCopyrightText: 2023 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-FileCopyrightText: 2023 Andy Scherzinger <info@andy-scherzinger.de>
- * SPDX-FileCopyrightText: 2023 TSI-mc
+ * SPDX-FileCopyrightText: 2023-2024 TSI-mc <surinder.kumar@t-systems.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.nmc.android.ui
@@ -18,6 +18,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.nextcloud.client.preferences.AppPreferences
 import com.owncloud.android.R
+import com.owncloud.android.authentication.AuthenticatorActivity
 import com.owncloud.android.databinding.ActivitySplashBinding
 import com.owncloud.android.ui.activity.BaseActivity
 import com.owncloud.android.ui.activity.FileDisplayActivity
@@ -65,6 +66,8 @@ class LauncherActivity : BaseActivity() {
         Handler(Looper.getMainLooper()).postDelayed({
             if (user.isPresent) {
                 startActivity(Intent(this, FileDisplayActivity::class.java))
+            } else {
+                startActivity(Intent(this, AuthenticatorActivity::class.java))
             }
             finish()
         }, SPLASH_DURATION)

--- a/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2023 TSI-mc
+ * SPDX-FileCopyrightText: 2023-2024 TSI-mc <surinder.kumar@t-systems.com>
  * SPDX-FileCopyrightText: 2019-2021 Tobias Kaminsky <tobias@kaminsky.me>
  * SPDX-FileCopyrightText: 2018 Andy Scherzinger <info@andy-scherzinger>
  * SPDX-FileCopyrightText: 2017 Mario Danic <mario@lovelyhq.com>
@@ -1364,14 +1364,13 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     }
 
     private void endSuccess() {
-        if (onlyAdd) {
-            finish();
-        } else {
+        if (!onlyAdd) {
             Intent i = new Intent(this, FileDisplayActivity.class);
             i.setAction(FileDisplayActivity.RESTART);
             i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(i);
         }
+        finish();
     }
 
     private void getUserCapabilitiesAndFinish() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -2,6 +2,7 @@
  * Nextcloud - Android Client
  *
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2024 TSI-mc <surinder.kumar@t-systems.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.owncloud.android.ui.activity;
@@ -115,7 +116,9 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     protected void onRestart() {
         Log_OC.v(TAG, "onRestart() start");
         super.onRestart();
-        mixinRegistry.onRestart();
+        if (enableAccountHandling) {
+            mixinRegistry.onRestart();
+        }
     }
 
     private void onThemeSettingsModeChanged() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -328,7 +328,7 @@ public class SettingsActivity extends PreferenceActivity
         viewThemeUtils.files.themePreferenceCategory(preferenceCategorySync);
 
         setupAutoUploadPreference(preferenceCategorySync);
-        setupInternalTwoWaySyncPreference(preferenceCategorySync);
+        setupInternalTwoWaySyncPreference();
     }
 
     private void setupMoreCategory() {
@@ -567,7 +567,7 @@ public class SettingsActivity extends PreferenceActivity
         }
     }
 
-    private void setupInternalTwoWaySyncPreference(PreferenceCategory preferenceCategorySync) {
+    private void setupInternalTwoWaySyncPreference() {
         Preference twoWaySync = findPreference("internal_two_way_sync");
 
         twoWaySync.setOnPreferenceClickListener(preference -> {

--- a/app/src/test/java/com/nextcloud/client/onboarding/OnboardingServiceTest.kt
+++ b/app/src/test/java/com/nextcloud/client/onboarding/OnboardingServiceTest.kt
@@ -2,13 +2,15 @@
  * Nextcloud - Android Client
  *
  * SPDX-FileCopyrightText: 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * SPDX-FileCopyrightText: 2024 TSI-mc <surinder.kumar@t-systems.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.nextcloud.client.onboarding
 
-import android.accounts.Account
 import android.content.res.Resources
+import com.nextcloud.client.account.AnonymousUser
 import com.nextcloud.client.account.CurrentAccountProvider
+import com.nextcloud.client.account.User
 import com.nextcloud.client.preferences.AppPreferences
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -30,7 +32,7 @@ class OnboardingServiceTest {
     private lateinit var currentAccountProvider: CurrentAccountProvider
 
     @Mock
-    private lateinit var account: Account
+    private lateinit var user: User
 
     private lateinit var onboardingService: OnboardingServiceImpl
 
@@ -43,13 +45,16 @@ class OnboardingServiceTest {
     @Test
     fun `first run flag toggles with current current account`() {
         // GIVEN
-        //      current account is not set
+        //      current account is anonymous
+        whenever(currentAccountProvider.user).thenReturn(AnonymousUser("dummy"))
+
+        // THEN
         //      first run flag is true
         assertTrue(onboardingService.isFirstRun)
 
         // WHEN
         //      current account is set
-        whenever(currentAccountProvider.currentAccount).thenReturn(account)
+        whenever(currentAccountProvider.user).thenReturn(user)
 
         // THEN
         //      first run flag toggles


### PR DESCRIPTION
This PR contains the following fixes:
1. Launching Launcher & FirstRun Activity Properly: https://github.com/nextcloud/android/issues/12652
2. Account login screen opens again on back press: https://github.com/nextcloud/android/issues/12652
3. Locking & Unlocking phone in FirstRunActivity redirects to AuthenticatorActivity: https://github.com/nextcloud/android/issues/4993

**Previous Behaviour:**
1. User is not logged In.
4. App launches and directly redirects to AuthenticatorActivity without showing Launcher and FirstRun Activity.
5. On doing successful authentication when user presses back button then AuthenticatorActivity shows again. (This happens only for First login but while adding account this works fine)

**Modified Behaviour:**
1. User is not logged In.
2. App launches and firstly shows LauncherActivity and then redirects to FirstRunActivity.
3. Now, from FirstRunActivity clicking on Login it opens AuthenticatorActivity and once user is authenticated, pressing back finishes the app instead of showing AuthenticatorActivity again.

**Changes Explained:**

-  Starting any Activity checks for User and startAccountCreation() if user not found. This bypass showing Launcher and FirstRun Activity.

To avoid this I have added check for both Activities and skipping redirection to AuthenticatorActivity in **UserAccountManagerImpl** class.
```
public void startAccountCreation(final Activity activity) {
        // skipping AuthenticatorActivity redirection when user is on Launcher or FirstRun Activity
        if (activity instanceof LauncherActivity || activity instanceof FirstRunActivity) return;

        Intent intent = new Intent(context, AuthenticatorActivity.class);

        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
        context.startActivity(intent);
    }
```

- Making the above change will directly finishes the app as AuthenticatorActivity doesn't shows from LauncherActivity.

To fix this I have added AuthenticatorActivity Intent in **LauncherActivity** if user is not present.
```
private fun scheduleSplashScreen() {
        Handler(Looper.getMainLooper()).postDelayed({
            if (user.isPresent) {
                startActivity(Intent(this, FileDisplayActivity::class.java))
            } else {
                startActivity(Intent(this, AuthenticatorActivity::class.java))
            }
            finish()
        }, SPLASH_DURATION)
    }
```

- To show the FirstRunActivity, under **OnboardingServiceImpl** -> isFirstRun flag which checks currentAccount as shown below always returns false as for no user we are returning **Anonymous** account.

```
override val isFirstRun: Boolean
        get() {
            return accountProvider.currentAccount == null
        }
```
To fix this I have updated the logic as below:
``` 
override val isFirstRun: Boolean
        get() {
            return accountProvider.user.isAnonymous
        }
```

- When user is on FirstRunActivity and locks his phone then unlocks , it redirected to AuthenticatorActivity (mentioned here: https://github.com/nextcloud/android/issues/4993). To avoid this we have add a check in **BaseActivity** for onRestart method. 

```
@Override
    protected void onRestart() {
        Log_OC.v(TAG, "onRestart() start");
        super.onRestart();
        if (enableAccountHandling) {
            mixinRegistry.onRestart();
        }
    }
```

- Finally, to finish the **AuthenticatorActivity** after successful login at first time (Refer: https://github.com/nextcloud/android/issues/12652). I have updated logic as below:

```
private void endSuccess() {
        if (!onlyAdd) {
            Intent i = new Intent(this, FileDisplayActivity.class);
            i.setAction(FileDisplayActivity.RESTART);
            i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
            startActivity(i);
        }
        finish();
    }
```

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
