### PR TITLE
Improve RTL support

### DIFF
--- a/app/src/main/res/layout/activity_list_item.xml
+++ b/app/src/main/res/layout/activity_list_item.xml
@@ -34,7 +34,7 @@
 
         <TextView
             android:id="@+id/subject"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:paddingStart="@dimen/activity_icon_layout_right_end_margin"

--- a/app/src/main/res/layout/dialog_data_storage_location.xml
+++ b/app/src/main/res/layout/dialog_data_storage_location.xml
@@ -22,14 +22,14 @@
 
         <RadioButton
             android:id="@+id/storage_internal_radio"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:enabled="false"
             android:text="@string/storage_internal_storage" />
 
         <RadioButton
             android:id="@+id/storage_external_radio"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:enabled="false"
             android:text="@string/storage_external_storage" />

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -81,7 +81,6 @@
             android:id="@+id/Filename"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
             android:ellipsize="middle"
             android:singleLine="true"
             android:textColor="@color/text_color"

--- a/app/src/main/res/layout/notification_list_item.xml
+++ b/app/src/main/res/layout/notification_list_item.xml
@@ -8,7 +8,7 @@
   ~ SPDX-FileCopyrightText: 2018 Tobias Kaminsky <tobias@kaminsky.me>
   ~ SPDX-License-Identifier: GPL-3.0-or-later AND AGPL-3.0-or-later
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -23,46 +23,31 @@
         android:id="@+id/icon"
         android:layout_width="@dimen/notification_icon_width"
         android:layout_height="@dimen/notification_icon_height"
-        android:layout_alignParentTop="true"
         android:layout_marginEnd="@dimen/notification_icon_layout_right_end_margin"
         android:contentDescription="@string/notification_icon"
         android:src="@drawable/ic_notification" />
 
     <LinearLayout
-        android:layout_width="match_parent"
+        android:id="@+id/notification_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_alignTop="@id/icon"
-        android:layout_toEndOf="@id/icon"
+        android:layout_weight="1"
         android:orientation="vertical">
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/subject"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/subject"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:ellipsize="end"
-                android:textAppearance="?android:attr/textAppearanceListItem"
-                android:textColor="@color/text_color"
-                android:textSize="@dimen/txt_size_16sp"
-                android:paddingBottom="@dimen/standard_half_padding"
-                tools:text="@string/placeholder_filename" />
-
-            <ImageView
-                android:id="@+id/dismiss"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/dismiss_notification_description"
-                android:src="@drawable/ic_close" />
-        </LinearLayout>
+            android:ellipsize="end"
+            android:paddingBottom="@dimen/standard_half_padding"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:textColor="@color/text_color"
+            android:textSize="@dimen/txt_size_16sp"
+            tools:text="@string/placeholder_filename" />
 
         <TextView
             android:id="@+id/message"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:paddingBottom="@dimen/standard_quarter_padding"
@@ -92,4 +77,11 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+    <ImageView
+        android:id="@+id/dismiss"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/dismiss_notification_description"
+        android:src="@drawable/ic_close" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/trashbin_item.xml
+++ b/app/src/main/res/layout/trashbin_item.xml
@@ -45,9 +45,9 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="middle"
                 android:singleLine="true"
-                tools:text="@string/placeholder_filename"
                 android:textColor="@color/text_color"
-                android:textSize="@dimen/two_line_primary_text_size"/>
+                android:textSize="@dimen/two_line_primary_text_size"
+                tools:text="@string/placeholder_filename" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/version_list_item.xml
+++ b/app/src/main/res/layout/version_list_item.xml
@@ -33,7 +33,7 @@
 
         <TextView
             android:id="@+id/version_created"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:text="@string/new_version_was_created"
@@ -41,7 +41,7 @@
 
         <TextView
             android:id="@+id/size"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:layout_weight="1"
             android:ellipsize="end"


### PR DESCRIPTION
https://github.com/nextcloud/files-clients/issues/74

Improves various layouts where non-RTL-text (like file names in English) would be left aligned instead of right aligned.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
