### PR TITLE
BugFix - Don't Use File Download Worker for Two Way Sync

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/InternalTwoWaySyncWork.kt
@@ -67,7 +67,7 @@ class InternalTwoWaySyncWork(
                 }
 
                 Log_OC.d(TAG, "Folder ${folder.remotePath}: started!")
-                operation = SynchronizeFolderOperation(context, folder.remotePath, user, fileDataStorageManager)
+                operation = SynchronizeFolderOperation(context, folder.remotePath, user, fileDataStorageManager, true)
                 val operationResult = operation?.execute(context)
 
                 if (operationResult?.isSuccess == true) {

--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -77,7 +77,8 @@ class OfflineSyncWork constructor(
                     user,
                     true,
                     context,
-                    storageManager
+                    storageManager,
+                    true
                 )
                 synchronizeFileOperation.execute(context)
             }

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -114,7 +114,8 @@ public class SynchronizeFileOperation extends SyncOperation {
         User user,
         boolean syncFileContents,
         Context context,
-        FileDataStorageManager storageManager) {
+        FileDataStorageManager storageManager,
+        boolean syncForInternalTwoWaySyncWorker) {
         super(storageManager);
 
         mLocalFile = localFile;
@@ -134,6 +135,7 @@ public class SynchronizeFileOperation extends SyncOperation {
         mSyncFileContents = syncFileContents;
         mContext = context;
         mAllowUploads = true;
+        this.syncForInternalTwoWaySyncWorker = syncForInternalTwoWaySyncWorker;
     }
 
 
@@ -163,9 +165,9 @@ public class SynchronizeFileOperation extends SyncOperation {
         boolean syncFileContents,
         boolean allowUploads,
         Context context,
-        FileDataStorageManager storageManager) {
-
-        this(localFile, serverFile, user, syncFileContents, context, storageManager);
+        FileDataStorageManager storageManager,
+        boolean syncForInternalTwoWaySyncWorker) {
+        this(localFile, serverFile, user, syncFileContents, context, storageManager, syncForInternalTwoWaySyncWorker);
         mAllowUploads = allowUploads;
     }
 

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -17,7 +17,6 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import com.nextcloud.client.account.User;
-import com.nextcloud.client.jobs.download.FileDownloadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -296,10 +295,22 @@ public class SynchronizeFileOperation extends SyncOperation {
 
     private void requestForDownload(OCFile file) {
         Log_OC.d("InternalTwoWaySyncWork", "download file: " + file.getFileName());
-        
-        FileDownloadHelper.Companion.instance().downloadFile(
-            mUser,
-            file);
+
+        try {
+            final var operation = new DownloadFileOperation(mUser, file, mContext);
+            var result = operation.execute(getClient());
+
+            String filename = file.getFileName();
+            if (filename != null) {
+                if (result.isSuccess()) {
+                    Log_OC.d(TAG, "requestForDownload completed for: " + file.getFileName());
+                } else {
+                    Log_OC.d(TAG, "requestForDownload failed for: " + file.getFileName());
+                }
+            }
+        } catch (Exception e) {
+            Log_OC.d(TAG, "Exception caught at requestForDownload" + e);
+        }
 
         mTransferWasRequested = true;
     }

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -46,7 +46,7 @@ public class SynchronizeFileOperation extends SyncOperation {
     private boolean mSyncFileContents;
     private Context mContext;
     private boolean mTransferWasRequested;
-    private boolean syncForInternalTwoWaySyncWorker;
+    private final boolean syncInBackgroundWorker;
 
 
     /**
@@ -77,7 +77,7 @@ public class SynchronizeFileOperation extends SyncOperation {
         boolean syncFileContents,
         Context context,
         FileDataStorageManager storageManager,
-        boolean syncForInternalTwoWaySyncWorker) {
+        boolean syncInBackgroundWorker) {
         super(storageManager);
 
         mRemotePath = remotePath;
@@ -87,7 +87,7 @@ public class SynchronizeFileOperation extends SyncOperation {
         mSyncFileContents = syncFileContents;
         mContext = context;
         mAllowUploads = true;
-        this.syncForInternalTwoWaySyncWorker = syncForInternalTwoWaySyncWorker;
+        this.syncInBackgroundWorker = syncInBackgroundWorker;
     }
 
 
@@ -115,7 +115,7 @@ public class SynchronizeFileOperation extends SyncOperation {
         boolean syncFileContents,
         Context context,
         FileDataStorageManager storageManager,
-        boolean syncForInternalTwoWaySyncWorker) {
+        boolean syncInBackgroundWorker) {
         super(storageManager);
 
         mLocalFile = localFile;
@@ -135,7 +135,7 @@ public class SynchronizeFileOperation extends SyncOperation {
         mSyncFileContents = syncFileContents;
         mContext = context;
         mAllowUploads = true;
-        this.syncForInternalTwoWaySyncWorker = syncForInternalTwoWaySyncWorker;
+        this.syncInBackgroundWorker = syncInBackgroundWorker;
     }
 
 
@@ -166,8 +166,8 @@ public class SynchronizeFileOperation extends SyncOperation {
         boolean allowUploads,
         Context context,
         FileDataStorageManager storageManager,
-        boolean syncForInternalTwoWaySyncWorker) {
-        this(localFile, serverFile, user, syncFileContents, context, storageManager, syncForInternalTwoWaySyncWorker);
+        boolean syncInBackgroundWorker) {
+        this(localFile, serverFile, user, syncFileContents, context, storageManager, syncInBackgroundWorker);
         mAllowUploads = allowUploads;
     }
 
@@ -301,7 +301,7 @@ public class SynchronizeFileOperation extends SyncOperation {
     }
 
     private void requestForDownload(OCFile file) {
-        if (syncForInternalTwoWaySyncWorker) {
+        if (syncInBackgroundWorker) {
             Log_OC.d("InternalTwoWaySyncWork", "download file: " + file.getFileName());
 
             try {

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -300,6 +300,8 @@ public class SynchronizeFileOperation extends SyncOperation {
             final var operation = new DownloadFileOperation(mUser, file, mContext);
             var result = operation.execute(getClient());
 
+            mTransferWasRequested = true;
+
             String filename = file.getFileName();
             if (filename != null) {
                 if (result.isSuccess()) {
@@ -312,7 +314,7 @@ public class SynchronizeFileOperation extends SyncOperation {
             Log_OC.d(TAG, "Exception caught at requestForDownload" + e);
         }
 
-        mTransferWasRequested = true;
+
     }
 
     public boolean transferWasRequested() {

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -449,13 +449,17 @@ public class SynchronizeFolderOperation extends SyncOperation {
         if (syncInBackgroundWorker) {
             try {
                 for (OCFile file: mFilesForDirectDownload) {
-                    if (file == null) continue;
+                    if (file == null) {
+                        continue;
+                    }
 
                     final var operation = new DownloadFileOperation(user, file, mContext);
                     var result = operation.execute(getClient());
 
                     String filename = file.getFileName();
-                    if (filename == null) continue;
+                    if (filename == null) {
+                        continue;
+                    }
 
                     if (result.isSuccess()) {
                         Log_OC.d(TAG, "startDirectDownloads completed for: " + file.getFileName());

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -449,6 +449,12 @@ public class SynchronizeFolderOperation extends SyncOperation {
         if (syncInBackgroundWorker) {
             try {
                 for (OCFile file: mFilesForDirectDownload) {
+                    synchronized (mCancellationRequested) {
+                        if (mCancellationRequested.get()) {
+                            break;
+                        }
+                    }
+
                     if (file == null) {
                         continue;
                     }

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -409,7 +409,8 @@ public class SynchronizeFolderOperation extends SyncOperation {
                 user,
                 true,
                 mContext,
-                getStorageManager()
+                getStorageManager(),
+                syncForInternalTwoWaySyncWorker
             );
             mFilesToSyncContents.add(operation);
         }
@@ -430,7 +431,8 @@ public class SynchronizeFolderOperation extends SyncOperation {
                         user,
                         true,
                         mContext,
-                        getStorageManager()
+                        getStorageManager(),
+                        syncForInternalTwoWaySyncWorker
                     );
                     mFilesToSyncContents.add(operation);
                 }

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -15,7 +15,6 @@ import android.content.Intent;
 import android.text.TextUtils;
 
 import com.nextcloud.client.account.User;
-import com.nextcloud.client.jobs.download.FileDownloadHelper;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.e2e.v1.decrypted.DecryptedFolderMetadataFileV1;
@@ -40,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -441,8 +439,28 @@ public class SynchronizeFolderOperation extends SyncOperation {
     }
 
     private void startDirectDownloads() {
-        final var fileDownloadHelper = FileDownloadHelper.Companion.instance();
-        mFilesForDirectDownload.forEach(file -> fileDownloadHelper.downloadFile(user, file));
+        try {
+            for (OCFile file: mFilesForDirectDownload) {
+                if (file != null) {
+                    // delay 1 second before each download
+                    Thread.sleep(1000);
+
+                    final var operation = new DownloadFileOperation(user, file, mContext);
+                    var result = operation.execute(getClient());
+
+                    String filename = file.getFileName();
+                    if (filename != null) {
+                        if (result.isSuccess()) {
+                            Log_OC.d(TAG, "startDirectDownloads completed for: " + file.getFileName());
+                        } else {
+                            Log_OC.d(TAG, "startDirectDownloads failed for: " + file.getFileName());
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log_OC.d(TAG, "Exception caught at startDirectDownloads" + e);
+        }
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -86,7 +86,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
 
     private final AtomicBoolean mCancellationRequested;
 
-    private final boolean syncForInternalTwoWaySyncWorker;
+    private final boolean syncInBackgroundWorker;
 
     /**
      * Creates a new instance of {@link SynchronizeFolderOperation}.
@@ -99,7 +99,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
                                       String remotePath,
                                       User user,
                                       FileDataStorageManager storageManager,
-                                      boolean syncForInternalTwoWaySyncWorker) {
+                                      boolean syncInBackgroundWorker) {
         super(storageManager);
 
         mRemotePath = remotePath;
@@ -109,7 +109,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
         mFilesForDirectDownload = new Vector<>();
         mFilesToSyncContents = new Vector<>();
         mCancellationRequested = new AtomicBoolean(false);
-        this.syncForInternalTwoWaySyncWorker = syncForInternalTwoWaySyncWorker;
+        this.syncInBackgroundWorker = syncInBackgroundWorker;
     }
 
 
@@ -410,7 +410,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
                 true,
                 mContext,
                 getStorageManager(),
-                syncForInternalTwoWaySyncWorker
+                syncInBackgroundWorker
             );
             mFilesToSyncContents.add(operation);
         }
@@ -432,7 +432,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
                         true,
                         mContext,
                         getStorageManager(),
-                        syncForInternalTwoWaySyncWorker
+                        syncInBackgroundWorker
                     );
                     mFilesToSyncContents.add(operation);
                 }
@@ -446,7 +446,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
     }
 
     private void startDirectDownloads() {
-        if (syncForInternalTwoWaySyncWorker) {
+        if (syncInBackgroundWorker) {
             try {
                 for (OCFile file: mFilesForDirectDownload) {
                     if (file == null) continue;

--- a/app/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/app/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -698,7 +698,8 @@ public class OperationsService extends Service {
                                                                  user,
                                                                  syncFileContents,
                                                                  getApplicationContext(),
-                                                                 fileDataStorageManager);
+                                                                 fileDataStorageManager,
+                                                                 false);
                         break;
 
                     case ACTION_SYNC_FOLDER:
@@ -707,7 +708,8 @@ public class OperationsService extends Service {
                             this,                       // TODO remove this dependency from construction time
                             remotePath,
                             user,
-                            fileDataStorageManager
+                            fileDataStorageManager,
+                            false
                         );
                         break;
 

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -225,7 +225,8 @@ public class FileOperationsHelper {
                                                                     user,
                                                                     true,
                                                                     fileActivity,
-                                                                    storageManager);
+                                                                    storageManager,
+                                                                    false);
         RemoteOperationResult result = sfo.execute(fileActivity);
 
         if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {
@@ -303,7 +304,8 @@ public class FileOperationsHelper {
                                                                                 user,
                                                                                 true,
                                                                                 fileActivity,
-                                                                                storageManager);
+                                                                                storageManager,
+                                                                                false);
                     RemoteOperationResult result = sfo.execute(fileActivity);
                     fileActivity.dismissLoadingDialog();
                     if (result.getCode() == RemoteOperationResult.ResultCode.SYNC_CONFLICT) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Changes**

- Use FileDownloadWorker only for manual sync to ensure that notifications for downloads do not disappear. Additionally, observe the sync status in the adapter, and ensure the cancellation functionality for sync is not broken after these changes for Two-Way-Sync

- Add operation?.cancel() in the onStopped() method to improve cancellation handling through SynchronizeFolderOperations