### PR TITLE
MANAGE_EXTERNAL_STORAGE not possible for gplay flavor anylonger

### DIFF
--- a/app/src/gplay/AndroidManifest.xml
+++ b/app/src/gplay/AndroidManifest.xml
@@ -13,6 +13,11 @@
         android:name="android.permission.REQUEST_INSTALL_PACKAGES"
         tools:node="remove"/>
 
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:node="remove"
+        tools:ignore="ScopedStorage" />
+
     <application
         android:name=".MainApp"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -400,4 +400,7 @@ public interface AppPreferences {
 
     boolean shouldStopDownloadJobsOnStart();
     void setStopDownloadJobsOnStart(boolean value);
+    
+    boolean isAutoUploadGPlayWarningShown();
+    void setAutoUploadGPlayWarningShown(boolean value);
 }

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -107,6 +107,8 @@ public final class AppPreferencesImpl implements AppPreferences {
     private static final String PREF__TWO_WAY_SYNC_INTERVAL = "two_way_sync_interval";
 
     private static final String PREF__STOP_DOWNLOAD_JOBS_ON_START = "stop_download_jobs_on_start";
+    
+    private static final String PREF__AUTO_UPLOAD_GPLAY_WARNING_SHOWN = "auto_upload_gplay_warning_shown";
 
     private static final String LOG_ENTRY = "log_entry";
 
@@ -824,5 +826,15 @@ public final class AppPreferencesImpl implements AppPreferences {
     @Override
     public void setStopDownloadJobsOnStart(boolean value) {
         preferences.edit().putBoolean(PREF__STOP_DOWNLOAD_JOBS_ON_START, value).apply();
+    }
+
+    @Override
+    public boolean isAutoUploadGPlayWarningShown() {
+        return preferences.getBoolean(PREF__AUTO_UPLOAD_GPLAY_WARNING_SHOWN, false);
+    }
+
+    @Override
+    public void setAutoUploadGPlayWarningShown(boolean value) {
+        preferences.edit().putBoolean(PREF__AUTO_UPLOAD_GPLAY_WARNING_SHOWN, value).apply();
     }
 }

--- a/app/src/main/java/com/nextcloud/utils/BuildHelper.kt
+++ b/app/src/main/java/com/nextcloud/utils/BuildHelper.kt
@@ -1,0 +1,11 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.nextcloud.utils
+
+object BuildHelper {
+    const val GPLAY: String = "gplay"
+}

--- a/app/src/main/java/com/nextcloud/utils/BuildHelper.kt
+++ b/app/src/main/java/com/nextcloud/utils/BuildHelper.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2024 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2024 Tobias Kaminsky <tobias.kaminsky@nextcloud.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 package com.nextcloud.utils

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -385,6 +385,8 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
         if (!MDMConfig.INSTANCE.sendFilesSupport(this)) {
             disableDocumentsStorageProvider();
         }
+        
+        
      }
 
     public void disableDocumentsStorageProvider() {
@@ -843,6 +845,8 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
             }
         }
     }
+
+    
 
     private static void showAutoUploadAlertDialog(Context context) {
         new MaterialAlertDialogBuilder(context, R.style.Theme_ownCloud_Dialog)

--- a/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -20,6 +20,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import com.nextcloud.utils.BuildHelper;
 import com.owncloud.android.BuildConfig;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.network.WebdavEntry;
@@ -1092,7 +1093,7 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
     }
     
     public boolean isAPKorAAB() {
-        if ("gplay".equals(BuildConfig.FLAVOR)) {
+        if (BuildHelper.GPLAY.equals(BuildConfig.FLAVOR)) {
             return getFileName().endsWith(".apk") || getFileName().endsWith(".aab");
         } else {
             return false;

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -13,6 +13,7 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.Manifest;
 import android.accounts.Account;
 import android.accounts.AuthenticatorException;
 import android.annotation.SuppressLint;
@@ -50,6 +51,7 @@ import com.nextcloud.appReview.InAppReviewHelper;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.appinfo.AppInfo;
 import com.nextcloud.client.core.AsyncRunner;
+import com.nextcloud.client.core.Clock;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.editimage.EditImageActivity;
 import com.nextcloud.client.files.DeepLinkHandler;
@@ -59,7 +61,6 @@ import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.media.PlayerServiceConnection;
 import com.nextcloud.client.network.ClientFactory;
-import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.utils.IntentUtil;
 import com.nextcloud.model.WorkerState;
@@ -70,11 +71,14 @@ import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
 import com.nextcloud.utils.fileNameValidator.FileNameValidator;
 import com.nextcloud.utils.view.FastScrollUtils;
+import com.owncloud.android.BuildConfig;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.FilesBinding;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.SyncedFolder;
+import com.owncloud.android.datamodel.SyncedFolderProvider;
 import com.owncloud.android.datamodel.VirtualFolderType;
 import com.owncloud.android.files.services.NameCollisionPolicy;
 import com.owncloud.android.lib.common.OwnCloudClient;
@@ -241,6 +245,8 @@ public class FileDisplayActivity extends FileActivity
 
     @Inject FastScrollUtils fastScrollUtils;
     @Inject AsyncRunner asyncRunner;
+    @Inject Clock clock;
+    @Inject SyncedFolderProvider syncedFolderProvider;
 
     public static Intent openFileIntent(Context context, User user, OCFile file) {
         final Intent intent = new Intent(context, PreviewImageActivity.class);
@@ -275,6 +281,7 @@ public class FileDisplayActivity extends FileActivity
         mPlayerConnection = new PlayerServiceConnection(this);
 
         checkStoragePath();
+        checkAutoUploadOnGPlay();
 
         initSyncBroadcastReceiver();
         observeWorkerState();
@@ -282,6 +289,43 @@ public class FileDisplayActivity extends FileActivity
 
         OfflineFolderConflictManager offlineFolderConflictManager = new OfflineFolderConflictManager(this);
         offlineFolderConflictManager.registerRefreshSearchEventReceiver();
+    }
+
+    private void checkAutoUploadOnGPlay() {
+        if (!"gplay".equals(BuildConfig.FLAVOR)) {
+            return;
+        }
+        
+        if (PermissionUtil.checkSelfPermission(this, Manifest.permission.MANAGE_EXTERNAL_STORAGE)) {
+            return;
+        }
+        
+        if (preferences.isAutoUploadGPlayWarningShown()) {
+            return;
+        }
+        
+        boolean showInfoDialog = false;
+        for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
+            // move or delete after success
+            if (syncedFolder.getUploadAction() == 1 || syncedFolder.getUploadAction() == 2) {
+                showInfoDialog = true;
+                break;
+            }
+        }
+
+        if (showInfoDialog) {
+            new MaterialAlertDialogBuilder(this, R.style.Theme_ownCloud_Dialog)
+                .setTitle(R.string.auto_upload_gplay)
+                .setMessage(R.string.auto_upload_gplay_desc)
+                .setNegativeButton(R.string.dialog_close, (dialog, which) -> {
+                    dialog.dismiss();
+                })
+                .setIcon(R.drawable.nav_synced_folders)
+                .create()
+                .show();
+        }
+
+        preferences.setAutoUploadGPlayWarningShown(true);
     }
 
     @SuppressWarnings("unchecked")

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -65,6 +65,7 @@ import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.utils.IntentUtil;
 import com.nextcloud.model.WorkerState;
 import com.nextcloud.model.WorkerStateLiveData;
+import com.nextcloud.utils.BuildHelper;
 import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.FileExtensionsKt;
@@ -292,7 +293,7 @@ public class FileDisplayActivity extends FileActivity
     }
 
     private void checkAutoUploadOnGPlay() {
-        if (!"gplay".equals(BuildConfig.FLAVOR)) {
+        if (!BuildHelper.GPLAY.equals(BuildConfig.FLAVOR)) {
             return;
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -295,6 +295,11 @@ public class FileDisplayActivity extends FileActivity
         if (!"gplay".equals(BuildConfig.FLAVOR)) {
             return;
         }
+
+        // only show on Android11+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return;
+        }
         
         if (PermissionUtil.checkSelfPermission(this, Manifest.permission.MANAGE_EXTERNAL_STORAGE)) {
             return;

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -49,6 +49,7 @@ import com.owncloud.android.ui.fragment.ExtendedListFragment;
 import com.owncloud.android.ui.fragment.LocalFileListFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.FileSortOrder;
+import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.PermissionUtil;
 
 import java.io.File;
@@ -563,7 +564,8 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     }
 
     private void checkWritableFolder(File folder) {
-        boolean canWriteIntoFolder = folder.canWrite();
+        boolean canWriteIntoFolder = FileStorageUtils.isFolderWritable(folder);
+        
         binding.uploadFilesSpinnerBehaviour.setEnabled(canWriteIntoFolder);
 
         TextView textView = findViewById(R.id.upload_files_upload_files_behaviour_text);

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.kt
@@ -277,8 +277,9 @@ class SyncedFolderPreferencesDialogFragment : DialogFragment(), Injectable {
             binding?.settingInstantBehaviourContainer?.alpha = ALPHA_DISABLED
             return
         }
-        if (syncedFolder!!.localPath != null && 
-            FileStorageUtils.isFolderWritable(File(syncedFolder!!.localPath))) {
+        if (syncedFolder!!.localPath != null &&
+            FileStorageUtils.isFolderWritable(File(syncedFolder!!.localPath))
+        ) {
             binding?.settingInstantBehaviourContainer?.isEnabled = true
             binding?.settingInstantBehaviourContainer?.alpha = ALPHA_ENABLED
             binding?.settingInstantBehaviourSummary?.text =

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SyncedFolderPreferencesDialogFragment.kt
@@ -277,7 +277,8 @@ class SyncedFolderPreferencesDialogFragment : DialogFragment(), Injectable {
             binding?.settingInstantBehaviourContainer?.alpha = ALPHA_DISABLED
             return
         }
-        if (syncedFolder!!.localPath != null && File(syncedFolder!!.localPath).canWrite()) {
+        if (syncedFolder!!.localPath != null && 
+            FileStorageUtils.isFolderWritable(File(syncedFolder!!.localPath))) {
             binding?.settingInstantBehaviourContainer?.isEnabled = true
             binding?.settingInstantBehaviourContainer?.alpha = ALPHA_ENABLED
             binding?.settingInstantBehaviourSummary?.text =

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -680,6 +680,16 @@ public final class FileStorageUtils {
 
         return checkIfEnoughSpace(availableSpaceOnDevice, file);
     }
+    
+    public static boolean isFolderWritable(File folder) {
+        File[] children = folder.listFiles();
+        
+        if (children != null && children.length > 0) {
+            return children[0].canWrite();
+        } else {
+            return folder.canWrite();
+        }
+    }
 
     @VisibleForTesting
     public static boolean checkIfEnoughSpace(long availableSpaceOnDevice, OCFile file) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1275,4 +1275,6 @@
     <string name="two_way_sync_activity_disable_all_button_title">Disable for all folders</string>
     <string name="oc_file_list_adapter_offline_operation_remove_description_text">Pending Remove Operation</string>
     <string name="warn_rename_extension">Changing the extension might cause this file to open in a different application</string>
+    <string name="auto_upload_gplay">Auto upload behaviour changed</string>
+    <string name="auto_upload_gplay_desc">Due to Google restrictions auto upload cannot move or delete files after uploading.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1276,5 +1276,5 @@
     <string name="oc_file_list_adapter_offline_operation_remove_description_text">Pending Remove Operation</string>
     <string name="warn_rename_extension">Changing the extension might cause this file to open in a different application</string>
     <string name="auto_upload_gplay">Auto upload behaviour changed</string>
-    <string name="auto_upload_gplay_desc">Due to Google restrictions auto upload cannot move or delete files after uploading.</string>
+    <string name="auto_upload_gplay_desc">Due to new restrictions imposed by Google, the auto upload feature will no longer be able to automatically remove uploaded files.</string>
 </resources>


### PR DESCRIPTION
- only for GPLAY
- shows a warning only for users that use autoupload with move/delete
- correctly show if files are read-only (folder read-only check seems not to be enough)

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
