### PR TITLE
BugFix - Do Not Apply HideBottomViewOnScrollBehavior For Bottom Navigation View

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
@@ -95,7 +95,7 @@ class GalleryAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SectionedViewHolder {
         val inflater = LayoutInflater.from(parent.context)
 
-        return when(viewType) {
+        return when (viewType) {
             VIEW_TYPE_HEADER -> {
                 val binding = GalleryHeaderBinding.inflate(inflater, parent, false)
                 GalleryHeaderViewHolder(binding)

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListFooterViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListFooterViewHolder.kt
@@ -7,10 +7,10 @@
  */
 package com.owncloud.android.ui.adapter
 
-import androidx.recyclerview.widget.RecyclerView
+import com.afollestad.sectionedrecyclerview.SectionedViewHolder
 import com.owncloud.android.databinding.ListFooterBinding
 
-internal class OCFileListFooterViewHolder(var binding: ListFooterBinding) : RecyclerView.ViewHolder(
+internal class OCFileListFooterViewHolder(var binding: ListFooterBinding) : SectionedViewHolder(
     binding.root
 ) {
     val footerText

--- a/app/src/main/res/layout/files.xml
+++ b/app/src/main/res/layout/files.xml
@@ -51,8 +51,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            app:menu="@menu/bottom_navigation_menu"
-            app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior" />
+            app:menu="@menu/bottom_navigation_menu" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_main"

--- a/app/src/main/res/layout/list_footer.xml
+++ b/app/src/main/res/layout/list_footer.xml
@@ -12,6 +12,7 @@
     android:layout_gravity="center_horizontal"
     android:gravity="center_horizontal"
     android:orientation="vertical"
+    android:layout_marginBottom="@dimen/standard_double_margin"
     android:showDividers="none">
 
     <ProgressBar


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### How to reproduce?

1. Ensure there are enough files in the list to cover the full height of the device screen.
2. Scroll down slightly.
3. Observe that the Bottom Navigation View and the Plus (+) button disappear.
4. Tap on any folder to navigate into it.
5. Notice that within the folder, the Bottom Navigation View remains hidden, and only the Plus (+) button is visible.

### Demo


https://github.com/user-attachments/assets/755bc4ed-2b27-4aae-a9c9-b68c745cfcc1


