### PR TITLE
Optimize testing assertions

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/activity/ConflictsResolveActivityIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/ui/activity/ConflictsResolveActivityIT.java
@@ -167,7 +167,7 @@ public class ConflictsResolveActivityIT extends AbstractIT {
         ConflictsResolveActivity sut = activityRule.launchActivity(intent);
 
         sut.listener = decision -> {
-            assertEquals(decision, ConflictsResolveDialog.Decision.CANCEL);
+            assertEquals(ConflictsResolveDialog.Decision.CANCEL, decision);
             returnCode = true;
         };
 
@@ -210,7 +210,7 @@ public class ConflictsResolveActivityIT extends AbstractIT {
         ConflictsResolveActivity sut = activityRule.launchActivity(intent);
 
         sut.listener = decision -> {
-            assertEquals(decision, ConflictsResolveDialog.Decision.KEEP_SERVER);
+            assertEquals(ConflictsResolveDialog.Decision.KEEP_SERVER, decision);
             returnCode = true;
         };
 
@@ -256,7 +256,7 @@ public class ConflictsResolveActivityIT extends AbstractIT {
         ConflictsResolveActivity sut = activityRule.launchActivity(intent);
 
         sut.listener = decision -> {
-            assertEquals(decision, ConflictsResolveDialog.Decision.KEEP_LOCAL);
+            assertEquals(ConflictsResolveDialog.Decision.KEEP_LOCAL, decision);
             returnCode = true;
         };
 
@@ -303,7 +303,7 @@ public class ConflictsResolveActivityIT extends AbstractIT {
         ConflictsResolveActivity sut = activityRule.launchActivity(intent);
 
         sut.listener = decision -> {
-            assertEquals(decision, ConflictsResolveDialog.Decision.KEEP_BOTH);
+            assertEquals(ConflictsResolveDialog.Decision.KEEP_BOTH, decision);
             returnCode = true;
         };
 

--- a/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
+++ b/app/src/androidTest/java/com/owncloud/android/util/EncryptionTestIT.java
@@ -79,6 +79,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertArrayEquals;
 
 public class EncryptionTestIT extends AbstractIT {
     @Rule public RetryTestRule retryTestRule = new RetryTestRule();
@@ -149,7 +150,7 @@ public class EncryptionTestIT extends AbstractIT {
 
         byte[] key2 = decodeStringToBase64Bytes(decryptedString);
 
-        assertTrue(Arrays.equals(key1, key2));
+        assertArrayEquals(key1, key2);
     }
 
     @Test
@@ -164,7 +165,7 @@ public class EncryptionTestIT extends AbstractIT {
 
         byte[] key2 = decodeStringToBase64Bytes(decryptedString);
 
-        assertTrue(Arrays.equals(key1, key2));
+        assertArrayEquals(key1, key2);
     }
 
     @Test(expected = BadPaddingException.class)


### PR DESCRIPTION
Found a couple of optimizations to make in testing:
1. Flip assertEquals arguments to _expected_ followed by _provided_
2. Leverage assertArrayEquals