### PR TITLE
BugFix - Get Files For Auto Upload

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FilesystemDataProvider.java
@@ -14,16 +14,11 @@ import android.net.Uri;
 
 import com.owncloud.android.db.ProviderMeta;
 import com.owncloud.android.lib.common.utils.Log_OC;
-import com.owncloud.android.utils.SyncedFolderUtils;
 
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.zip.CRC32;
 
 /**
@@ -61,49 +56,6 @@ public class FilesystemDataProvider {
                 ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ?",
             new String[]{path, syncedFolderId}
                               );
-    }
-
-    public Set<String> getFilesForUpload(String localPath, String syncedFolderId) {
-        Set<String> localPathsToUpload = new HashSet<>();
-
-        String likeParam = localPath + "%";
-
-        Cursor cursor = contentResolver.query(
-            ProviderMeta.ProviderTableMeta.CONTENT_URI_FILESYSTEM,
-            null,
-            ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH + " LIKE ? and " +
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID + " = ? and " +
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD + " = ? and " +
-                ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER + " = ?",
-            new String[]{likeParam, syncedFolderId, "0", "0"},
-            null);
-
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                do {
-                    String value = cursor.getString(cursor.getColumnIndexOrThrow(
-                        ProviderMeta.ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH));
-                    if (value == null) {
-                        Log_OC.e(TAG, "Cannot get local path");
-                    } else {
-                        File file = new File(value);
-                        if (!file.exists()) {
-                            Log_OC.d(TAG, "Ignoring file for upload (doesn't exist): " + value);
-                        } else if (!SyncedFolderUtils.isQualifiedFolder(file.getParent())) {
-                            Log_OC.d(TAG, "Ignoring file for upload (unqualified folder): " + value);
-                        } else if (!SyncedFolderUtils.isFileNameQualifiedForAutoUpload(file.getName())) {
-                            Log_OC.d(TAG, "Ignoring file for upload (unqualified file): " + value);
-                        } else {
-                            localPathsToUpload.add(value);
-                        }
-                    }
-                } while (cursor.moveToNext());
-            }
-
-            cursor.close();
-        }
-
-        return localPathsToUpload;
     }
 
     public void storeOrUpdateFileValue(String localPath, long modifiedAt, boolean isFolder, SyncedFolder syncedFolder) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

FilesystemDataProvider.getFilesForUpload → This function returns local paths for auto-upload.

The new function performs the same task. When I pass syncedFolder.localPath, the new function returns the expected result, but the old function returns an empty list.

**How to Test**

Set up auto-upload. The local path must contain nested folders, and each folder should have files.

Ensure all files are fetched from the given directory, even with subfiles

The correct name collision policy should be applied. For example:
	• Ask Every Time or Skip Upload: Files should not be re-uploaded.
	• Overwrite: Files should be re-uploaded.
