### PR TITLE
Handle Sample Bitmap Decoding Better

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -35,8 +35,8 @@ import com.owncloud.android.lib.resources.users.Status;
 import com.owncloud.android.lib.resources.users.StatusType;
 import com.owncloud.android.ui.StatusDrawable;
 
-
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -44,6 +44,7 @@ import java.util.Locale;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.core.graphics.drawable.RoundedBitmapDrawable;
 import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
 import androidx.exifinterface.media.ExifInterface;
@@ -75,6 +76,32 @@ public final class BitmapUtils {
         return resultBitmap;
     }
 
+    @RequiresApi(Build.VERSION_CODES.P)
+    private static Bitmap decodeSampledBitmapViaImageDecoder(String srcPath, int reqWidth, int reqHeight) {
+        try {
+            Log_OC.i(TAG, "Decoding Bitmap via ImageDecoder");
+
+            final var file = new File(srcPath);
+            if (file.exists()) {
+                final var imageDecoderSource = ImageDecoder.createSource(file);
+                final var onDecoderListener = new ImageDecoder.OnHeaderDecodedListener() {
+                    @Override
+                    public void onHeaderDecoded(@NonNull ImageDecoder decoder, @NonNull ImageDecoder.ImageInfo info, @NonNull ImageDecoder.Source source) {
+                        decoder.setTargetSize(reqWidth, reqHeight);
+                    }
+                };
+                return ImageDecoder.decodeBitmap(imageDecoderSource, onDecoderListener);
+            }
+
+            Log_OC.w(TAG, "File does not exists: " + srcPath + " BitmapFactory.decodeFile will be used");
+
+            return null;
+        } catch (IOException exception) {
+            Log_OC.w(TAG, "Warning Decoding Bitmap via ImageDecoder failed, BitmapFactory.decodeFile will be used");
+            return null;
+        }
+    }
+
     /**
      * Decodes a bitmap from a file containing it minimizing the memory use, known that the bitmap will be drawn in a
      * surface of reqWidth x reqHeight
@@ -86,17 +113,14 @@ public final class BitmapUtils {
      */
     public static Bitmap decodeSampledBitmapFromFile(String srcPath, int reqWidth, int reqHeight) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            // For API 28 and above, use ImageDecoder
-            try {
-                return ImageDecoder.decodeBitmap(ImageDecoder.createSource(new File(srcPath)),
-                                                 (decoder, info, source) -> {
-                                                     // Set the target size
-                                                     decoder.setTargetSize(reqWidth, reqHeight);
-                                                 });
-            } catch (Exception exception) {
-                Log_OC.e("BitmapUtil", "Error decoding the bitmap from file: " + srcPath + ", exception: " + exception.getMessage());
+            final var result = decodeSampledBitmapViaImageDecoder(srcPath, reqWidth, reqHeight);
+            if (result != null) {
+                return result;
             }
         }
+
+        Log_OC.i(TAG, "Decoding Bitmap via BitmapFactory.decodeFile");
+
         // set desired options that will affect the size of the bitmap
         final Options options = new Options();
 

--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -76,6 +76,7 @@ public final class BitmapUtils {
         return resultBitmap;
     }
 
+    @Nullable
     @RequiresApi(Build.VERSION_CODES.P)
     private static Bitmap decodeSampledBitmapViaImageDecoder(@NonNull File file, int reqWidth, int reqHeight) {
         try {
@@ -106,6 +107,7 @@ public final class BitmapUtils {
      * @param reqHeight Height of the surface where the Bitmap will be drawn on, in pixels.
      * @return decoded bitmap
      */
+    @Nullable
     public static Bitmap decodeSampledBitmapFromFile(String srcPath, int reqWidth, int reqHeight) {
         final var file = new File(srcPath);
         if (!file.exists()) {

--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -109,7 +109,7 @@ public final class BitmapUtils {
     public static Bitmap decodeSampledBitmapFromFile(String srcPath, int reqWidth, int reqHeight) {
         final var file = new File(srcPath);
         if (!file.exists()) {
-            Log_OC.w(TAG, "File does not exists, returning null");
+            Log_OC.e(TAG, "File does not exists, returning null");
             return null;
         }
 

--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -82,6 +82,7 @@ public final class BitmapUtils {
             Log_OC.i(TAG, "Decoding Bitmap via ImageDecoder");
 
             final var imageDecoderSource = ImageDecoder.createSource(file);
+
             final var onDecoderListener = new ImageDecoder.OnHeaderDecodedListener() {
                 @Override
                 public void onHeaderDecoded(@NonNull ImageDecoder decoder, @NonNull ImageDecoder.ImageInfo info, @NonNull ImageDecoder.Source source) {

--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -109,7 +109,7 @@ public final class BitmapUtils {
     public static Bitmap decodeSampledBitmapFromFile(String srcPath, int reqWidth, int reqHeight) {
         final var file = new File(srcPath);
         if (!file.exists()) {
-            Log_OC.w(TAG, "File does not exists, returning empty bitmap");
+            Log_OC.w(TAG, "File does not exists, returning null");
             return null;
         }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The decodeSampledBitmapFromFile() function may return null, and while null checks are implemented throughout the codebase, the associated log messages are often misleading. The current implementation lacks a check for file existence prior to decoding, making it difficult to accurately identify and debug the root cause of failures.

### Changes

1. Added a check to ensure the file exists before attempting to decode.
2. Replaced direct exception logging during decoding with conditional throwing of IOException when necessary.
3. Prevented ImageDecoder from attempting to decode non-existent files to avoid decoding failures.
4. Ensured BitmapFactory.decodeFile is only called when the target file exists.

### Related Issue

This PR helps us better understand the following issue

https://github.com/nextcloud/android/issues/14821
