### PR TITLE
Fix Image Scaling/Rotating

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -64,7 +64,6 @@ import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.preview.PreviewMediaFragment.Companion.newInstance
 import com.owncloud.android.utils.BitmapUtils
 import com.owncloud.android.utils.DisplayUtils
-import com.owncloud.android.utils.MimeType
 import com.owncloud.android.utils.MimeTypeUtil
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
@@ -529,7 +528,7 @@ class PreviewImageFragment : FileFragment(), Injectable {
                         }
 
                         try {
-                            bitmapResult = BitmapUtils.retrieveBitmapFromFile(storagePath, minWidth, minHeight);
+                            bitmapResult = BitmapUtils.retrieveBitmapFromFile(storagePath, minWidth, minHeight)
 
                             if (isCancelled) {
                                 return LoadImage(bitmapResult, null, ocFile)
@@ -540,7 +539,6 @@ class PreviewImageFragment : FileFragment(), Injectable {
                                 Log_OC.e(TAG, "File could not be loaded as a bitmap: $storagePath")
                                 break
                             }
-
                         } catch (e: OutOfMemoryError) {
                             mErrorMessageId = R.string.common_error_out_memory
                             if (i < maxDownScale - 1) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -529,11 +529,7 @@ class PreviewImageFragment : FileFragment(), Injectable {
                         }
 
                         try {
-                            bitmapResult = BitmapUtils.decodeSampledBitmapFromFile(
-                                storagePath,
-                                minWidth,
-                                minHeight
-                            )
+                            bitmapResult = BitmapUtils.retrieveBitmapFromFile(storagePath, minWidth, minHeight);
 
                             if (isCancelled) {
                                 return LoadImage(bitmapResult, null, ocFile)
@@ -543,12 +539,8 @@ class PreviewImageFragment : FileFragment(), Injectable {
                                 mErrorMessageId = R.string.preview_image_error_unknown_format
                                 Log_OC.e(TAG, "File could not be loaded as a bitmap: $storagePath")
                                 break
-                            } else {
-                                if (MimeType.JPEG.equals(ocFile.mimeType, ignoreCase = true)) {
-                                    // Rotate image, obeying exif tag.
-                                    bitmapResult = BitmapUtils.rotateImage(bitmapResult, storagePath)
-                                }
                             }
+
                         } catch (e: OutOfMemoryError) {
                             mErrorMessageId = R.string.common_error_out_memory
                             if (i < maxDownScale - 1) {


### PR DESCRIPTION
Problem:

Application is opening some images incorrectly. The image is being rotated incorrectly and the wrong heights/widths are being used for scaling.

For example, this image with a Width of 4096 pixels and Height of 3072 pixels and an orientation of upper-right was showing like this:
![image](https://github.com/user-attachments/assets/fc1cd8c5-99cc-4bd8-be04-8a7996e34c06)
My screen size is 1080x2460

It appears after BitmapUtils.decodeSampledBitmapFromFile() is run, that the orientation is changed successfully. 

The problem then was the height/width used. When originally using my screen size, the scaling was affected by stretching the image to fit the height of my screen. It needs to maintain the original aspect ratio of the image.

The image was then being rotated again, thus resulting in the image above.

Solution:
Take original heights and widths of file.
Determine if this image is to be rotated 90 or 270 degrees. If so, the height and width needs to accommodate for that.
Now, decode the bitmap using the original image's height/width.
Next, scale the image based on your screen size.


