### PR TITLE
Open Document Timeout

### DIFF
--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -288,7 +288,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             .execute(document.getUser(), context);
         switch (result.getCode()) {
             case ETAG_CHANGED:
-                return true;
+                return result.getData() != null;
             case ETAG_UNCHANGED:
                 return false;
             case FILE_NOT_FOUND:


### PR DESCRIPTION
Problem:

When offline and attempting to open a document via the Document Provider, the wait time is excessive.

CheckEtagRemoteOperation is reporting ETAG_CHANGED when the connection times out to the server, thus triggering needsDownload.

Instead, if the file is saved offline and the etag cannot be read from the server, there is no need for download.

Solution:

If the etag has changed and we have a connection to the server, then result's data will be populated.
We now check whether this data exists.
If data returns null (which results from a timeout), then we return false. This skips the unnecessary download attempt.

Fixes https://github.com/nextcloud/android/issues/14478