### PR TITLE
BugFix - E2EE Image Preview

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -23,8 +23,6 @@ import android.widget.TextView;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.jobs.download.FileDownloadHelper;
-import com.nextcloud.model.WorkerState;
-import com.nextcloud.model.WorkerStateLiveData;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
@@ -67,17 +65,16 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
 
     private boolean mIgnoreFirstSavedState;
     private boolean mError;
-    private Integer filePosition;
 
 
     /**
      * Public factory method to create a new fragment that shows the progress of a file download.
-     *
+     * <p>
      * Android strongly recommends keep the empty constructor of fragments as the only public constructor, and
      * use {@link #setArguments(Bundle)} to set the needed arguments.
-     *
+     * <p>
      * This method hides to client objects the need of doing the construction in two steps.
-     *
+     * <p>
      * When 'file' is null creates a dummy layout (useful when a file wasn't tapped before).
      *
      * @param file                      An {@link OCFile} to show in the fragment
@@ -85,11 +82,10 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
      * @param ignoreFirstSavedState     Flag to work around an unexpected behaviour of {@link FragmentStatePagerAdapter}
      *                                  TODO better solution
      */
-    public static Fragment newInstance(OCFile file, User user, boolean ignoreFirstSavedState, Integer filePosition) {
+    public static Fragment newInstance(OCFile file, User user, boolean ignoreFirstSavedState) {
         FileDownloadFragment frag = new FileDownloadFragment();
         Bundle args = new Bundle();
         args.putParcelable(ARG_FILE, file);
-        args.putInt(ARG_FILE_POSITION, filePosition);
         args.putParcelable(ARG_USER, user);
         args.putBoolean(ARG_IGNORE_FIRST, ignoreFirstSavedState);
         frag.setArguments(args);
@@ -121,9 +117,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
 
         mIgnoreFirstSavedState = args.getBoolean(ARG_IGNORE_FIRST);
         user = BundleExtensionsKt.getParcelableArgument(args, ARG_USER, User.class);
-        filePosition = args.getInt(ARG_FILE_POSITION);
     }
-
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -163,19 +157,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
             setButtonsForTransferring();
         }
 
-        observeWorkerState();
-
         return mView;
-    }
-
-    private void observeWorkerState() {
-        WorkerStateLiveData.Companion.instance().observe(getViewLifecycleOwner(), state -> {
-            if (state instanceof WorkerState.DownloadFinished &&
-                requireActivity() instanceof PreviewImageActivity activity &&
-                filePosition != null) {
-                activity.setPreviewImagePagerCurrentItem(filePosition);
-            }
-        });
     }
 
     @Override
@@ -183,7 +165,6 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
         super.onSaveInstanceState(outState);
         FileExtensionsKt.logFileSize(getFile(), TAG);
         outState.putParcelable(FileDownloadFragment.EXTRA_FILE, getFile());
-        outState.putInt(FileDownloadFragment.ARG_FILE_POSITION, filePosition);
         outState.putParcelable(FileDownloadFragment.EXTRA_USER, user);
         outState.putBoolean(FileDownloadFragment.EXTRA_ERROR, mError);
     }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
@@ -142,24 +142,25 @@ class PreviewImagePagerAdapter : FragmentStateAdapter {
     fun getItem(i: Int): Fragment {
         val file = getFileAt(i)
         val fragment: Fragment
+        val ignoreFirstSavedState = mObsoletePositions.contains(i)
 
         if (file == null) {
             fragment = PreviewImageErrorFragment.newInstance()
         } else if (file.isDown) {
-            fragment = PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), false)
+            fragment = PreviewImageFragment.newInstance(file, ignoreFirstSavedState, false)
         } else {
             addVideoOfLivePhoto(file)
 
             if (mDownloadErrors.remove(i)) {
-                fragment = FileDownloadFragment.newInstance(file, user, true, i)
+                fragment = FileDownloadFragment.newInstance(file, user, true)
                 (fragment as FileDownloadFragment).setError(true)
             } else {
                 fragment = if (file.isEncrypted) {
-                    FileDownloadFragment.newInstance(file, user, mObsoletePositions.contains(i), i)
+                    FileDownloadFragment.newInstance(file, user, ignoreFirstSavedState)
                 } else if (PreviewMediaFragment.canBePreviewed(file)) {
                     PreviewMediaFragment.newInstance(file, user, 0, false, file.livePhotoVideo != null)
                 } else {
-                    PreviewImageFragment.newInstance(file, mObsoletePositions.contains(i), true)
+                    PreviewImageFragment.newInstance(file, ignoreFirstSavedState, true)
                 }
             }
         }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
@@ -156,6 +156,8 @@ class PreviewImagePagerAdapter : FragmentStateAdapter {
                 (fragment as FileDownloadFragment).setError(true)
             } else {
                 fragment = if (file.isEncrypted) {
+                    // The FileDownloadFragment is used exclusively for encrypted files, as they cannot be previewed
+                    // without first being downloaded.
                     FileDownloadFragment.newInstance(file, user, ignoreFirstSavedState)
                 } else if (PreviewMediaFragment.canBePreviewed(file)) {
                     PreviewMediaFragment.newInstance(file, user, 0, false, file.livePhotoVideo != null)

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
@@ -160,7 +160,8 @@ class PreviewImagePagerAdapter : FragmentStateAdapter {
                     // without first being downloaded.
                     FileDownloadFragment.newInstance(file, user, ignoreFirstSavedState)
                 } else if (PreviewMediaFragment.canBePreviewed(file)) {
-                    PreviewMediaFragment.newInstance(file, user, 0, false, file.livePhotoVideo != null)
+                    val isLivePhoto = file.livePhotoVideo != null
+                    PreviewMediaFragment.newInstance(file, user, 0, false, isLivePhoto)
                 } else {
                     PreviewImageFragment.newInstance(file, ignoreFirstSavedState, true)
                 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Problem

Opening a single image triggers the sequential opening and downloading of all images in the encrypted folder instead of just the selected file.

### Demo

https://github.com/user-attachments/assets/9dfa25bf-fc22-44f7-9690-8da7699511b3
