### PR TITLE
BugFix - java.lang.IllegalStateException LoadingDialog

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.kt
@@ -23,18 +23,16 @@ class LoadingDialog :
     DialogFragment(),
     Injectable {
 
-    @JvmField
     @Inject
-    var viewThemeUtils: ViewThemeUtils? = null
+    lateinit var viewThemeUtils: ViewThemeUtils
 
     private var mMessage: String? = null
     private lateinit var binding: LoadingDialogBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        retainInstance = true
         isCancelable = false
+        mMessage = arguments?.getString(ARG_MESSAGE)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -43,29 +41,31 @@ class LoadingDialog :
 
         val loadingDrawable = binding.loadingBar.indeterminateDrawable
         if (loadingDrawable != null) {
-            viewThemeUtils?.platform?.tintDrawable(requireContext(), loadingDrawable)
+            viewThemeUtils.platform.tintDrawable(requireContext(), loadingDrawable)
         }
 
-        viewThemeUtils?.platform?.colorViewBackground(binding.loadingLayout, ColorRole.SURFACE)
+        viewThemeUtils.platform.colorViewBackground(binding.loadingLayout, ColorRole.SURFACE)
 
         return binding.root
     }
 
     override fun onDestroyView() {
-        if (dialog != null && retainInstance) {
-            dialog?.setDismissMessage(null)
-        }
-
+        dialog?.setDismissMessage(null)
         super.onDestroyView()
     }
 
     companion object {
+        private const val ARG_MESSAGE = "message"
 
         @JvmStatic
         fun newInstance(message: String?): LoadingDialog {
-            val loadingDialog = LoadingDialog()
-            loadingDialog.mMessage = message
-            return loadingDialog
+            val args = Bundle().apply {
+                putString(ARG_MESSAGE, message)
+            }
+
+            return LoadingDialog().apply {
+                arguments = args
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

```
Exception java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
  at androidx.fragment.app.FragmentManager.checkStateLoss (FragmentManager.java:1862)
  at androidx.fragment.app.FragmentManager.ensureExecReady (FragmentManager.java:1963)
  at androidx.fragment.app.FragmentManager.execSingleAction (FragmentManager.java:1977)
  at androidx.fragment.app.BackStackRecord.commitNow (BackStackRecord.java:317)
  at com.owncloud.android.ui.activity.FileActivity.lambda$showLoadingDialog$0 (FileActivity.java:561)
  at com.owncloud.android.ui.activity.FileActivity.$r8$lambda$nnl4G_wZDgkvD6wdFZ2uoTUqJso (Unknown Source)
  at com.owncloud.android.ui.activity.FileActivity$$ExternalSyntheticLambda3.run (D8$$SyntheticClass)
  at android.app.Activity.runOnUiThread (Activity.java:7363)
  at com.owncloud.android.ui.activity.FileActivity.showLoadingDialog (FileActivity.java:551)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.lambda$syncFile$1 (FileOperationsHelper.java:219)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.$r8$lambda$Zjp8lEWqA9AaSFevrtcfzcD4bWI (Unknown Source)
  at com.owncloud.android.ui.helpers.FileOperationsHelper$$ExternalSyntheticLambda2.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:8061)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:703)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:911)
```

### Changes

- Since LoadingDialog extends DialogFragment, there is no need to commit a transaction manually — we can use show() instead.
- Check for the existence of the LoadingDialog fragment before showing the dialog and dismiss it properly.
- Remove the deprecated usage of retainInstance.

### How to test?

Open PDF file.

### Demo

https://github.com/user-attachments/assets/c23a6ade-c423-4d46-98a0-d5fea9fcaa2c

Now we can actually see the loading dialog.

<img width="295" height="642" alt="Screenshot 2025-07-18 at 16 29 47" src="https://github.com/user-attachments/assets/1053b303-a769-4ec1-b4d8-cb780bd1493e" />

