### PR TITLE
Don't Check or Create Singleton FileDownloadHelper Instance Inside Loops

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/FilesExportWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesExportWork.kt
@@ -57,6 +57,9 @@ class FilesExportWork(
     }
 
     private fun exportFiles(fileIDs: LongArray): Int {
+        val fileDownloadHelper = FileDownloadHelper.instance()
+        val fileExportUtil = FileExportUtils()
+
         var successfulExports = 0
         fileIDs
             .asSequence()
@@ -70,37 +73,28 @@ class FilesExportWork(
 
                 if (ocFile.isDown) {
                     try {
-                        exportFile(ocFile)
+                        fileExportUtil.exportFile(
+                            ocFile.fileName,
+                            ocFile.mimeType,
+                            contentResolver,
+                            ocFile,
+                            null
+                        )
                     } catch (e: IllegalStateException) {
                         Log_OC.e(TAG, "Error exporting file", e)
                         showErrorNotification(successfulExports)
                     }
                 } else {
-                    downloadFile(ocFile)
+                    fileDownloadHelper.downloadFile(
+                        user,
+                        ocFile,
+                        downloadType = DownloadType.EXPORT
+                    )
                 }
 
                 successfulExports++
             }
         return successfulExports
-    }
-
-    @Throws(IllegalStateException::class)
-    private fun exportFile(ocFile: OCFile) {
-        FileExportUtils().exportFile(
-            ocFile.fileName,
-            ocFile.mimeType,
-            contentResolver,
-            ocFile,
-            null
-        )
-    }
-
-    private fun downloadFile(ocFile: OCFile) {
-        FileDownloadHelper.instance().downloadFile(
-            user,
-            ocFile,
-            downloadType = DownloadType.EXPORT
-        )
     }
 
     private fun showErrorNotification(successfulExports: Int) {

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesExportWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesExportWork.kt
@@ -58,7 +58,6 @@ class FilesExportWork(
 
     private fun exportFiles(fileIDs: LongArray): Int {
         val fileDownloadHelper = FileDownloadHelper.instance()
-        val fileExportUtil = FileExportUtils()
 
         var successfulExports = 0
         fileIDs
@@ -73,13 +72,7 @@ class FilesExportWork(
 
                 if (ocFile.isDown) {
                     try {
-                        fileExportUtil.exportFile(
-                            ocFile.fileName,
-                            ocFile.mimeType,
-                            contentResolver,
-                            ocFile,
-                            null
-                        )
+                        exportFile(ocFile)
                     } catch (e: IllegalStateException) {
                         Log_OC.e(TAG, "Error exporting file", e)
                         showErrorNotification(successfulExports)
@@ -95,6 +88,17 @@ class FilesExportWork(
                 successfulExports++
             }
         return successfulExports
+    }
+
+    @Throws(IllegalStateException::class)
+    private fun exportFile(ocFile: OCFile) {
+        FileExportUtils().exportFile(
+            ocFile.fileName,
+            ocFile.mimeType,
+            contentResolver,
+            ocFile,
+            null
+        )
     }
 
     private fun showErrorNotification(successfulExports: Int) {

--- a/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -397,8 +397,10 @@ public class FileMenuFilter {
     }
 
     private boolean anyFileDownloading() {
+        final var fileDownloadHelper = FileDownloadHelper.Companion.instance();
+
         for (OCFile file : files) {
-            if (FileDownloadHelper.Companion.instance().isDownloading(user, file)) {
+            if (fileDownloadHelper.isDownloading(user, file)) {
                 return true;
             }
         }

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -441,7 +441,8 @@ public class SynchronizeFolderOperation extends SyncOperation {
     }
 
     private void startDirectDownloads() {
-        mFilesForDirectDownload.forEach(file -> FileDownloadHelper.Companion.instance().downloadFile(user, file));
+        final var fileDownloadHelper = FileDownloadHelper.Companion.instance();
+        mFilesForDirectDownload.forEach(file -> fileDownloadHelper.downloadFile(user, file));
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -335,10 +335,11 @@ class OCFileListDelegate(
 
     private fun showLocalFileIndicator(file: OCFile, gridViewHolder: ListViewHolder) {
         val operationsServiceBinder = transferServiceGetter.operationsServiceBinder
+        val fileDownloadHelper = FileDownloadHelper.instance()
 
         val icon: Int? = when {
             operationsServiceBinder?.isSynchronizing(user, file) == true ||
-                FileDownloadHelper.instance().isDownloading(user, file) ||
+                fileDownloadHelper.isDownloading(user, file) ||
                 fileUploadHelper.isUploading(user, file) -> {
                 // synchronizing, downloading or uploading
                 R.drawable.ic_synchronizing

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -653,13 +653,15 @@ class PreviewMediaActivity :
         packageName: String? = null,
         activityName: String? = null
     ) {
-        if (FileDownloadHelper.instance().isDownloading(user, file)) {
+        val fileDownloadHelper = FileDownloadHelper.instance()
+
+        if (fileDownloadHelper.isDownloading(user, file)) {
             return
         }
 
         user?.let { user ->
             file?.let { file ->
-                FileDownloadHelper.instance().downloadFile(
+                fileDownloadHelper.downloadFile(
                     user,
                     file,
                     downloadBehavior ?: "",


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Refactored code to reduce redundant instance() calls for FileDownloadHelper.