### PR TITLE
BugFix - Use Previous eTag for Shared Folder If Exists

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -762,7 +762,7 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
     }
 
     public boolean isShared() {
-        return isSharedViaLink() || isSharedWithSharee() || isSharedWithMe();
+        return isSharedViaLink() || isSharedWithSharee() || isSharedWithMe() || !sharees.isEmpty();
     }
 
     public String getPermissions() {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -825,6 +825,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             ocFileListDelegate.setShowShareAvatar(true);
             this.user = account;
         }
+
         if (mStorageManager != null) {
             // TODO refactor filtering mechanism for mFiles
             mFiles = mStorageManager.getFolderContent(directory, onlyOnDevice);
@@ -860,7 +861,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         searchType = null;
-        notifyDataSetChanged();
+        activity.runOnUiThread(this::notifyDataSetChanged);
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
@@ -77,6 +77,9 @@ class SharedListFragment : OCFileListFragment(), Injectable {
             if (fetchResult.isSuccess) {
                 val remoteFile = (fetchResult.data[0] as RemoteFile).apply {
                     val prevETag = mContainerActivity.storageManager.getFileByDecryptedRemotePath(remotePath)
+
+                    // Use previous eTag if exists to prevent break checkForChanges logic in RefreshFolderOperation.
+                    // Otherwise RefreshFolderOperation will show empty list
                     prevETag?.etag?.let {
                         etag = prevETag.etag
                     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Problem

In `SharedListFragment`, the `ReadFileRemoteOperation` is invoked, followed by `checkForChanges()` in `RefreshFolderOperation`, which also calls `ReadFileRemoteOperation`. As a result, the eTags remain unchanged, leading to an empty list being displayed. This occurs because the eTag is updated just before `checkForChanges()` is executed in `SharedListFragment`.

### How to Reproduce?

1. Create shared folder with items from web app
2. Open the Android app
3. Do not open the shared folder from the file list
4. Navigate to the shared file list from drawer menu
5. Open shared folder
6. Empty list will be visible

### Solution

In the application's database, the previous eTag is already stored. Overwriting it with the latest eTag results in an empty list being displayed, as the eTag remains unchanged. In `SharedListFragment`, the application needs to call `ReadFileRemoteOperation` to handle events; however, it does not need to update the eTag, since the previous eTag is already present in the database.

### Demo

https://github.com/user-attachments/assets/aeb1dc48-169f-442f-bdfd-02ece5386cc5

