### PR TITLE
Check BOOT_COMPLETED BroadcastReceiver Usage For API Level 35

### DIFF
--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -352,7 +352,8 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
         } catch (Exception e) {
             Log_OC.d("Debug", "Failed to disable uri exposure");
         }
-        initSyncOperations(this,
+        initSyncOperations(true,
+                    this,
                            preferences,
                            uploadsStorageManager,
                            accountManager,
@@ -363,7 +364,7 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
                            viewThemeUtils,
                            walledCheckCache,
                            syncedFolderProvider);
-        initContactsBackup(accountManager, backgroundJobManager);
+        initContactsBackup(accountManager, backgroundJobManager, true);
         notificationChannels();
 
         if (backgroundJobManager != null) {
@@ -505,7 +506,11 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
         });
     }
 
-    public static void initContactsBackup(UserAccountManager accountManager, BackgroundJobManager backgroundJobManager) {
+    public static void initContactsBackup(UserAccountManager accountManager, BackgroundJobManager backgroundJobManager, boolean shouldSchedulePeriodicContactsBackup) {
+        if (!shouldSchedulePeriodicContactsBackup) {
+            return;
+        }
+
         ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProviderImpl(appContext.get());
         if (accountManager == null) {
             return;
@@ -606,7 +611,14 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
         }
     }
 
+    /**
+     * @param shouldSync Android 15 restricts BOOT_COMPLETED broadcast receivers from starting certain foreground
+     *                   services (dataSync, mediaPlayback, mediaProjection ...), throwing a
+     *                   ForegroundServiceStartNotAllowedException if violated. Under the hood, WorkManager manages and
+     *                   runs a foreground service. The shouldSync flag ensures proper WorkManager usage.
+     */
     public static void initSyncOperations(
+        final boolean shouldSync,
         final Context context,
         final AppPreferences preferences,
         final UploadsStorageManager uploadsStorageManager,
@@ -618,6 +630,7 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
         final ViewThemeUtils viewThemeUtils,
         final WalledCheckCache walledCheckCache,
         final SyncedFolderProvider syncedFolderProvider) {
+
         updateToAutoUpload(context);
         cleanOldEntries(clock);
         updateAutoUploadEntries(clock);
@@ -630,35 +643,40 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
             }
         }
 
-        if (!preferences.isAutoUploadInitialized()) {
+        if (!preferences.isAutoUploadInitialized() && shouldSync) {
             FilesSyncHelper.startFilesSyncForAllFolders(syncedFolderProvider, backgroundJobManager,false, new String[]{});
             preferences.setAutoUploadInit(true);
         }
 
-        FilesSyncHelper.scheduleFilesSyncForAllFoldersIfNeeded(appContext.get(), syncedFolderProvider, backgroundJobManager);
-        FilesSyncHelper.restartUploadsIfNeeded(
-            uploadsStorageManager,
-            accountManager,
-            connectivityService,
-            powerManagementService);
+        if (shouldSync) {
+            FilesSyncHelper.scheduleFilesSyncForAllFoldersIfNeeded(appContext.get(), syncedFolderProvider, backgroundJobManager);
+            FilesSyncHelper.restartUploadsIfNeeded(
+                uploadsStorageManager,
+                accountManager,
+                connectivityService,
+                powerManagementService);
 
-        backgroundJobManager.scheduleOfflineSync();
+            backgroundJobManager.scheduleOfflineSync();
+        }
 
         ReceiversHelper.registerNetworkChangeReceiver(uploadsStorageManager,
                                                       accountManager,
                                                       connectivityService,
                                                       powerManagementService,
-                                                      walledCheckCache);
+                                                      walledCheckCache,
+                                                      shouldSync);
 
         ReceiversHelper.registerPowerChangeReceiver(uploadsStorageManager,
                                                     accountManager,
                                                     connectivityService,
-                                                    powerManagementService);
+                                                    powerManagementService,
+                                                    shouldSync);
 
         ReceiversHelper.registerPowerSaveReceiver(uploadsStorageManager,
                                                   accountManager,
                                                   connectivityService,
-                                                  powerManagementService);
+                                                  powerManagementService,
+                                                  shouldSync);
     }
 
     public static void notificationChannels() {

--- a/app/src/main/java/com/owncloud/android/files/BootupBroadcastReceiver.java
+++ b/app/src/main/java/com/owncloud/android/files/BootupBroadcastReceiver.java
@@ -14,6 +14,7 @@ package com.owncloud.android.files;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 import com.nextcloud.client.account.UserAccountManager;
 import com.nextcloud.client.core.Clock;
@@ -62,7 +63,10 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
         AndroidInjection.inject(this, context);
 
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-            MainApp.initSyncOperations(context,
+            boolean isApiLevel35OrHigher = (Build.VERSION.SDK_INT >= 35);
+
+            MainApp.initSyncOperations(!isApiLevel35OrHigher,
+                                       context,
                                        preferences,
                                        uploadsStorageManager,
                                        accountManager,
@@ -73,8 +77,8 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
                                        viewThemeUtils,
                                        walledCheckCache,
                                        syncedFolderProvider
-                                       );
-            MainApp.initContactsBackup(accountManager, backgroundJobManager);
+                                      );
+            MainApp.initContactsBackup(accountManager, backgroundJobManager, !isApiLevel35OrHigher);
         } else {
             Log_OC.d(TAG, "Getting wrong intent: " + intent.getAction());
         }

--- a/app/src/main/java/com/owncloud/android/files/BootupBroadcastReceiver.java
+++ b/app/src/main/java/com/owncloud/android/files/BootupBroadcastReceiver.java
@@ -63,9 +63,9 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
         AndroidInjection.inject(this, context);
 
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-            boolean isApiLevel35OrHigher = (Build.VERSION.SDK_INT >= 35);
+            boolean isApiLevelLowerThan35 = (Build.VERSION.SDK_INT < 35);
 
-            MainApp.initSyncOperations(!isApiLevel35OrHigher,
+            MainApp.initSyncOperations(isApiLevelLowerThan35,
                                        context,
                                        preferences,
                                        uploadsStorageManager,
@@ -78,7 +78,7 @@ public class BootupBroadcastReceiver extends BroadcastReceiver {
                                        walledCheckCache,
                                        syncedFolderProvider
                                       );
-            MainApp.initContactsBackup(accountManager, backgroundJobManager, !isApiLevel35OrHigher);
+            MainApp.initContactsBackup(accountManager, backgroundJobManager, isApiLevelLowerThan35);
         } else {
             Log_OC.d(TAG, "Getting wrong intent: " + intent.getAction());
         }

--- a/app/src/main/java/com/owncloud/android/utils/ReceiversHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/ReceiversHelper.java
@@ -36,7 +36,8 @@ public final class ReceiversHelper {
                                                      final UserAccountManager accountManager,
                                                      final ConnectivityService connectivityService,
                                                      final PowerManagementService powerManagementService,
-                                                     final WalledCheckCache walledCheckCache) {
+                                                     final WalledCheckCache walledCheckCache,
+                                                     final boolean shouldRegister) {
         Context context = MainApp.getAppContext();
 
         IntentFilter intentFilter = new IntentFilter();
@@ -48,7 +49,7 @@ public final class ReceiversHelper {
             public void onReceive(Context context, Intent intent) {
                 DNSCache.clear();
                 walledCheckCache.clear();
-                if (connectivityService.getConnectivity().isConnected()) {
+                if (connectivityService.getConnectivity().isConnected() && shouldRegister) {
                     FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
                                                            accountManager,
                                                            connectivityService,
@@ -64,8 +65,8 @@ public final class ReceiversHelper {
         final UploadsStorageManager uploadsStorageManager,
         final UserAccountManager accountManager,
         final ConnectivityService connectivityService,
-        final PowerManagementService powerManagementService
-                                                  ) {
+        final PowerManagementService powerManagementService,
+        final boolean shouldRegister) {
         Context context = MainApp.getAppContext();
 
         IntentFilter intentFilter = new IntentFilter();
@@ -75,7 +76,7 @@ public final class ReceiversHelper {
         BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-                if (Intent.ACTION_POWER_CONNECTED.equals(intent.getAction())) {
+                if (Intent.ACTION_POWER_CONNECTED.equals(intent.getAction()) && shouldRegister) {
                     FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
                                                            accountManager,
                                                            connectivityService,
@@ -91,8 +92,8 @@ public final class ReceiversHelper {
         final UploadsStorageManager uploadsStorageManager,
         final UserAccountManager accountManager,
         final ConnectivityService connectivityService,
-        final PowerManagementService powerManagementService
-                                                ) {
+        final PowerManagementService powerManagementService,
+        final boolean shouldRegister) {
         Context context = MainApp.getAppContext();
 
         IntentFilter intentFilter = new IntentFilter();
@@ -101,7 +102,7 @@ public final class ReceiversHelper {
         BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-                if (!powerManagementService.isPowerSavingEnabled()) {
+                if (!powerManagementService.isPowerSavingEnabled() && shouldRegister) {
                     FilesSyncHelper.restartUploadsIfNeeded(uploadsStorageManager,
                                                            accountManager,
                                                            connectivityService,


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


Android 15 introduces new restrictions on BOOT_COMPLETED broadcast receivers launching foreground services. Specifically, BOOT_COMPLETED receivers are prohibited from starting the following types of foreground services: dataSync, mediaPlayback, mediaProjection, phoneCall, microphone

If a BOOT_COMPLETED receiver attempts to start any of these service types, the system will throw a ForegroundServiceStartNotAllowedException.

WorkManager provides a solution by managing and running a foreground service on your behalf to execute a WorkRequest, while also displaying a configurable notification.

MainApp.initSyncOperations() this function triggers a series of workers and is also invoked by the BOOT_COMPLETED broadcast receiver. The shouldSync flag differentiates between scenarios and ensures that WorkManager is triggered appropriately.

[BOOT_COMPLETED BroadcastReceiver Behavior Changes Doc](https://developer.android.com/about/versions/15/behavior-changes-15#fgs-boot-completed)

[Worker Document](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running)