### PR TITLE
BugFix - Configure FileDisplayActivity's Toolbar

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -267,6 +267,7 @@ public abstract class DrawerActivity extends ToolbarActivity
                 }
                 EventBus.getDefault().post(new ChangeMenuEvent());
             } else if (menuItemId == R.id.nav_favorites) {
+                setupToolbar();
                 handleSearchEvents(new SearchEvent("", SearchRemoteOperation.SearchType.FAVORITE_SEARCH), menuItemId);
             } else if (menuItemId == R.id.nav_assistant && !(this instanceof ComposeActivity)) {
                 startComposeActivity(ComposeDestination.AssistantScreen, R.string.assistant_screen_top_bar_title);
@@ -585,8 +586,8 @@ public abstract class DrawerActivity extends ToolbarActivity
 
             closeDrawer();
         } else if (itemId == R.id.nav_favorites) {
-            handleSearchEvents(new SearchEvent("", SearchRemoteOperation.SearchType.FAVORITE_SEARCH),
-                               menuItem.getItemId());
+            setupToolbar();
+            handleSearchEvents(new SearchEvent("", SearchRemoteOperation.SearchType.FAVORITE_SEARCH), menuItem.getItemId());
         } else if (itemId == R.id.nav_gallery) {
             startPhotoSearch(menuItem.getItemId());
         } else if (itemId == R.id.nav_on_device) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -259,6 +259,7 @@ public abstract class DrawerActivity extends ToolbarActivity
             menuItemId = menuItem.getItemId();
 
             exitSelectionMode();
+            resetOnlyPersonalAndOnDevice();
 
             if (menuItemId == R.id.nav_all_files) {
                 showFiles(false,false);
@@ -563,13 +564,13 @@ public abstract class DrawerActivity extends ToolbarActivity
         setNavigationViewItemChecked();
 
         if (itemId == R.id.nav_all_files || itemId == R.id.nav_personal_files) {
-            if (this instanceof FileDisplayActivity &&
-                !(((FileDisplayActivity) this).getLeftFragment() instanceof GalleryFragment) &&
-                !(((FileDisplayActivity) this).getLeftFragment() instanceof SharedListFragment) &&
-                !(((FileDisplayActivity) this).getLeftFragment() instanceof GroupfolderListFragment) &&
-                !(((FileDisplayActivity) this).getLeftFragment() instanceof PreviewTextStringFragment)) {
+            if (this instanceof FileDisplayActivity fda &&
+                !(fda.getLeftFragment() instanceof GalleryFragment) &&
+                !(fda.getLeftFragment() instanceof SharedListFragment) &&
+                !(fda.getLeftFragment() instanceof GroupfolderListFragment) &&
+                !(fda.getLeftFragment() instanceof PreviewTextStringFragment)) {
                 showFiles(false, itemId == R.id.nav_personal_files);
-                ((FileDisplayActivity) this).browseToRoot();
+                fda.browseToRoot();
                 EventBus.getDefault().post(new ChangeMenuEvent());
             } else {
                 MainApp.showOnlyFilesOnDevice(false);
@@ -587,25 +588,33 @@ public abstract class DrawerActivity extends ToolbarActivity
 
             closeDrawer();
         } else if (itemId == R.id.nav_favorites) {
+            resetOnlyPersonalAndOnDevice();
             setupToolbar();
             handleSearchEvents(new SearchEvent("", SearchRemoteOperation.SearchType.FAVORITE_SEARCH), menuItem.getItemId());
         } else if (itemId == R.id.nav_gallery) {
+            resetOnlyPersonalAndOnDevice();
             setupToolbar();
             startPhotoSearch(menuItem.getItemId());
         } else if (itemId == R.id.nav_on_device) {
             EventBus.getDefault().post(new ChangeMenuEvent());
             showFiles(true, false);
         } else if (itemId == R.id.nav_uploads) {
+            resetOnlyPersonalAndOnDevice();
             startActivity(UploadListActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP);
         } else if (itemId == R.id.nav_trashbin) {
+            resetOnlyPersonalAndOnDevice();
             startActivity(TrashbinActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP);
         } else if (itemId == R.id.nav_activity) {
+            resetOnlyPersonalAndOnDevice();
             startActivity(ActivitiesActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP);
         } else if (itemId == R.id.nav_settings) {
+            resetOnlyPersonalAndOnDevice();
             startActivity(SettingsActivity.class);
         } else if (itemId == R.id.nav_community) {
+            resetOnlyPersonalAndOnDevice();
             startActivity(CommunityActivity.class);
         } else if (itemId == R.id.nav_logout) {
+            resetOnlyPersonalAndOnDevice();
             menuItemId = Menu.NONE;
             MenuItem isNewMenuItemChecked = menuItem.setChecked(false);
             Log_OC.d(TAG,"onNavigationItemClicked nav_logout setChecked " + isNewMenuItemChecked);
@@ -614,13 +623,16 @@ public abstract class DrawerActivity extends ToolbarActivity
                 UserInfoActivity.openAccountRemovalDialog(optionalUser.get(), getSupportFragmentManager());
             }
         } else if (itemId == R.id.nav_shared) {
+            resetOnlyPersonalAndOnDevice();
             startSharedSearch(menuItem);
         } else if (itemId == R.id.nav_recently_modified) {
+            resetOnlyPersonalAndOnDevice();
             startRecentlyModifiedSearch(menuItem);
         } else if (itemId == R.id.nav_assistant) {
+            resetOnlyPersonalAndOnDevice();
             startComposeActivity(ComposeDestination.AssistantScreen, R.string.assistant_screen_top_bar_title);
         } else if (itemId == R.id.nav_groupfolders) {
-            MainApp.showOnlyFilesOnDevice(false);
+            resetOnlyPersonalAndOnDevice();
             Intent intent = new Intent(getApplicationContext(), FileDisplayActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             intent.setAction(FileDisplayActivity.LIST_GROUPFOLDERS);
@@ -1222,6 +1234,11 @@ public abstract class DrawerActivity extends ToolbarActivity
         startActivity(i);
 
         fetchExternalLinks(false);
+    }
+
+    private void resetOnlyPersonalAndOnDevice() {
+        MainApp.showOnlyFilesOnDevice(false);
+        MainApp.showOnlyPersonalFiles(false);
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -272,6 +272,7 @@ public abstract class DrawerActivity extends ToolbarActivity
             } else if (menuItemId == R.id.nav_assistant && !(this instanceof ComposeActivity)) {
                 startComposeActivity(ComposeDestination.AssistantScreen, R.string.assistant_screen_top_bar_title);
             } else if (menuItemId == R.id.nav_gallery) {
+                setupToolbar();
                 startPhotoSearch(menuItem.getItemId());
             }
 
@@ -589,6 +590,7 @@ public abstract class DrawerActivity extends ToolbarActivity
             setupToolbar();
             handleSearchEvents(new SearchEvent("", SearchRemoteOperation.SearchType.FAVORITE_SEARCH), menuItem.getItemId());
         } else if (itemId == R.id.nav_gallery) {
+            setupToolbar();
             startPhotoSearch(menuItem.getItemId());
         } else if (itemId == R.id.nav_on_device) {
             EventBus.getDefault().post(new ChangeMenuEvent());

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1235,11 +1235,14 @@ public class FileDisplayActivity extends FileActivity
         excludedMenuItemIds.add(R.id.nav_settings);
         excludedMenuItemIds.add(R.id.nav_assistant);
 
-        // FIXME: Media to All files app in background and foreground wrong toolbar type
-        // check fragment type and MainApp static booleans to fix it
+        boolean isSearchEventExists = false;
+        if (getLeftFragment() instanceof OCFileListFragment fileListFragment) {
+            isSearchEventExists = (fileListFragment.getSearchEvent() != null);
+        }
 
         if (!(getLeftFragment() instanceof GalleryFragment) &&
-            (menuItemId == R.id.nav_all_files ||
+            (!isSearchEventExists ||
+                menuItemId == R.id.nav_all_files ||
                 menuItemId == R.id.nav_personal_files ||
                 excludedMenuItemIds.contains(menuItemId))) {
             setupHomeSearchToolbarWithSortAndListButtons();

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1199,19 +1199,14 @@ public class FileDisplayActivity extends FileActivity
         mDownloadFinishReceiver = new DownloadFinishReceiver();
         localBroadcastManager.registerReceiver(mDownloadFinishReceiver, downloadIntentFilter);
 
+        checkAndSetMenuItemId();
+
         if (menuItemId == Menu.NONE) {
             setDrawerAllFiles();
         } else {
-            if (menuItemId == R.id.nav_all_files || menuItemId == R.id.nav_personal_files) {
-                setupHomeSearchToolbarWithSortAndListButtons();
-            } else {
-                setupToolbar();
-            }
+            configureToolbar();
         }
 
-        if (ocFileListFragment instanceof GalleryFragment) {
-            updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_item_gallery));
-        }
         //show in-app review dialog to user
         inAppReviewHelper.showInAppReview(this);
 
@@ -1219,7 +1214,8 @@ public class FileDisplayActivity extends FileActivity
 
         Log_OC.v(TAG, "onResume() end");
     }
-    private void setDrawerAllFiles() {
+
+    private void checkAndSetMenuItemId() {
         if (MainApp.isOnlyPersonFiles()) {
             menuItemId = R.id.nav_personal_files;
         } else if (MainApp.isOnlyOnDevice()) {
@@ -1227,7 +1223,33 @@ public class FileDisplayActivity extends FileActivity
         } else if (menuItemId == Menu.NONE) {
             menuItemId = R.id.nav_all_files;
         }
+    }
 
+    private void configureToolbar() {
+        // Other activities menuItemIds must be excluded to show correct toolbar.
+        final var excludedMenuItemIds = new ArrayList<>();
+        excludedMenuItemIds.add(R.id.nav_community);
+        excludedMenuItemIds.add(R.id.nav_trashbin);
+        excludedMenuItemIds.add(R.id.nav_uploads);
+        excludedMenuItemIds.add(R.id.nav_activity);
+        excludedMenuItemIds.add(R.id.nav_settings);
+        excludedMenuItemIds.add(R.id.nav_assistant);
+
+        // FIXME: Media to All files app in background and foreground wrong toolbar type
+        // check fragment type and MainApp static booleans to fix it
+
+        if (!(getLeftFragment() instanceof GalleryFragment) &&
+            (menuItemId == R.id.nav_all_files ||
+                menuItemId == R.id.nav_personal_files ||
+                excludedMenuItemIds.contains(menuItemId))) {
+            setupHomeSearchToolbarWithSortAndListButtons();
+        } else {
+            setupToolbar();
+        }
+    }
+
+    private void setDrawerAllFiles() {
+        checkAndSetMenuItemId();
         setNavigationViewItemChecked();
 
         if (MainApp.isOnlyOnDevice()) {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -490,6 +490,7 @@ public class FileDetailActivitiesFragment extends Fragment implements
                 callback.onSuccess();
             } else {
                 callback.onError(R.string.error_comment_file);
+
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailActivitiesFragment.java
@@ -490,7 +490,6 @@ public class FileDetailActivitiesFragment extends Fragment implements
                 callback.onSuccess();
             } else {
                 callback.onError(R.string.error_comment_file);
-
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -2300,4 +2300,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
         return false;
     }
+
+    public SearchEvent getSearchEvent() {
+        return searchEvent;
+    }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Note

### **Please only test toolbar behavior**. To understand the problem fully, you can check [this](https://github.com/nextcloud/android/issues/14149) issue.

### Issue

After going back to FileDisplayActivity from CommunityActivity, TrashBinActivity, UploadListActivity, etc. search bar, disappears.

### Before

![Screenshot 2025-07-08 at 16 16 06](https://github.com/user-attachments/assets/19e54b4a-3b51-4bcb-8bd4-5d2a01215098)

### After

![Screenshot 2025-07-08 at 16 15 34](https://github.com/user-attachments/assets/529ecf0f-0e07-43b1-a262-b2b1f28802bf)

### How to reproduce?

- Press back button from mentioned activities.
