### PR TITLE
BugFix - Execute Pending Transaction In FileDisplayActivity

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/interfaces/TransactionInterface.kt
+++ b/app/src/main/java/com/owncloud/android/ui/interfaces/TransactionInterface.kt
@@ -1,0 +1,14 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.ui.interfaces
+
+import com.owncloud.android.ui.fragment.OCFileListFragment
+
+interface TransactionInterface {
+    fun onOCFileListFragmentComplete(fragment: OCFileListFragment)
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issues

`FragmentManager is already executing transactions` error occurs when calling `executePendingTransactions()` while the `FragmentManager` is already in the middle of executing other transactions.

1. The method `executePendingTransactions()` must not be called before `commit()`, as it is designed to force the immediate execution of any transactions that have already been committed but not yet executed.

![ac](https://github.com/user-attachments/assets/d10129cb-9e35-4d9d-a330-441c9a67b52c)


2. The method `getOCFileListFragmentFromFile()` handles fragment instantiation and transaction asynchronously. Because of this asynchronicity, returning the fragment instance directly would be unreliable there is no guarantee it has been committed or is ready for use. Therefore callback needed.


### Note: Use of `commitNow()` not viable due to `addToBackStack()`

While `commitNow()` offers synchronous fragment transaction behavior, it cannot be used in combination with `addToBackStack()`, as doing so will throw an `IllegalStateException`.

Removing` addToBackStack()` to use `commitNow()` would break expected navigation behavior. e.g.


https://github.com/user-attachments/assets/d522d2bc-0100-4f69-900b-8872aedaaed8


<details>
  <summary>Stacktrace</summary>
  

```
java.lang.IllegalStateException: FragmentManager is already executing transactions
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentManager.ensureExecReady([FragmentManager.java:1937](http://fragmentmanager.java:1937/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentManager.execPendingActions([FragmentManager.java:1996](http://fragmentmanager.java:1996/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentManager.executePendingTransactions([FragmentManager.java:778](http://fragmentmanager.java:778/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.activity.FileDisplayActivity.getOCFileListFragmentFromFile([FileDisplayActivity.java:752](http://filedisplayactivity.java:752/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.activity.FileDisplayActivity.showFile([FileDisplayActivity.java:2676](http://filedisplayactivity.java:2676/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.fragment.UnifiedSearchFragment.showFile(UnifiedSearchFragment.kt:247)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.fragment.UnifiedSearchFragment.setUpViewModel$lambda$8(UnifiedSearchFragment.kt:228)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.fragment.UnifiedSearchFragment.$r8$lambda$aDXNYjZbSeoE4oVeHT8KnluoPBM(Unknown Source:0)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.fragment.UnifiedSearchFragment$$ExternalSyntheticLambda4.invoke(D8$$SyntheticClass:0)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.fragment.UnifiedSearchFragment$sam$androidx_lifecycle_Observer$0.onChanged(Unknown Source:2)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LiveData.considerNotify([LiveData.java:133](http://livedata.java:133/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LiveData.dispatchingValue([LiveData.java:146](http://livedata.java:146/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LiveData$ObserverWrapper.activeStateChanged([LiveData.java:483](http://livedata.java:483/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LiveData$LifecycleBoundObserver.onStateChanged([LiveData.java:440](http://livedata.java:440/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.jvm.kt:320)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.jvm.kt:257)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.jvm.kt:293)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.jvm.kt:142)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.jvm.kt:124)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).Fragment.performStart([Fragment.java:3197](http://fragment.java:3197/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentStateManager.start([FragmentStateManager.java:648](http://fragmentstatemanager.java:648/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentStateManager.moveToExpectedState([FragmentStateManager.java:304](http://fragmentstatemanager.java:304/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentStore.moveToExpectedState([FragmentStore.java:114](http://fragmentstore.java:114/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentManager.moveToState([FragmentManager.java:1675](http://fragmentmanager.java:1675/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentManager.dispatchStateChange([FragmentManager.java:3259](http://fragmentmanager.java:3259/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentManager.dispatchStart([FragmentManager.java:3184](http://fragmentmanager.java:3184/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentController.dispatchStart([FragmentController.java:274](http://fragmentcontroller.java:274/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.fragment.app](http://androidx.fragment.app/).FragmentActivity.onStart([FragmentActivity.java:358](http://fragmentactivity.java:358/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [androidx.appcompat.app](http://androidx.appcompat.app/).AppCompatActivity.onStart([AppCompatActivity.java:251](http://appcompatactivity.java:251/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.activity.DrawerActivity.onStart([DrawerActivity.java:1101](http://draweractivity.java:1101/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.activity.FileActivity.onStart([FileActivity.java:243](http://fileactivity.java:243/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.owncloud.android](http://com.owncloud.android/).ui.activity.FileDisplayActivity.onStart([FileDisplayActivity.java:2322](http://filedisplayactivity.java:2322/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).Instrumentation.callActivityOnStart([Instrumentation.java:1582](http://instrumentation.java:1582/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).Activity.performStart([Activity.java:9034](http://activity.java:9034/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).ActivityThread.handleStartActivity([ActivityThread.java:4206](http://activitythread.java:4206/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).servertransaction.TransactionExecutor.performLifecycleSequence([TransactionExecutor.java:225](http://transactionexecutor.java:225/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).servertransaction.TransactionExecutor.cycleToPath([TransactionExecutor.java:205](http://transactionexecutor.java:205/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).servertransaction.TransactionExecutor.executeLifecycleState([TransactionExecutor.java:177](http://transactionexecutor.java:177/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).servertransaction.TransactionExecutor.execute([TransactionExecutor.java:98](http://transactionexecutor.java:98/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).ActivityThread$H.handleMessage([ActivityThread.java:2693](http://activitythread.java:2693/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at android.os.Handler.dispatchMessage([Handler.java:106](http://handler.java:106/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at android.os.Looper.loopOnce([Looper.java:230](http://looper.java:230/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at android.os.Looper.loop([Looper.java:319](http://looper.java:319/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [android.app](http://android.app/).ActivityThread.main([ActivityThread.java:9063](http://activitythread.java:9063/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at java.lang.reflect.Method.invoke(Native Method)
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.android](http://com.android/).internal.os.RuntimeInit$MethodAndArgsCaller.run([RuntimeInit.java:588](http://runtimeinit.java:588/))
01-23 11:50:16.791 13161 13161 E AndroidRuntime: at [com.android](http://com.android/).internal.os.ZygoteInit.main([ZygoteInit.java:1103](http://zygoteinit.java:1103/))
```
</details>


### How to test?

1. Search a folder via Unified Search
4. Open folder
5. Tap back button