### PR TITLE
Do not release video player on pause

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -575,7 +575,6 @@ class PreviewMediaFragment : FileFragment(), OnTouchListener, Injectable {
 
     override fun onPause() {
         exoPlayer?.pause()
-        releaseVideoPlayer()
         super.onPause()
     }
 


### PR DESCRIPTION
Previously the media player was be released when the associated `PreviewMediaFragment` was moved to the background. This resulted in an unresponsive media player when the fragment was brought back to the foreground.

### Testing
1. Open Nextcloud app
2. Open *Media* tab from navigation drawer
3. Open any image
4. Swipe until video player is visible (requires a video file to be uploaded)
5. Go back to the previous file
6. Swipe back to the video

With this change in place the video player should still function as expected.

---
- [x] Tests written, or not not needed
