### PR TITLE
fix obsolete method plus force use of type

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -899,7 +899,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                     });
 
 
-                    SimpleTarget target = new SimpleTarget<Drawable>() {
+                    SimpleTarget<Drawable> target = new SimpleTarget<>() {
                         @Override
                         public void onResourceReady(Drawable resource, GlideAnimation glideAnimation) {
                             Drawable test = resource.getCurrent();
@@ -1037,7 +1037,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                                                             MENU_ITEM_EXTERNAL_LINK + link.getId(), MENU_ORDER_EXTERNAL_LINKS, link.getName())
                     .setCheckable(true).getItemId();
 
-                MenuSimpleTarget target = new MenuSimpleTarget<Drawable>(id) {
+                MenuSimpleTarget<Drawable> target = new MenuSimpleTarget<>(id) {
                     @Override
                     public void onResourceReady(Drawable resource, GlideAnimation glideAnimation) {
                         setExternalLinkIcon(getIdMenuItem(), resource, greyColor);

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -91,6 +91,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.IDN;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
@@ -186,7 +187,7 @@ public final class DisplayUtils {
             }
 
             return new BigDecimal(String.valueOf(result)).setScale(
-                sizeScales[suffixIndex], BigDecimal.ROUND_HALF_UP) + " " + sizeSuffixes[suffixIndex];
+                sizeScales[suffixIndex], RoundingMode.HALF_UP) + " " + sizeSuffixes[suffixIndex];
         }
     }
 

--- a/app/src/main/java/third_parties/sufficientlysecure/SaveCalendar.java
+++ b/app/src/main/java/third_parties/sufficientlysecure/SaveCalendar.java
@@ -301,7 +301,7 @@ public class SaveCalendar {
             return null;
         }
 
-        PropertyList l = new PropertyList();
+        PropertyList<Property> l = new PropertyList<>();
         l.add(timestamp);
         copyProperty(l, Property.UID, cur, Events.UID_2445);
 
@@ -527,7 +527,7 @@ public class SaveCalendar {
         return dt;
     }
 
-    private String copyProperty(PropertyList l, String evName, Cursor cur, String dbName) {
+    private String copyProperty(PropertyList<Property> l, String evName, Cursor cur, String dbName) {
         // None of the exceptions caught below should be able to be thrown AFAICS.
         try {
             String value = getString(cur, dbName);
@@ -542,7 +542,7 @@ public class SaveCalendar {
         return null;
     }
 
-    private void copyEnumProperty(PropertyList l, String evName, Cursor cur, String dbName,
+    private void copyEnumProperty(PropertyList<Property> l, String evName, Cursor cur, String dbName,
                                   List<String> vals) {
         // None of the exceptions caught below should be able to be thrown AFAICS.
         try {


### PR DESCRIPTION
Problem:

Identified an obsolete method being used (BigDecimal.ROUND_HALF_UP) and some objects that weren't declared right

Solution:

Using RoundingMode.HALF_UP and declaring these objects correctly