### PR TITLE
Bump search bar icon size 20->24dp for M3 styling

### DIFF
--- a/app/src/main/res/layout/toolbar_standard.xml
+++ b/app/src/main/res/layout/toolbar_standard.xml
@@ -180,6 +180,7 @@
                     app:cornerRadius="@dimen/button_corner_radius"
                     app:icon="@drawable/ic_menu"
                     app:iconTint="@color/fontAppbar"
+                    app:iconSize="@dimen/search_bar_icon_size"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
@@ -208,7 +209,7 @@
                     android:layout_height="48dp"
                     android:contentDescription="@string/notification_icon_description"
                     app:cornerRadius="@dimen/button_corner_radius"
-                    app:iconSize="20dp"
+                    app:iconSize="@dimen/search_bar_icon_size"
                     app:icon="@drawable/ic_notification"
                     app:iconTint="@color/fontAppbar"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/dims.xml
+++ b/app/src/main/res/values/dims.xml
@@ -157,4 +157,5 @@
     <dimen name="adaptive_icon_size">108dp</dimen>
     <dimen name="adaptive_icon_padding">18dp</dimen>
     <dimen name="tag_height">18dp</dimen>
+    <dimen name="search_bar_icon_size">24dp</dimen>
 </resources>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Icon size bumped for search bar according to https://m3.material.io/components/search/specs (file listing removed from screenshots since it contained production data)

|Before|After|
|---|---|
|<img width="540" height="1188" alt="before" src="https://github.com/user-attachments/assets/786f7b77-4739-4e74-a9ca-8612d3e2f983" />|<img width="540" height="1188" alt="after" src="https://github.com/user-attachments/assets/0626211d-934b-4d46-8ba3-fdea9d1d4776" />|

