### PR TITLE
Add checks for DecryptedFolderMetadataFile object to see if actually encrypted

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -324,14 +324,10 @@ public class SynchronizeFolderOperation extends SyncOperation {
             FileStorageUtils.searchForLocalFileInDefaultPath(updatedFile, user.getAccountName());
 
             // update file name for encrypted files
-            if (e2EVersion == E2EVersion.V1_2) {
-                RefreshFolderOperation.updateFileNameForEncryptedFileV1(storageManager,
-                                                 (DecryptedFolderMetadataFileV1) object,
-                                                 updatedFile);
-            } else {
-                RefreshFolderOperation.updateFileNameForEncryptedFile(storageManager,
-                                               (DecryptedFolderMetadataFile) object,
-                                               updatedFile);
+            if (object instanceof DecryptedFolderMetadataFileV1 metadataFile) {
+                RefreshFolderOperation.updateFileNameForEncryptedFileV1(storageManager, metadataFile, updatedFile);
+            } else if (object instanceof DecryptedFolderMetadataFile metadataFile) {
+                RefreshFolderOperation.updateFileNameForEncryptedFile(storageManager, metadataFile, updatedFile);
             }
 
             // we parse content, so either the folder itself or its direct parent (which we check) must be encrypted
@@ -345,14 +341,10 @@ public class SynchronizeFolderOperation extends SyncOperation {
         }
 
         // update file name for encrypted files
-        if (e2EVersion == E2EVersion.V1_2) {
-            RefreshFolderOperation.updateFileNameForEncryptedFileV1(storageManager,
-                                                                    (DecryptedFolderMetadataFileV1) object,
-                                                                    mLocalFolder);
-        } else {
-            RefreshFolderOperation.updateFileNameForEncryptedFile(storageManager,
-                                                                  (DecryptedFolderMetadataFile) object,
-                                                                  mLocalFolder);
+        if (object instanceof DecryptedFolderMetadataFileV1 metadataFile) {
+            RefreshFolderOperation.updateFileNameForEncryptedFileV1(storageManager, metadataFile, mLocalFolder);
+        } else if (object instanceof DecryptedFolderMetadataFile metadataFile) {
+            RefreshFolderOperation.updateFileNameForEncryptedFile(storageManager, metadataFile, mLocalFolder);
         }
 
         // save updated contents in local database


### PR DESCRIPTION
Problem:

updateFileNameForEncryptedFile will run even if the object in question is null. As a result, we get an error.

Solution:

Add check for object to see if not null before performing an operation on a file which may not be encrypted.