### PR TITLE
fix(Thumbnails): Use local id rather than remote id

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -1400,7 +1400,7 @@ public final class ThumbnailsCacheManager {
                     GetMethod getMethod = null;
                     try {
                         String uri = mClient.getBaseUri() + "/index.php/core/preview?fileId="
-                            + file.getRemoteId()
+                            + file.getLocalId()
                             + "&x=" + (pxW / 2) + "&y=" + (pxH / 2) + "&a=1&mode=cover&forceIcon=0";
                         Log_OC.d(TAG, "generate resized image: " + file.getFileName() + " URI: " + uri);
                         getMethod = new GetMethod(uri);


### PR DESCRIPTION
This should the scenarios described in #13743
May also fix #13515 and #13989

It's a regression from #13164 where the wrong DAV property (`id` / remote id) was used instead of `fileid` / local id) for some thumbnail retrievals.

Looks like the bug made its way into >= 3.30.0 + (via backport) 3.29.3 aka "3.29.2"

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
