### PR TITLE
Fix exception when closing choose storage location dialogue

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -799,6 +799,8 @@ public class SettingsActivity extends PreferenceActivity
         final PreferenceCategory preferenceCategoryGeneral = (PreferenceCategory) findPreference("general");
         viewThemeUtils.files.themePreferenceCategory(preferenceCategoryGeneral);
 
+        readStoragePath();
+
         prefDataLoc = findPreference(AppPreferencesImpl.DATA_STORAGE_LOCATION);
         if (prefDataLoc != null) {
             prefDataLoc.setOnPreferenceClickListener(p -> {
@@ -978,7 +980,7 @@ public class SettingsActivity extends PreferenceActivity
         } else if (requestCode == ACTION_SET_STORAGE_LOCATION && data != null) {
             String newPath = data.getStringExtra(ChooseStorageLocationActivity.KEY_RESULT_STORAGE_LOCATION);
 
-            if (!storagePath.equals(newPath)) {
+            if (storagePath != null && !storagePath.equals(newPath)) {
                 StorageMigration storageMigration = new StorageMigration(this, user, storagePath, newPath, viewThemeUtils);
                 storageMigration.setStorageMigrationProgressListener(this);
                 storageMigration.migrate();
@@ -1126,6 +1128,12 @@ public class SettingsActivity extends PreferenceActivity
         SharedPreferences.Editor editor = appPrefs.edit();
         editor.putString(AppPreferencesImpl.STORAGE_PATH, storagePath);
         editor.apply();
+    }
+
+    private void readStoragePath() {
+        SharedPreferences appPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        // Load storage path from shared preferences. Use private internal storage by default.
+        storagePath = appPrefs.getString(AppPreferencesImpl.STORAGE_PATH, getApplicationContext().getFilesDir().getAbsolutePath());
     }
 
     @Override


### PR DESCRIPTION
This change is an addition to #14005. Previously, the app would crash after closing the *Choose storage location* dialogue.

- read `storagePath` from shared preferences
- check if `storagePath` is null

Replaces #14060

---
- [ ] Tests written, or not not needed
