### PR TITLE
BugFix - E2EE Delete File

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -80,6 +80,7 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
     lateinit var localBroadcastManager: LocalBroadcastManager
 
     private var actionBar: ActionBar? = null
+    private var showDirectoryWhenDeletionCompleted = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -118,6 +119,10 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
         }
 
         observeWorkerState()
+    }
+
+    fun showDirectoryWhenDeletionCompleted() {
+        showDirectoryWhenDeletionCompleted = true
     }
 
     fun toggleActionBarVisibility(hide: Boolean) {
@@ -265,6 +270,10 @@ class PreviewImageActivity : FileActivity(), FileFragment.ContainerActivity, OnR
 
             viewPager?.setCurrentItem(nextPosition, true)
             previewImagePagerAdapter?.delete(deletePosition)
+
+            if (showDirectoryWhenDeletionCompleted) {
+                backToDisplayActivity()
+            }
         } else if (operation is SynchronizeFileOperation) {
             onSynchronizeFileOperationFinish(result)
         }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Problem**

If the user tries to preview an image from the directory, the file cannot be deleted.

**How to test?**

1. Create an encrypted folder
2. Add images into the encrypted folder
3. Open image from folder
4. Try to delete image from top right more menu

