### PR TITLE
Improve File Download Worker

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -631,6 +631,7 @@ internal class BackgroundJobManagerImpl(
             .setInputData(data)
             .build()
 
+        // Since for each file new FileDownloadWorker going to be scheduled, better to use ExistingWorkPolicy.KEEP policy.
         workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.KEEP, request)
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -631,7 +631,8 @@ internal class BackgroundJobManagerImpl(
             .setInputData(data)
             .build()
 
-        // Since for each file new FileDownloadWorker going to be scheduled, better to use ExistingWorkPolicy.KEEP policy.
+        // Since for each file new FileDownloadWorker going to be scheduled,
+        // better to use ExistingWorkPolicy.KEEP policy.
         workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.KEEP, request)
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -631,7 +631,7 @@ internal class BackgroundJobManagerImpl(
             .setInputData(data)
             .build()
 
-        workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.REPLACE, request)
+        workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.KEEP, request)
     }
 
     override fun getFileUploads(user: User): LiveData<List<JobInfo>> {

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -25,17 +25,8 @@ class DownloadNotificationManager(
 ) : WorkerNotificationManager(id, context, viewThemeUtils, R.string.downloader_download_in_progress_ticker) {
 
     @Suppress("MagicNumber")
-    fun prepareForStart(operation: DownloadFileOperation, currentDownloadIndex: Int, totalDownloadSize: Int) {
-        currentOperationTitle = if (totalDownloadSize > 1) {
-            String.format(
-                context.getString(R.string.downloader_notification_manager_download_text),
-                currentDownloadIndex,
-                totalDownloadSize,
-                File(operation.savePath).name
-            )
-        } else {
-            File(operation.savePath).name
-        }
+    fun prepareForStart(operation: DownloadFileOperation) {
+        currentOperationTitle = File(operation.savePath).name
 
         notificationBuilder.run {
             setContentTitle(currentOperationTitle)

--- a/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/DownloadNotificationManager.kt
@@ -11,6 +11,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import com.nextcloud.client.jobs.notification.WorkerNotificationManager
+import com.nextcloud.utils.numberFormatter.NumberFormatter
 import com.owncloud.android.R
 import com.owncloud.android.operations.DownloadFileOperation
 import com.owncloud.android.utils.theme.ViewThemeUtils
@@ -46,7 +47,8 @@ class DownloadNotificationManager(
 
     @Suppress("MagicNumber")
     fun updateDownloadProgress(percent: Int, totalToTransfer: Long) {
-        setProgress(percent, R.string.downloader_notification_manager_in_progress_text, totalToTransfer < 0)
+        val progressText = NumberFormatter.getPercentageText(percent)
+        setProgress(percent, progressText, totalToTransfer < 0)
         showNotification()
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -111,7 +111,7 @@ class FileDownloadWorker(
 
     private var downloadError: FileDownloadError? = null
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "ReturnCount")
     override suspend fun doWork(): Result {
         val foregroundInfo = createWorkerForegroundInfo()
         setForeground(foregroundInfo)

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -51,16 +51,14 @@ open class WorkerNotificationManager(
     }
 
     @Suppress("MagicNumber")
-    fun setProgress(percent: Int, progressTextId: Int, indeterminate: Boolean) {
-        val progressText = String.format(
-            context.getString(progressTextId),
-            percent
-        )
-
+    fun setProgress(percent: Int, progressText: String?, indeterminate: Boolean) {
         notificationBuilder.run {
             setProgress(100, percent, indeterminate)
             setContentTitle(currentOperationTitle)
-            setContentText(progressText)
+
+            progressText?.let {
+                setContentText(progressText)
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -11,6 +11,7 @@ import android.app.PendingIntent
 import android.content.Context
 import com.nextcloud.client.jobs.notification.WorkerNotificationManager
 import com.nextcloud.utils.extensions.isFileSpecificError
+import com.nextcloud.utils.numberFormatter.NumberFormatter
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.operations.UploadFileOperation
@@ -43,10 +44,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             uploadFileOperation.fileName
         }
 
-        val progressText = String.format(
-            context.getString(R.string.upload_notification_manager_upload_in_progress_text),
-            0
-        )
+        val progressText = NumberFormatter.getPercentageText(0)
 
         notificationBuilder.run {
             setProgress(100, 0, false)
@@ -71,7 +69,8 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
 
     @Suppress("MagicNumber")
     fun updateUploadProgress(percent: Int, currentOperation: UploadFileOperation?) {
-        setProgress(percent, R.string.upload_notification_manager_upload_in_progress_text, false)
+        val progressText = NumberFormatter.getPercentageText(percent)
+        setProgress(percent, progressText, false)
         showNotification()
         dismissOldErrorNotification(currentOperation)
     }

--- a/app/src/main/java/com/nextcloud/utils/numberFormatter/NumberFormatter.kt
+++ b/app/src/main/java/com/nextcloud/utils/numberFormatter/NumberFormatter.kt
@@ -1,0 +1,19 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.numberFormatter
+
+import java.text.NumberFormat
+import java.util.Locale
+
+object NumberFormatter {
+    fun getPercentageText(percent: Int): String {
+        val formatter = NumberFormat.getPercentInstance(Locale.getDefault())
+        formatter.maximumFractionDigits = 0
+        return formatter.format(percent / 100.0)
+    }
+}

--- a/app/src/main/java/com/nextcloud/utils/numberFormatter/NumberFormatter.kt
+++ b/app/src/main/java/com/nextcloud/utils/numberFormatter/NumberFormatter.kt
@@ -11,6 +11,8 @@ import java.text.NumberFormat
 import java.util.Locale
 
 object NumberFormatter {
+
+    @Suppress("MagicNumber")
     fun getPercentageText(percent: Int): String {
         val formatter = NumberFormat.getPercentInstance(Locale.getDefault())
         formatter.maximumFractionDigits = 0

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,6 @@
     <string name="uploader_info_dirname">Folder name</string>
 
     <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
-    <string name="upload_notification_manager_upload_in_progress_text" translatable="false">%1$d%%</string>
 
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>
@@ -262,9 +261,6 @@
     <string name="uploads_view_upload_status_fetching_server_version">Fetching server version…</string>
     <string name="uploads_view_later_waiting_to_upload">Waiting to upload</string>
     <string name="uploads_view_group_header" translatable="false">%1$s (%2$d)</string>
-
-    <string name="downloader_notification_manager_download_text" translatable="false">%1$d / %2$d - %3$s</string>
-    <string name="downloader_notification_manager_in_progress_text" translatable="false">%1$d%%</string>
 
     <string name="downloader_download_in_progress_ticker">Downloading…</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Changes**

- Convert worker to CoroutineWorker

- Call setForeground() before starting any task

- Remove non-translatable texts

- Fixes FileDownloadWorker crashes due to an asynchronous start, causing android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException.

- Remove total and current index tracking from DownloadNotificationManager. This feature can be reintroduced after addressing [this](https://github.com/nextcloud/android/issues/13906) issue. Refer to the Technical Explanation section for more details; without resolving this, the download status tracking feature is ineffective and nonfunctional.




