### PR TITLE
Fix Performance Warnings

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -806,8 +806,8 @@ public final class ThumbnailsCacheManager {
         private int getThumbnailDimension() {
             // Converts dp to pixel
             Resources r = MainApp.getAppContext().getResources();
-            Double d = Math.pow(2, Math.floor(Math.log(r.getDimension(R.dimen.file_icon_size_grid)) / Math.log(2)));
-            return d.intValue();
+            double d = Math.pow(2, Math.floor(Math.log(r.getDimension(R.dimen.file_icon_size_grid)) / Math.log(2)));
+            return (int) d;
         }
 
         private Bitmap doFileInBackground() {

--- a/app/src/main/java/com/owncloud/android/datastorage/providers/VDCStoragePointProvider.java
+++ b/app/src/main/java/com/owncloud/android/datastorage/providers/VDCStoragePointProvider.java
@@ -28,11 +28,8 @@ public class VDCStoragePointProvider extends AbstractCommandLineStoragePoint {
 
     @Override
     public List<StoragePoint> getAvailableStoragePoint() {
-        List<StoragePoint> result = new Vector<>();
 
-        result.addAll(getPaths(getCommandLineResult()));
-
-        return result;
+        return new Vector<>(getPaths(getCommandLineResult()));
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateShareWithShareeOperation.java
@@ -124,7 +124,7 @@ public class CreateShareWithShareeOperation extends SyncOperation {
             try {
                 String publicKey = EncryptionUtils.getPublicKey(user, shareeName, arbitraryDataProvider);
 
-                if ("".equals(publicKey)) {
+                if (publicKey.isEmpty()) {
                     NextcloudClient nextcloudClient = new ClientFactoryImpl(context).createNextcloudClient(user);
                     RemoteOperationResult<String> result = new GetPublicKeyRemoteOperation(shareeName).execute(nextcloudClient);
                     if (result.isSuccess()) {

--- a/app/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/app/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -481,10 +481,8 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
         /// includes a pending intent in the notification showing a more detailed explanation
         Intent explanationIntent = new Intent(getContext(), ErrorsWhileCopyingHandlerActivity.class);
         explanationIntent.putExtra(ErrorsWhileCopyingHandlerActivity.EXTRA_USER, getUser());
-        ArrayList<String> remotePaths = new ArrayList<String>();
-        ArrayList<String> localPaths = new ArrayList<String>();
-        remotePaths.addAll(mForgottenLocalFiles.keySet());
-        localPaths.addAll(mForgottenLocalFiles.values());
+        ArrayList<String> remotePaths = new ArrayList<String>(mForgottenLocalFiles.keySet());
+        ArrayList<String> localPaths = new ArrayList<String>(mForgottenLocalFiles.values());
         explanationIntent.putExtra(ErrorsWhileCopyingHandlerActivity.EXTRA_LOCAL_PATHS, localPaths);
         explanationIntent.putExtra(ErrorsWhileCopyingHandlerActivity.EXTRA_REMOTE_PATHS, remotePaths);
         explanationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -684,7 +684,7 @@ public abstract class FileActivity extends DrawerActivity
                                        Integer latestVersion,
                                        boolean openDirectly,
                                        boolean inBackground) {
-        Integer currentVersion = -1;
+        int currentVersion = -1;
         try {
             currentVersion = activity.getPackageManager().getPackageInfo(activity.getPackageName(), 0).versionCode;
         } catch (PackageManager.NameNotFoundException e) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -879,12 +879,13 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private String generatePath(Stack<String> dirs) {
-        String full_path = "";
+        StringBuilder full_path = new StringBuilder();
 
         for (String a : dirs) {
-            full_path += a + OCFile.PATH_SEPARATOR;
+            full_path.append(a).append(OCFile.PATH_SEPARATOR);
         }
-        return full_path;
+        String fullpath = full_path.toString();
+        return fullpath;
     }
 
     private void prepareStreamsToUpload() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -884,8 +884,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         for (String a : dirs) {
             full_path.append(a).append(OCFile.PATH_SEPARATOR);
         }
-        String fullpath = full_path.toString();
-        return fullpath;
+        return full_path.toString();
     }
 
     private void prepareStreamsToUpload() {

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -277,7 +277,7 @@ public final class DisplayUtils {
     public static String convertIdn(String url, boolean toASCII) {
 
         String urlNoDots = url;
-        String dots = "";
+        StringBuilder dots = new StringBuilder();
         while (urlNoDots.length() > 0 && urlNoDots.charAt(0) == '.') {
             urlNoDots = url.substring(1);
             dots.append(".");
@@ -298,7 +298,7 @@ public final class DisplayUtils {
         String host = urlNoDots.substring(hostStart, hostEnd);
         host = toASCII ? IDN.toASCII(host) : IDN.toUnicode(host);
 
-        return dots + urlNoDots.substring(0, hostStart) + host + urlNoDots.substring(hostEnd);
+        return dots.toString() + urlNoDots.substring(0, hostStart) + host + urlNoDots.substring(hostEnd);
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -280,7 +280,7 @@ public final class DisplayUtils {
         String dots = "";
         while (urlNoDots.length() > 0 && urlNoDots.charAt(0) == '.') {
             urlNoDots = url.substring(1);
-            dots = dots + ".";
+            dots.append(".");
         }
 
         // Find host name after '//' or '@'

--- a/app/src/main/java/third_parties/sufficientlysecure/ProcessVEvent.java
+++ b/app/src/main/java/third_parties/sufficientlysecure/ProcessVEvent.java
@@ -593,8 +593,7 @@ public class ProcessVEvent {
             reminderValues.append(sep).append(i);
             sep = ",";
         }
-        String remainder = reminderValues.toString();
-        c.put("reminders", remainder);
+        c.put("reminders", reminderValues.toString());
 
         for (Object o : e.getProperties()) {
             Property p = (Property) o;

--- a/app/src/main/java/third_parties/sufficientlysecure/ProcessVEvent.java
+++ b/app/src/main/java/third_parties/sufficientlysecure/ProcessVEvent.java
@@ -512,7 +512,7 @@ public class ProcessVEvent {
 
     private Cursor queryEvents(ContentResolver resolver, StringBuilder b, List<String> argsList) {
         final String where = b.toString() + " AND deleted=0";
-        final String[] args = argsList.toArray(new String[argsList.size()]);
+        final String[] args = argsList.toArray(new String[0]);
         return resolver.query(Events.CONTENT_URI, EVENT_QUERY_COLUMNS, where, args, null);
     }
 
@@ -587,13 +587,14 @@ public class ProcessVEvent {
         // This is a test event. Verify it using the embedded meta data.
         Log_OC.i(TAG, "Processing test case " + testName.getValue() + "...");
 
-        String reminderValues = "";
+        StringBuilder reminderValues = new StringBuilder();
         String sep = "";
         for (Integer i : reminders) {
-            reminderValues += sep + i;
+            reminderValues.append(sep).append(i);
             sep = ",";
         }
-        c.put("reminders", reminderValues);
+        String remainder = reminderValues.toString();
+        c.put("reminders", remainder);
 
         for (Object o : e.getProperties()) {
             Property p = (Property) o;


### PR DESCRIPTION
Problem:

-Calling toArray with a pre-sized array argument when we are not checking the elements of the argument. The argument could contain null items, for instance. 
-ArrayLists addAll call was redundant
-Vector addAll was redundant
-String concatenations in loops, thus creating new strings every time.
-Using object type Integer and Double

Solution:

-Using a less error-prone declaration for toArray
-Declaring ArrayLists on one line
-Declaring and returning Vector on one line
-Leveraging StringBuilder which can use simple appends
-Using primitive int and double instead