### PR TITLE
Fix app crashes if local folder is null

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -275,7 +275,7 @@ public class RefreshFolderOperation extends RemoteOperation {
             sendLocalBroadcast(EVENT_SINGLE_FOLDER_CONTENTS_SYNCED, mLocalFolder.getRemotePath(), result);
         }
 
-        if (result.isSuccess() && !mSyncFullAccount && !mOnlyFileMetadata) {
+        if (result.isSuccess() && !mSyncFullAccount && !mOnlyFileMetadata && mLocalFolder != null) {
             refreshSharesForFolder(client); // share result is ignored
         }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not needed

This PR fixes #14845 by handling the mLocalFolder state to avoid the application crashes when it tries to perform the refresh folder operation on a low internet speed connection.
