### PR TITLE
BugFix - Check Device Credentials Existance

### DIFF
--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -168,14 +168,6 @@ public interface AppPreferences {
     String[] getPassCode();
 
     /**
-     * Gets the unlock via fingerprint preference configured by the user.
-     *
-     * @implNote  this is always false
-     * @return useFingerprint     is unlock with fingerprint enabled
-     */
-    boolean isFingerprintUnlockEnabled();
-
-    /**
      * Gets the auto upload paths flag last set.
      *
      * @return ascending order     the legacy cleaning flag, default is false
@@ -210,7 +202,7 @@ public interface AppPreferences {
      * Get preferred folder sort order.
      *
      * @param folder Folder whoch order is being retrieved or null for root folder
-     * @return sort order     the sort order, default is {@link FileSortOrder#sort_a_to_z} (sort by name)
+     * @return sort order     the sort order, default is {@link FileSortOrder# sort_a_to_z} (sort by name)
      */
     FileSortOrder getSortOrderByFolder(@Nullable OCFile folder);
 
@@ -232,7 +224,7 @@ public interface AppPreferences {
     /**
      * Get preferred folder sort order.
      *
-     * @return sort order     the sort order, default is {@link FileSortOrder#sort_a_to_z} (sort by name)
+     * @return sort order     the sort order, default is {@link FileSortOrder# sort_a_to_z} (sort by name)
      */
     FileSortOrder getSortOrderByType(FileSortOrder.Type type, FileSortOrder defaultOrder);
     FileSortOrder getSortOrderByType(FileSortOrder.Type type);

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -313,11 +313,6 @@ public final class AppPreferencesImpl implements AppPreferences {
     }
 
     @Override
-    public boolean isFingerprintUnlockEnabled() {
-        return preferences.getBoolean(SettingsActivity.PREFERENCE_USE_FINGERPRINT, false);
-    }
-
-    @Override
     public String getFolderLayout(OCFile folder) {
         return getFolderPreference(context,
                                    userAccountManager.getUser(),

--- a/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
+++ b/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
@@ -133,7 +133,7 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
     }
 
     private fun deviceCredentialsAreEnabled(activity: Activity): Boolean {
-        return SettingsActivity.LOCK_DEVICE_CREDENTIALS == preferences.lockPreference ||
+        return SettingsActivity.LOCK_DEVICE_CREDENTIALS == preferences.lockPreference &&
             (preferences.isFingerprintUnlockEnabled && DeviceCredentialUtils.areCredentialsAvailable(activity))
     }
 

--- a/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
+++ b/app/src/main/java/com/owncloud/android/authentication/PassCodeManager.kt
@@ -133,8 +133,8 @@ class PassCodeManager(private val preferences: AppPreferences, private val clock
     }
 
     private fun deviceCredentialsAreEnabled(activity: Activity): Boolean {
-        return SettingsActivity.LOCK_DEVICE_CREDENTIALS == preferences.lockPreference &&
-            (preferences.isFingerprintUnlockEnabled && DeviceCredentialUtils.areCredentialsAvailable(activity))
+        return (preferences.lockPreference == SettingsActivity.LOCK_DEVICE_CREDENTIALS) &&
+            DeviceCredentialUtils.areCredentialsAvailable(activity)
     }
 
     private fun getActivityRootView(activity: Activity): View? {

--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -109,7 +109,6 @@ public class SettingsActivity extends PreferenceActivity
     public static final String LOCK_DEVICE_CREDENTIALS = "device_credentials";
 
 
-    public final static String PREFERENCE_USE_FINGERPRINT = "use_fingerprint";
     public static final String PREFERENCE_SHOW_MEDIA_SCAN_NOTIFICATIONS = "show_media_scan_notifications";
 
     private static final int ACTION_REQUEST_PASSCODE = 5;

--- a/app/src/main/java/com/owncloud/android/utils/DeviceCredentialUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DeviceCredentialUtils.java
@@ -27,7 +27,7 @@ public final class DeviceCredentialUtils {
         KeyguardManager keyguardManager = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
 
         if (keyguardManager != null) {
-            return keyguardManager.isDeviceSecure();
+            return keyguardManager.isKeyguardSecure();
         } else {
             Log_OC.e(TAG, "Keyguard manager is null");
             return false;

--- a/app/src/main/java/com/owncloud/android/utils/DeviceCredentialUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DeviceCredentialUtils.java
@@ -27,7 +27,7 @@ public final class DeviceCredentialUtils {
         KeyguardManager keyguardManager = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
 
         if (keyguardManager != null) {
-            return keyguardManager.isKeyguardSecure();
+            return keyguardManager.isDeviceSecure();
         } else {
             Log_OC.e(TAG, "Keyguard manager is null");
             return false;


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### How to reproduce?

- set a device protection  (e.g. PIN or patter)
- go to app settings
- enable passcode using device protection
- close the app
- remove your local device protection
- restart the app
- app will not launch


### Changes

- Remove unnecessary internal boolean flag. Because there is no set method for the PREFERENCE_USE_FINGERPRINT.
- Fix `deviceCredentialsAreEnabled()` function condition

### Before

https://github.com/user-attachments/assets/e1cb9079-e7d3-4610-8ea2-948a8648cf37


### After

https://github.com/user-attachments/assets/9b8e335e-bf91-41f8-8edf-846f0ccad2e5

