### PR TITLE
Fix remove files

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1761,7 +1761,7 @@ public class FileDisplayActivity extends FileActivity
             (ActivityExtensionsKt.lastFragment(this) instanceof OCFileListFragment fragment) ? fragment : getListOfFilesFragment();
 
         if (fileListFragment != null) {
-            fileListFragment.listDirectory(currentDir, false, false);
+            fileListFragment.listDirectory(currentDir, MainApp.isOnlyOnDevice(), false);
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
@@ -105,12 +105,16 @@ class RemoveFilesDialogFragment : ConfirmationDialogFragment(), ConfirmationDial
                     fda?.refreshCurrentDirectory()
                 }
             } else {
-                files.forEach { file ->
-                    fileDataStorageManager.addRemoveFileOfflineOperation(
-                        file.decryptedRemotePath,
-                        file.fileName,
-                        file.parentId
-                    )
+                if (onlyLocalCopy) {
+                    fileActivity.fileOperationsHelper?.removeFiles(files, true, false)
+                } else {
+                    files.forEach { file ->
+                        fileDataStorageManager.addRemoveFileOfflineOperation(
+                            file.decryptedRemotePath,
+                            file.fileName,
+                            file.parentId
+                        )
+                    }
                 }
 
                 fda?.refreshCurrentDirectory()


### PR DESCRIPTION
- fix: obey offline state when refresh
- fix: remove local files directly


To test
- sync files
- switch to offline
- remove a file local only
-> should remove file and still show "offline files only"

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
