### PR TITLE
BugFix - Software rendering doesn't support hardware bitmaps

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -60,13 +60,9 @@ public final class BitmapUtils {
     }
 
     public static Bitmap addColorFilter(Bitmap originalBitmap, int filterColor, int opacity) {
-        int width = originalBitmap.getWidth();
-        int height = originalBitmap.getHeight();
-
-        Bitmap resultBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Bitmap resultBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true);
         Canvas canvas = new Canvas(resultBitmap);
-
-        canvas.drawBitmap(originalBitmap, 0, 0, null);
+        canvas.drawBitmap(resultBitmap, 0, 0, null);
 
         Paint paint = new Paint();
         paint.setColor(filterColor);
@@ -74,7 +70,7 @@ public final class BitmapUtils {
         paint.setAlpha(opacity);
 
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_ATOP));
-        canvas.drawRect(0, 0, width, height, paint);
+        canvas.drawRect(0, 0, resultBitmap.getWidth(), resultBitmap.getHeight(), paint);
 
         return resultBitmap;
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**How to Test:**

1. Turn off mobile data and Wi-Fi
2. Upload a file.
3. App will crash due to -->` java.lang.IllegalArgumentException: Software rendering doesn't support hardware bitmaps`

**Note:** addColorFilter() is only used for offline file creation operations to dim the thumbnail
