### PR TITLE
fix(richdocuments): Let new file load on creation

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -77,7 +77,10 @@ public abstract class EditorWebView extends ExternalSiteWebView {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
             }
-            this.getWebView().loadUrl(url);
+
+            if (!url.equals(this.getWebView().getUrl())) {
+                this.getWebView().loadUrl(url);
+            }
 
             new Handler().postDelayed(() -> {
                 if (this.getWebView().getVisibility() != View.VISIBLE) {


### PR DESCRIPTION
Previously when trying to create a file, it would always fail to load, making you spin forever until you re-entered the file picker.

Upon closer inspection it seems like this is due to a 403 response to the /direct/ editor URL

    100.64.0.1 - - [12/Feb/2025:13:03:43 +0000] "GET /index.php/apps/richdocuments/direct/Zj4Xu3mKQRUhb53b10FT3nwrLlxOauaWsrb23v9HczGwDK9MDqAukfwGFQwa5w9N HTTP/1.1" 403 26870 "-" "Mozilla/5.0 (Android) Nextcloud-android/20250207"

Normally, this would load the editor which would then query WOPI, etc. as normal...

    100.64.0.1 - - [12/Feb/2025:13:08:18 +0000] "GET /index.php/apps/richdocuments/direct/wC0K6A6Zkwy6MwFtdEjwU4VJdTbWmIUFWgXuP8SOUrNFxTUg8Hcz9cgvCOZVAt82 HTTP/1.1" 200 9533 "-" "Mozilla/5.0 (Android) Nextcloud-android/20250207"
    100.64.0.40 - - [12/Feb/2025:13:08:18 +0000] "GET /index.php/apps/files/api/v1/stats HTTP/1.1" 200 1042 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0"
    fe80::e7b2:72eb:8e62:74eb%enx908d6e3ca1f5 - - [12/Feb/2025:13:08:19 +0000] "GET /index.php/apps/richdocuments/wopi/files/61_ocyrhf1mv22k?access_token=jSI97GAbzmQc7ckm3RVdvy8PG1pLek7r&access_token_ttl=0 HTTP/1.1" 200 2418 "-" "COOLWSD HTTP Agent 24.04.13.0"
    fe80::e7b2:72eb:8e62:74eb%enx908d6e3ca1f5 - - [12/Feb/2025:13:08:19 +0000] "GET /index.php/apps/richdocuments/wopi/files/61_ocyrhf1mv22k/contents?access_token=jSI97GAbzmQc7ckm3RVdvy8PG1pLek7r&access_token_ttl=1739401698000 HTTP/1.1" 200 1501 "-" "COOLWSD HTTP Agent 24.04.13.0"

Upon further inspection, it looked like we were reusing a token... commenting the deletion of the token in lib/Controller/DirectViewController.php on the server also let us access the editor

    -               $this->directMapper->delete($direct);
    +               // $this->directMapper->delete($direct);

And on closer inspection I noticed that there was 2 requests to /direct/
 - the first of which worked!

Finally, that led me here: it seems like both ExternalSiteWebView.java and EditorWebView.java were calling loadUrl with *the same /direct/ url* which made it expire before the editor could actually load...

...no good...!

Commenting either of these solved the problem but I wasn't thoroughly sure that they weren't important for something else, therefore I devised the cunning plan you see before you: in the editor web view, never *re*load the url. If we're loading something else, that's fine. If not, we shouldn't reuse the token since as this will invalidate it.

Fixes: https://github.com/nextcloud/android/issues/14548

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
