### PR TITLE
BugFix - Slide HideBottomViewOnScrollBehavior For BottomNavigationView

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/extensions/ViewExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/ViewExtensions.kt
@@ -15,6 +15,8 @@ import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewOutlineProvider
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
 
 fun View?.setVisibleIf(condition: Boolean) {
     if (this == null) return
@@ -81,5 +83,18 @@ fun createRoundedOutline(context: Context, cornerRadiusValue: Float): ViewOutlin
 
             outline.setRoundRect(left, top, right, bottom, cornerRadius.toFloat())
         }
+    }
+}
+
+@Suppress("UNCHECKED_CAST", "ReturnCount")
+fun <T : View?> T.slideHideBottomBehavior(visible: Boolean) {
+    this ?: return
+    val params = layoutParams as? CoordinatorLayout.LayoutParams ?: return
+    val behavior = params.behavior as? HideBottomViewOnScrollBehavior<T> ?: return
+
+    if (visible) {
+        behavior.slideUp(this)
+    } else {
+        behavior.slideDown(this)
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -1398,4 +1398,8 @@ public abstract class DrawerActivity extends ToolbarActivity
     public void showBottomNavigationBar(boolean show) {
         ViewExtensionsKt.setVisibleIf(bottomNavigationView, show);
     }
+
+    public BottomNavigationView getBottomNavigationView() {
+       return bottomNavigationView;
+    }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -66,6 +66,7 @@ import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
+import com.nextcloud.utils.extensions.ViewExtensionsKt;
 import com.nextcloud.utils.fileNameValidator.FileNameValidator;
 import com.nextcloud.utils.view.FastScrollUtils;
 import com.owncloud.android.MainApp;

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -36,7 +36,6 @@ import android.view.ViewGroup;
 import android.widget.AbsListView;
 import android.widget.Toast;
 
-import com.google.android.material.behavior.HideBottomViewOnScrollBehavior;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -60,6 +59,7 @@ import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.FragmentExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
+import com.nextcloud.utils.extensions.ViewExtensionsKt;
 import com.nextcloud.utils.fileNameValidator.FileNameValidator;
 import com.nextcloud.utils.view.FastScrollUtils;
 import com.owncloud.android.MainApp;
@@ -68,7 +68,6 @@ import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.SyncedFolderProvider;
-import com.owncloud.android.datamodel.VirtualFolderType;
 import com.owncloud.android.datamodel.e2e.v2.decrypted.DecryptedFolderMetadataFile;
 import com.owncloud.android.lib.common.Creator;
 import com.owncloud.android.lib.common.OwnCloudClient;
@@ -106,13 +105,11 @@ import com.owncloud.android.ui.helpers.FileOperationsHelper;
 import com.owncloud.android.ui.interfaces.OCFileListFragmentInterface;
 import com.owncloud.android.ui.preview.PreviewImageFragment;
 import com.owncloud.android.ui.preview.PreviewMediaActivity;
-import com.owncloud.android.ui.preview.PreviewTextFileFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.EncryptionUtils;
 import com.owncloud.android.utils.EncryptionUtilsV2;
 import com.owncloud.android.utils.FileSortOrder;
 import com.owncloud.android.utils.FileStorageUtils;
-import com.owncloud.android.utils.MimeTypeUtil;
 import com.owncloud.android.utils.PermissionUtil;
 import com.owncloud.android.utils.theme.ThemeUtils;
 
@@ -140,7 +137,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.FragmentActivity;
@@ -2241,41 +2237,25 @@ public class OCFileListFragment extends ExtendedListFragment implements
             return;
         }
 
-        if (getActivity() != null) {
-            getActivity().runOnUiThread(() -> {
-                if (visible) {
-                    mFabMain.show();
-                    viewThemeUtils.material.themeFAB(mFabMain);
-                } else {
-                    mFabMain.hide();
-                }
-
-                showFabWithBehavior(visible);
-            });
+        final var activity = getActivity();
+        if (activity == null) {
+            return;
         }
-    }
 
-    /**
-     * Remove this, if HideBottomViewOnScrollBehavior is fix by Google
-     *
-     * @param visible flag if FAB should be shown or hidden
-     */
-    private void showFabWithBehavior(boolean visible) {
-        ViewGroup.LayoutParams layoutParams = mFabMain.getLayoutParams();
-        if (layoutParams instanceof CoordinatorLayout.LayoutParams) {
-            CoordinatorLayout.Behavior coordinatorLayoutBehavior =
-                ((CoordinatorLayout.LayoutParams) layoutParams).getBehavior();
-            if (coordinatorLayoutBehavior instanceof HideBottomViewOnScrollBehavior) {
-                @SuppressWarnings("unchecked")
-                HideBottomViewOnScrollBehavior<FloatingActionButton> behavior =
-                    (HideBottomViewOnScrollBehavior<FloatingActionButton>) coordinatorLayoutBehavior;
-                if (visible) {
-                    behavior.slideUp(mFabMain);
-                } else {
-                    behavior.slideDown(mFabMain);
-                }
+        activity.runOnUiThread(() -> {
+            if (visible) {
+                mFabMain.show();
+                viewThemeUtils.material.themeFAB(mFabMain);
+            } else {
+                mFabMain.hide();
             }
-        }
+
+            if (activity instanceof DrawerActivity drawerActivity) {
+                ViewExtensionsKt.slideHideBottomBehavior(drawerActivity.getBottomNavigationView(), visible);
+            }
+
+            ViewExtensionsKt.slideHideBottomBehavior(mFabMain, visible);
+        });
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1635,9 +1635,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
 
         setFabVisible(!mHideFab);
+        slideHideBottomBehaviourForBottomNavigationView(!mHideFab);
 
-        // FAB
-        setFabEnabled(mFile != null && (mFile.canWrite() || mFile.isOfflineOperation()));
+        final var showBottomLayoutItems = (mFile != null && (mFile.canWrite() || mFile.isOfflineOperation()));
+        setFabEnabled(showBottomLayoutItems);
 
         invalidateActionMode();
     }
@@ -1828,6 +1829,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
 
         setFabVisible(true);
+        slideHideBottomBehaviourForBottomNavigationView(true);
     }
 
     private void resetMenuItems() {
@@ -2250,12 +2252,14 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 mFabMain.hide();
             }
 
-            if (activity instanceof DrawerActivity drawerActivity) {
-                ViewExtensionsKt.slideHideBottomBehavior(drawerActivity.getBottomNavigationView(), visible);
-            }
-
             ViewExtensionsKt.slideHideBottomBehavior(mFabMain, visible);
         });
+    }
+
+    public void slideHideBottomBehaviourForBottomNavigationView(boolean visible) {
+        if (getActivity() instanceof DrawerActivity drawerActivity) {
+            ViewExtensionsKt.slideHideBottomBehavior(drawerActivity.getBottomNavigationView(), visible);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### How to reproduce?

1. Ensure there are enough files in the list to cover the full height of the device screen.
2. Scroll down slightly.
3. Observe that the Bottom Navigation View and the Plus (+) button disappear.
4. Tap on any folder to navigate into it.
5. Notice that within the folder, the Bottom Navigation View remains hidden, and only the Plus (+) button is visible.


### Demo

https://github.com/user-attachments/assets/587ebcaf-63f8-40ab-a402-f247ba7e5fc7

