### PR TITLE
Fix favourites sort and view options

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -952,7 +952,11 @@ public class OCFileListFragment extends ExtendedListFragment implements
             menu.removeItem(R.id.action_search);
         }
 
-        updateSortAndGridMenuItems();
+        if (currentSearchType == FAVORITE_SEARCH) {
+            resetMenuItems();
+        } else {
+            updateSortAndGridMenuItems();
+        }
     }
 
     private void updateSortAndGridMenuItems() {


### PR DESCRIPTION
When opening the *Favourites* tab from the *Media* tab using the drawer menu or the navigation bar, the sort option and view (list/grid) option buttons would disappear. With this change the buttons are now accessible.

### How to reproduce and test
1. Open set up Nextcloud app
2. Open *Media* tab
3. Open *Favourites* tab

#### Previous Behaviour
Sort options and button to switch between list and grid view are hidden.

#### Expected Behaviour
Sort options and button to switch between list and grid view are displayed.

---

- [ ] Tests written, or not not needed
