### PR TITLE
Improve CI Performance

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/lib/android-sdk/cmdline-tools/
 RUN cd /tmp/ && mv cmdline-tools/ latest/ && mv latest/ /usr/lib/android-sdk/cmdline-tools/
 RUN mkdir /usr/lib/android-sdk/licenses/
 RUN chmod -R 755 /usr/lib/android-sdk/
-RUN mkdir -p $HOME/.gradle && \
+RUN mkdir -p "$HOME/.gradle" && \
     echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties" && \
     echo "org.gradle.caching=true" >> "$HOME/.gradle/gradle.properties" && \
     echo "org.gradle.parallel=true" >> "$HOME/.gradle/gradle.properties" && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,8 +12,9 @@ RUN mkdir -p /usr/lib/android-sdk/cmdline-tools/
 RUN cd /tmp/ && mv cmdline-tools/ latest/ && mv latest/ /usr/lib/android-sdk/cmdline-tools/
 RUN mkdir /usr/lib/android-sdk/licenses/
 RUN chmod -R 755 /usr/lib/android-sdk/
-RUN mkdir -p $HOME/.gradle
-RUN echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
-RUN echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
-RUN echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
-RUN echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
+RUN mkdir -p $HOME/.gradle && \
+    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties" && \
+    echo "org.gradle.caching=true" >> "$HOME/.gradle/gradle.properties" && \
+    echo "org.gradle.parallel=true" >> "$HOME/.gradle/gradle.properties" && \
+    echo "org.gradle.configureondemand=true" >> "$HOME/.gradle/gradle.properties" && \
+    echo "kapt.incremental.apt=true" >> "$HOME/.gradle/gradle.properties"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,7 @@ RUN cd /tmp/ && mv cmdline-tools/ latest/ && mv latest/ /usr/lib/android-sdk/cmd
 RUN mkdir /usr/lib/android-sdk/licenses/
 RUN chmod -R 755 /usr/lib/android-sdk/
 RUN mkdir -p $HOME/.gradle
-RUN echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties
+RUN echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
+RUN echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
+RUN echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
+RUN echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /tmp/ && mv cmdline-tools/ latest/ && mv latest/ /usr/lib/android-sdk/cmd
 RUN mkdir /usr/lib/android-sdk/licenses/
 RUN chmod -R 755 /usr/lib/android-sdk/
 RUN mkdir -p $HOME/.gradle && \
-    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties" && \
+    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties" && \
     echo "org.gradle.caching=true" >> "$HOME/.gradle/gradle.properties" && \
     echo "org.gradle.parallel=true" >> "$HOME/.gradle/gradle.properties" && \
     echo "org.gradle.configureondemand=true" >> "$HOME/.gradle/gradle.properties" && \

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,5 +61,8 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     mkdir -p "$HOME/.gradle"
-                    echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > "$HOME/.gradle/gradle.properties"
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties"
+                    echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
+                    echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
+                    echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
                     scripts/analysis/analysis-wrapper.sh ${{ steps.get-vars.outputs.branch }} ${{ secrets.LOG_USERNAME }} ${{ secrets.LOG_PASSWORD }} "$GITHUB_RUN_NUMBER" ${{ steps.get-vars.outputs.pr }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,7 +61,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     mkdir -p "$HOME/.gradle"
-                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties"
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties"
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,8 +61,9 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     mkdir -p "$HOME/.gradle"
-                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties"
+                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > "$HOME/.gradle/gradle.properties"
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
+                    echo "kapt.incremental.apt=true" >> $HOME/.gradle/gradle.properties
                     scripts/analysis/analysis-wrapper.sh ${{ steps.get-vars.outputs.branch }} ${{ secrets.LOG_USERNAME }} ${{ secrets.LOG_PASSWORD }} "$GITHUB_RUN_NUMBER" ${{ steps.get-vars.outputs.pr }}

--- a/.github/workflows/assembleFlavors.yml
+++ b/.github/workflows/assembleFlavors.yml
@@ -30,5 +30,8 @@ jobs:
                     java-version: 17
             -   name: Build ${{ matrix.flavor }}
                 run: |
-                    echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" >> gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" >> gradle.properties
+                    echo "org.gradle.caching=true" >> gradle.properties
+                    echo "org.gradle.parallel=true" >> gradle.properties
+                    echo "org.gradle.configureondemand=true" >> gradle.properties
                     ./gradlew assemble${{ matrix.flavor }}

--- a/.github/workflows/assembleFlavors.yml
+++ b/.github/workflows/assembleFlavors.yml
@@ -30,7 +30,7 @@ jobs:
                     java-version: 17
             -   name: Build ${{ matrix.flavor }}
                 run: |
-                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" >> gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" >> gradle.properties
                     echo "org.gradle.caching=true" >> gradle.properties
                     echo "org.gradle.parallel=true" >> gradle.properties
                     echo "org.gradle.configureondemand=true" >> gradle.properties

--- a/.github/workflows/assembleFlavors.yml
+++ b/.github/workflows/assembleFlavors.yml
@@ -30,8 +30,9 @@ jobs:
                     java-version: 17
             -   name: Build ${{ matrix.flavor }}
                 run: |
-                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" >> gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" >> gradle.properties
                     echo "org.gradle.caching=true" >> gradle.properties
                     echo "org.gradle.parallel=true" >> gradle.properties
                     echo "org.gradle.configureondemand=true" >> gradle.properties
+                    echo "kapt.incremental.apt=true" >> gradle.properties
                     ./gradlew assemble${{ matrix.flavor }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -41,7 +41,10 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
+                    echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
+                    echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
                     sed -i "/qa/,/\}/ s/versionCode .*/versionCode ${{github.event.number}} /" app/build.gradle
                     sed -i "/qa/,/\}/ s/versionName .*/versionName \"${{github.event.number}}\"/" app/build.gradle
                     ./gradlew assembleQaDebug

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -41,10 +41,11 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
+                    echo "kapt.incremental.apt=true" >> $HOME/.gradle/gradle.properties
                     sed -i "/qa/,/\}/ s/versionCode .*/versionCode ${{github.event.number}} /" app/build.gradle
                     sed -i "/qa/,/\}/ s/versionName .*/versionName \"${{github.event.number}}\"/" app/build.gradle
                     ./gradlew assembleQaDebug

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -41,7 +41,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 run: |
                     mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties

--- a/.github/workflows/screenShotTest.yml
+++ b/.github/workflows/screenShotTest.yml
@@ -69,10 +69,11 @@ jobs:
             -   name: Configure gradle daemon
                 run: |
                     mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
+                    echo "kapt.incremental.apt=true" >> $HOME/.gradle/gradle.properties
 
             -   name: Build gplay
                 run: ./gradlew assembleGplayDebug

--- a/.github/workflows/screenShotTest.yml
+++ b/.github/workflows/screenShotTest.yml
@@ -69,8 +69,10 @@ jobs:
             -   name: Configure gradle daemon
                 run: |
                     mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
+                    echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
+                    echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties
 
             -   name: Build gplay
                 run: ./gradlew assembleGplayDebug

--- a/.github/workflows/screenShotTest.yml
+++ b/.github/workflows/screenShotTest.yml
@@ -69,7 +69,7 @@ jobs:
             -   name: Configure gradle daemon
                 run: |
                     mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
+                    echo "org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g" > $HOME/.gradle/gradle.properties
                     echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
                     echo "org.gradle.configureondemand=true" >> $HOME/.gradle/gradle.properties


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

The CI process was failing with 1GB of memory allocation. 2GB resolved the issue intermittently, but it was still insufficient in certain cases. 

To address this, I allocated 6GB of memory, which may be excessive for the CI environment. @tobiasKaminsky What do you think?