### PR TITLE
Finish PreviewImageActivity After Image Deletion

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
@@ -24,6 +24,7 @@ import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.ui.activity.FileActivity
 import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment.ConfirmationDialogFragmentListener
+import com.owncloud.android.ui.preview.PreviewImageActivity
 import javax.inject.Inject
 
 /**
@@ -116,10 +117,13 @@ class RemoveFilesDialogFragment : ConfirmationDialogFragment(), ConfirmationDial
             }
 
             finishActionMode()
+            finishPreviewImageActivity()
         }
     }
 
     override fun onNeutral(callerTag: String?) = Unit
+
+    private fun finishPreviewImageActivity() = getTypedActivity(PreviewImageActivity::class.java)?.finish()
 
     private fun setActionMode(actionMode: ActionMode?) {
         this.actionMode = actionMode


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### How to reproduce?

1. Create a folder and upload two image files of the same type.
2. Tap on one of the image files to open its preview, then delete it from there.
3. Repeat the same process for an encrypted folder.
4. App gets stuck in the PreviewImageActivity


