### PR TITLE
Fix -  ChooseStorageLocationDialogFragment NoSuchElementException

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/ChooseStorageLocationDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/ui/ChooseStorageLocationDialogFragment.kt
@@ -146,7 +146,8 @@ class ChooseStorageLocationDialogFragment : DialogFragment(), Injectable {
 
     private fun notifyResult() {
         val newPath =
-            storagePoints.find { it.storageType == selectedStorageType && it.privacyType == selectedPrivacyType } ?: return
+            storagePoints.find { it.storageType == selectedStorageType && it.privacyType == selectedPrivacyType }
+                ?: return
 
         val resultBundle = Bundle().apply {
             putString(KEY_RESULT_STORAGE_LOCATION, newPath.path)

--- a/app/src/main/java/com/nextcloud/ui/ChooseStorageLocationDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/ui/ChooseStorageLocationDialogFragment.kt
@@ -86,8 +86,9 @@ class ChooseStorageLocationDialogFragment : DialogFragment(), Injectable {
 
     private fun setupLocationSelection() {
         updateStorageTypeSelection()
+        val currentStorageLocation = getCurrentStorageLocation() ?: return
 
-        val radioButton = when (getCurrentStorageLocation().storageType) {
+        val radioButton = when (currentStorageLocation.storageType) {
             StorageType.EXTERNAL -> binding.storageExternalRadio
             else -> binding.storageInternalRadio
         }
@@ -103,7 +104,7 @@ class ChooseStorageLocationDialogFragment : DialogFragment(), Injectable {
         }
 
         val storagePath =
-            storagePoints.firstOrNull { it.storageType == storageType && it.privacyType == privacyType }?.path
+            storagePoints.find { it.storageType == storageType && it.privacyType == privacyType }?.path
 
         return storagePath?.let {
             val file = File(it)
@@ -136,16 +137,16 @@ class ChooseStorageLocationDialogFragment : DialogFragment(), Injectable {
         binding.storageExternalRadio.text = getStoragePointLabel(StorageType.EXTERNAL, selectedPrivacyType)
     }
 
-    private fun getCurrentStorageLocation(): StoragePoint {
+    private fun getCurrentStorageLocation(): StoragePoint? {
         val appContext = MainApp.getAppContext()
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(appContext)
         val storagePath = sharedPreferences.getString(AppPreferencesImpl.STORAGE_PATH, appContext.filesDir.absolutePath)
-        return storagePoints.first { it.path == storagePath }
+        return storagePoints.find { it.path == storagePath }
     }
 
     private fun notifyResult() {
         val newPath =
-            storagePoints.first { it.storageType == selectedStorageType && it.privacyType == selectedPrivacyType }
+            storagePoints.find { it.storageType == selectedStorageType && it.privacyType == selectedPrivacyType } ?: return
 
         val resultBundle = Bundle().apply {
             putString(KEY_RESULT_STORAGE_LOCATION, newPath.path)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


```
Exception in thread "main" java.util.NoSuchElementException: Array contains no element matching the predicate.
    at com.nextcloud.ui.ChooseStorageLocationDialogFragment.getCurrentStorageLocation(ChooseStorageLocationDialogFragment.kt:183)
    at com.nextcloud.ui.ChooseStorageLocationDialogFragment.setupLocationSelection(ChooseStorageLocationDialogFragment.kt:90)
    at com.nextcloud.ui.ChooseStorageLocationDialogFragment.onViewCreated(ChooseStorageLocationDialogFragment.kt:78)
    at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3152)
    at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:608)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2214)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2115)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2052)
    at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3327)
    at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:3237)
    at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
    at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
    at androidx.appcompat.app.AppCompatActivity.onStart(AppCompatActivity.java:251)
    at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1707)
    at android.app.Activity.performStart(Activity.java:9406)
    at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4473)
    at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:270)
    at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:250)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:222)
    at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:107)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:81)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2880)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loopOnce(Looper.java:257)
    at android.os.Looper.loop(Looper.java:342)
    at android.app.ActivityThread.main(ActivityThread.java:9579)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:619)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

Use`find` instead`first` and `firstOrNull` 
