### PR TITLE
BugFix - Thumbnail not updating when replacing remote file with new local file

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -205,6 +205,24 @@ public final class ThumbnailsCacheManager {
         return thumbnail;
     }
 
+    public static void removeFromCache(@Nullable OCFile file) {
+        if (file == null) {
+            return;
+        }
+
+        final var keys = new String[] { PREFIX_RESIZED_IMAGE + file.getRemoteId(), PREFIX_THUMBNAIL + file.getRemoteId() };
+
+        synchronized (mThumbnailsDiskCacheLock) {
+            if (mThumbnailCache == null) {
+                return;
+            }
+
+            for (String key: keys) {
+                mThumbnailCache.removeKey(key);
+            }
+        }
+    }
+
     public static void addBitmapToCache(String key, Bitmap bitmap) {
         synchronized (mThumbnailsDiskCacheLock) {
             if (mThumbnailCache == null) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -134,7 +134,7 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
     private fun updateThumbnailIfNeeded(decision: Decision?, file: OCFile?, oldFile: OCFile?) {
         if (decision == Decision.KEEP_BOTH || decision == Decision.KEEP_LOCAL) {
 
-            // When the user chooses to replace the local file with the remote one,
+            // When the user chooses to replace the remote file with the new local file,
             // remove the old file's thumbnail so a new one can be generated
             if (decision == Decision.KEEP_LOCAL) {
                 ThumbnailsCacheManager.removeFromCache(oldFile)

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -31,6 +31,7 @@ import com.nextcloud.utils.extensions.getParcelableArgument
 import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.datamodel.ThumbnailsCacheManager
 import com.owncloud.android.datamodel.UploadsStorageManager
 import com.owncloud.android.db.OCUpload
 import com.owncloud.android.files.services.NameCollisionPolicy
@@ -116,20 +117,29 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
                 Decision.KEEP_LOCAL -> keepLocal(file, upload, user)
                 Decision.KEEP_BOTH -> keepBoth(file, upload, user)
                 Decision.KEEP_SERVER -> keepServer(file, upload)
-                Decision.KEEP_OFFLINE_FOLDER -> keepOfflineFolder(newFile, offlineOperation)
+                Decision.KEEP_OFFLINE_FOLDER -> keepOfflineFolder(file, offlineOperation)
                 Decision.KEEP_SERVER_FOLDER -> keepServerFile(offlineOperation)
-                Decision.KEEP_BOTH_FOLDER -> keepBothFolder(offlineOperation, newFile)
+                Decision.KEEP_BOTH_FOLDER -> keepBothFolder(offlineOperation, file)
                 else -> Unit
             }
 
-            updateThumbnailIfNeeded(decision, file)
+            val oldFile = storageManager.getFileByDecryptedRemotePath(upload?.remotePath)
+
+            updateThumbnailIfNeeded(decision, file, oldFile)
             dismissConflictResolveNotification(file)
             finish()
         }
     }
 
-    private fun updateThumbnailIfNeeded(decision: Decision?, file: OCFile?) {
+    private fun updateThumbnailIfNeeded(decision: Decision?, file: OCFile?, oldFile: OCFile?) {
         if (decision == Decision.KEEP_BOTH || decision == Decision.KEEP_LOCAL) {
+
+            // When the user chooses to replace the local file with the remote one,
+            // remove the old file's thumbnail so a new one can be generated
+            if (decision == Decision.KEEP_LOCAL) {
+                ThumbnailsCacheManager.removeFromCache(oldFile)
+            }
+
             file?.isUpdateThumbnailNeeded = true
             fileDataStorageManager.saveFile(file)
         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -133,7 +133,6 @@ class ConflictsResolveActivity : FileActivity(), OnConflictDecisionMadeListener 
 
     private fun updateThumbnailIfNeeded(decision: Decision?, file: OCFile?, oldFile: OCFile?) {
         if (decision == Decision.KEEP_BOTH || decision == Decision.KEEP_LOCAL) {
-
             // When the user chooses to replace the remote file with the new local file,
             // remove the old file's thumbnail so a new one can be generated
             if (decision == Decision.KEEP_LOCAL) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

This PR fixes an issue where the thumbnail was not refreshed after the user chose to replace the remote file with the new local file (Decision.KEEP_LOCAL).

### How to reproduce?

1. Upload file (test.jpg)
2. Upload another file with same name
3. Replace from conflict resolve dialog
4. Thumbnail is not correct

### Demo

https://github.com/user-attachments/assets/45a44e74-0e93-4115-a60e-7b90c5d7a33d


