### PR TITLE
fix: FilesSyncHelper: Shuffle array after null check, else NullPointerException is thrown

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -72,8 +72,8 @@ public final class FilesSyncHelper {
                 FileVisitResult preVisitDirectoryResult = visitor.preVisitDirectory(start, (BasicFileAttributes)null);
                 if (preVisitDirectoryResult == FileVisitResult.CONTINUE) {
                     File[] children = start.toFile().listFiles();
-                    Collections.shuffle(Arrays.asList(children));
                     if (children != null) {
+                        Collections.shuffle(Arrays.asList(children));
                         File[] var5 = children;
                         int var6 = children.length;
 

--- a/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
+++ b/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
@@ -44,7 +44,10 @@ public class FilesSyncHelperTest {
         mockPath = mock(Path.class);
         Mockito.when(mockFile.isDirectory()).thenReturn(true);
         Mockito.when(mockPath.toFile()).thenReturn(mockFile);
-        Mockito.when(mockFile.listFiles()).thenReturn(new File[]{mockFile, mockFile, mockFile}).thenReturn(new File[0]).thenReturn(null);
+        Mockito.when(mockFile.listFiles())
+            .thenReturn(new File[]{mockFile, mockFile, mockFile})
+            .thenReturn(new File[0])
+            .thenReturn(null);
         Mockito.when(mockFile.canRead()).thenReturn(true);
 
         SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {

--- a/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
+++ b/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
@@ -44,10 +44,7 @@ public class FilesSyncHelperTest {
         mockPath = mock(Path.class);
         Mockito.when(mockFile.isDirectory()).thenReturn(true);
         Mockito.when(mockPath.toFile()).thenReturn(mockFile);
-        Mockito.when(mockFile.listFiles())
-            .thenReturn(new File[]{mockFile, mockFile, mockFile})
-            .thenReturn(new File[0])
-            .thenReturn(null);
+        Mockito.when(mockFile.listFiles()).thenReturn(null);
         Mockito.when(mockFile.canRead()).thenReturn(true);
 
         SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {

--- a/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
+++ b/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
@@ -1,0 +1,79 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Benedek Major <benedek@major.onl>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.utils;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.lukhnos.nnio.file.FileVisitResult;
+import org.lukhnos.nnio.file.Path;
+import org.lukhnos.nnio.file.Paths;
+import org.lukhnos.nnio.file.SimpleFileVisitor;
+import org.lukhnos.nnio.file.attribute.BasicFileAttributes;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import static com.owncloud.android.utils.FilesSyncHelper.walkFileTreeRandomly;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+
+
+public class FilesSyncHelperTest {
+    @Mock
+    private File mockFile;
+
+    @Mock
+    private Path mockPath;
+
+    @Test
+    public void testWalkFileTreeNullHandling(){
+        mockFile = mock(File.class);
+        mockPath = mock(Path.class);
+        Mockito.when(mockFile.isDirectory()).thenReturn(true);
+        Mockito.when(mockPath.toFile()).thenReturn(mockFile);
+        Mockito.when(mockFile.listFiles()).thenReturn(new File[]{mockFile, mockFile, mockFile}).thenReturn(new File[0]).thenReturn(null);
+        Mockito.when(mockFile.canRead()).thenReturn(true);
+
+        SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+        };
+        try{
+            walkFileTreeRandomly(mockPath,visitor);
+        } catch (Exception e){
+            StringWriter writer = new StringWriter();
+            PrintWriter printWriter = new PrintWriter( writer );
+            e.printStackTrace( printWriter );
+            printWriter.flush();
+
+            String stackTrace = writer.toString();
+            fail("walkFileTree throws an exception: \n" + stackTrace);
+        }
+    }
+    
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [X] Tests written, or not not needed

This again fixes: #12964 
change should be obvious, first shuffling a null array and then checking is not a good idea.

I also now added some tests, that only test for the null condition, so this issue hopefully does not arise in the future