### PR TITLE
Remove Airplane mode Check Due to Configurable Unmetered Wi-Fi

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -9,7 +9,6 @@ package com.nextcloud.client.jobs.upload
 
 import android.app.PendingIntent
 import android.content.Context
-import android.provider.Settings
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -148,7 +147,6 @@ class FileUploadWorker(
             }
 
             if (canExitEarly()) {
-                Log_OC.d(TAG, "Airplane mode is enabled or no internet connection, stopping worker.")
                 notificationManager.showConnectionErrorNotification()
                 return Result.failure()
             }
@@ -171,18 +169,15 @@ class FileUploadWorker(
     private fun canExitEarly(): Boolean {
         val result = !connectivityService.isConnected ||
             connectivityService.isInternetWalled ||
-            isStopped ||
-            isAirplaneModeEnabled()
+            isStopped
 
-        if (!result) {
+        if (result) {
+            Log_OC.d(TAG, "No internet connection, stopping worker.")
+        } else {
             notificationManager.dismissErrorNotification()
         }
 
         return result
-    }
-
-    private fun isAirplaneModeEnabled(): Boolean {
-        return Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
     }
 
     @Suppress("NestedBlockDepth")
@@ -191,7 +186,6 @@ class FileUploadWorker(
         setWorkerState(user.get(), uploadsPerPage)
 
         if (canExitEarly()) {
-            Log_OC.d(TAG, "Airplane mode is enabled or no internet connection, stopping worker.")
             notificationManager.showConnectionErrorNotification()
             return
         }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


Some users prefer not to initiate uploads while their device is in airplane mode. For instance, a user may have Wi-Fi during a flight to browse the internet, but triggering an auto-upload in such cases would be undesirable due to the typically slow and limited in-flight Wi-Fi.

After discussing with the team, we have determined that since Android 9, users have the ability to designate Wi-Fi networks as metered or unmetered. 

<img src="https://github.com/user-attachments/assets/49e494d6-3112-44d7-900f-098ffb1861d2" width="300" alt="Image 1">

Given that we already offer an option to upload only on unmetered Wi-Fi, there is no longer a need to check for airplane mode.

<img src="https://github.com/user-attachments/assets/8f9a26a7-3e49-4491-b838-59602db77bdd" width="300" alt="Image 2">

As a result, we will remove the airplane mode check. If a user wishes to prevent auto-uploads when connected to a specific Wi-Fi network—such as in airplane mode—they can simply configure the network as metered in the Wi-Fi settings.

This approach supports both use cases—allowing uploads in airplane mode by default, while giving users the option to disable auto-uploads by setting the network as metered.
