### PR TITLE
BugFix - Infinite Storage Permission Check

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -191,6 +191,7 @@ class SyncedFoldersActivity :
             setTheme(R.style.FallbackThemingTheme)
         }
         binding.emptyList.emptyListViewAction.setOnClickListener { showHiddenItems() }
+        PermissionUtil.requestExternalStoragePermission(this, viewThemeUtils, true)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -808,9 +809,6 @@ class SyncedFoldersActivity :
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted
                     load(getItemsDisplayedPerFolder(), true)
-                } else {
-                    // permission denied --> request again
-                    PermissionUtil.requestExternalStoragePermission(this, viewThemeUtils, true)
                 }
             }
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -99,7 +99,7 @@ object PermissionUtil {
         ActivityCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
     }
 
-    // TODO rename function name to requestExternalStoragePermissionIfNeeded to prevent confusion
+    // TODO: Rename the function to requestExternalStoragePermissionIfNeeded to avoid confusion.
     /**
      * Request relevant external storage permission depending on SDK, if needed.
      *

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -160,7 +160,7 @@ object PermissionUtil {
             }
 
             if (grantedPermissions) {
-                // Permissions already granted, proceed with functionality
+                // Permissions already granted
                 return
             }
 

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -99,7 +99,7 @@ object PermissionUtil {
         ActivityCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
     }
 
-    // TODO: Rename the function to requestExternalStoragePermissionIfNeeded to avoid confusion.
+    // TODO Rename the function to requestExternalStoragePermissionIfNeeded to avoid confusion.
     /**
      * Request relevant external storage permission depending on SDK, if needed.
      *

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -99,7 +99,6 @@ object PermissionUtil {
         ActivityCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
     }
 
-
     // TODO: Rename the function to requestExternalStoragePermissionIfNeeded to avoid confusion.
     /**
      * Request relevant external storage permission depending on SDK, if needed.

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -99,6 +99,7 @@ object PermissionUtil {
         ActivityCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
     }
 
+
     // TODO: Rename the function to requestExternalStoragePermissionIfNeeded to avoid confusion.
     /**
      * Request relevant external storage permission depending on SDK, if needed.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,6 +500,7 @@
     <string name="forbidden_permissions_create">to create this file</string>
     <string name="uploader_upload_forbidden_permissions">to upload to this folder</string>
     <string name="downloader_download_file_not_found">The file is no longer available on the server</string>
+
     <string name="file_migration_dialog_title">Updating data storage folder</string>
     <string name="file_migration_preparing">Preparing migration…</string>
     <string name="file_migration_checking_destination">Checking destination…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="actionbar_see_details">Details</string>
     <string name="actionbar_send_file">Send</string>
     <string name="actionbar_sort">Sort</string>
+    <string name="common_settings">Settings</string>
     <string name="sort_by">Sort by</string>
     <string name="menu_item_sort_by_name_a_z">A - Z</string>
     <string name="menu_item_sort_by_name_z_a">Z - A</string>
@@ -500,7 +501,6 @@
     <string name="forbidden_permissions_create">to create this file</string>
     <string name="uploader_upload_forbidden_permissions">to upload to this folder</string>
     <string name="downloader_download_file_not_found">The file is no longer available on the server</string>
-
     <string name="file_migration_dialog_title">Updating data storage folder</string>
     <string name="file_migration_preparing">Preparing migration…</string>
     <string name="file_migration_checking_destination">Checking destination…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
     <string name="actionbar_see_details">Details</string>
     <string name="actionbar_send_file">Send</string>
     <string name="actionbar_sort">Sort</string>
-    <string name="common_settings">Settings</string>
     <string name="sort_by">Sort by</string>
     <string name="menu_item_sort_by_name_a_z">A - Z</string>
     <string name="menu_item_sort_by_name_z_a">Z - A</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem**

In SyncedFoldersActivity, the requestExternalStoragePermission function was triggering the onRequestPermissionsResult method, which in turn called the requestExternalStoragePermission function, causing an infinite loop and resulting in a crash.

https://github.com/user-attachments/assets/9f1d0ed4-17cb-4766-9452-26b6b061c423



