### PR TITLE
Add disable all button to InternalTwoWaySyncActivity menu

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -130,6 +130,11 @@ interface BackgroundJobManager {
         changedFiles: Array<String> = arrayOf<String>()
     )
 
+    /**
+     * Cancel two-way sync. Existing tasks might finish, but no new invocations will occur.
+     */
+    fun cancelTwoWaySyncJob(user: User)
+
     fun scheduleOfflineSync()
 
     fun scheduleMediaFoldersDetectionJob()

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -503,6 +503,10 @@ internal class BackgroundJobManagerImpl(
         )
     }
 
+    override fun cancelTwoWaySyncJob(user: User) {
+        workManager.cancelJob(JOB_INTERNAL_TWO_WAY_SYNC, user)
+    }
+
     override fun scheduleOfflineSync() {
         val constrains = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.UNMETERED)

--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -29,6 +29,8 @@ class InternalTwoWaySyncWork(
     private val powerManagementService: PowerManagementService,
     private val connectivityService: ConnectivityService
 ) : Worker(context, params) {
+    private var shouldRun = true
+
     override fun doWork(): Result {
         Log_OC.d(TAG, "Worker started!")
 
@@ -50,6 +52,11 @@ class InternalTwoWaySyncWork(
             val folders = fileDataStorageManager.getInternalTwoWaySyncFolders(user)
 
             for (folder in folders) {
+                if (!shouldRun) {
+                    Log_OC.d(TAG, "Worker was stopped!")
+                    return Result.failure()
+                }
+
                 checkFreeSpace(folder)?.let { checkFreeSpaceResult ->
                     return checkFreeSpaceResult
                 }
@@ -88,6 +95,12 @@ class InternalTwoWaySyncWork(
             Log_OC.d(TAG, "Worker finished with failure!")
             Result.failure()
         }
+    }
+
+    override fun onStopped() {
+        Log_OC.d(TAG, "OnStopped of worker called!")
+        shouldRun = false
+        super.onStopped()
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
@@ -8,13 +8,24 @@
 package com.owncloud.android.ui.activity
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.nextcloud.client.di.Injectable
+import com.owncloud.android.R
 import com.owncloud.android.databinding.InternalTwoWaySyncLayoutBinding
 import com.owncloud.android.ui.adapter.InternalTwoWaySyncAdapter
+import com.owncloud.android.utils.theme.ViewThemeUtils
+import javax.inject.Inject
 
-class InternalTwoWaySyncActivity : BaseActivity(), Injectable {
+class InternalTwoWaySyncActivity : DrawerActivity(), Injectable {
     lateinit var binding: InternalTwoWaySyncLayoutBinding
+
+    @Inject
+    lateinit var viewThemeUtils: ViewThemeUtils
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,8 +34,53 @@ class InternalTwoWaySyncActivity : BaseActivity(), Injectable {
         setContentView(binding.root)
 
         binding.list.apply {
-            adapter = InternalTwoWaySyncAdapter(fileDataStorageManager, user.get(), context)
+            setEmptyView(binding.emptyList.emptyListView)
+
+            binding.emptyList.emptyListViewHeadline.apply {
+                visibility = View.VISIBLE
+                setText(R.string.internal_two_way_sync_list_empty_headline)
+            }
+            binding.emptyList.emptyListViewText.apply {
+                visibility = View.VISIBLE
+                setText(R.string.internal_two_way_sync_text)
+            }
+            binding.emptyList.emptyListIcon.apply {
+                visibility = View.VISIBLE
+                setImageDrawable(
+                    viewThemeUtils.platform.tintPrimaryDrawable(
+                        context,
+                        R.drawable.ic_sync
+                    )
+                )
+            }
+
+            adapter = InternalTwoWaySyncAdapter(fileDataStorageManager, user.get(), context).apply {
+                notifyDataSetChanged()
+            }
             layoutManager = LinearLayoutManager(context)
         }
+
+        setupToolbar()
+        updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_synced_folders))
+        if (supportActionBar != null) {
+            supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+        }
+
+        addMenuProvider(
+            object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    return when (menuItem.itemId) {
+                        android.R.id.home -> {
+                            onBackPressed()
+                            true
+                        }
+                        else -> false
+                    }
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
@@ -96,6 +96,9 @@ class InternalTwoWaySyncActivity : DrawerActivity(), Injectable {
      */
     private fun removeAllFolders() {
         CoroutineScope(Dispatchers.Main).launch {
+            // cancel main worker
+            backgroundJobManager.cancelTwoWaySyncJob(user.get())
+
             val folders = fileDataStorageManager.getInternalTwoWaySyncFolders(user.get())
             folders.forEach { folder ->
                 // update database to ignore folder

--- a/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
@@ -15,6 +15,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.di.Injectable
 import com.owncloud.android.R
 import com.owncloud.android.databinding.InternalTwoWaySyncLayoutBinding
@@ -23,52 +24,65 @@ import com.owncloud.android.ui.adapter.InternalTwoWaySyncAdapter
 class InternalTwoWaySyncActivity : DrawerActivity(), Injectable {
     lateinit var binding: InternalTwoWaySyncLayoutBinding
 
-    @SuppressLint("NotifyDataSetChanged")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = InternalTwoWaySyncLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.run {
-            list.run {
-                setEmptyView(binding.emptyList.emptyListView)
-
-                emptyList.run {
-                    emptyListViewHeadline.apply {
-                        visibility = View.VISIBLE
-                        setText(R.string.internal_two_way_sync_list_empty_headline)
-                    }
-                    emptyList.emptyListViewText.apply {
-                        visibility = View.VISIBLE
-                        setText(R.string.internal_two_way_sync_text)
-                    }
-                    emptyList.emptyListIcon.apply {
-                        visibility = View.VISIBLE
-                        setImageDrawable(
-                            viewThemeUtils.platform.tintPrimaryDrawable(
-                                context,
-                                R.drawable.ic_sync
-                            )
-                        )
-                    }
-                }
-
-                adapter = InternalTwoWaySyncAdapter(fileDataStorageManager, user.get(), context).apply {
-                    notifyDataSetChanged()
-                }
-                layoutManager = LinearLayoutManager(context)
-            }
-        }
-
         setupToolbar()
+        setupActionBar()
+        setupMenuProvider()
+        setupTwoWaySyncAdapter()
+        setupEmptyList()
+    }
+
+    private fun setupActionBar() {
         updateActionBarTitleAndHomeButtonByString(getString(R.string.internal_two_way_sync_headline))
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
 
+    @SuppressLint("NotifyDataSetChanged")
+    private fun setupTwoWaySyncAdapter() {
+        binding.run {
+            list.run {
+                setEmptyView(emptyList.emptyListView)
+                adapter = InternalTwoWaySyncAdapter(fileDataStorageManager, user.get(), this@InternalTwoWaySyncActivity)
+                layoutManager = LinearLayoutManager(this@InternalTwoWaySyncActivity)
+                adapter?.notifyDataSetChanged()
+            }
+        }
+    }
+
+    private fun setupEmptyList() {
+        binding.emptyList.run {
+            emptyListViewHeadline.run {
+                visibility = View.VISIBLE
+                setText(R.string.internal_two_way_sync_list_empty_headline)
+            }
+
+            emptyListViewText.run {
+                visibility = View.VISIBLE
+                setText(R.string.internal_two_way_sync_text)
+            }
+
+            emptyListIcon.run {
+                visibility = View.VISIBLE
+                setImageDrawable(
+                    viewThemeUtils.platform.tintDrawable(
+                        context,
+                        R.drawable.ic_sync,
+                        ColorRole.PRIMARY
+                    )
+                )
+            }
+        }
+    }
+
+    private fun setupMenuProvider() {
         addMenuProvider(
             object : MenuProvider {
-                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                }
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) = Unit
 
                 override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
                     return when (menuItem.itemId) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.jobs.BackgroundJobManager
+import com.nextcloud.client.jobs.download.FileDownloadWorker
 import com.owncloud.android.R
 import com.owncloud.android.databinding.InternalTwoWaySyncLayoutBinding
 import com.owncloud.android.ui.adapter.InternalTwoWaySyncAdapter
@@ -101,6 +102,10 @@ class InternalTwoWaySyncActivity : DrawerActivity(), Injectable {
 
             val folders = fileDataStorageManager.getInternalTwoWaySyncFolders(user.get())
             folders.forEach { folder ->
+                // cancel download operation
+                FileDownloadWorker.cancelOperation(user.get().accountName, folder.fileId)
+                backgroundJobManager.cancelFilesDownloadJob(user.get(), folder.fileId)
+
                 // update database to ignore folder
                 folder.internalFolderSyncTimestamp = -1L
                 fileDataStorageManager.saveFile(folder)

--- a/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/InternalTwoWaySyncActivity.kt
@@ -7,6 +7,7 @@
 
 package com.owncloud.android.ui.activity
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -18,53 +19,51 @@ import com.nextcloud.client.di.Injectable
 import com.owncloud.android.R
 import com.owncloud.android.databinding.InternalTwoWaySyncLayoutBinding
 import com.owncloud.android.ui.adapter.InternalTwoWaySyncAdapter
-import com.owncloud.android.utils.theme.ViewThemeUtils
-import javax.inject.Inject
 
 class InternalTwoWaySyncActivity : DrawerActivity(), Injectable {
     lateinit var binding: InternalTwoWaySyncLayoutBinding
 
-    @Inject
-    lateinit var viewThemeUtils: ViewThemeUtils
-
+    @SuppressLint("NotifyDataSetChanged")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = InternalTwoWaySyncLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.list.apply {
-            setEmptyView(binding.emptyList.emptyListView)
+        binding.run {
+            list.run {
+                setEmptyView(binding.emptyList.emptyListView)
 
-            binding.emptyList.emptyListViewHeadline.apply {
-                visibility = View.VISIBLE
-                setText(R.string.internal_two_way_sync_list_empty_headline)
-            }
-            binding.emptyList.emptyListViewText.apply {
-                visibility = View.VISIBLE
-                setText(R.string.internal_two_way_sync_text)
-            }
-            binding.emptyList.emptyListIcon.apply {
-                visibility = View.VISIBLE
-                setImageDrawable(
-                    viewThemeUtils.platform.tintPrimaryDrawable(
-                        context,
-                        R.drawable.ic_sync
-                    )
-                )
-            }
+                emptyList.run {
+                    emptyListViewHeadline.apply {
+                        visibility = View.VISIBLE
+                        setText(R.string.internal_two_way_sync_list_empty_headline)
+                    }
+                    emptyList.emptyListViewText.apply {
+                        visibility = View.VISIBLE
+                        setText(R.string.internal_two_way_sync_text)
+                    }
+                    emptyList.emptyListIcon.apply {
+                        visibility = View.VISIBLE
+                        setImageDrawable(
+                            viewThemeUtils.platform.tintPrimaryDrawable(
+                                context,
+                                R.drawable.ic_sync
+                            )
+                        )
+                    }
+                }
 
-            adapter = InternalTwoWaySyncAdapter(fileDataStorageManager, user.get(), context).apply {
-                notifyDataSetChanged()
+                adapter = InternalTwoWaySyncAdapter(fileDataStorageManager, user.get(), context).apply {
+                    notifyDataSetChanged()
+                }
+                layoutManager = LinearLayoutManager(context)
             }
-            layoutManager = LinearLayoutManager(context)
         }
 
         setupToolbar()
-        updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_synced_folders))
-        if (supportActionBar != null) {
-            supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-        }
+        updateActionBarTitleAndHomeButtonByString(getString(R.string.internal_two_way_sync_headline))
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         addMenuProvider(
             object : MenuProvider {
@@ -77,6 +76,7 @@ class InternalTwoWaySyncActivity : DrawerActivity(), Injectable {
                             onBackPressed()
                             true
                         }
+
                         else -> false
                     }
                 }

--- a/app/src/main/res/layout/internal_two_way_sync_layout.xml
+++ b/app/src/main/res/layout/internal_two_way_sync_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Nextcloud - Android Client
   ~
   ~ SPDX-FileCopyrightText: 2024 Tobias Kaminsky <tobias@kaminsky.me>

--- a/app/src/main/res/layout/internal_two_way_sync_layout.xml
+++ b/app/src/main/res/layout/internal_two_way_sync_layout.xml
@@ -1,18 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Nextcloud - Android Client
   ~
   ~ SPDX-FileCopyrightText: 2024 Tobias Kaminsky <tobias@kaminsky.me>
   ~ SPDX-License-Identifier: AGPL-3.0-or-later
   -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:openDrawer="start">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/list"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical" />
+        android:layout_height="match_parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <include layout="@layout/toolbar_standard" />
+
+        <com.owncloud.android.ui.EmptyRecyclerView
+            android:id="@+id/list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical" />
+
+        <include
+            android:id="@+id/empty_list"
+            layout="@layout/empty_list" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/internal_two_way_sync_layout.xml
+++ b/app/src/main/res/layout/internal_two_way_sync_layout.xml
@@ -12,7 +12,8 @@
     android:fitsSystemWindows="true"
     tools:openDrawer="start">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -28,5 +29,5 @@
             android:id="@+id/empty_list"
             layout="@layout/empty_list" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/menu/activity_internal_two_way_sync.xml
+++ b/app/src/main/res/menu/activity_internal_two_way_sync.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Nextcloud - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2024 ZetaTom
+  ~ SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_dismiss_two_way_sync"
+        android:contentDescription="@string/action_dismiss_two_way_sync"
+        android:orderInCategory="1"
+        android:title="@string/action_dismiss_two_way_sync"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1250,4 +1250,5 @@
     <string name="unset_internal_two_way_sync_description">Remove folder from internal two way sync</string>
     <string name="internal_two_way_sync_list_empty_headline">No two way sync folder yet</string>
     <string name="internal_two_way_sync_text">To setup a two way sync folder, please enable it in details of desired folder.</string>
+    <string name="internal_two_way_sync_headline">Internal two way sync</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1248,7 +1248,7 @@
     <string name="please_select_a_server">Please select a server…</string>
     <string name="notification_icon_description">Unread notifications exist</string>
     <string name="unset_internal_two_way_sync_description">Remove folder from internal two way sync</string>
-    <string name="internal_two_way_sync_list_empty_headline">No two way sync folder yet</string>
+    <string name="internal_two_way_sync_list_empty_headline">Two way sync not set up</string>
     <string name="internal_two_way_sync_text">To set up a two way sync folder, please enable it in the details tab of the folder in question.</string>
     <string name="internal_two_way_sync_headline">Internal two way sync</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1249,6 +1249,6 @@
     <string name="notification_icon_description">Unread notifications exist</string>
     <string name="unset_internal_two_way_sync_description">Remove folder from internal two way sync</string>
     <string name="internal_two_way_sync_list_empty_headline">No two way sync folder yet</string>
-    <string name="internal_two_way_sync_text">To setup a two way sync folder, please enable it in details of desired folder.</string>
+    <string name="internal_two_way_sync_text">To set up a two way sync folder, please enable it in the details tab of the folder in question.</string>
     <string name="internal_two_way_sync_headline">Internal two way sync</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1248,4 +1248,6 @@
     <string name="please_select_a_server">Please select a server…</string>
     <string name="notification_icon_description">Unread notifications exist</string>
     <string name="unset_internal_two_way_sync_description">Remove folder from internal two way sync</string>
+    <string name="internal_two_way_sync_list_empty_headline">No two way sync folder yet</string>
+    <string name="internal_two_way_sync_text">To setup a two way sync folder, please enable it in details of desired folder.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1251,4 +1251,5 @@
     <string name="internal_two_way_sync_list_empty_headline">Two way sync not set up</string>
     <string name="internal_two_way_sync_text">To set up a two way sync folder, please enable it in the details tab of the folder in question.</string>
     <string name="internal_two_way_sync_headline">Internal two way sync</string>
+    <string name="action_dismiss_two_way_sync">Disable all folders</string>
 </resources>


### PR DESCRIPTION
This change adds a button to disable two-way synchronisation for all folders. It also stops the two-way sync worker and already enqueued download workers. The latter is necessary, because the two-way sync worker will only check for changes and hand off the actual download to a separate worker, which will continue to run even when the two-way sync worker is no longer running.

The button is located in the overflow menu of the two-way sync settings activity.

### Testing
Start with a fresh install of the Nextcloud app. No folders should be scheduled for two-way sync (Settings → Internal two way sync). To schedule all folders for two-way sync, set a break point on line 41 in `InternalTwoWaySyncActivity.kt`, start the debugger and activity. Once the breakpoint is hit, evaluate the following code snippet:

```kt
fileDataStorageManager.getFolderContent(fileDataStorageManager.getFileById(1), false).forEach { it.internalFolderSyncTimestamp = 0; fileDataStorageManager.saveFile(it) }
```

Once this has finished, resume and relaunch the activity. All sub-directories of the root folder should be scheduled for two-way sync. To disable two-way sync for all folders, tap *Disable all folders* in the overflow menu. After a short time all folders should disappear.

Depends on #13494

---

- [ ] Tests written, or not not needed
