### PR TITLE
Fix Image Loading When Offline

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1206,9 +1206,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
                     case GALLERY_SEARCH -> VirtualFolderType.GALLERY;
                     default -> VirtualFolderType.NONE;
                 };
-                ((FileDisplayActivity) mContainerActivity).startImagePreview(file, type, !file.isDown());
+                ((FileDisplayActivity) mContainerActivity).startImagePreview(file, type, file.isDown());
             } else {
-                ((FileDisplayActivity) mContainerActivity).startImagePreview(file, !file.isDown());
+                ((FileDisplayActivity) mContainerActivity).startImagePreview(file, file.isDown());
             }
         } else if (file.isDown() && MimeTypeUtil.isVCard(file)) {
             ((FileDisplayActivity) mContainerActivity).startContactListFragment(file);


### PR DESCRIPTION
Problem:

Although Videos were loading immediately when offline, Images were not

Solution:
Found that checking for whether file is offline was passing, but the ! in the code was making it false, forcing a sync which would timeout (taking extra time) and preventing immediate access to images

Fixes https://github.com/nextcloud/android/issues/14470