### PR TITLE
Fix Redundancy in Explicit Types

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
@@ -502,7 +502,7 @@ public class EncryptionTestIT extends AbstractIT {
 
         // de-serialize
         EncryptedFolderMetadataFileV1 encryptedFolderMetadata2 = deserializeJSON(encryptedJson,
-                                                                                 new TypeToken<EncryptedFolderMetadataFileV1>() {
+                                                                                 new TypeToken<>() {
                                                                                  });
 
         // decrypt

--- a/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -667,7 +667,7 @@ public class OCFile implements Parcelable, Comparable<OCFile>, ServerFileInterfa
         }
     }
 
-    public static final Parcelable.Creator<OCFile> CREATOR = new Parcelable.Creator<OCFile>() {
+    public static final Parcelable.Creator<OCFile> CREATOR = new Parcelable.Creator<>() {
 
         @Override
         public OCFile createFromParcel(Parcel source) {

--- a/app/src/main/java/com/owncloud/android/db/OCUpload.java
+++ b/app/src/main/java/com/owncloud/android/db/OCUpload.java
@@ -238,7 +238,7 @@ public class OCUpload implements Parcelable {
     /****
      *
      */
-    public static final Parcelable.Creator<OCUpload> CREATOR = new Parcelable.Creator<OCUpload>() {
+    public static final Parcelable.Creator<OCUpload> CREATOR = new Parcelable.Creator<>() {
 
         @Override
         public OCUpload createFromParcel(Parcel source) {

--- a/app/src/main/java/com/owncloud/android/operations/GetServerInfoOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/GetServerInfoOperation.java
@@ -77,7 +77,7 @@ public class GetServerInfoOperation extends RemoteOperation {
             // third: merge results
             if (detectAuthResult.isSuccess()) {
                 mResultData.mAuthMethod = (AuthenticationMethod) detectAuthResult.getData().get(0);
-                ArrayList<Object> data = new ArrayList<Object>();
+                ArrayList<Object> data = new ArrayList<>();
                 data.add(mResultData);
                 result.setData(data);
             } else {

--- a/app/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/app/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -153,7 +153,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
         mLastFailedResult = null;
         mConflictsFound = 0;
         mFailsInFavouritesFound = 0;
-        mForgottenLocalFiles = new HashMap<String, String>();
+        mForgottenLocalFiles = new HashMap<>();
         mSyncResult = syncResult;
         mSyncResult.fullSyncRequested = false;
         mSyncResult.delayUntil = (System.currentTimeMillis()/1000) + 3*60*60; // avoid too many automatic synchronizations
@@ -481,8 +481,8 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
         /// includes a pending intent in the notification showing a more detailed explanation
         Intent explanationIntent = new Intent(getContext(), ErrorsWhileCopyingHandlerActivity.class);
         explanationIntent.putExtra(ErrorsWhileCopyingHandlerActivity.EXTRA_USER, getUser());
-        ArrayList<String> remotePaths = new ArrayList<String>(mForgottenLocalFiles.keySet());
-        ArrayList<String> localPaths = new ArrayList<String>(mForgottenLocalFiles.values());
+        ArrayList<String> remotePaths = new ArrayList<>(mForgottenLocalFiles.keySet());
+        ArrayList<String> localPaths = new ArrayList<>(mForgottenLocalFiles.values());
         explanationIntent.putExtra(ErrorsWhileCopyingHandlerActivity.EXTRA_LOCAL_PATHS, localPaths);
         explanationIntent.putExtra(ErrorsWhileCopyingHandlerActivity.EXTRA_REMOTE_PATHS, remotePaths);
         explanationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/app/src/main/java/com/owncloud/android/ui/activities/data/activities/RemoteActivitiesRepository.java
+++ b/app/src/main/java/com/owncloud/android/ui/activities/data/activities/RemoteActivitiesRepository.java
@@ -24,16 +24,16 @@ public class RemoteActivitiesRepository implements ActivitiesRepository {
     @Override
     public void getActivities(long lastGiven, @NonNull LoadActivitiesCallback callback) {
         activitiesServiceApi.getAllActivities(lastGiven,
-                                              new ActivitiesServiceApi.ActivitiesServiceCallback<List<Object>>() {
-            @Override
-            public void onLoaded(List<Object> activities, NextcloudClient client, long lastGiven) {
-                callback.onActivitiesLoaded(activities, client, lastGiven);
-            }
+                                              new ActivitiesServiceApi.ActivitiesServiceCallback<>() {
+                                                  @Override
+                                                  public void onLoaded(List<Object> activities, NextcloudClient client, long lastGiven) {
+                                                      callback.onActivitiesLoaded(activities, client, lastGiven);
+                                                  }
 
-            @Override
-            public void onError(String error) {
-                callback.onActivitiesLoadedError(error);
-            }
-        });
+                                                  @Override
+                                                  public void onError(String error) {
+                                                      callback.onActivitiesLoadedError(error);
+                                                  }
+                                              });
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activities/data/files/RemoteFilesRepository.java
+++ b/app/src/main/java/com/owncloud/android/ui/activities/data/files/RemoteFilesRepository.java
@@ -22,16 +22,16 @@ public class RemoteFilesRepository implements FilesRepository {
 
     @Override
     public void readRemoteFile(String path, BaseActivity activity, @NonNull ReadRemoteFileCallback callback) {
-        filesServiceApi.readRemoteFile(path, activity, new FilesServiceApi.FilesServiceCallback<OCFile>() {
-                    @Override
-                    public void onLoaded(OCFile ocFile) {
-                        callback.onFileLoaded(ocFile);
-                    }
+        filesServiceApi.readRemoteFile(path, activity, new FilesServiceApi.FilesServiceCallback<>() {
+            @Override
+            public void onLoaded(OCFile ocFile) {
+                callback.onFileLoaded(ocFile);
+            }
 
-                    @Override
-                    public void onError(String error) {
-                        callback.onFileLoadError(error);
-                    }
-                });
+            @Override
+            public void onError(String error) {
+                callback.onFileLoadError(error);
+            }
+        });
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/parcel/SyncedFolderParcelable.java
@@ -105,7 +105,7 @@ public class SyncedFolderParcelable implements Parcelable {
     }
 
     public static final Creator<SyncedFolderParcelable> CREATOR =
-            new Creator<SyncedFolderParcelable>() {
+            new Creator<>() {
 
                 @Override
                 public SyncedFolderParcelable createFromParcel(Parcel source) {

--- a/app/src/main/java/com/owncloud/android/ui/helpers/SparseBooleanArrayParcelable.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/SparseBooleanArrayParcelable.java
@@ -19,28 +19,28 @@ public class SparseBooleanArrayParcelable implements Parcelable {
 
     @SuppressWarnings("PMD.SuspiciousConstantFieldName")
     public static Parcelable.Creator<SparseBooleanArrayParcelable> CREATOR =
-        new Parcelable.Creator<SparseBooleanArrayParcelable>() {
+        new Parcelable.Creator<>() {
 
-        @Override
-        public SparseBooleanArrayParcelable createFromParcel(Parcel source) {
-            // read size of array from source
-            int size = source.readInt();
+            @Override
+            public SparseBooleanArrayParcelable createFromParcel(Parcel source) {
+                // read size of array from source
+                int size = source.readInt();
 
-            // then pairs of (key, value)s, in the object to wrap
-            SparseBooleanArray sba = new SparseBooleanArray();
-            for (int i = 0; i < size; i++) {
-                sba.put(source.readInt(), source.readInt() != 0);
+                // then pairs of (key, value)s, in the object to wrap
+                SparseBooleanArray sba = new SparseBooleanArray();
+                for (int i = 0; i < size; i++) {
+                    sba.put(source.readInt(), source.readInt() != 0);
+                }
+
+                // wrap SparseBooleanArray
+                return new SparseBooleanArrayParcelable(sba);
             }
 
-            // wrap SparseBooleanArray
-            return new SparseBooleanArrayParcelable(sba);
-        }
-
-        @Override
-        public SparseBooleanArrayParcelable[] newArray(int size) {
-            return new SparseBooleanArrayParcelable[size];
-        }
-    };
+            @Override
+            public SparseBooleanArrayParcelable[] newArray(int size) {
+                return new SparseBooleanArrayParcelable[size];
+            }
+        };
 
     private final SparseBooleanArray mSba;
 

--- a/app/src/main/java/com/owncloud/android/utils/DataHolderUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/DataHolderUtil.java
@@ -22,7 +22,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 
 public class DataHolderUtil {
-    private Map<String, WeakReference<Object>> data = new HashMap<String, WeakReference<Object>>();
+    private Map<String, WeakReference<Object>> data = new HashMap<>();
 
     private static DataHolderUtil instance;
 
@@ -38,7 +38,7 @@ public class DataHolderUtil {
     }
 
     public void save(String id, Object object) {
-        data.put(id, new WeakReference<Object>(object));
+        data.put(id, new WeakReference<>(object));
     }
 
     public Object retrieve(String id) {

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -288,7 +288,7 @@ public final class FileStorageUtils {
         file.setOwnerId(remote.getOwnerId());
         file.setOwnerDisplayName(remote.getOwnerDisplayName());
         file.setNote(remote.getNote());
-        file.setSharees(new ArrayList<ShareeUser>(Arrays.asList(remote.getSharees())));
+        file.setSharees(new ArrayList<>(Arrays.asList(remote.getSharees())));
         file.setRichWorkspace(remote.getRichWorkspace());
         file.setLocked(remote.isLocked());
         file.setLockType(remote.getLockType());

--- a/app/src/main/java/third_parties/ezvcard_android/AndroidCustomField.java
+++ b/app/src/main/java/third_parties/ezvcard_android/AndroidCustomField.java
@@ -17,7 +17,7 @@ import ezvcard.property.VCardProperty;
 public class AndroidCustomField extends VCardProperty {
     private String type;
     private boolean dir;
-    private List<String> values = new ArrayList<String>();
+    private List<String> values = new ArrayList<>();
 
     /**
      * Creates an "item" field.

--- a/app/src/main/java/third_parties/ezvcard_android/ContactOperations.java
+++ b/app/src/main/java/third_parties/ezvcard_android/ContactOperations.java
@@ -75,7 +75,7 @@ public class ContactOperations {
     public void insertContact(VCard vcard) throws RemoteException, OperationApplicationException {
         // TODO handle Raw properties - Raw properties include various extension which start with "X-" like X-ASSISTANT, X-AIM, X-SPOUSE
 
-        List<NonEmptyContentValues> contentValues = new ArrayList<NonEmptyContentValues>();
+        List<NonEmptyContentValues> contentValues = new ArrayList<>();
         convertName(contentValues, vcard);
         convertNickname(contentValues, vcard);
         convertPhones(contentValues, vcard);
@@ -97,7 +97,7 @@ public class ContactOperations {
         convertPhotos(contentValues, vcard);
         convertOrganization(contentValues, vcard);
 
-        ArrayList<ContentProviderOperation> operations = new ArrayList<ContentProviderOperation>(contentValues.size());
+        ArrayList<ContentProviderOperation> operations = new ArrayList<>(contentValues.size());
         ContentValues cv = account.getContentValues();
         //ContactsContract.RawContact.CONTENT_URI needed to add account, backReference is also not needed
         ContentProviderOperation operation =
@@ -127,7 +127,7 @@ public class ContactOperations {
 
     public void updateContact(VCard vcard, Long key) throws RemoteException, OperationApplicationException {
 
-        List<NonEmptyContentValues> contentValues = new ArrayList<NonEmptyContentValues>();
+        List<NonEmptyContentValues> contentValues = new ArrayList<>();
         convertName(contentValues, vcard);
         convertNickname(contentValues, vcard);
         convertPhones(contentValues, vcard);
@@ -149,7 +149,7 @@ public class ContactOperations {
         convertPhotos(contentValues, vcard);
         convertOrganization(contentValues, vcard);
 
-        ArrayList<ContentProviderOperation> operations = new ArrayList<ContentProviderOperation>(contentValues.size());
+        ArrayList<ContentProviderOperation> operations = new ArrayList<>(contentValues.size());
         ContentValues cv = account.getContentValues();
         //ContactsContract.RawContact.CONTENT_URI needed to add account, backReference is also not needed
         long contactID = key;
@@ -598,7 +598,7 @@ public class ContactOperations {
      * belong to that group
      */
     private <T extends VCardProperty> Map<String, List<T>> orderPropertiesByGroup(Iterable<T> properties) {
-        Map<String, List<T>> groupedProperties = new HashMap<String, List<T>>();
+        Map<String, List<T>> groupedProperties = new HashMap<>();
 
         for (T property : properties) {
             String group = property.getGroup();
@@ -608,7 +608,7 @@ public class ContactOperations {
 
             List<T> groupPropertiesList = groupedProperties.get(group);
             if (groupPropertiesList == null) {
-                groupPropertiesList = new ArrayList<T>();
+                groupPropertiesList = new ArrayList<>();
                 groupedProperties.put(group, groupPropertiesList);
             }
             groupPropertiesList.add(property);

--- a/app/src/main/java/third_parties/ezvcard_android/DataMappings.java
+++ b/app/src/main/java/third_parties/ezvcard_android/DataMappings.java
@@ -30,7 +30,7 @@ import ezvcard.property.Telephone;
 public class DataMappings {
     private static final Map<TelephoneType, Integer> phoneTypeMappings;
     static {
-        Map<TelephoneType, Integer> m = new HashMap<TelephoneType, Integer>();
+        Map<TelephoneType, Integer> m = new HashMap<>();
         m.put(TelephoneType.BBS, ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM);
         m.put(TelephoneType.CAR, ContactsContract.CommonDataKinds.Phone.TYPE_CAR);
         m.put(TelephoneType.CELL, ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE);
@@ -51,7 +51,7 @@ public class DataMappings {
 
     private static final Map<String, Integer> websiteTypeMappings;
     static {
-        Map<String, Integer> m = new HashMap<String, Integer>();
+        Map<String, Integer> m = new HashMap<>();
         m.put("home", ContactsContract.CommonDataKinds.Website.TYPE_HOME);
         m.put("work", ContactsContract.CommonDataKinds.Website.TYPE_WORK);
         m.put("homepage", ContactsContract.CommonDataKinds.Website.TYPE_HOMEPAGE);
@@ -61,7 +61,7 @@ public class DataMappings {
 
     private static final Map<EmailType, Integer> emailTypeMappings;
     static {
-        Map<EmailType, Integer> m = new HashMap<EmailType, Integer>();
+        Map<EmailType, Integer> m = new HashMap<>();
         m.put(EmailType.HOME, ContactsContract.CommonDataKinds.Email.TYPE_HOME);
         m.put(EmailType.WORK, ContactsContract.CommonDataKinds.Email.TYPE_WORK);
         emailTypeMappings = Collections.unmodifiableMap(m);
@@ -69,7 +69,7 @@ public class DataMappings {
 
     private static final Map<AddressType, Integer> addressTypeMappings;
     static {
-        Map<AddressType, Integer> m = new HashMap<AddressType, Integer>();
+        Map<AddressType, Integer> m = new HashMap<>();
         m.put(AddressType.HOME, ContactsContract.CommonDataKinds.StructuredPostal.TYPE_HOME);
         m.put(AddressType.get("business"), ContactsContract.CommonDataKinds.StructuredPostal.TYPE_WORK);
         m.put(AddressType.WORK, ContactsContract.CommonDataKinds.StructuredPostal.TYPE_WORK);
@@ -79,7 +79,7 @@ public class DataMappings {
 
     private static final Map<String, Integer> abRelatedNamesMappings;
     static {
-        Map<String, Integer> m = new HashMap<String, Integer>();
+        Map<String, Integer> m = new HashMap<>();
         m.put("father", ContactsContract.CommonDataKinds.Relation.TYPE_FATHER);
         m.put("spouse", ContactsContract.CommonDataKinds.Relation.TYPE_SPOUSE);
         m.put("mother", ContactsContract.CommonDataKinds.Relation.TYPE_MOTHER);
@@ -95,7 +95,7 @@ public class DataMappings {
 
     private static final Map<String, Integer> abDateMappings;
     static {
-        Map<String, Integer> m = new HashMap<String, Integer>();
+        Map<String, Integer> m = new HashMap<>();
         m.put("anniversary", ContactsContract.CommonDataKinds.Event.TYPE_ANNIVERSARY);
         m.put("other", ContactsContract.CommonDataKinds.Event.TYPE_OTHER);
         abDateMappings = Collections.unmodifiableMap(m);
@@ -103,7 +103,7 @@ public class DataMappings {
 
     private static final Map<String, Integer> imPropertyNameMappings;
     static{
-        Map<String, Integer> m = new HashMap<String, Integer>();
+        Map<String, Integer> m = new HashMap<>();
         m.put("X-AIM", ContactsContract.CommonDataKinds.Im.PROTOCOL_AIM);
         m.put("X-ICQ", ContactsContract.CommonDataKinds.Im.PROTOCOL_ICQ);
         m.put("X-QQ", ContactsContract.CommonDataKinds.Im.PROTOCOL_ICQ);
@@ -120,7 +120,7 @@ public class DataMappings {
 
     private static final Map<String, Integer> imProtocolMappings;
     static{
-        Map<String, Integer> m = new HashMap<String, Integer>();
+        Map<String, Integer> m = new HashMap<>();
         m.put("aim", ContactsContract.CommonDataKinds.Im.PROTOCOL_AIM);
         m.put("icq", ContactsContract.CommonDataKinds.Im.PROTOCOL_ICQ);
         m.put("msn", ContactsContract.CommonDataKinds.Im.PROTOCOL_MSN);

--- a/app/src/test/java/com/owncloud/android/ui/activity/SyncedFoldersActivityTest.java
+++ b/app/src/test/java/com/owncloud/android/ui/activity/SyncedFoldersActivityTest.java
@@ -159,7 +159,7 @@ public class SyncedFoldersActivityTest {
                                            NameCollisionPolicy.ASK_USER.serialize(),
                                            enabled,
                                            System.currentTimeMillis(),
-                                           new ArrayList<String>(),
+                                           new ArrayList<>(),
                                            folderName,
                                            2,
                                            MediaFolderType.IMAGE,

--- a/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
+++ b/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.java
@@ -44,7 +44,7 @@ public class FilesSyncHelperTest {
         Mockito.when(mockFile.listFiles()).thenReturn(null);
         Mockito.when(mockFile.canRead()).thenReturn(true);
 
-        SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {
+        SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) {
                 return FileVisitResult.CONTINUE;


### PR DESCRIPTION
Problem:

Declaring the explicit types of variables twice, when using <> on the right side can just interpret what is on the left side.

Solution:

Change to <>