### PR TITLE
Fix error handling issues

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -75,7 +75,7 @@ public abstract class EditorWebView extends ExternalSiteWebView {
             new WebViewUtil().setProxyKKPlus(this.getWebView());
             try {
                 Thread.sleep(1000);
-            } catch (InterruptedException e) {
+            } catch (InterruptedException ignored) {
             }
 
             if (!url.equals(this.getWebView().getUrl())) {


### PR DESCRIPTION
Problem:

- Empty catch block
- Catch parameter that said ignored was actually used
- Throw inside of a finally block


Solution
- Change empty block to ignored
- Change parameter to e
- Logging error instead of a throw, as doing this in a finally is not recommended