### PR TITLE
Hard-code ignore files with prefix .trashed

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/utils/SyncedFolderUtilsTest.kt
+++ b/app/src/androidTest/java/com/owncloud/android/utils/SyncedFolderUtilsTest.kt
@@ -11,6 +11,7 @@ import com.owncloud.android.AbstractIT
 import com.owncloud.android.datamodel.MediaFolder
 import com.owncloud.android.datamodel.MediaFolderType
 import com.owncloud.android.datamodel.SyncedFolder
+import com.owncloud.android.utils.SyncedFolderUtils.hasExcludePrefix
 import org.apache.commons.io.FileUtils
 import org.junit.AfterClass
 import org.junit.Assert
@@ -203,6 +204,21 @@ class SyncedFolderUtilsTest : AbstractIT() {
             SyncedFolder.NOT_SCANNED_YET
         )
         Assert.assertFalse(SyncedFolderUtils.isQualifyingMediaFolder(folder))
+    }
+
+    @Test
+    fun testInstantUploadPathIgnoreExcludedPrefixes() {
+        val testFiles = listOf(
+            "IMG_nnn.jpg",
+            "my_documents",
+            "Music",
+            ".trashed_IMG_nnn.jpg",
+            ".pending_IMG_nnn.jpg",
+            ".nomedia",
+            ".thumbdata_IMG_nnn",
+            ".thumbnail"
+        ).filter { !hasExcludePrefix(it) }
+        Assert.assertTrue(testFiles.size == 3)
     }
 
     companion object {

--- a/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
@@ -27,6 +27,7 @@ object SyncedFolderUtils {
     private const val THUMBNAIL_FOLDER_PREFIX = ".thumbnail"
     private const val THUMBNAIL_DATA_FILE_PREFIX = ".thumbdata"
     private const val SINGLE_FILE = 1
+    private const val EXTERNAL_TRASHCAN_PREFIX = ".trashed"
 
     /**
      * analyzes a given media folder if its content qualifies for the folder to be handled as a media folder.
@@ -129,7 +130,8 @@ object SyncedFolderUtils {
         return when {
             fileName != null -> {
                 !DISQUALIFIED_MEDIA_DETECTION_FILE_SET.contains(fileName.lowercase()) &&
-                    !fileName.startsWith(THUMBNAIL_DATA_FILE_PREFIX)
+                    !fileName.startsWith(THUMBNAIL_DATA_FILE_PREFIX) &&
+                    !fileName.startsWith(EXTERNAL_TRASHCAN_PREFIX)
             }
             else -> false
         }

--- a/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
@@ -24,9 +24,9 @@ object SyncedFolderUtils {
     )
     private val DISQUALIFIED_MEDIA_DETECTION_FILE_SET: Set<String> = DISQUALIFIED_MEDIA_DETECTION_SOURCE.toSet()
     private val AUTO_QUALIFYING_FOLDER_TYPE_SET: Set<MediaFolderType> = setOf(MediaFolderType.CUSTOM)
-    private const val THUMBNAIL_FOLDER_PREFIX = ".thumbnail"
     private const val SINGLE_FILE = 1
-    private val EXCLUDE_FILENAME_PREFIXES = listOf(
+    private val EXCLUDE_PREFIXES = listOf(
+        ".thumbnail",
         ".thumbdata",
         ".trashed",
         ".pending",
@@ -110,7 +110,7 @@ object SyncedFolderUtils {
         }
         val folder = File(folderPath)
         // check if folder starts with thumbnail prefix
-        return folder.isDirectory && !folder.name.startsWith(THUMBNAIL_FOLDER_PREFIX)
+        return folder.isDirectory && !hasExcludePrefix(folder.name)
     }
 
     /**
@@ -155,18 +155,18 @@ object SyncedFolderUtils {
     }
 
     /**
-     * check if filename has prefix in the list to exclude from auto upload
+     * check if file or folder name has prefix in the list to exclude from auto upload
      *
-     * @param fileName name of file to check
+     * @param name name of file to check
      * @return `true` if file has one of the prefixes in EXCLUDE_FILENAME_PREFIXES
      */
-    private fun hasExcludePrefix(fileName: String?): Boolean {
-        if (fileName == null) {
-            return false
-        }
-        EXCLUDE_FILENAME_PREFIXES.forEach {
-            if (fileName.startsWith(it)) {
-                return true
+    fun hasExcludePrefix(name: String?): Boolean {
+        val hasPrefix = false
+        if (name != null) {
+            EXCLUDE_PREFIXES.forEach {
+                if (name.startsWith(it)) {
+                    return true
+                }
             }
         }
         return false

--- a/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
@@ -25,9 +25,13 @@ object SyncedFolderUtils {
     private val DISQUALIFIED_MEDIA_DETECTION_FILE_SET: Set<String> = DISQUALIFIED_MEDIA_DETECTION_SOURCE.toSet()
     private val AUTO_QUALIFYING_FOLDER_TYPE_SET: Set<MediaFolderType> = setOf(MediaFolderType.CUSTOM)
     private const val THUMBNAIL_FOLDER_PREFIX = ".thumbnail"
-    private const val THUMBNAIL_DATA_FILE_PREFIX = ".thumbdata"
     private const val SINGLE_FILE = 1
-    private const val EXTERNAL_TRASHCAN_PREFIX = ".trashed"
+    private val EXCLUDE_FILENAME_PREFIXES = listOf(
+        ".thumbdata",
+        ".trashed",
+        ".pending",
+        ".nomedia"
+    )
 
     /**
      * analyzes a given media folder if its content qualifies for the folder to be handled as a media folder.
@@ -130,8 +134,7 @@ object SyncedFolderUtils {
         return when {
             fileName != null -> {
                 !DISQUALIFIED_MEDIA_DETECTION_FILE_SET.contains(fileName.lowercase()) &&
-                    !fileName.startsWith(THUMBNAIL_DATA_FILE_PREFIX) &&
-                    !fileName.startsWith(EXTERNAL_TRASHCAN_PREFIX)
+                    !hasExcludePrefix(fileName)
             }
             else -> false
         }
@@ -149,5 +152,23 @@ object SyncedFolderUtils {
             .map { Pair(it, it.lastModified()) }
             .sortedBy { it.second }
             .map { it.first }
+    }
+
+    /**
+     * check if filename has prefix in the list to exclude from auto upload
+     *
+     * @param fileName name of file to check
+     * @return `true` if file has one of the prefixes in EXCLUDE_FILENAME_PREFIXES
+     */
+    private fun hasExcludePrefix(fileName: String?): Boolean {
+        if (fileName == null) {
+            return false
+        }
+        EXCLUDE_FILENAME_PREFIXES.forEach {
+            if (fileName.startsWith(it)) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
@@ -161,7 +161,6 @@ object SyncedFolderUtils {
      * @return `true` if file has one of the prefixes in EXCLUDE_FILENAME_PREFIXES
      */
     fun hasExcludePrefix(name: String?): Boolean {
-        val hasPrefix = false
         if (name != null) {
             EXCLUDE_PREFIXES.forEach {
                 if (name.startsWith(it)) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Creating initally as a draft. Help on how to write tests for this is most welcome, if necessary, as other comments too.

Fixes issue #10645 for people using Google Photos for handling their local copies of photos. Samsung Photos seems to use the same trashcan method too, though this hasn't been tried on a Samsung phone.

Files with the prefix `.trashed` are excluded from the list of files eligible for sync using the same method as is used for thumbnail files (hard-coded).
