### PR TITLE
BugFix - Sync Nested Folder

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -414,23 +413,21 @@ public class SynchronizeFolderOperation extends SyncOperation {
 
 
     private void prepareOpsFromLocalKnowledge() throws OperationCancelledException {
-        List<OCFile> children = getStorageManager().getFolderContent(mLocalFolder, false);
+        List<OCFile> children = getStorageManager().getAllFilesRecursivelyInsideFolder(mLocalFolder);
         for (OCFile child : children) {
-            if (!child.isFolder()) {
-                if (!child.isDown()) {
-                    mFilesForDirectDownload.add(child);
-                } else {
-                    /// this should result in direct upload of files that were locally modified
-                    SynchronizeFileOperation operation = new SynchronizeFileOperation(
-                        child,
-                        child.getEtagInConflict() != null ? child : null,
-                        user,
-                        true,
-                        mContext,
-                        getStorageManager()
-                    );
-                    mFilesToSyncContents.add(operation);
-                }
+            if (!child.isDown()) {
+                mFilesForDirectDownload.add(child);
+            } else {
+                /// this should result in direct upload of files that were locally modified
+                SynchronizeFileOperation operation = new SynchronizeFileOperation(
+                    child,
+                    child.getEtagInConflict() != null ? child : null,
+                    user,
+                    true,
+                    mContext,
+                    getStorageManager()
+                );
+                mFilesToSyncContents.add(operation);
             }
         }
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


**How to Test?**

The sync folder action should sync all files within the selected folder, not just those one level below.