### PR TITLE
Stop Uploads When the Device Doesn’t Have an Internet Connection

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -584,9 +584,14 @@ internal class BackgroundJobManagerImpl(
 
         val tag = startFileUploadJobTag(user)
 
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
         val request = oneTimeRequestBuilder(FileUploadWorker::class, JOB_FILES_UPLOAD, user)
             .addTag(tag)
             .setInputData(data)
+            .setConstraints(constraints)
             .build()
 
         workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.KEEP, request)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -171,10 +171,16 @@ class FileUploadWorker(
     }
 
     private fun canExitEarly(): Boolean {
-        return !connectivityService.isConnected ||
+        val result = !connectivityService.isConnected ||
             connectivityService.isInternetWalled ||
             isStopped ||
             isAirplaneModeEnabled()
+
+        if (!result) {
+            notificationManager.dismissErrorNotification()
+        }
+
+        return result
     }
 
     private fun isAirplaneModeEnabled(): Boolean {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -9,6 +9,7 @@ package com.nextcloud.client.jobs.upload
 
 import android.app.PendingIntent
 import android.content.Context
+import android.provider.Settings
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -148,6 +149,12 @@ class FileUploadWorker(
                 return Result.success()
             }
 
+            if (canExitEarly()) {
+                Log_OC.d(TAG, "Airplane mode is enabled or no internet connection, stopping worker.")
+                notificationManager.showConnectionErrorNotification()
+                return Result.failure()
+            }
+
             Log_OC.d(TAG, "Handling ${uploadsPerPage.size} uploads for account $accountName")
             val lastId = uploadsPerPage.last().uploadId
             uploadFiles(totalUploadSize, uploadsPerPage, accountName)
@@ -163,14 +170,32 @@ class FileUploadWorker(
         return Result.success()
     }
 
+    private fun canExitEarly(): Boolean {
+        return !connectivityService.isConnected ||
+            connectivityService.isInternetWalled ||
+            isStopped ||
+            isAirplaneModeEnabled()
+    }
+
+    private fun isAirplaneModeEnabled(): Boolean {
+        return Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
+    }
+
     @Suppress("NestedBlockDepth")
     private fun uploadFiles(totalUploadSize: Int, uploadsPerPage: List<OCUpload>, accountName: String) {
         val user = userAccountManager.getUser(accountName)
         setWorkerState(user.get(), uploadsPerPage)
 
+        if (canExitEarly()) {
+            Log_OC.d(TAG, "Airplane mode is enabled or no internet connection, stopping worker.")
+            notificationManager.showConnectionErrorNotification()
+            return
+        }
+
         run uploads@{
             uploadsPerPage.forEach { upload ->
-                if (isStopped) {
+                if (canExitEarly()) {
+                    notificationManager.showConnectionErrorNotification()
                     return@uploads
                 }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -167,6 +167,8 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         }
     }
 
+    fun dismissErrorNotification() = notificationManager.cancel(FileUploadWorker.NOTIFICATION_ERROR_ID)
+
     fun dismissOldErrorNotification(remotePath: String, localPath: String) {
         notificationManager.cancel(
             NotificationUtils.createUploadNotificationTag(remotePath, localPath),

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -143,6 +143,18 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         )
     }
 
+    fun showConnectionErrorNotification() {
+        notificationBuilder.run {
+            setContentTitle(context.getString(R.string.file_upload_worker_error_notification_title))
+            setContentText("")
+        }
+
+        notificationManager.notify(
+            FileUploadWorker.NOTIFICATION_ERROR_ID,
+            notificationBuilder.build()
+        )
+    }
+
     fun dismissOldErrorNotification(operation: UploadFileOperation?) {
         if (operation == null) {
             return

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -144,6 +144,8 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
     }
 
     fun showConnectionErrorNotification() {
+        notificationManager.cancel(getId())
+
         notificationBuilder.run {
             setContentTitle(context.getString(R.string.file_upload_worker_error_notification_title))
             setContentText("")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <string name="upload_list_empty_headline">No uploads available</string>
     <string name="upload_list_empty_text_auto_upload">Upload some content or activate auto upload.</string>
     <string name="file_list_folder">folder</string>
+    <string name="file_upload_worker_error_notification_title">Upload failed. No internet connection</string>
     <string name="filedetails_download">Download</string>
     <string name="filedetails_sync_file">Sync</string>
     <string name="filedetails_renamed_in_upload_msg">File renamed %1$s during upload</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


**Problem**

When the device lacks an active internet connection or is in airplane mode, the app continues attempting to upload files. This results in numerous “upload failed” notifications appearing repeatedly.

**How to Test**

1. Attempt to upload multiple files
2. During the upload process, disconnect the internet or enable airplane mode.
3. Observe that multiple error notifications are generated.
