### PR TITLE
Check Nullable Fields During Folder Changes Check 

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -172,8 +172,12 @@ public class SynchronizeFolderOperation extends SyncOperation {
             }
 
             OCFile remoteFolder = FileStorageUtils.fillOCFile(remoteFile);
+            if (mLocalFolder == null) {
+                return new RemoteOperationResult<>(ResultCode.LOCAL_FILE_NOT_FOUND);
+            }
+
             String localETag = mLocalFolder.getEtag();
-            if (mLocalFolder == null || localETag == null) {
+            if (localETag == null) {
                 return new RemoteOperationResult<>(ResultCode.LOCAL_FILE_NOT_FOUND);
             }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**How to Test?**

1. Place a debugger in the checkForChanges() function.
2. Try syncing both a changed and an unchanged folder; the debugger should hit the selected line, and the correct result should be returned.
