### PR TITLE
BugFix - Track File Upload Index

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
+++ b/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
@@ -18,6 +18,7 @@ import com.nextcloud.client.core.ClockImpl
 import com.nextcloud.client.database.dao.ArbitraryDataDao
 import com.nextcloud.client.database.dao.FileDao
 import com.nextcloud.client.database.dao.OfflineOperationDao
+import com.nextcloud.client.database.dao.UploadDao
 import com.nextcloud.client.database.entity.ArbitraryDataEntity
 import com.nextcloud.client.database.entity.CapabilityEntity
 import com.nextcloud.client.database.entity.ExternalLinkEntity
@@ -85,6 +86,7 @@ abstract class NextcloudDatabase : RoomDatabase() {
     abstract fun arbitraryDataDao(): ArbitraryDataDao
     abstract fun fileDao(): FileDao
     abstract fun offlineOperationDao(): OfflineOperationDao
+    abstract fun uploadDao(): UploadDao
 
     companion object {
         const val FIRST_ROOM_DB_VERSION = 65

--- a/app/src/main/java/com/nextcloud/client/database/dao/UploadDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/UploadDao.kt
@@ -1,0 +1,22 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
+
+@Dao
+interface UploadDao {
+    @Query(
+        "SELECT _id FROM " + ProviderTableMeta.UPLOADS_TABLE_NAME +
+            " WHERE " + ProviderTableMeta.UPLOADS_STATUS + " = :status AND " +
+            ProviderTableMeta.UPLOADS_ACCOUNT_NAME + " = :accountName AND _id IS NOT NULL"
+    )
+    fun getAllIds(status: Int, accountName: String): List<Int>
+}

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -139,8 +139,7 @@ interface BackgroundJobManager {
 
     fun startNotificationJob(subject: String, signature: String)
     fun startAccountRemovalJob(accountName: String, remoteWipe: Boolean)
-    fun startFilesUploadJob(user: User)
-    fun startFilesUploadJob(user: User, totalUploadSize: Int)
+    fun startFilesUploadJob(user: User, totalUploadSize: Int? = null)
     fun getFileUploads(user: User): LiveData<List<JobInfo>>
     fun cancelFilesUploadJob(user: User)
     fun isStartFileUploadJobScheduled(user: User): Boolean

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -139,7 +139,7 @@ interface BackgroundJobManager {
 
     fun startNotificationJob(subject: String, signature: String)
     fun startAccountRemovalJob(accountName: String, remoteWipe: Boolean)
-    fun startFilesUploadJob(user: User, totalUploadSize: Int? = null)
+    fun startFilesUploadJob(user: User, uploadIds: LongArray)
     fun getFileUploads(user: User): LiveData<List<JobInfo>>
     fun cancelFilesUploadJob(user: User)
     fun isStartFileUploadJobScheduled(user: User): Boolean

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -140,6 +140,7 @@ interface BackgroundJobManager {
     fun startNotificationJob(subject: String, signature: String)
     fun startAccountRemovalJob(accountName: String, remoteWipe: Boolean)
     fun startFilesUploadJob(user: User)
+    fun startFilesUploadJob(user: User, totalUploadSize: Int)
     fun getFileUploads(user: User): LiveData<List<JobInfo>>
     fun cancelFilesUploadJob(user: User)
     fun isStartFileUploadJobScheduled(user: User): Boolean

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -36,7 +36,6 @@ import com.owncloud.android.operations.DownloadType
 import java.util.Date
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import kotlin.random.Random
 import kotlin.reflect.KClass
 
 /**
@@ -584,7 +583,7 @@ internal class BackgroundJobManagerImpl(
      * @param uploadIds array of upload ids
      */
     override fun startFilesUploadJob(user: User, uploadIds: LongArray) {
-        val tag = startFileUploadJobTag(user) + Random.nextLong()
+        val tag = startFileUploadJobTag(user)
         val dataBuilder = Data.Builder()
             .putString(FileUploadWorker.ACCOUNT, user.accountName)
             .putLongArray(FileUploadWorker.UPLOAD_IDS, uploadIds)
@@ -599,7 +598,7 @@ internal class BackgroundJobManagerImpl(
             .setConstraints(constraints)
             .build()
 
-        workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.KEEP, request)
+        workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.APPEND_OR_REPLACE, request)
     }
 
     private fun startFileDownloadJobTag(user: User, fileId: Long): String =

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -36,6 +36,7 @@ import com.owncloud.android.operations.DownloadType
 import java.util.Date
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 import kotlin.reflect.KClass
 
 /**
@@ -576,7 +577,7 @@ internal class BackgroundJobManagerImpl(
         startFilesUploadJobInternal(user, totalUploadSize)
 
     private fun startFilesUploadJobInternal(user: User, totalUploadSize: Int?) {
-        val tag = startFileUploadJobTag(user)
+        val tag = startFileUploadJobTag(user) + Random.nextLong()
         val dataBuilder = Data.Builder()
             .putString(FileUploadWorker.ACCOUNT, user.accountName)
 

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -581,16 +581,13 @@ internal class BackgroundJobManagerImpl(
      * number of files so it's safer to treat each invocation as an independent job.
      *
      * @param user The user for whom the upload job is being created.
-     * @param totalUploadSize Optional total size of the files to upload to track upload progress
+     * @param uploadIds array of upload ids
      */
-    override fun startFilesUploadJob(user: User, totalUploadSize: Int?) {
+    override fun startFilesUploadJob(user: User, uploadIds: LongArray) {
         val tag = startFileUploadJobTag(user) + Random.nextLong()
         val dataBuilder = Data.Builder()
             .putString(FileUploadWorker.ACCOUNT, user.accountName)
-
-        totalUploadSize?.let {
-            dataBuilder.putInt(FileUploadWorker.TOTAL_UPLOAD_SIZE, it)
-        }
+            .putLongArray(FileUploadWorker.UPLOAD_IDS, uploadIds)
 
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -571,6 +571,18 @@ internal class BackgroundJobManagerImpl(
     override fun isStartFileUploadJobScheduled(user: User): Boolean =
         workManager.isWorkScheduled(startFileUploadJobTag(user))
 
+    /**
+     * This method supports initiating uploads for various scenarios, including:
+     * - New upload batches
+     * - Failed uploads
+     * - FilesSyncWork
+     *
+     * A unique tag is generated for each upload job. This is intentional because this job may encapsulate an arbitrary
+     * number of files so it's safer to treat each invocation as an independent job.
+     *
+     * @param user The user for whom the upload job is being created.
+     * @param totalUploadSize Optional total size of the files to upload to track upload progress
+     */
     override fun startFilesUploadJob(user: User, totalUploadSize: Int?) {
         val tag = startFileUploadJobTag(user) + Random.nextLong()
         val dataBuilder = Data.Builder()

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -575,12 +575,12 @@ internal class BackgroundJobManagerImpl(
      * - New upload batches
      * - Failed uploads
      * - FilesSyncWork
-     *
-     * A unique tag is generated for each upload job. This is intentional because this job may encapsulate an arbitrary
-     * number of files so it's safer to treat each invocation as an independent job.
+     * - ...
      *
      * @param user The user for whom the upload job is being created.
-     * @param uploadIds array of upload ids
+     * @param uploadIds Array of upload IDs to be processed. These IDs originate from multiple sources
+     *                  and cannot be determined directly from the account name or a single function
+     *                  within the worker.
      */
     override fun startFilesUploadJob(user: User, uploadIds: LongArray) {
         val tag = startFileUploadJobTag(user)

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -571,12 +571,7 @@ internal class BackgroundJobManagerImpl(
     override fun isStartFileUploadJobScheduled(user: User): Boolean =
         workManager.isWorkScheduled(startFileUploadJobTag(user))
 
-    override fun startFilesUploadJob(user: User) = startFilesUploadJobInternal(user, null)
-
-    override fun startFilesUploadJob(user: User, totalUploadSize: Int) =
-        startFilesUploadJobInternal(user, totalUploadSize)
-
-    private fun startFilesUploadJobInternal(user: User, totalUploadSize: Int?) {
+    override fun startFilesUploadJob(user: User, totalUploadSize: Int?) {
         val tag = startFileUploadJobTag(user) + Random.nextLong()
         val dataBuilder = Data.Builder()
             .putString(FileUploadWorker.ACCOUNT, user.accountName)

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -103,7 +103,8 @@ class FilesSyncWork(
 
         val user = userAccountManager.getUser(syncedFolder.account)
         if (user.isPresent) {
-            backgroundJobManager.startFilesUploadJob(user.get())
+            var uploadIds = uploadsStorageManager.getCurrentUploadIds(user.get().accountName)
+            backgroundJobManager.startFilesUploadJob(user.get(), uploadIds)
         }
 
         // Get changed files from ContentObserverWork (only images and videos) or by scanning filesystem

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -255,6 +255,7 @@ class FileUploadHelper {
         }
     }
 
+    @JvmOverloads
     fun cancelAndRestartUploadJob(user: User, totalUploadSize: Int? = null) {
         backgroundJobManager.run {
             cancelFilesUploadJob(user)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -259,12 +259,7 @@ class FileUploadHelper {
     fun cancelAndRestartUploadJob(user: User, totalUploadSize: Int? = null) {
         backgroundJobManager.run {
             cancelFilesUploadJob(user)
-
-            if (totalUploadSize != null) {
-                startFilesUploadJob(user, totalUploadSize)
-            } else {
-                startFilesUploadJob(user)
-            }
+            startFilesUploadJob(user, totalUploadSize)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -182,7 +182,7 @@ class FileUploadHelper {
         accountNames.forEach { accountName ->
             val user = accountManager.getUser(accountName)
             if (user.isPresent) {
-                backgroundJobManager.startFilesUploadJob(user.get())
+                backgroundJobManager.startFilesUploadJob(user.get(), failedUploads.size)
             }
         }
 
@@ -213,7 +213,7 @@ class FileUploadHelper {
             }
         }
         uploadsStorageManager.storeUploads(uploads)
-        backgroundJobManager.startFilesUploadJob(user)
+        backgroundJobManager.startFilesUploadJob(user, uploads.size)
     }
 
     fun removeFileUpload(remotePath: String, accountName: String) {
@@ -226,7 +226,7 @@ class FileUploadHelper {
 
             cancelAndRestartUploadJob(user)
         } catch (e: NoSuchElementException) {
-            Log_OC.e(TAG, "Error cancelling current upload because user does not exist!")
+            Log_OC.e(TAG, "Error cancelling current upload because user does not exist!: " + e.message)
         }
     }
 
@@ -249,16 +249,21 @@ class FileUploadHelper {
 
         try {
             val user = accountManager.getUser(accountName).get()
-            cancelAndRestartUploadJob(user)
+            cancelAndRestartUploadJob(user, uploads.size)
         } catch (e: NoSuchElementException) {
-            Log_OC.e(TAG, "Error restarting upload job because user does not exist!")
+            Log_OC.e(TAG, "Error restarting upload job because user does not exist!: " + e.message)
         }
     }
 
-    fun cancelAndRestartUploadJob(user: User) {
+    fun cancelAndRestartUploadJob(user: User, totalUploadSize: Int? = null) {
         backgroundJobManager.run {
             cancelFilesUploadJob(user)
-            startFilesUploadJob(user)
+
+            if (totalUploadSize != null) {
+                startFilesUploadJob(user, totalUploadSize)
+            } else {
+                startFilesUploadJob(user)
+            }
         }
     }
 
@@ -373,7 +378,7 @@ class FileUploadHelper {
             }
         }
         uploadsStorageManager.storeUploads(uploads)
-        backgroundJobManager.startFilesUploadJob(user)
+        backgroundJobManager.startFilesUploadJob(user, uploads.size)
     }
 
     /**

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -57,6 +57,7 @@ class FileUploadWorker(
 
         const val NOTIFICATION_ERROR_ID: Int = 413
         const val ACCOUNT = "data_account"
+        const val TOTAL_UPLOAD_SIZE = "total_upload_size"
         var currentUploadFileOperation: UploadFileOperation? = null
 
         private const val UPLOADS_ADDED_MESSAGE = "UPLOADS_ADDED"
@@ -127,7 +128,8 @@ class FileUploadWorker(
     private fun retrievePagesBySortingUploadsByID(): Result {
         val accountName = inputData.getString(ACCOUNT) ?: return Result.failure()
         var uploadsPerPage = uploadsStorageManager.getCurrentUploadsForAccountPageAscById(-1, accountName)
-        val totalUploadSize = uploadsStorageManager.getTotalUploadSize(accountName)
+        val totalUploadSize =
+            inputData.getInt(TOTAL_UPLOAD_SIZE, defaultValue = uploadsStorageManager.getTotalUploadSize(accountName))
 
         Log_OC.d(TAG, "FileUploadWorker:retrievePagesBySortingUploadsByID: $uploadsPerPage")
         Log_OC.d(TAG, "FileUploadWorker:totalUploadSize: $totalUploadSize")

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -50,15 +50,14 @@ class FileUploadWorker(
     val preferences: AppPreferences,
     val context: Context,
     params: WorkerParameters
-) : Worker(context, params),
-    OnDatatransferProgressListener {
+) : Worker(context, params), OnDatatransferProgressListener {
 
     companion object {
         val TAG: String = FileUploadWorker::class.java.simpleName
 
         const val NOTIFICATION_ERROR_ID: Int = 413
         const val ACCOUNT = "data_account"
-        const val TOTAL_UPLOAD_SIZE = "total_upload_size"
+        const val UPLOAD_IDS = "uploads_ids"
         var currentUploadFileOperation: UploadFileOperation? = null
 
         private const val UPLOADS_ADDED_MESSAGE = "UPLOADS_ADDED"
@@ -85,26 +84,27 @@ class FileUploadWorker(
         fun getUploadFinishMessage(): String = FileUploadWorker::class.java.name + UPLOAD_FINISH_MESSAGE
     }
 
-    private var currentUploadIndex: Int = 1
     private var lastPercent = 0
     private val notificationManager = UploadNotificationManager(context, viewThemeUtils, Random.nextInt())
     private val intents = FileUploaderIntents(context)
     private val fileUploaderDelegate = FileUploaderDelegate()
 
     @Suppress("TooGenericExceptionCaught")
-    override fun doWork(): Result = try {
-        Log_OC.d(TAG, "FileUploadWorker started")
-        backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class))
-        val result = retrievePagesBySortingUploadsByID()
-        backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
-        notificationManager.dismissNotification()
-        if (result == Result.success()) {
-            setIdleWorkerState()
+    override fun doWork(): Result {
+        return try {
+            Log_OC.d(TAG, "FileUploadWorker started")
+            backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class))
+            val result = uploadFiles()
+            backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
+            notificationManager.dismissNotification()
+            if (result == Result.success()) {
+                setIdleWorkerState()
+            }
+            result
+        } catch (t: Throwable) {
+            Log_OC.e(TAG, "Error caught at FileUploadWorker $t")
+            Result.failure()
         }
-        result
-    } catch (t: Throwable) {
-        Log_OC.e(TAG, "Error caught at FileUploadWorker $t")
-        Result.failure()
     }
 
     override fun onStopped() {
@@ -117,8 +117,8 @@ class FileUploadWorker(
         super.onStopped()
     }
 
-    private fun setWorkerState(user: User?, uploads: List<OCUpload>) {
-        WorkerStateLiveData.instance().setWorkState(WorkerState.UploadStarted(user, uploads))
+    private fun setWorkerState(user: User?) {
+        WorkerStateLiveData.instance().setWorkState(WorkerState.UploadStarted(user))
     }
 
     private fun setIdleWorkerState() {
@@ -126,16 +126,13 @@ class FileUploadWorker(
     }
 
     @Suppress("ReturnCount")
-    private fun retrievePagesBySortingUploadsByID(): Result {
+    private fun uploadFiles(): Result {
         val accountName = inputData.getString(ACCOUNT) ?: return Result.failure()
-        var uploadsPerPage = uploadsStorageManager.getCurrentUploadsForAccountPageAscById(-1, accountName)
-        val totalUploadSize =
-            inputData.getInt(TOTAL_UPLOAD_SIZE, defaultValue = uploadsStorageManager.getTotalUploadSize(accountName))
+        val uploadIds = inputData.getLongArray(UPLOAD_IDS) ?: return Result.success()
+        val uploads = uploadIds.map { id -> uploadsStorageManager.getUploadById(id) }.filterNotNull()
+        val totalUploadSize = uploadIds.size
 
-        Log_OC.d(TAG, "FileUploadWorker:retrievePagesBySortingUploadsByID: $uploadsPerPage")
-        Log_OC.d(TAG, "FileUploadWorker:totalUploadSize: $totalUploadSize")
-
-        while (uploadsPerPage.isNotEmpty() && !isStopped) {
+        for ((index, upload) in uploads.withIndex()) {
             if (preferences.isGlobalUploadPaused) {
                 Log_OC.d(TAG, "Upload is paused, skip uploading files!")
                 notificationManager.notifyPaused(
@@ -149,18 +146,41 @@ class FileUploadWorker(
                 return Result.failure()
             }
 
-            Log_OC.d(TAG, "Handling ${uploadsPerPage.size} uploads for account $accountName")
-            val lastId = uploadsPerPage.last().uploadId
-            uploadFiles(totalUploadSize, uploadsPerPage, accountName)
-            uploadsPerPage =
-                uploadsStorageManager.getCurrentUploadsForAccountPageAscById(lastId, accountName)
+            val user = userAccountManager.getUser(accountName)
+            if (!user.isPresent) {
+                uploadsStorageManager.removeUpload(upload.uploadId)
+                continue
+            }
+
+            if (isStopped) {
+                continue
+            }
+
+            setWorkerState(user.get())
+
+            val operation = createUploadFileOperation(upload, user.get())
+            currentUploadFileOperation = operation
+
+            notificationManager.prepareForStart(
+                operation,
+                cancelPendingIntent = intents.startIntent(operation),
+                startIntent = intents.notificationStartIntent(operation),
+                currentUploadIndex = index,
+                totalUploadSize = totalUploadSize
+            )
+
+            val result = upload(operation, user.get())
+            currentUploadFileOperation = null
+
+            fileUploaderDelegate.sendBroadcastUploadFinished(
+                operation,
+                result,
+                operation.oldFile?.storagePath,
+                context,
+                localBroadcastManager
+            )
         }
 
-        if (isStopped) {
-            Log_OC.d(TAG, "FileUploadWorker for account $accountName was stopped")
-        } else {
-            Log_OC.d(TAG, "No more pending uploads for account $accountName, stopping work")
-        }
         return Result.success()
     }
 
@@ -178,74 +198,24 @@ class FileUploadWorker(
         return result
     }
 
-    @Suppress("NestedBlockDepth")
-    private fun uploadFiles(totalUploadSize: Int, uploadsPerPage: List<OCUpload>, accountName: String) {
-        val user = userAccountManager.getUser(accountName)
-        setWorkerState(user.get(), uploadsPerPage)
-
-        if (canExitEarly()) {
-            notificationManager.showConnectionErrorNotification()
-            return
+    private fun createUploadFileOperation(upload: OCUpload, user: User): UploadFileOperation {
+        return UploadFileOperation(
+            uploadsStorageManager,
+            connectivityService,
+            powerManagementService,
+            user,
+            null,
+            upload,
+            upload.nameCollisionPolicy,
+            upload.localAction,
+            context,
+            upload.isUseWifiOnly,
+            upload.isWhileChargingOnly,
+            true,
+            FileDataStorageManager(user, context.contentResolver)
+        ).apply {
+            addDataTransferProgressListener(this@FileUploadWorker)
         }
-
-        run uploads@{
-            uploadsPerPage.forEach { upload ->
-                if (canExitEarly()) {
-                    notificationManager.showConnectionErrorNotification()
-                    return@uploads
-                }
-
-                if (user.isPresent) {
-                    val uploadFileOperation = createUploadFileOperation(upload, user.get())
-
-                    currentUploadFileOperation = uploadFileOperation
-
-                    notificationManager.prepareForStart(
-                        uploadFileOperation,
-                        cancelPendingIntent = intents.startIntent(uploadFileOperation),
-                        startIntent = intents.notificationStartIntent(uploadFileOperation),
-                        currentUploadIndex = currentUploadIndex,
-                        totalUploadSize = totalUploadSize
-                    )
-
-                    val result = upload(uploadFileOperation, user.get())
-
-                    if (result.isSuccess) {
-                        currentUploadIndex += 1
-                    }
-
-                    currentUploadFileOperation = null
-
-                    fileUploaderDelegate.sendBroadcastUploadFinished(
-                        uploadFileOperation,
-                        result,
-                        uploadFileOperation.oldFile?.storagePath,
-                        context,
-                        localBroadcastManager
-                    )
-                } else {
-                    uploadsStorageManager.removeUpload(upload.uploadId)
-                }
-            }
-        }
-    }
-
-    private fun createUploadFileOperation(upload: OCUpload, user: User): UploadFileOperation = UploadFileOperation(
-        uploadsStorageManager,
-        connectivityService,
-        powerManagementService,
-        user,
-        null,
-        upload,
-        upload.nameCollisionPolicy,
-        upload.localAction,
-        context,
-        upload.isUseWifiOnly,
-        upload.isWhileChargingOnly,
-        true,
-        FileDataStorageManager(user, context.contentResolver)
-    ).apply {
-        addDataTransferProgressListener(this@FileUploadWorker)
     }
 
     @Suppress("TooGenericExceptionCaught", "DEPRECATION")
@@ -296,8 +266,7 @@ class FileUploadWorker(
         }
 
         // Only notify if it is not same file on remote that causes conflict
-        if (uploadResult.code == ResultCode.SYNC_CONFLICT &&
-            FileUploadHelper().isSameFileOnRemote(
+        if (uploadResult.code == ResultCode.SYNC_CONFLICT && FileUploadHelper().isSameFileOnRemote(
                 uploadFileOperation.user,
                 File(uploadFileOperation.storagePath),
                 uploadFileOperation.remotePath,

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -50,7 +50,8 @@ class FileUploadWorker(
     val preferences: AppPreferences,
     val context: Context,
     params: WorkerParameters
-) : Worker(context, params), OnDatatransferProgressListener {
+) : Worker(context, params),
+    OnDatatransferProgressListener {
 
     companion object {
         val TAG: String = FileUploadWorker::class.java.simpleName
@@ -90,21 +91,19 @@ class FileUploadWorker(
     private val fileUploaderDelegate = FileUploaderDelegate()
 
     @Suppress("TooGenericExceptionCaught")
-    override fun doWork(): Result {
-        return try {
-            Log_OC.d(TAG, "FileUploadWorker started")
-            backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class))
-            val result = uploadFiles()
-            backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
-            notificationManager.dismissNotification()
-            if (result == Result.success()) {
-                setIdleWorkerState()
-            }
-            result
-        } catch (t: Throwable) {
-            Log_OC.e(TAG, "Error caught at FileUploadWorker $t")
-            Result.failure()
+    override fun doWork(): Result = try {
+        Log_OC.d(TAG, "FileUploadWorker started")
+        backgroundJobManager.logStartOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class))
+        val result = uploadFiles()
+        backgroundJobManager.logEndOfWorker(BackgroundJobManagerImpl.formatClassTag(this::class), result)
+        notificationManager.dismissNotification()
+        if (result == Result.success()) {
+            setIdleWorkerState()
         }
+        result
+    } catch (t: Throwable) {
+        Log_OC.e(TAG, "Error caught at FileUploadWorker $t")
+        Result.failure()
     }
 
     override fun onStopped() {
@@ -198,24 +197,22 @@ class FileUploadWorker(
         return result
     }
 
-    private fun createUploadFileOperation(upload: OCUpload, user: User): UploadFileOperation {
-        return UploadFileOperation(
-            uploadsStorageManager,
-            connectivityService,
-            powerManagementService,
-            user,
-            null,
-            upload,
-            upload.nameCollisionPolicy,
-            upload.localAction,
-            context,
-            upload.isUseWifiOnly,
-            upload.isWhileChargingOnly,
-            true,
-            FileDataStorageManager(user, context.contentResolver)
-        ).apply {
-            addDataTransferProgressListener(this@FileUploadWorker)
-        }
+    private fun createUploadFileOperation(upload: OCUpload, user: User): UploadFileOperation = UploadFileOperation(
+        uploadsStorageManager,
+        connectivityService,
+        powerManagementService,
+        user,
+        null,
+        upload,
+        upload.nameCollisionPolicy,
+        upload.localAction,
+        context,
+        upload.isUseWifiOnly,
+        upload.isWhileChargingOnly,
+        true,
+        FileDataStorageManager(user, context.contentResolver)
+    ).apply {
+        addDataTransferProgressListener(this@FileUploadWorker)
     }
 
     @Suppress("TooGenericExceptionCaught", "DEPRECATION")
@@ -266,7 +263,8 @@ class FileUploadWorker(
         }
 
         // Only notify if it is not same file on remote that causes conflict
-        if (uploadResult.code == ResultCode.SYNC_CONFLICT && FileUploadHelper().isSameFileOnRemote(
+        if (uploadResult.code == ResultCode.SYNC_CONFLICT &&
+            FileUploadHelper().isSameFileOnRemote(
                 uploadFileOperation.user,
                 File(uploadFileOperation.storagePath),
                 uploadFileOperation.remotePath,

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -36,6 +36,7 @@ import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.utils.ErrorMessageAdapter
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.io.File
+import kotlin.random.Random
 
 @Suppress("LongParameterList")
 class FileUploadWorker(
@@ -86,7 +87,7 @@ class FileUploadWorker(
 
     private var currentUploadIndex: Int = 1
     private var lastPercent = 0
-    private val notificationManager = UploadNotificationManager(context, viewThemeUtils)
+    private val notificationManager = UploadNotificationManager(context, viewThemeUtils, Random.nextInt())
     private val intents = FileUploaderIntents(context)
     private val fileUploaderDelegate = FileUploaderDelegate()
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -18,12 +18,8 @@ import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
-class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils) :
-    WorkerNotificationManager(ID, context, viewThemeUtils, R.string.foreground_service_upload) {
-
-    companion object {
-        private const val ID = 411
-    }
+class UploadNotificationManager(private val context: Context, viewThemeUtils: ViewThemeUtils, id: Int) :
+    WorkerNotificationManager(id, context, viewThemeUtils, R.string.foreground_service_upload) {
 
     @Suppress("MagicNumber")
     fun prepareForStart(

--- a/app/src/main/java/com/nextcloud/model/WorkerState.kt
+++ b/app/src/main/java/com/nextcloud/model/WorkerState.kt
@@ -9,7 +9,6 @@ package com.nextcloud.model
 
 import com.nextcloud.client.account.User
 import com.owncloud.android.datamodel.OCFile
-import com.owncloud.android.db.OCUpload
 import com.owncloud.android.operations.DownloadFileOperation
 
 sealed class WorkerState {
@@ -17,6 +16,6 @@ sealed class WorkerState {
     data class DownloadStarted(var user: User?, var currentDownload: DownloadFileOperation?, var percent: Int) :
         WorkerState()
     data class UploadFinished(var currentFile: OCFile?) : WorkerState()
-    data class UploadStarted(var user: User?, var uploads: List<OCUpload>) : WorkerState()
+    data class UploadStarted(var user: User?) : WorkerState()
     data object OfflineOperationsCompleted : WorkerState()
 }

--- a/app/src/main/java/com/nextcloud/utils/extensions/OCUploadExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OCUploadExtensions.kt
@@ -1,0 +1,14 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import com.owncloud.android.db.OCUpload
+
+fun List<OCUpload>.getUploadIds(): LongArray = map { it.uploadId }.toLongArray()
+
+fun Array<OCUpload>.getUploadIds(): LongArray = map { it.uploadId }.toLongArray()

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -638,6 +638,33 @@ public class UploadsStorageManager extends Observable {
         return getUploadPage(QUERY_PAGE_SIZE, afterId, false, selection, accountName);
     }
 
+    public long[] getCurrentUploadIds(String accountName) {
+        List<Long> uploadIds = new ArrayList<>();
+        long lastId = -1L;
+
+        do {
+            List<OCUpload> page = getCurrentUploadsForAccountPageAscById(lastId, accountName);
+            if (page.isEmpty()) {
+                break;
+            }
+
+            for (OCUpload upload : page) {
+                uploadIds.add(upload.getUploadId());
+            }
+
+            lastId = uploadIds.get(uploadIds.size() - 1);
+
+            Log_OC.d(TAG, "Fetched " + page.size() + " uploads. Last ID: " + lastId);
+        } while (true);
+
+        long[] result = new long[uploadIds.size()];
+        for (int i = 0; i < uploadIds.size(); i++) {
+            result[i] = uploadIds.get(i);
+        }
+
+        return result;
+    }
+
 
     /**
      * Gets a page of uploads after <code>afterId</code>, where uploads are sorted by ascending upload id.

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -25,6 +25,8 @@ import android.os.RemoteException;
 
 import com.nextcloud.client.account.CurrentAccountProvider;
 import com.nextcloud.client.account.User;
+import com.nextcloud.client.database.NextcloudDatabase;
+import com.nextcloud.client.database.dao.UploadDao;
 import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.utils.autoRename.AutoRename;
@@ -69,6 +71,7 @@ public class UploadsStorageManager extends Observable {
     private final ContentResolver contentResolver;
     private final CurrentAccountProvider currentAccountProvider;
     private OCCapability capability;
+    public final UploadDao uploadDao = NextcloudDatabase.getInstance(MainApp.getAppContext()).uploadDao();
 
     public UploadsStorageManager(
         CurrentAccountProvider currentAccountProvider,
@@ -494,28 +497,6 @@ public class UploadsStorageManager extends Observable {
             " ) AND " + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL;
     }
 
-    public int getTotalUploadSize(@Nullable String... selectionArgs) {
-        final String selection = ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value +
-            AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL;
-        int totalSize = 0;
-
-        Cursor cursor = getDB().query(
-            ProviderTableMeta.CONTENT_URI_UPLOADS,
-            new String[]{"COUNT(*) AS count"},
-            selection,
-            selectionArgs,
-            null);
-
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                totalSize = cursor.getInt(cursor.getColumnIndexOrThrow("count"));
-            }
-            cursor.close();
-        }
-
-        return totalSize;
-    }
-
     @NonNull
     private List<OCUpload> getUploadPage(long limit, final long afterId, final boolean descending, @Nullable String selection, @Nullable String... selectionArgs) {
         List<OCUpload> uploads = new ArrayList<>();
@@ -627,44 +608,12 @@ public class UploadsStorageManager extends Observable {
         return getUploads(inProgressUploadsSelection, accountName);
     }
 
-    public OCUpload[] getCurrentUploadsForAccount(final @NonNull String accountName) {
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value + AND +
-                              ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, accountName);
+    public long[] getCurrentUploadIds(final @NonNull String accountName) {
+        final var result = uploadDao.getAllIds(UploadStatus.UPLOAD_IN_PROGRESS.value, accountName);
+        return result.stream()
+            .mapToLong(Integer::longValue)
+            .toArray();
     }
-
-    public List<OCUpload> getCurrentUploadsForAccountPageAscById(final long afterId, final @NonNull String accountName) {
-        final String selection = ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_IN_PROGRESS.value +
-            AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL;
-        return getUploadPage(QUERY_PAGE_SIZE, afterId, false, selection, accountName);
-    }
-
-    public long[] getCurrentUploadIds(String accountName) {
-        List<Long> uploadIds = new ArrayList<>();
-        long lastId = -1L;
-
-        do {
-            List<OCUpload> page = getCurrentUploadsForAccountPageAscById(lastId, accountName);
-            if (page.isEmpty()) {
-                break;
-            }
-
-            for (OCUpload upload : page) {
-                uploadIds.add(upload.getUploadId());
-            }
-
-            lastId = uploadIds.get(uploadIds.size() - 1);
-
-            Log_OC.d(TAG, "Fetched " + page.size() + " uploads. Last ID: " + lastId);
-        } while (true);
-
-        long[] result = new long[uploadIds.size()];
-        for (int i = 0; i < uploadIds.size(); i++) {
-            result[i] = uploadIds.get(i);
-        }
-
-        return result;
-    }
-
 
     /**
      * Gets a page of uploads after <code>afterId</code>, where uploads are sorted by ascending upload id.

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -228,7 +228,8 @@ class ConflictsResolveActivity :
 
             UploadNotificationManager(
                 applicationContext,
-                viewThemeUtils
+                viewThemeUtils,
+                upload.uploadId.toInt()
             ).dismissOldErrorNotification(it.remotePath, it.localPath)
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -277,7 +277,7 @@ public class UploadListActivity extends FileActivity {
 
         for (User user : accountManager.getAllUsers()) {
             if (user != null) {
-                FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user, null);
+                FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user);
             }
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -277,7 +277,8 @@ public class UploadListActivity extends FileActivity {
 
         for (User user : accountManager.getAllUsers()) {
             if (user != null) {
-                FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user);
+                final var uploadIds = uploadsStorageManager.getCurrentUploadIds(user.getAccountName());
+                FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user, uploadIds);
             }
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -277,7 +277,7 @@ public class UploadListActivity extends FileActivity {
 
         for (User user : accountManager.getAllUsers()) {
             if (user != null) {
-                FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user);
+                FileUploadHelper.Companion.instance().cancelAndRestartUploadJob(user, null);
             }
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -57,7 +57,7 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
 
     /**
      * Helper method building a correct array of parameters to be passed to {@link #execute(Object[])} )}
-     *
+     * <p>
      * Just packages the received parameters in correct order, doesn't check anything about them.
      *
      * @param   user                user uploading shared files
@@ -66,19 +66,19 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
      * @param   behaviour           Indicates what to do with the local file once uploaded.
      * @param   contentResolver     {@link ContentResolver} instance with appropriate permissions to open the
      *                              URIs in 'sourceUris'.
-     *
+     * <p>
      * Handling this parameter in {@link #doInBackground(Object[])} keeps an indirect reference to the
      * caller Activity, what is technically wrong, since it will be held in memory
      * (with all its associated resources) until the task finishes even though the user leaves the Activity.
-     *
+     * <p>
      * But we really, really, really want that the files are copied to temporary files in the OC folder and then
      * uploaded, even if the user gets bored of waiting while the copy finishes. And we can't forward the job to
      * another {@link Context}, because if any of the content:// URIs is constrained by a TEMPORARY READ PERMISSION,
      * trying to open it will fail with a {@link SecurityException} after the user leaves the ReceiveExternalFilesActivity Activity. We
      * really tried it.
-     *
+     * <p>
      * So we are doomed to leak here for the best interest of the user. Please, don't do similar in other places.
-     *
+     * <p>
      * Any idea to prevent this while keeping the functionality will be welcome.
      *
      * @return Correct array of parameters to be passed to {@link #execute(Object[])}
@@ -88,22 +88,17 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
         Uri[] sourceUris,
         String[] remotePaths,
         int behaviour,
-        ContentResolver contentResolver
-                                              ) {
-
+        ContentResolver contentResolver) {
         return new Object[]{
             user,
             sourceUris,
             remotePaths,
-            Integer.valueOf(behaviour),
+            behaviour,
             contentResolver
         };
     }
 
-    public CopyAndUploadContentUrisTask(
-        OnCopyTmpFilesTaskListener listener,
-        Context context
-                                       ) {
+    public CopyAndUploadContentUrisTask(OnCopyTmpFilesTaskListener listener, Context context) {
         mListener = new WeakReference<>(listener);
         mAppContext = context.getApplicationContext();
     }
@@ -148,16 +143,23 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                 fullTempPath = FileStorageUtils.getTemporalPath(user.getAccountName()) + currentRemotePath;
                 File cacheFile = new File(fullTempPath);
                 File tempDir = cacheFile.getParentFile();
-                if (!tempDir.exists()) {
-                    tempDir.mkdirs();
+                if (tempDir != null && !tempDir.exists()) {
+                    boolean isTempFileCreated = tempDir.mkdirs();
+                    Log_OC.d(TAG, "Temp file creation result: " + isTempFileCreated);
                 }
-                cacheFile.createNewFile();
+
+                boolean isCacheFileCreated = cacheFile.createNewFile();
+                Log_OC.d(TAG, "Cache file creation result: " + isCacheFileCreated);
+
                 try (InputStream inputStream = leakedContentResolver.openInputStream(currentUri);
                      FileOutputStream outputStream = new FileOutputStream(fullTempPath)) {
                     byte[] buffer = new byte[4096];
                     int count;
-                    while ((count = inputStream.read(buffer)) > 0) {
-                        outputStream.write(buffer, 0, count);
+
+                    if (inputStream != null) {
+                        while ((count = inputStream.read(buffer)) > 0) {
+                            outputStream.write(buffer, 0, count);
+                        }
                     }
 
                     if (lastModified != 0) {
@@ -172,9 +174,10 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                         }
                     }
 
-                localPaths[i] = fullTempPath;
-                currentRemotePaths[i] = currentRemotePath;
-                fullTempPath = null;
+                    localPaths[i] = fullTempPath;
+                    currentRemotePaths[i] = currentRemotePath;
+                    fullTempPath = null;
+                }
             }
 
             FileUploadHelper.Companion.instance().uploadNewFiles(
@@ -192,30 +195,23 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
 
         } catch (ArrayIndexOutOfBoundsException e) {
             Log_OC.e(TAG, "Wrong number of arguments received ", e);
-
         } catch (ClassCastException e) {
             Log_OC.e(TAG, "Wrong parameter received ", e);
-
         } catch (FileNotFoundException e) {
             Log_OC.e(TAG, "Could not find source file " + currentUri, e);
             result = ResultCode.LOCAL_FILE_NOT_FOUND;
-
         } catch (SecurityException e) {
             Log_OC.e(TAG, "Not enough permissions to read source file " + currentUri, e);
             result = ResultCode.FORBIDDEN;
-
         } catch (Exception e) {
             Log_OC.e(TAG, "Exception while copying " + currentUri + " to temporary file", e);
             result = ResultCode.LOCAL_STORAGE_NOT_COPIED;
-
-            // clean
             if (fullTempPath != null) {
                 File f = new File(fullTempPath);
                 if (f.exists() && !f.delete()) {
                     Log_OC.e(TAG, "Could not delete temporary file " + fullTempPath);
                 }
             }
-
         }
 
         return result;

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -126,7 +126,8 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
             String[] remotePaths = (String[]) params[2];
             int behaviour = (Integer) params[3];
             ContentResolver leakedContentResolver = (ContentResolver) params[4];
-
+            String[] localPaths = new String[uris.length];
+            String[] currentRemotePaths = new String[uris.length];
             String currentRemotePath;
 
             for (int i = 0; i < uris.length; i++) {
@@ -171,11 +172,22 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                         }
                     }
 
-                    requestUpload(user, fullTempPath, currentRemotePath, behaviour);
-                    fullTempPath = null;
-                }
-
+                localPaths[i] = fullTempPath;
+                currentRemotePaths[i] = currentRemotePath;
+                fullTempPath = null;
             }
+
+            FileUploadHelper.Companion.instance().uploadNewFiles(
+                user,
+                localPaths,
+                currentRemotePaths,
+                behaviour,
+                false,      // do not create parent folder if not existent
+                UploadFileOperation.CREATED_BY_USER,
+                false,
+                false,
+                NameCollisionPolicy.ASK_USER);
+
             result = ResultCode.OK;
 
         } catch (ArrayIndexOutOfBoundsException e) {
@@ -207,19 +219,6 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
         }
 
         return result;
-    }
-
-    private void requestUpload(User user, String localPath, String remotePath, int behaviour) {
-        FileUploadHelper.Companion.instance().uploadNewFiles(
-            user,
-            new String[]{ localPath },
-            new String[]{ remotePath },
-            behaviour,
-            false,      // do not create parent folder if not existent
-            UploadFileOperation.CREATED_BY_USER,
-            false,
-            false,
-            NameCollisionPolicy.ASK_USER);
     }
 
     @Override


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Problem

Currently, the logic implemented in FileUploadWorker processes file uploads in discrete batches, which limits our ability to track the overall upload progress accurately and total upload index is wrong. We have outer while loop to update uploads and inner for loop for uploads.

For example, when a user attempts to upload 164 files:

1. The first batch is processed, triggering a progress notification for files 1–2.
2. The second batch then triggers a notification for files 23–2.
3. The third batch triggers a notification for files 53–2
4. ... and final batch 164-2.

### How to reproduce?

1. Create a folder
2. Try to upload n times file
3. Observe file upload notification

### Solution

- Pass totalUploadSize to the worker and utilize it internally.
- Update FileUploadWorker to support parallel job execution instead of queuing. This allows users to initiate multiple folder uploads independently, enabling better performance and more accurate tracking in notifications.


### Demo

https://github.com/user-attachments/assets/80b0ecb4-f4cd-4200-b604-af2bedd09bee
