### PR TITLE
BugFix - ANR ReceiveExternalFilesActivity. startSyncFolderOperation()

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -865,7 +865,11 @@ public class ReceiveExternalFilesActivity extends FileActivity
                                                                 context
             );
 
-            operation.execute(getAccount(), context, null, null);
+            try {
+                operation.execute(getAccount(), context, null, null);
+            } catch (Exception e) {
+                Log_OC.d(TAG, "Exception startSyncFolderOperation: " + e);
+            }
         });
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -857,12 +857,12 @@ public class ReceiveExternalFilesActivity extends FileActivity
             }
 
             final var operation = new RefreshFolderOperation(folder,
-                                                                currentSyncTime,
-                                                                false,
-                                                                false,
-                                                                getStorageManager(),
-                                                                optionalUser.get(),
-                                                                context
+                                                             currentSyncTime,
+                                                             false,
+                                                             false,
+                                                             getStorageManager(),
+                                                             optionalUser.get(),
+                                                             context
             );
 
             try {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -98,6 +98,8 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Stack;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.inject.Inject;
 
@@ -164,6 +166,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     private ImageView mEmptyListIcon;
     private MaterialButton sortButton;
     private ReceiveExternalFilesBinding binding;
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -283,6 +286,8 @@ public class ReceiveExternalFilesActivity extends FileActivity
         if (mSyncBroadcastReceiver != null) {
             localBroadcastManager.unregisterReceiver(mSyncBroadcastReceiver);
         }
+
+        executorService.shutdown();
         super.onDestroy();
     }
 
@@ -840,20 +845,28 @@ public class ReceiveExternalFilesActivity extends FileActivity
             return;
         }
 
-        long currentSyncTime = System.currentTimeMillis();
+        final var context = this;
 
-        mSyncInProgress = true;
+        executorService.execute(() -> {
+            long currentSyncTime = System.currentTimeMillis();
+            mSyncInProgress = true;
+            final var optionalUser = getUser();
+            if (optionalUser.isEmpty()) {
+                DisplayUtils.showSnackMessage(this, R.string.user_information_retrieval_error);
+                return;
+            }
 
-        // perform folder synchronization
-        RemoteOperation syncFolderOp = new RefreshFolderOperation(folder,
-                                                                  currentSyncTime,
-                                                                  false,
-                                                                  false,
-                                                                  getStorageManager(),
-                                                                  getUser().orElseThrow(RuntimeException::new),
-                                                                  getApplicationContext()
-        );
-        syncFolderOp.execute(getAccount(), this, null, null);
+            final var operation = new RefreshFolderOperation(folder,
+                                                                currentSyncTime,
+                                                                false,
+                                                                false,
+                                                                getStorageManager(),
+                                                                optionalUser.get(),
+                                                                context
+            );
+
+            operation.execute(getAccount(), context, null, null);
+        });
     }
 
     private List<OCFile> sortFileList(List<OCFile> files) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


```
Exception java.lang.RuntimeException:
    at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.$r8$lambda$daVwSEQ7kWGhbbkfTn_9SdSDcKE (Unknown Source:2)
    at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity$$ExternalSyntheticLambda4.get (D8$$SyntheticClass)
    at java.util.Optional.orElseThrow (Optional.java:403)
    at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.startSyncFolderOperation (ReceiveExternalFilesActivity.java:853)
    at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.browseToFolderIfItExists (ReceiveExternalFilesActivity.java:260)
    at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.onStart (ReceiveExternalFilesActivity.java:253)
    at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1582)
    at android.app.Activity.performStart (Activity.java:9008)
    at android.app.ActivityThread.handleStartActivity (ActivityThread.java:4198)
    at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:225)
    at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:205)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:177)
    at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:98)
    at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2685)
    at android.os.Handler.dispatchMessage (Handler.java:106)
    at android.os.Looper.loopOnce (Looper.java:230)
    at android.os.Looper.loop (Looper.java:319)
    at android.app.ActivityThread.main (ActivityThread.java:8919)
    at java.lang.reflect.Method.invoke
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
    at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```
