### PR TITLE
Auto Sign off Git hook

### DIFF
--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Add Signed-off-by if not already present
+
+# Nextcloud - Android Client
+#
+# SPDX-FileCopyrightText: 2025 Eeshan Jamal <eeshan.jamal@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
+
+COMMIT_MSG_FILE="$1"
+
+# Validate existing sign off
+if grep -qiE "^Signed-off-by: " "$COMMIT_MSG_FILE"; then
+  exit 0
+fi
+
+# Get current Git identity
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+# Append sign off
+{
+  echo ""
+  echo "Signed-off-by: $NAME <$EMAIL>"
+} >> "$COMMIT_MSG_FILE"
+


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed

> Since I started contributing to this repo. I often miss doing Sign off for my commits and the reason for it's my habit of using Git GUI tools (such as SourceTree, Github Desktop) where you have to manually check Sign off for each commit. So, I've came up with this Git hook which auto Sign off my commits in-case I miss it doing manually. 
> 
> I found it useful and maybe it would be helpful for other developers as well contributing to this repo. So, I've parked it at the same place where other git hooks of this repo exist and created this pull request. You can review it and take final decision on wether to keep it or not.  