### PR TITLE
Remove misleading error

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -469,9 +469,6 @@ public class SyncedFolderProvider extends Observable {
         } else {
             if (cursor == null) {
                 Log_OC.e(TAG, "Sync folder db cursor for remote path = " + remotePath + " in NULL.");
-            } else {
-                Log_OC.e(TAG, cursor.getCount() + " items for remote path = " + remotePath
-                    + " available in sync folder db. Expected 1 or greater than 1. Failed to update sync folder db.");
             }
         }
 


### PR DESCRIPTION
Problem:

On startup, we check every folder to see if the folder is part of the synced folders database. If it isn't, we are getting an error how we expected to see an entry for the folder in the sync database, which isn't true.
![Screenshot From 2025-04-24 09-04-20](https://github.com/user-attachments/assets/b6c804fd-f989-455c-ae2d-0341601995cc)

Solution:
Hide (cosmetic) error