### PR TITLE
Don't Show Failed Upload Message For Same File and Handle Local Behavior

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -282,6 +282,7 @@ class FileUploadWorker(
                 context
             )
         ) {
+            uploadFileOperation.handleLocalBehaviour()
             return
         }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -22,8 +22,6 @@ import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.model.WorkerState
 import com.nextcloud.model.WorkerStateLiveData
 import com.nextcloud.utils.extensions.getPercent
-import com.nextcloud.utils.extensions.showToast
-import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
 import com.owncloud.android.datamodel.UploadsStorageManager
@@ -284,7 +282,6 @@ class FileUploadWorker(
                 context
             )
         ) {
-            context.showToast(R.string.file_upload_worker_same_file_already_exists)
             return
         }
 

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -452,13 +452,11 @@ public class UploadFileOperation extends SyncOperation {
         }
     }
 
-    private E2EFiles e2eFiles;
-
     // region E2E Upload
     @SuppressLint("AndroidLintUseSparseArrays") // gson cannot handle sparse arrays easily, therefore use hashmap
     private RemoteOperationResult encryptedUpload(OwnCloudClient client, OCFile parentFile) {
         RemoteOperationResult result = null;
-        e2eFiles = new E2EFiles(parentFile, null, new File(mOriginalStoragePath), null, null);
+        E2EFiles e2eFiles = new E2EFiles(parentFile, null, new File(mOriginalStoragePath), null, null);
         FileLock fileLock = null;
         long size;
 
@@ -1211,22 +1209,13 @@ public class UploadFileOperation extends SyncOperation {
             return;
         }
 
-        if (encryptedAncestor) {
-            if (e2eFiles == null) {
-                Log_OC.d(TAG, "handleLocalBehaviour: e2eFiles is null");
-                return;
-            }
+        String expectedPath = FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), mFile);
+        File expectedFile = new File(expectedPath);
+        File originalFile = new File(mOriginalStoragePath);
+        String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) + mFile.getRemotePath();
+        File temporalFile = new File(temporalPath);
 
-            handleLocalBehaviour(e2eFiles.getTemporalFile(), e2eFiles.getExpectedFile(), e2eFiles.getOriginalFile(), client);
-        } else {
-            String expectedPath = FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), mFile);
-            File expectedFile = new File(expectedPath);
-            File originalFile = new File(mOriginalStoragePath);
-            String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) + mFile.getRemotePath();
-            File temporalFile = new File(temporalPath);
-
-            handleLocalBehaviour(temporalFile, expectedFile, originalFile, client);
-        }
+        handleLocalBehaviour(temporalFile, expectedFile, originalFile, client);
     }
 
     private void handleLocalBehaviour(File temporalFile,

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -845,7 +845,7 @@ public class UploadFileOperation extends SyncOperation {
 
     private void completeE2EUpload(RemoteOperationResult result, E2EFiles e2eFiles, OwnCloudClient client) {
         if (result.isSuccess()) {
-            handleSuccessfulUpload(e2eFiles.getTemporalFile(), e2eFiles.getExpectedFile(), e2eFiles.getOriginalFile(), client);
+            handleLocalBehaviour(e2eFiles.getTemporalFile(), e2eFiles.getExpectedFile(), e2eFiles.getOriginalFile(), client);
         } else if (result.getCode() == ResultCode.SYNC_CONFLICT) {
             getStorageManager().saveConflict(mFile, mFile.getEtagInConflict());
         }
@@ -1098,7 +1098,7 @@ public class UploadFileOperation extends SyncOperation {
         }
 
         if (result.isSuccess()) {
-            handleSuccessfulUpload(temporalFile, expectedFile, originalFile, client);
+            handleLocalBehaviour(temporalFile, expectedFile, originalFile, client);
         } else if (result.getCode() == ResultCode.SYNC_CONFLICT) {
             getStorageManager().saveConflict(mFile, mFile.getEtagInConflict());
         }
@@ -1197,10 +1197,20 @@ public class UploadFileOperation extends SyncOperation {
         return null;
     }
 
-    private void handleSuccessfulUpload(File temporalFile,
-                                        File expectedFile,
-                                        File originalFile,
-                                        OwnCloudClient client) {
+    public void handleLocalBehaviour() {
+        String expectedPath = FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), mFile);
+        File expectedFile = new File(expectedPath);
+        File originalFile = new File(mOriginalStoragePath);
+        String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) + mFile.getRemotePath();
+        File temporalFile = new File(temporalPath);
+
+        handleLocalBehaviour(temporalFile, expectedFile, originalFile, getClient());
+    }
+
+    private void handleLocalBehaviour(File temporalFile,
+                                      File expectedFile,
+                                      File originalFile,
+                                      OwnCloudClient client) {
         switch (mLocalBehaviour) {
             case FileUploadWorker.LOCAL_BEHAVIOUR_FORGET:
             default:

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -452,11 +452,13 @@ public class UploadFileOperation extends SyncOperation {
         }
     }
 
+    private E2EFiles e2eFiles;
+
     // region E2E Upload
     @SuppressLint("AndroidLintUseSparseArrays") // gson cannot handle sparse arrays easily, therefore use hashmap
     private RemoteOperationResult encryptedUpload(OwnCloudClient client, OCFile parentFile) {
         RemoteOperationResult result = null;
-        E2EFiles e2eFiles = new E2EFiles(parentFile, null, new File(mOriginalStoragePath), null, null);
+        e2eFiles = new E2EFiles(parentFile, null, new File(mOriginalStoragePath), null, null);
         FileLock fileLock = null;
         long size;
 
@@ -1199,16 +1201,32 @@ public class UploadFileOperation extends SyncOperation {
 
     public void handleLocalBehaviour() {
         if (user == null || mFile == null || mContext == null) {
+            Log_OC.d(TAG, "handleLocalBehaviour: user, file, or context is null.");
             return;
         }
 
-        String expectedPath = FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), mFile);
-        File expectedFile = new File(expectedPath);
-        File originalFile = new File(mOriginalStoragePath);
-        String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) + mFile.getRemotePath();
-        File temporalFile = new File(temporalPath);
+        final var client = getClient();
+        if (client == null) {
+            Log_OC.d(TAG, "handleLocalBehaviour: client is null");
+            return;
+        }
 
-        handleLocalBehaviour(temporalFile, expectedFile, originalFile, getClient());
+        if (encryptedAncestor) {
+            if (e2eFiles == null) {
+                Log_OC.d(TAG, "handleLocalBehaviour: e2eFiles is null");
+                return;
+            }
+
+            handleLocalBehaviour(e2eFiles.getTemporalFile(), e2eFiles.getExpectedFile(), e2eFiles.getOriginalFile(), client);
+        } else {
+            String expectedPath = FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), mFile);
+            File expectedFile = new File(expectedPath);
+            File originalFile = new File(mOriginalStoragePath);
+            String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) + mFile.getRemotePath();
+            File temporalFile = new File(temporalPath);
+
+            handleLocalBehaviour(temporalFile, expectedFile, originalFile, client);
+        }
     }
 
     private void handleLocalBehaviour(File temporalFile,

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -1198,6 +1198,10 @@ public class UploadFileOperation extends SyncOperation {
     }
 
     public void handleLocalBehaviour() {
+        if (user == null || mFile == null || mContext == null) {
+            return;
+        }
+
         String expectedPath = FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), mFile);
         File expectedFile = new File(expectedPath);
         File originalFile = new File(mOriginalStoragePath);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,7 +172,6 @@
     <string name="uploader_upload_files_behaviour_only_upload">Keep file in source folder</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Delete file from source folder</string>
     <string name="file_list_seconds_ago">seconds ago</string>
-    <string name="file_upload_worker_same_file_already_exists">Same file already exists, no conflict detected</string>
     <string name="file_list_live">LIVE</string>
     <string name="file_list_empty_headline">No files here</string>
     <string name="folder_list_empty_headline">No folders here</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

• Removes messages related to failed uploads
• Manages local behavior in cases of upload synchronization conflicts and when the remote directory contains the same file