### PR TITLE
Update Thumbnail After Resolving Conflict

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -120,8 +120,16 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
                 else -> Unit
             }
 
+            updateThumbnailIfNeeded(decision, file)
             dismissConflictResolveNotification(file)
             finish()
+        }
+    }
+
+    private fun updateThumbnailIfNeeded(decision: Decision?, file: OCFile?) {
+        if (decision == Decision.KEEP_BOTH || decision == Decision.KEEP_SERVER) {
+            file?.isUpdateThumbnailNeeded = true
+            fileDataStorageManager.saveFile(file)
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -127,7 +127,7 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
     }
 
     private fun updateThumbnailIfNeeded(decision: Decision?, file: OCFile?) {
-        if (decision == Decision.KEEP_BOTH || decision == Decision.KEEP_SERVER) {
+        if (decision == Decision.KEEP_BOTH || decision == Decision.KEEP_LOCAL) {
             file?.isUpdateThumbnailNeeded = true
             fileDataStorageManager.saveFile(file)
         }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Issue**

Keep both option from conflict dialog needs hard refresh to get file added. 

**Step to reproduce**

1. Create folder and upload some file(eg- test1.jpg file)
2. Upload same file name again with different content
3. Check both to keep both files from conflict dialog, and wait to get uploaded


https://github.com/user-attachments/assets/b632e6d1-66dc-4639-b428-817377837463



https://github.com/user-attachments/assets/69d9fdbb-ae18-41f5-8eac-31cba6fa2c87


