### PR TITLE
Clear download jobs on first start

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -173,4 +173,5 @@ interface BackgroundJobManager {
     fun startOfflineOperations()
     fun startPeriodicallyOfflineOperation()
     fun scheduleInternal2WaySync(intervalMinutes: Long)
+    fun cancelAllFilesDownloadJobs()
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -507,6 +507,10 @@ internal class BackgroundJobManagerImpl(
         workManager.cancelJob(JOB_INTERNAL_TWO_WAY_SYNC)
     }
 
+    override fun cancelAllFilesDownloadJobs() {
+        workManager.cancelAllWorkByTag(formatClassTag(FileDownloadWorker::class))
+    }
+
     override fun scheduleOfflineSync() {
         val constrains = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.UNMETERED)

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -397,4 +397,7 @@ public interface AppPreferences {
 
     void setTwoWaySyncInterval(Long value);
     Long getTwoWaySyncInterval();
+
+    boolean shouldStopDownloadJobsOnStart();
+    void setStopDownloadJobsOnStart(boolean value);
 }

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -105,6 +105,8 @@ public final class AppPreferencesImpl implements AppPreferences {
     private static final String PREF__TWO_WAY_STATUS = "two_way_sync_status";
     private static final String PREF__TWO_WAY_SYNC_INTERVAL = "two_way_sync_interval";
 
+    private static final String PREF__STOP_DOWNLOAD_JOBS_ON_START = "stop_download_jobs_on_start";
+
     private static final String LOG_ENTRY = "log_entry";
 
     private final Context context;
@@ -811,5 +813,15 @@ public final class AppPreferencesImpl implements AppPreferences {
     @Override
     public Long getTwoWaySyncInterval() {
         return preferences.getLong(PREF__TWO_WAY_SYNC_INTERVAL, 15L);
+    }
+
+    @Override
+    public boolean shouldStopDownloadJobsOnStart() {
+        return preferences.getBoolean(PREF__STOP_DOWNLOAD_JOBS_ON_START, true);
+    }
+
+    @Override
+    public void setStopDownloadJobsOnStart(boolean value) {
+        preferences.edit().putBoolean(PREF__STOP_DOWNLOAD_JOBS_ON_START, value).apply();
     }
 }

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -326,6 +326,8 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
 
         fixStoragePath();
 
+        checkCancelDownloadJobs();
+
         MainApp.storagePath = preferences.getStoragePath(getApplicationContext().getFilesDir().getAbsolutePath());
 
         OwnCloudClientManagerFactory.setUserAgent(getUserAgent());
@@ -565,6 +567,13 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
                                        .detectLeakedClosableObjects()
                                        .penaltyLog()
                                        .build());
+        }
+    }
+
+    private void checkCancelDownloadJobs() {
+        if (backgroundJobManager != null && preferences.shouldStopDownloadJobsOnStart()) {
+            backgroundJobManager.cancelAllFilesDownloadJobs();
+            preferences.setStopDownloadJobsOnStart(false);
         }
     }
 


### PR DESCRIPTION
This will cause all pending download jobs to be cancelled once on the first start.

The reasoning behind this change is that all download jobs, including those issued by two-way sync, should be cancelled after updating the app.

---
- [ ] Tests written, or not not needed
