### PR TITLE
Bugfix - E2E Share File From Other Apps

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -240,6 +240,19 @@ public class FileDataStorageManager {
         offlineOperationDao.insert(entity);
     }
 
+    public String getFileNameBasedOnEncryptionStatus(OCFile file) {
+        FileEntity entity = fileDao.getFileById(file.getFileId());
+        if (entity == null) {
+            return file.getFileName();
+        }
+
+        if (file.isEncrypted()) {
+            return entity.getEncryptedName();
+        } else {
+            return entity.getName();
+        }
+    }
+
     public String getFilenameConsideringOfflineOperation(OCFile file) {
         String filename = file.getDecryptedFileName();
         OfflineOperationEntity renameEntity = offlineOperationDao.getByPath(file.getDecryptedRemotePath());

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -234,7 +234,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     public void onAccountChosen(@NonNull User user) {
         setAccount(user.toPlatformAccount(), false);
         initTargetFolder();
-        populateDirectoryList();
+        populateDirectoryList(null);
     }
 
     @Override
@@ -258,7 +258,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         final OCFile fileByPath = getStorageManager().getFileByPath(full_path);
         if (fileByPath != null) {
             startSyncFolderOperation(fileByPath);
-            populateDirectoryList();
+            populateDirectoryList(null);
         } else {
             browseToRoot();
             preferences.setLastUploadPath(OCFile.ROOT_PATH);
@@ -290,7 +290,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     public void onSortingOrderChosen(FileSortOrder newSortOrder) {
         preferences.setSortOrder(mFile, newSortOrder);
         sortButton.setText(DisplayUtils.getSortOrderStringId(newSortOrder));
-        populateDirectoryList();
+        populateDirectoryList(null);
     }
 
     @Override
@@ -310,8 +310,10 @@ public class ReceiveExternalFilesActivity extends FileActivity
             }
 
             startSyncFolderOperation(file);
-            mParents.push(file.getFileName());
-            populateDirectoryList();
+
+            String filename = fileDataStorageManager.getFileNameBasedOnEncryptionStatus(file);
+            mParents.push(filename);
+            populateDirectoryList(file);
         }
     }
 
@@ -706,7 +708,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 // account at this point
                 // since account setup can set only one account at time
                 setAccount(accounts[0], false);
-                populateDirectoryList();
+                populateDirectoryList(null);
             }
         }
     }
@@ -721,7 +723,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         }
     }
 
-    private void populateDirectoryList() {
+    private void populateDirectoryList(OCFile file) {
         setupEmptyList();
         setupToolbar();
         ActionBar actionBar = getSupportActionBar();
@@ -737,7 +739,11 @@ public class ReceiveExternalFilesActivity extends FileActivity
             if (TextUtils.isEmpty(current_dir)) {
                 viewThemeUtils.files.themeActionBar(this, actionBar, R.string.uploader_top_message);
             } else {
-                viewThemeUtils.files.themeActionBar(this, actionBar, current_dir);
+                if (file != null) {
+                    viewThemeUtils.files.themeActionBar(this, actionBar, file.getFileName());
+                } else {
+                    viewThemeUtils.files.themeActionBar(this, actionBar, current_dir);
+                }
             }
 
             actionBar.setDisplayHomeAsUpEnabled(notRoot);
@@ -748,37 +754,44 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
         Log_OC.d(TAG, "Populating view with content of : " + full_path);
 
-        mFile = getStorageManager().getFileByPath(full_path);
-        if (mFile != null) {
-            List<OCFile> files = getStorageManager().getFolderContent(mFile, false);
-
-            if (files.isEmpty()) {
-                setMessageForEmptyList(R.string.file_list_empty_headline, R.string.empty,
-                                       R.drawable.uploads);
-                mEmptyListContainer.setVisibility(View.VISIBLE);
-                binding.list.setVisibility(View.GONE);
-            } else {
-                mEmptyListContainer.setVisibility(View.GONE);
-                files = sortFileList(files);
-                setupReceiveExternalFilesAdapter(files);
-            }
-
-            MaterialButton btnChooseFolder = binding.uploaderChooseFolder;
-            viewThemeUtils.material.colorMaterialButtonPrimaryFilled(btnChooseFolder);
-            btnChooseFolder.setOnClickListener(this);
-
-            btnChooseFolder.setEnabled(mFile.canWrite());
-
-            viewThemeUtils.platform.themeStatusBar(this);
-
-            viewThemeUtils.material.colorMaterialButtonPrimaryOutlined(binding.uploaderCancel);
-            binding.uploaderCancel.setOnClickListener(this);
-
-            sortButton = binding.toolbarLayout.sortButton;
-            FileSortOrder sortOrder = preferences.getSortOrderByFolder(mFile);
-            sortButton.setText(DisplayUtils.getSortOrderStringId(sortOrder));
-            sortButton.setOnClickListener(l -> openSortingOrderDialogFragment(getSupportFragmentManager(), sortOrder));
+        if (file != null) {
+            mFile = file;
+        } else {
+            mFile = getStorageManager().getFileByPath(full_path);
         }
+
+        if (mFile == null) {
+            return;
+        }
+
+        List<OCFile> files = getStorageManager().getFolderContent(mFile, false);
+
+        if (files.isEmpty()) {
+            setMessageForEmptyList(R.string.file_list_empty_headline, R.string.empty,
+                                   R.drawable.uploads);
+            mEmptyListContainer.setVisibility(View.VISIBLE);
+            binding.list.setVisibility(View.GONE);
+        } else {
+            mEmptyListContainer.setVisibility(View.GONE);
+            files = sortFileList(files);
+            setupReceiveExternalFilesAdapter(files);
+        }
+
+        MaterialButton btnChooseFolder = binding.uploaderChooseFolder;
+        viewThemeUtils.material.colorMaterialButtonPrimaryFilled(btnChooseFolder);
+        btnChooseFolder.setOnClickListener(this);
+
+        btnChooseFolder.setEnabled(mFile.canWrite());
+
+        viewThemeUtils.platform.themeStatusBar(this);
+
+        viewThemeUtils.material.colorMaterialButtonPrimaryOutlined(binding.uploaderCancel);
+        binding.uploaderCancel.setOnClickListener(this);
+
+        sortButton = binding.toolbarLayout.sortButton;
+        FileSortOrder sortOrder = preferences.getSortOrderByFolder(mFile);
+        sortButton.setText(DisplayUtils.getSortOrderStringId(sortOrder));
+        sortButton.setOnClickListener(l -> openSortingOrderDialogFragment(getSupportFragmentManager(), sortOrder));
     }
 
     private void setupReceiveExternalFilesAdapter(List<OCFile> files) {
@@ -969,19 +982,15 @@ public class ReceiveExternalFilesActivity extends FileActivity
      * @param operation Creation operation performed.
      * @param result    Result of the creation.
      */
-    private void onCreateFolderOperationFinish(CreateFolderOperation operation,
-                                               RemoteOperationResult result) {
+    private void onCreateFolderOperationFinish(CreateFolderOperation operation, RemoteOperationResult result) {
         if (result.isSuccess()) {
             String remotePath = operation.getRemotePath().substring(0, operation.getRemotePath().length() - 1);
             String newFolder = remotePath.substring(remotePath.lastIndexOf('/') + 1);
             mParents.push(newFolder);
-            populateDirectoryList();
+            populateDirectoryList(null);
         } else {
             try {
-                DisplayUtils.showSnackMessage(
-                    this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
-                                             );
-
+                DisplayUtils.showSnackMessage(this, ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()));
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
             }
@@ -1033,8 +1042,10 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
         setupSearchView(menu);
 
-        MenuItem newFolderMenuItem = menu.findItem(R.id.action_create_dir);
-        newFolderMenuItem.setEnabled(mFile.canWrite());
+        if (mFile != null) {
+            MenuItem newFolderMenuItem = menu.findItem(R.id.action_create_dir);
+            newFolderMenuItem.setEnabled(mFile.canWrite());
+        }
 
         return true;
     }
@@ -1145,9 +1156,8 @@ public class ReceiveExternalFilesActivity extends FileActivity
                             }
 
                             if (currentDir.getRemotePath().equals(syncFolderRemotePath)) {
-                                populateDirectoryList();
+                                populateDirectoryList(currentFile);
                             }
-                            mFile = currentFile;
                         }
 
                         mSyncInProgress = !FileSyncAdapter.EVENT_FULL_SYNC_END.equals(event) &&


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Fixes:**

• Resolved the crash issue.
• Made mParents variable compatible with encrypted files. The remotePath now uses the encrypted path instead of the decrypted path, allowing files to be uploaded via FileUploadWorker.

**Steps to Reproduce:**

1. Open the app and log in.
2. Use any gallery app to select a file, then share it to the NextCloud app.
3. On the “Choose upload folder” screen, select an encrypted folder.
4. Tap “Create new folder” and create a subfolder in the encrypted folder.
5. App will crash

**Crash Report**

```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean [com.owncloud.android](http://com.owncloud.android/).datamodel.OCFile.canWrite()' on a null object reference
                                                    at [com.owncloud.android](http://com.owncloud.android/).ui.activity.ReceiveExternalFilesActivity.onCreateOptionsMenu([ReceiveExternalFilesActivity.java:1037](http://receiveexternalfilesactivity.java:1037/))
                                                    at [android.app](http://android.app/).Activity.onCreatePanelMenu([Activity.java:3680](http://activity.java:3680/))
                                                    at androidx.activity.ComponentActivity.onCreatePanelMenu(ComponentActivity.kt:470)
                                                    at androidx.appcompat.view.WindowCallbackWrapper.onCreatePanelMenu([WindowCallbackWrapper.java:94](http://windowcallbackwrapper.java:94/))
                                                    at [androidx.appcompat.app](http://androidx.appcompat.app/).AppCompatDelegateImpl$AppCompatWindowCallback.onCreatePanelMenu([AppCompatDelegateImpl.java:3413](http://appcompatdelegateimpl.java:3413/))
                                                    at [androidx.appcompat.app](http://androidx.appcompat.app/).ToolbarActionBar.populateOptionsMenu([ToolbarActionBar.java:458](http://toolbaractionbar.java:458/))
                                                    at [androidx.appcompat.app](http://androidx.appcompat.app/).ToolbarActionBar$1.run([ToolbarActionBar.java:58](http://toolbaractionbar.java:58/))
                                                    at android.view.Choreographer$CallbackRecord.run([Choreographer.java:1092](http://choreographer.java:1092/))
                                                    at android.view.Choreographer.doCallbacks([Choreographer.java:893](http://choreographer.java:893/))
                                                    at android.view.Choreographer.doFrame([Choreographer.java:809](http://choreographer.java:809/))
                                                    at android.view.Choreographer$FrameDisplayEventReceiver.run([Choreographer.java:1078](http://choreographer.java:1078/))
                                                    at android.os.Handler.handleCallback([Handler.java:907](http://handler.java:907/))
                                                    at android.os.Handler.dispatchMessage([Handler.java:105](http://handler.java:105/))
                                                    at android.os.Looper.loop([Looper.java:216](http://looper.java:216/))
                                                    at [android.app](http://android.app/).ActivityThread.main([ActivityThread.java:7625](http://activitythread.java:7625/))
                                                    at java.lang.reflect.Method.invoke(Native Method)
                                                    at [com.android](http://com.android/).internal.os.RuntimeInit$MethodAndArgsCaller.run([RuntimeInit.java:524](http://runtimeinit.java:524/))
                                                    at [com.android](http://com.android/).internal.os.ZygoteInit.main([ZygoteInit.java:987](http://zygoteinit.java:987/))

```