### PR TITLE
Add Initial Delay For Two Way Sync

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -711,7 +711,9 @@ internal class BackgroundJobManagerImpl(
             jobClass = InternalTwoWaySyncWork::class,
             jobName = JOB_INTERNAL_TWO_WAY_SYNC,
             intervalMins = intervalMinutes
-        ).build()
+        )
+            .setInitialDelay(intervalMinutes, TimeUnit.MINUTES)
+            .build()
 
         workManager.enqueueUniquePeriodicWork(JOB_INTERNAL_TWO_WAY_SYNC, ExistingPeriodicWorkPolicy.UPDATE, request)
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


Toggling the switch on and off immediately triggers a two-way sync. This PR fixes the issue so that enabling the two-way sync switch from the off state doesn’t trigger sync immediately.