### PR TITLE
BugFix - Hide Keyboard After Search

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -8,6 +8,7 @@
 package com.owncloud.android.ui.fragment
 
 import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -16,6 +17,9 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import android.widget.ImageView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
@@ -180,6 +184,33 @@ class UnifiedSearchFragment :
             setOnQueryTextListener(this@UnifiedSearchFragment)
             isIconified = false
             clearFocus()
+            setSearchAction(this)
+        }
+    }
+
+    private fun setSearchAction(searchView: SearchView) {
+        val searchEditText = searchView.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)
+        searchEditText.setOnEditorActionListener { v, actionId, _ ->
+            val isActionSearch = (actionId == EditorInfo.IME_ACTION_SEARCH)
+            if (isActionSearch) {
+                // Hide keyboard
+                (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).apply {
+                    hideSoftInputFromWindow(v.windowToken, 0)
+                }
+
+                // Disable cursor
+                searchEditText.run {
+                    isCursorVisible = false
+                    clearFocus()
+                    onQueryTextSubmit(text.toString())
+                }
+            }
+
+            isActionSearch
+        }
+
+        searchView.setOnQueryTextFocusChangeListener { _, hasFocus ->
+            searchEditText.isCursorVisible = hasFocus
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

After performing a search and tapping the "DONE" button, the keyboard does not close and the cursor remains visible.

### Before

https://github.com/user-attachments/assets/527b63f8-6724-4b68-964c-052035eef02f


### After


https://github.com/user-attachments/assets/c83e11a4-a360-4477-ba5e-ce68bcce3a99


### Similar Behavior From Files, Phone, Maps Apps


https://github.com/user-attachments/assets/6292d7d0-9e6a-42c2-9e32-39860d783d80


https://github.com/user-attachments/assets/42b3d2b0-68bf-4ae8-8a6d-03498ee75938


https://github.com/user-attachments/assets/4a281e63-48e2-4261-95e0-b666d2ca233b

