### PR TITLE
Fix FileDetailFragment not starting

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -352,12 +352,13 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
             }
         });
 
-        // FIXME file detail not opening from Media tab
-        if (binding != null) {
-            TabLayout.Tab tab = binding.tabLayout.getTabAt(activeTab);
-            if (tab == null) return;
-            binding.tabLayout.selectTab(tab);
-        }
+        binding.tabLayout.post(() -> {
+            if (binding != null) {
+                TabLayout.Tab tab = binding.tabLayout.getTabAt(activeTab);
+                if (tab == null) return;
+                tab.select();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -357,7 +357,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
         }
 
         startActivity(intent)
-        backToDisplayActivity()
+        finish()
     }
 
     override fun showDetails(file: OCFile, activeTab: Int) {


### PR DESCRIPTION
This fixes an issue where the `FileDetailFragment` would not start or would start on the wrong tab.

---
- [x] Tests written, or not not needed
