### PR TITLE
 Improve E2EE dialog description for better clarity

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/setupEncryption/SetupEncryptionDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/setupEncryption/SetupEncryptionDialogFragment.kt
@@ -402,7 +402,7 @@ class SetupEncryptionDialogFragment : DialogFragment(), Injectable {
                     binding.encryptionStatus.setText(R.string.common_error)
                 }
             } else if (privateKey.isNotEmpty()) {
-                binding.encryptionStatus.setText(R.string.end_to_end_encryption_enter_password)
+                binding.encryptionStatus.setText(R.string.end_to_end_encryption_enter_passphrase_to_access_files)
                 binding.encryptionPasswordInputContainer.visibility = View.VISIBLE
                 positiveButton?.visibility = View.VISIBLE
             } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -846,6 +846,7 @@
     <string name="end_to_end_encryption_wrong_password">Error while decrypting. Wrong password?</string>
     <string name="end_to_end_encryption_decrypting">Decrypting…</string>
     <string name="end_to_end_encryption_retrieving_keys">Retrieving keys…</string>
+    <string name="end_to_end_encryption_enter_passphrase_to_access_files">Enter your passphrase to access your files</string>
     <string name="end_to_end_encryption_enter_password">Please enter password to decrypt private key.</string>
     <string name="end_to_end_encryption_generating_keys">Generating new keys…</string>
     <string name="end_to_end_encryption_keywords_description">All 12 words together make a very strong password, letting only you view and make use of your encrypted files. Please write it down and keep it somewhere safe.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -847,7 +847,6 @@
     <string name="end_to_end_encryption_decrypting">Decrypting…</string>
     <string name="end_to_end_encryption_retrieving_keys">Retrieving keys…</string>
     <string name="end_to_end_encryption_enter_passphrase_to_access_files">Enter your passphrase to access your files</string>
-    <string name="end_to_end_encryption_enter_password">Please enter password to decrypt private key.</string>
     <string name="end_to_end_encryption_generating_keys">Generating new keys…</string>
     <string name="end_to_end_encryption_keywords_description">All 12 words together make a very strong password, letting only you view and make use of your encrypted files. Please write it down and keep it somewhere safe.</string>
     <string name="end_to_end_encryption_title">Set up encryption</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Updated the dialogue text from _"Please enter password to decrypt private key."_ to _"Enter your passphrase to access your files."_ for better user understanding. 

![Screenshot_20250303_152440](https://github.com/user-attachments/assets/86f5a22a-20c5-436a-b840-cd37d6b5b4fd)

