### PR TITLE
Update ConnectivityServiceImpl.java

### DIFF
--- a/app/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
+++ b/app/src/main/java/com/nextcloud/client/network/ConnectivityServiceImpl.java
@@ -25,7 +25,6 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import org.apache.commons.httpclient.HttpStatus;
 
 import androidx.annotation.NonNull;
-import androidx.core.net.ConnectivityManagerCompat;
 import kotlin.jvm.functions.Function1;
 
 class ConnectivityServiceImpl implements ConnectivityService {
@@ -146,19 +145,13 @@ class ConnectivityServiceImpl implements ConnectivityService {
         }
     }
 
+    // 
+    // Determine if the currently active network is metered
+    // Detects both metered cellular and Wi-Fi connections
+    //
     private boolean isNetworkMetered() {
         final Network network = platformConnectivityManager.getActiveNetwork();
-        try {
-            NetworkCapabilities networkCapabilities = platformConnectivityManager.getNetworkCapabilities(network);
-            if (networkCapabilities != null) {
-                return !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED);
-            } else {
-                return ConnectivityManagerCompat.isActiveNetworkMetered(platformConnectivityManager);
-            }
-        } catch (RuntimeException e) {
-            Log_OC.e(TAG, "Exception when checking network capabilities", e);
-            return false;
-        }
+        return platformConnectivityManager.isActiveNetworkMetered(platformConnectivityManager);
     }
 
     private boolean hasNonCellularConnectivity() {


### PR DESCRIPTION
Fixes #6851

`NET_CAPABILITY_NOT_RESTRICTED` is not sufficient to check if a network is metered. 
Checking either `NET_CAPABILITY_NOT_METERED` or calling `isActiveNetworkMetered()` are likely more appropriate. While we do call `isNetworkActiveNetworked()`, it's never executed since `getActiveNetwork()` will rarely be null.

In addition, `ConnectivityManagerCompat` doesn't seem to be needed any longer since it's for API <16.

TODO (out of scope for this PR): [Callbacks](https://developer.android.com/develop/connectivity/network-ops/reading-network-state#java)

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
