### PR TITLE
Don't Use Cached Image For Preview

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -63,7 +63,6 @@ import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -251,23 +250,6 @@ public final class ThumbnailsCacheManager {
 
     public static boolean containsBitmap(String key) {
         return mThumbnailCache.containsKey(key);
-    }
-
-    public static Bitmap getScaledBitmapFromDiskCache(String key, int width, int height) {
-        synchronized (mThumbnailsDiskCacheLock) {
-            // Wait while disk cache is started from background thread
-            while (mThumbnailCacheStarting) {
-                try {
-                    mThumbnailsDiskCacheLock.wait();
-                } catch (InterruptedException e) {
-                    Log_OC.e(TAG, "Wait in mThumbnailsDiskCacheLock was interrupted", e);
-                }
-            }
-            if (mThumbnailCache != null) {
-                return mThumbnailCache.getScaledBitmap(key, width, height);
-            }
-        }
-        return null;
     }
 
     public static Bitmap getBitmapFromDiskCache(String key) {

--- a/app/src/main/res/layout/preview_image_fragment.xml
+++ b/app/src/main/res/layout/preview_image_fragment.xml
@@ -43,7 +43,7 @@
         android:layout_height="match_parent"
         android:layout_margin="@dimen/zero"
         android:contentDescription="@string/preview_image_description"
-        android:src="@drawable/image_fail" />
+        android:src="@drawable/file_image" />
 
     <LinearLayout
         android:id="@+id/empty_list_view"


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

In `PreviewImageFragment`, the image was being displayed using `getScaledBitmapFromDiskCache(`) when the file had not yet been downloaded. This resulted in a low-resolution preview being shown instead of the original high-quality image.

### Solution

Glide is used if image is not downloaded.

Check this issue for expected and actual behavior: https://github.com/nextcloud/android/issues/15163#issue-3231979025
