### PR TITLE
Bugfix - E2EE Copy, Lock, Unlock File

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/FileLockManager.kt
+++ b/app/src/main/java/com/owncloud/android/operations/FileLockManager.kt
@@ -19,7 +19,6 @@ object FileLockManager {
 
     @Throws(Exception::class)
     fun lockFile(path: String): Pair<FileChannel?, FileLock?> {
-
         val file = File(path)
         val channel = RandomAccessFile(file, "rw").channel
         val lock = channel.lock()

--- a/app/src/main/java/com/owncloud/android/operations/FileLockManager.kt
+++ b/app/src/main/java/com/owncloud/android/operations/FileLockManager.kt
@@ -1,0 +1,42 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.operations
+
+import com.owncloud.android.lib.common.utils.Log_OC
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+
+object FileLockManager {
+
+    private const val TAG = "FileLockManager"
+
+    @Throws(Exception::class)
+    fun lockFile(path: String): Pair<FileChannel?, FileLock?> {
+
+        val file = File(path)
+        val channel = RandomAccessFile(file, "rw").channel
+        val lock = channel.lock()
+        Log_OC.d(TAG, "Locked file: $path")
+
+        return Pair(channel, lock)
+    }
+
+    fun unlockFile(channel: FileChannel?, lock: FileLock?) {
+        if (lock != null && lock.isValid) {
+            lock.release()
+            Log_OC.d(TAG, "Released file lock.")
+        }
+
+        if (channel != null && channel.isOpen) {
+            channel.close()
+            Log_OC.d(TAG, "Closed file channel.")
+        }
+    }
+}

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -505,7 +505,7 @@ public class UploadFileOperation extends SyncOperation {
 
             final var copyResult = copyFile(e2eFiles.getOriginalFile(), expectedPath);
             if (!copyResult) {
-                return new RemoteOperationResult<>(ResultCode.LOCK_FAILED);
+                return new RemoteOperationResult<>(ResultCode.LOCAL_STORAGE_NOT_COPIED);
             }
 
             result = new RemoteOperationResult<>(ResultCode.OK);
@@ -980,7 +980,7 @@ public class UploadFileOperation extends SyncOperation {
             if (copyResult) {
                 result = new RemoteOperationResult<>(ResultCode.OK);
             } else {
-                return new RemoteOperationResult<>(ResultCode.LOCK_FAILED);
+                return new RemoteOperationResult<>(ResultCode.LOCAL_STORAGE_NOT_COPIED);
             }
 
             // Get the last modification date of the file from the file system
@@ -1011,7 +1011,7 @@ public class UploadFileOperation extends SyncOperation {
                         result = new RemoteOperationResult<>(ResultCode.LOCK_FAILED);
                     }
                 } else {
-                    result = new RemoteOperationResult<>(ResultCode.LOCK_FAILED);
+                    result = new RemoteOperationResult<>(ResultCode.LOCAL_STORAGE_NOT_COPIED);
                 }
             }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### How to Reproduce

1. Create an encrypted folder.  
2. Try to upload an image.  
3. Observe the log — you will see a "Failed to unlock file with path" error.

### Fix

```
UploadFileOperation com.nextcloud.client: Failed to unlock file with path /data/user/0/com.nextcloud.client/files/nextcloud/tmp/user@10.0.2.2%3A55002/abc/0008.webp
```

### Changes

- Uses `ApacheUtils` for copying the file.  
- Stops relying on `RemoteOperationResult` for the copy operation.