### PR TITLE
ThumbnailsCacheManager - AsyncTask to Executor

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/fragment/GalleryFragmentIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/fragment/GalleryFragmentIT.kt
@@ -23,7 +23,6 @@ import com.nextcloud.test.TestActivity
 import com.owncloud.android.AbstractIT
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
-import com.owncloud.android.datamodel.ThumbnailsCacheManager.InitDiskCacheTask
 import com.owncloud.android.datamodel.ThumbnailsCacheManager.PREFIX_RESIZED_IMAGE
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.lib.resources.files.model.ImageDimension
@@ -45,7 +44,7 @@ class GalleryFragmentIT : AbstractIT() {
 
         // initialise thumbnails cache on background thread
         @Suppress("DEPRECATION")
-        InitDiskCacheTask().execute()
+        ThumbnailsCacheManager.initDiskCacheAsync()
     }
 
     @After

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -339,7 +339,8 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
         }
 
         // initialise thumbnails cache on background thread
-        new ThumbnailsCacheManager.InitDiskCacheTask().execute();
+        ThumbnailsCacheManager.initDiskCacheAsync();
+
 
         if (MDMConfig.INSTANCE.isLogEnabled(this)) {
             // use app writable dir, no permissions needed

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -67,6 +67,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -111,9 +114,10 @@ public final class ThumbnailsCacheManager {
     private ThumbnailsCacheManager() {
     }
 
-    public static class InitDiskCacheTask extends AsyncTask<File, Void, Void> {
-        @Override
-        protected Void doInBackground(File... params) {
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public static void initDiskCacheAsync() {
+        executor.execute(() -> {
             synchronized (mThumbnailsDiskCacheLock) {
                 mThumbnailCacheStarting = true;
 
@@ -150,8 +154,7 @@ public final class ThumbnailsCacheManager {
                 mThumbnailCacheStarting = false; // Finished initialization
                 mThumbnailsDiskCacheLock.notifyAll(); // Wake any waiting threads
             }
-            return null;
-        }
+        });
     }
 
     /**
@@ -383,7 +386,7 @@ public final class ThumbnailsCacheManager {
         }
 
         protected void onPostExecute(Bitmap bitmap) {
-            if (bitmap != null && imageViewReference != null) {
+            if (bitmap != null && imageViewReference.get() != null) {
                 final ImageView imageView = imageViewReference.get();
                 final GalleryImageGenerationTask bitmapWorkerTask = getGalleryImageGenerationTask(imageView);
 
@@ -480,7 +483,7 @@ public final class ThumbnailsCacheManager {
         }
 
         protected void onPostExecute(Bitmap bitmap) {
-            if (imageViewReference != null) {
+            if (imageViewReference.get() != null) {
                 final ImageView imageView = imageViewReference.get();
                 final FrameLayout frameLayout = frameLayoutReference.get();
 
@@ -813,12 +816,7 @@ public final class ThumbnailsCacheManager {
         private Bitmap doFileInBackground() {
             File file = (File)mFile;
 
-            final String imageKey;
-            if (mImageKey != null) {
-                imageKey = mImageKey;
-            } else {
-                imageKey = String.valueOf(file.hashCode());
-            }
+            final String imageKey = Objects.requireNonNullElseGet(mImageKey, () -> String.valueOf(file.hashCode()));
 
             // local file should always generate a thumbnail
             mImageKey = PREFIX_THUMBNAIL + mImageKey;
@@ -930,13 +928,7 @@ public final class ThumbnailsCacheManager {
         }
 
         private Bitmap doFileInBackground(File file, Type type) {
-            final String imageKey;
-
-            if (mImageKey != null) {
-                imageKey = mImageKey;
-            } else {
-                imageKey = String.valueOf(file.hashCode());
-            }
+            final String imageKey = Objects.requireNonNullElseGet(mImageKey, () -> String.valueOf(file.hashCode()));
 
             // Check disk cache in background thread
             Bitmap thumbnail = getBitmapFromDiskCache(imageKey);
@@ -1047,17 +1039,6 @@ public final class ThumbnailsCacheManager {
                     }
                 }
             }
-        }
-
-        /**
-         * Converts size of file icon from dp to pixel
-         *
-         * @return int
-         */
-        private int getAvatarDimension() {
-            // Converts dp to pixel
-            Resources r = MainApp.getAppContext().getResources();
-            return Math.round(r.getDimension(R.dimen.file_avatar_size));
         }
 
         private @NonNull

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -198,7 +198,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         setHasStableIds(true);
 
         // initialise thumbnails cache on background thread
-        new ThumbnailsCacheManager.InitDiskCacheTask().execute();
+        ThumbnailsCacheManager.initDiskCacheAsync();
     }
 
     public boolean isMultiSelect() {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
@@ -23,7 +23,7 @@ import com.owncloud.android.databinding.UnifiedSearchFooterBinding
 import com.owncloud.android.databinding.UnifiedSearchHeaderBinding
 import com.owncloud.android.databinding.UnifiedSearchItemBinding
 import com.owncloud.android.datamodel.FileDataStorageManager
-import com.owncloud.android.datamodel.ThumbnailsCacheManager.InitDiskCacheTask
+import com.owncloud.android.datamodel.ThumbnailsCacheManager
 import com.owncloud.android.ui.interfaces.UnifiedSearchListInterface
 import com.owncloud.android.ui.unifiedsearch.UnifiedSearchSection
 import com.owncloud.android.utils.theme.ViewThemeUtils
@@ -155,6 +155,6 @@ class UnifiedSearchListAdapter(
 
     init {
         // initialise thumbnails cache on background thread
-        InitDiskCacheTask().execute()
+        ThumbnailsCacheManager.initDiskCacheAsync()
     }
 }

--- a/app/src/main/res/values/dims.xml
+++ b/app/src/main/res/values/dims.xml
@@ -23,7 +23,6 @@
     <dimen name="file_icon_size_grid">128dp</dimen>
     <dimen name="file_icon_rounded_corner_radius">8dp</dimen>
     <dimen name="file_icon_rounded_corner_radius_for_grid_mode">3dp</dimen>
-    <dimen name="file_avatar_size">128dp</dimen>
     <integer name="file_avatar_px">512</integer>
     <dimen name="drawer_content_horizontal_padding">28dp</dimen>
     <dimen name="standard_padding">16dp</dimen>


### PR DESCRIPTION
Problem:
-Android.os.AsyncTask is deprecated
-imageViewReference could not be null in some parts
-if/else could be optimized
-getAvatarDimension is unused

Solution
-Leverage Executor for InitDiskCacheTask
-Removed non-null check 
-Use requireNonNullElseGet
-Remove unused function 