### PR TITLE
BugFix - Upload Current File Index

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -90,6 +90,7 @@ class FileUploadWorker(
         }
     }
 
+    private var currentUploadIndex: Int = 1
     private var lastPercent = 0
     private val notificationManager = UploadNotificationManager(context, viewThemeUtils)
     private val intents = FileUploaderIntents(context)
@@ -167,7 +168,7 @@ class FileUploadWorker(
         setWorkerState(user.get(), uploadsPerPage)
 
         run uploads@{
-            uploadsPerPage.forEachIndexed { currentUploadIndex, upload ->
+            uploadsPerPage.forEach { upload ->
                 if (isStopped) {
                     return@uploads
                 }
@@ -181,11 +182,15 @@ class FileUploadWorker(
                         uploadFileOperation,
                         cancelPendingIntent = intents.startIntent(uploadFileOperation),
                         startIntent = intents.notificationStartIntent(uploadFileOperation),
-                        currentUploadIndex = currentUploadIndex + 1,
+                        currentUploadIndex = currentUploadIndex,
                         totalUploadSize = totalUploadSize
                     )
 
                     val result = upload(uploadFileOperation, user.get())
+
+                    if (result.isSuccess) {
+                        currentUploadIndex += 1
+                    }
 
                     currentUploadFileOperation = null
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -32,16 +32,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         currentUploadIndex: Int,
         totalUploadSize: Int
     ) {
-        currentOperationTitle = if (totalUploadSize > 1) {
-            String.format(
-                context.getString(R.string.upload_notification_manager_start_text),
-                currentUploadIndex,
-                totalUploadSize,
-                uploadFileOperation.fileName
-            )
-        } else {
-            uploadFileOperation.fileName
-        }
+        currentOperationTitle = "$currentUploadIndex / $totalUploadSize - ${uploadFileOperation.fileName}"
 
         val progressText = String.format(
             context.getString(R.string.upload_notification_manager_upload_in_progress_text),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,6 @@
     <string name="upload_chooser_title">Upload from…</string>
     <string name="uploader_info_dirname">Folder name</string>
 
-    <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
     <string name="upload_notification_manager_upload_in_progress_text" translatable="false">%1$d%%</string>
 
     <string name="uploader_upload_in_progress_ticker">Uploading…</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed


**Problem**

After uploading 100 files, the progress indicator resets back to 1. This occurs every 100 files.
For example, if the total number of files is 536, after the first 100 uploads, the current file index resets to 1.

**Demo**


https://github.com/user-attachments/assets/8b22a024-8b98-4833-8718-feabcc5345c6

