### PR TITLE
Decode and Scale Together

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -84,14 +84,11 @@ public final class BitmapUtils {
 
             final var imageDecoderSource = ImageDecoder.createSource(file);
 
-            final var onDecoderListener = new ImageDecoder.OnHeaderDecodedListener() {
-                @Override
-                public void onHeaderDecoded(@NonNull ImageDecoder decoder, @NonNull ImageDecoder.ImageInfo info, @NonNull ImageDecoder.Source source) {
-                    decoder.setTargetSize(reqWidth, reqHeight);
-                }
-            };
+            return ImageDecoder.decodeBitmap(imageDecoderSource, (decoder, info, source1) -> {
+                decoder.setTargetSize(reqWidth, reqHeight);
+            }
+            );
 
-            return ImageDecoder.decodeBitmap(imageDecoderSource, onDecoderListener);
         } catch (IOException exception) {
             Log_OC.w(TAG, "Decoding Bitmap via ImageDecoder failed, BitmapFactory.decodeFile will be used");
             return null;
@@ -161,25 +158,18 @@ public final class BitmapUtils {
             originalHeight = tempWidth;
         }
 
-        var bitmapResult = decodeSampledBitmapFromFile(storagePath, originalWidth, originalHeight);
-        if (bitmapResult == null) {
-            return null;
-        }
-
         // Calculate the scaling factors based on screen dimensions
-        var widthScaleFactor = (float) minWidth/ bitmapResult.getWidth();
-        var heightScaleFactor = (float) minHeight / bitmapResult.getHeight();
+        var widthScaleFactor = (float) minWidth/ originalWidth;
+        var heightScaleFactor = (float) minHeight / originalHeight;
 
         // Use the smaller scaling factor to maintain aspect ratio
         var scaleFactor = Math.min(widthScaleFactor, heightScaleFactor);
 
         // Calculate the new scaled width and height
-        var scaledWidth = (int) (bitmapResult.getWidth() * scaleFactor);
-        var scaledHeight = (int) (bitmapResult.getHeight() * scaleFactor);
+        var scaledWidth = (int) (originalWidth * scaleFactor);
+        var scaledHeight = (int) (originalHeight * scaleFactor);
 
-        bitmapResult = scaleBitmap(bitmapResult,scaledWidth,scaledHeight);
-
-        return bitmapResult;
+        return decodeSampledBitmapFromFile(storagePath, scaledWidth, scaledHeight);
     }
     /**
      * Calculates a proper value for options.inSampleSize in order to decode a Bitmap minimizing the memory overload and

--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -219,18 +219,6 @@ public final class BitmapUtils {
     }
 
     /**
-     * scales a given bitmap depending on the given size parameters.
-     *
-     * @param bitmap the bitmap to be scaled
-     * @param width  the width
-     * @param height the height
-     * @return the scaled bitmap
-     */
-    public static Bitmap scaleBitmap(Bitmap bitmap, int width, int height) {
-        return Bitmap.createScaledBitmap(bitmap, width, height, true);
-    }
-
-    /**
      * Rotate bitmap according to EXIF orientation. Cf. http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/
      *
      * @param bitmap      Bitmap to be rotated


### PR DESCRIPTION
Problem:

Images are decoded in full resolution and then later scaled for the screen size when this can be done together.

Solution:

Replace Decoder Listener and pass in desired height/width based on screen size. 
Remove call to scale after decoding in full resolution. 

This saves seconds off of loading images on my device.