### PR TITLE
BugFix - Re-Encrypt Same Folder

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
@@ -58,4 +58,11 @@ interface FileDao {
             "ORDER BY internal_two_way_sync_timestamp DESC"
     )
     fun getInternalTwoWaySyncFolders(fileOwner: String): List<FileEntity>
+
+    @Query("""
+        UPDATE ${ProviderTableMeta.FILE_TABLE_NAME} 
+        SET ${ProviderTableMeta.FILE_E2E_COUNTER} = -1 
+        WHERE ${ProviderTableMeta.FILE_IS_ENCRYPTED} > -1
+    """)
+    fun resetE2eCounterForEncryptedFiles()
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -45,6 +45,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.nextcloud.android.common.ui.util.extensions.WindowExtensionsKt;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.account.UserAccountManager;
+import com.nextcloud.client.database.NextcloudDatabase;
+import com.nextcloud.client.database.dao.FileDao;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.etm.EtmActivity;
 import com.nextcloud.client.logger.ui.LogsActivity;
@@ -569,6 +571,9 @@ public class SettingsActivity extends PreferenceActivity
                 if (pMnemonic != null) {
                     preferenceCategoryMore.removePreference(pMnemonic);
                 }
+
+                final FileDao fileDao = NextcloudDatabase.getInstance(MainApp.getAppContext()).fileDao();
+                fileDao.resetE2eCounterForEncryptedFiles();
 
                 dialog.dismiss();
             })

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -754,9 +754,6 @@ public final class EncryptionUtils {
         BadPaddingException, IllegalBlockSizeException,
         InvalidKeySpecException {
 
-        Log_OC.e("TAG","zako1: " + string);
-        Log_OC.e("TAG","zako2: " + privateKeyString);
-
         Cipher cipher = Cipher.getInstance(RSA_CIPHER);
 
         byte[] privateKeyBytes = decodeStringToBase64Bytes(privateKeyString);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### How to reproduce?

1. Create an empty encrypted folder.
2. Deactivate the encryption on this folder.
3. Reset end-to-end encryption from web client.
4. Delete the key from app from settings screen.
5. Set up an End-to-end encryption from settings again.
6. Encrypt the same folder.

This occurs when the app attempts to decrypt folder metadata using a invalid key. The key mismatch is caused by resetting end-to-end encryption and deleting the previous key.


```
### Cause of error
```java
Exception in thread "Thread-51" javax.crypto.BadPaddingException: error:04000085:RSA routines:OPENSSL_internal:OAEP_DECODING_ERROR
   at [com.google.android.gms.org](http://com.google.android.gms.org/).conscrypt.NativeCrypto.EVP_PKEY_decrypt(Native Method)
   at [com.google.android.gms.org](http://com.google.android.gms.org/).conscrypt.OpenSSLCipherRSA$OAEP.doCryptoOperation(:[com.google.android](http://com.google.android/).gms@252431029@25.24.31 (190400-772615181):24)
   at [com.google.android.gms.org](http://com.google.android.gms.org/).conscrypt.OpenSSLCipherRSA.engineDoFinal(:[com.google.android](http://com.google.android/).gms@252431029@25.24.31 (190400-772615181):8)
   at javax.crypto.Cipher.doFinal([Cipher.java:2074](http://cipher.java:2074/))
   at [com.owncloud.android](http://com.owncloud.android/).utils.EncryptionUtils.decryptStringAsymmetricV2([EncryptionUtils.java:773](http://encryptionutils.java:773/))
   at [com.owncloud.android](http://com.owncloud.android/).utils.EncryptionUtilsV2.decryptMetadataKey(EncryptionUtilsV2.kt:411)
   at [com.owncloud.android](http://com.owncloud.android/).utils.EncryptionUtilsV2.decryptFolderMetadataFile(EncryptionUtilsV2.kt:211)
   at [com.owncloud.android](http://com.owncloud.android/).utils.EncryptionUtilsV2.parseAnyMetadata(EncryptionUtilsV2.kt:621)
   at [com.owncloud.android](http://com.owncloud.android/).utils.EncryptionUtils.downloadFolderMetadata([EncryptionUtils.java:469](http://encryptionutils.java:469/))
   at [com.owncloud.android](http://com.owncloud.android/).operations.RefreshFolderOperation.getDecryptedFolderMetadata([RefreshFolderOperation.java:617](http://refreshfolderoperation.java:617/))
   at [com.owncloud.android](http://com.owncloud.android/).operations.RefreshFolderOperation.synchronizeData([RefreshFolderOperation.java:504](http://refreshfolderoperation.java:504/))
   at [com.owncloud.android](http://com.owncloud.android/).operations.RefreshFolderOperation.fetchAndSyncRemoteFolder([RefreshFolderOperation.java:433](http://refreshfolderoperation.java:433/))
   at [com.owncloud.android.operations.RefreshFolderOperation.run](http://com.owncloud.android.operations.refreshfolderoperation.run/)([RefreshFolderOperation.java:246](http://refreshfolderoperation.java:246/))
   at [com.owncloud.android.lib.common.operations.RemoteOperation.run](http://com.owncloud.android.lib.common.operations.remoteoperation.run/)([RemoteOperation.java:387](http://remoteoperation.java:387/))
   at [java.lang.Thread.run](http://java.lang.thread.run/)([Thread.java:1012](http://thread.java:1012/))
```


### Changes

To handle this situation, the logic has been updated to detect when end-to-end encryption has been reset. The reset e2e counter is now used to distinguish between:

1. Creating a new DecryptedFolderMetadataFile, and
2. Updating an existing one.

---

If the user removes the key from the device, E2E_COUNTER is reset.
When E2E_COUNTER is greater than -1, it indicates that encryption has been previously set up and then reset.