### PR TITLE
Add Remove Upload Action to Conflict Resolve Notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -273,6 +273,9 @@
             android:name="com.nextcloud.client.jobs.MediaFoldersDetectionWork$NotificationReceiver"
             android:exported="false" />
         <receiver
+            android:name="com.nextcloud.client.jobs.upload.FileUploadBroadcastReceiver"
+            android:exported="false" />
+        <receiver
             android:name="com.nextcloud.client.jobs.NotificationWork$NotificationReceiver"
             android:exported="false" />
         <receiver

--- a/app/src/main/java/com/nextcloud/client/di/AppComponent.java
+++ b/app/src/main/java/com/nextcloud/client/di/AppComponent.java
@@ -16,6 +16,7 @@ import com.nextcloud.client.device.DeviceModule;
 import com.nextcloud.client.integrations.IntegrationsModule;
 import com.nextcloud.client.jobs.JobsModule;
 import com.nextcloud.client.jobs.download.FileDownloadHelper;
+import com.nextcloud.client.jobs.upload.FileUploadBroadcastReceiver;
 import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.media.BackgroundPlayerService;
 import com.nextcloud.client.network.NetworkModule;
@@ -68,6 +69,8 @@ public interface AppComponent {
     void inject(FileDownloadHelper fileDownloadHelper);
 
     void inject(ProgressIndicator progressIndicator);
+
+    void inject(FileUploadBroadcastReceiver fileUploadBroadcastReceiver);
 
     @Component.Builder
     interface Builder {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadBroadcastReceiver.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadBroadcastReceiver.kt
@@ -27,6 +27,7 @@ class FileUploadBroadcastReceiver : BroadcastReceiver() {
         const val STORAGE_PATH = "STORAGE_PATH"
     }
 
+    @Suppress("ReturnCount")
     override fun onReceive(context: Context, intent: Intent) {
         MainApp.getAppComponent().inject(this)
 
@@ -40,7 +41,7 @@ class FileUploadBroadcastReceiver : BroadcastReceiver() {
         uploadsStorageManager.removeUpload(uploadId)
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancel(
-            NotificationUtils.createUploadNotificationTag(remotePath , storagePath),
+            NotificationUtils.createUploadNotificationTag(remotePath, storagePath),
             FileUploadWorker.NOTIFICATION_ERROR_ID
         )
     }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadBroadcastReceiver.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadBroadcastReceiver.kt
@@ -1,0 +1,47 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.jobs.upload
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.owncloud.android.MainApp
+import com.owncloud.android.datamodel.UploadsStorageManager
+import com.owncloud.android.ui.notifications.NotificationUtils
+import javax.inject.Inject
+
+class FileUploadBroadcastReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var uploadsStorageManager: UploadsStorageManager
+
+    companion object {
+        const val UPLOAD_ID = "UPLOAD_ID"
+        const val REMOTE_PATH = "REMOTE_PATH"
+        const val STORAGE_PATH = "STORAGE_PATH"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        MainApp.getAppComponent().inject(this)
+
+        val remotePath = intent.getStringExtra(REMOTE_PATH) ?: return
+        val storagePath = intent.getStringExtra(STORAGE_PATH) ?: return
+        val uploadId = intent.getLongExtra(UPLOAD_ID, -1L)
+        if (uploadId == -1L) {
+            return
+        }
+
+        uploadsStorageManager.removeUpload(uploadId)
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancel(
+            NotificationUtils.createUploadNotificationTag(remotePath , storagePath),
+            FileUploadWorker.NOTIFICATION_ERROR_ID
+        )
+    }
+}

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -309,10 +309,17 @@ class FileUploadWorker(
                 null
             }
 
+            val removeUploadActionIntent = if (conflictResolveIntent != null) {
+                intents.removeUploadActionIntent(uploadFileOperation)
+            } else {
+                null
+            }
+
             notifyForFailedResult(
                 uploadFileOperation,
                 uploadResult.code,
                 conflictResolveIntent,
+                removeUploadActionIntent,
                 credentialIntent,
                 errorMessage
             )

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -309,8 +309,8 @@ class FileUploadWorker(
                 null
             }
 
-            val removeUploadActionIntent = if (conflictResolveIntent != null) {
-                intents.removeUploadActionIntent(uploadFileOperation)
+            val cancelUploadActionIntent = if (conflictResolveIntent != null) {
+                intents.cancelUploadActionIntent(uploadFileOperation)
             } else {
                 null
             }
@@ -319,7 +319,7 @@ class FileUploadWorker(
                 uploadFileOperation,
                 uploadResult.code,
                 conflictResolveIntent,
-                removeUploadActionIntent,
+                cancelUploadActionIntent,
                 credentialIntent,
                 errorMessage
             )

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -246,7 +246,7 @@ class FileUploadWorker(
         }
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "LongMethod")
     private fun notifyUploadResult(
         uploadFileOperation: UploadFileOperation,
         uploadResult: RemoteOperationResult<Any?>

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploaderIntents.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploaderIntents.kt
@@ -93,7 +93,7 @@ class FileUploaderIntents(private val context: Context) {
         }
     }
 
-    fun removeUploadActionIntent(uploadFileOperation: UploadFileOperation): PendingIntent {
+    fun cancelUploadActionIntent(uploadFileOperation: UploadFileOperation): PendingIntent {
         val intent = Intent(context, FileUploadBroadcastReceiver::class.java).apply {
             putExtra(FileUploadBroadcastReceiver.UPLOAD_ID, uploadFileOperation.ocUploadId)
             putExtra(FileUploadBroadcastReceiver.REMOTE_PATH, uploadFileOperation.file.remotePath)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploaderIntents.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploaderIntents.kt
@@ -92,4 +92,19 @@ class FileUploaderIntents(private val context: Context) {
             )
         }
     }
+
+    fun removeUploadActionIntent(uploadFileOperation: UploadFileOperation): PendingIntent {
+        val intent = Intent(context, FileUploadBroadcastReceiver::class.java).apply {
+            putExtra(FileUploadBroadcastReceiver.UPLOAD_ID, uploadFileOperation.ocUploadId)
+            putExtra(FileUploadBroadcastReceiver.REMOTE_PATH, uploadFileOperation.file.remotePath)
+            putExtra(FileUploadBroadcastReceiver.STORAGE_PATH, uploadFileOperation.file.storagePath)
+        }
+
+        return PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -75,7 +75,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         uploadFileOperation: UploadFileOperation,
         resultCode: RemoteOperationResult.ResultCode,
         conflictsResolveIntent: PendingIntent?,
-        removeUploadActionIntent: PendingIntent?,
+        cancelUploadActionIntent: PendingIntent?,
         credentialIntent: PendingIntent?,
         errorMessage: String
     ) {
@@ -97,14 +97,12 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
                 )
             }
 
-            removeUploadActionIntent?.let {
+            cancelUploadActionIntent?.let {
                 addAction(
                     R.drawable.ic_delete,
-                    R.string.upload_list_remove_upload,
-                    removeUploadActionIntent
+                    R.string.upload_list_cancel_upload,
+                    cancelUploadActionIntent
                 )
-
-                setDeleteIntent(removeUploadActionIntent)
             }
 
             credentialIntent?.let {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -75,6 +75,7 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         uploadFileOperation: UploadFileOperation,
         resultCode: RemoteOperationResult.ResultCode,
         conflictsResolveIntent: PendingIntent?,
+        removeUploadActionIntent: PendingIntent?,
         credentialIntent: PendingIntent?,
         errorMessage: String
     ) {
@@ -94,6 +95,16 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
                     R.string.upload_list_resolve_conflict,
                     it
                 )
+            }
+
+            removeUploadActionIntent?.let {
+                addAction(
+                    R.drawable.ic_delete,
+                    R.string.upload_list_remove_upload,
+                    removeUploadActionIntent
+                )
+
+                setDeleteIntent(removeUploadActionIntent)
             }
 
             credentialIntent?.let {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1071,6 +1071,7 @@
     <string name="uploader_upload_failed_sync_conflict_error">File upload conflict</string>
     <string name="uploader_upload_failed_sync_conflict_error_content">Pick which version to keep of %1$s</string>
     <string name="upload_list_resolve_conflict">Resolve conflict</string>
+    <string name="upload_list_remove_upload">Remove upload</string>
     <string name="upload_list_delete">Delete</string>
     <string name="create_new">New</string>
     <string name="editor_placeholder" translatable="false">%1$s %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1071,7 +1071,7 @@
     <string name="uploader_upload_failed_sync_conflict_error">File upload conflict</string>
     <string name="uploader_upload_failed_sync_conflict_error_content">Pick which version to keep of %1$s</string>
     <string name="upload_list_resolve_conflict">Resolve conflict</string>
-    <string name="upload_list_remove_upload">Remove upload</string>
+    <string name="upload_list_remove_upload">Cancel upload</string>
     <string name="upload_list_delete">Delete</string>
     <string name="create_new">New</string>
     <string name="editor_placeholder" translatable="false">%1$s %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1071,7 +1071,7 @@
     <string name="uploader_upload_failed_sync_conflict_error">File upload conflict</string>
     <string name="uploader_upload_failed_sync_conflict_error_content">Pick which version to keep of %1$s</string>
     <string name="upload_list_resolve_conflict">Resolve conflict</string>
-    <string name="upload_list_remove_upload">Cancel upload</string>
+    <string name="upload_list_cancel_upload">Cancel upload</string>
     <string name="upload_list_delete">Delete</string>
     <string name="create_new">New</string>
     <string name="editor_placeholder" translatable="false">%1$s %2$s</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Changes

When the user selects the `Remove Upload` action, the conflicting upload will be cleared. As a result, previously dismissed notifications will not reappear upon app launch or when the user refreshes the directory.


https://github.com/user-attachments/assets/85fd371e-1dd3-4525-b887-13dbd780a78a


<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/473b0a03-8fea-420f-aef6-fe5231cedc08" width="300" alt="Image 1"></td>
  </tr>
</table>

