### PR TITLE
Use child threads to load the uploaded file list

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -201,9 +201,7 @@ public class UploadListActivity extends FileActivity {
                     connectivityService,
                     accountManager,
                     powerManagementService);
-                this.runOnUiThread(() -> {
-                    uploadListAdapter.loadUploadItemsFromDb();
-                });
+                uploadListAdapter.loadUploadItemsFromDb();
             }).start();
             DisplayUtils.showSnackMessage(this, R.string.uploader_local_files_uploaded);
         }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -58,6 +58,9 @@ import com.owncloud.android.utils.theme.ViewThemeUtils;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
 
@@ -79,6 +82,10 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
     private final boolean showUser;
     private final ViewThemeUtils viewThemeUtils;
     private NotificationManager mNotificationManager;
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1,
+                                                                       0L, TimeUnit.MILLISECONDS,
+                                                                       new LinkedBlockingQueue<>(1),
+                                                                       new ThreadPoolExecutor.DiscardOldestPolicy());
 
     private final FileUploadHelper uploadHelper = FileUploadHelper.Companion.instance();
 
@@ -131,7 +138,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                     }
 
                     uploadHelper.cancelFileUploads(Arrays.asList(group.items), accountName);
-                    parentActivity.runOnUiThread(this::loadUploadItemsFromDb);
+                    loadUploadItemsFromDb();
                 }).start();
                 case FINISHED -> {
                     uploadsStorageManager.clearSuccessfulUploads();
@@ -166,7 +173,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                         connectivityService,
                         accountManager,
                         powerManagementService);
-                    parentActivity.runOnUiThread(this::loadUploadItemsFromDb);
+                    loadUploadItemsFromDb();
                 }).start();
             }
 
@@ -210,8 +217,7 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 connectivityService,
                 accountManager,
                 powerManagementService);
-
-            parentActivity.runOnUiThread(this::loadUploadItemsFromDb);
+            loadUploadItemsFromDb();
             parentActivity.runOnUiThread(() -> {
                 if (showNotExistMessage) {
                     showNotExistMessage();
@@ -816,12 +822,18 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
      */
     public final void loadUploadItemsFromDb() {
         Log_OC.d(TAG, "loadUploadItemsFromDb");
-
-        for (UploadGroup group : uploadGroups) {
-            group.refresh();
-        }
-
-        notifyDataSetChanged();
+        // Use thread pool to avoid repeated loading of data
+        executor.execute(() -> {
+            for (UploadGroup group : uploadGroups) {
+                group.refresh();
+            }
+            parentActivity.runOnUiThread(() -> {
+                for (UploadGroup uploadGroup : uploadGroups) {
+                    uploadGroup.apply();
+                }
+                this.notifyDataSetChanged();
+            });
+        });
     }
 
     /**
@@ -902,13 +914,18 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         void refresh();
     }
 
+    interface Apply {
+        void apply();
+    }
+
     enum Type {
         CURRENT, FINISHED, FAILED, CANCELLED
     }
 
-    abstract class UploadGroup implements Refresh {
+    abstract class UploadGroup implements Refresh, Apply {
         private final Type type;
         private OCUpload[] items;
+        private OCUpload[] refreshItems;
         private final String name;
 
         UploadGroup(Type type, String groupName) {
@@ -937,17 +954,26 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
             this.items = items;
         }
 
+        public void setRefreshItems(OCUpload... items) {
+            this.refreshItems = items;
+        }
+
         void fixAndSortItems(OCUpload... array) {
             for (OCUpload upload : array) {
                 upload.setDataFixed(uploadHelper);
             }
             Arrays.sort(array, new OCUploadComparator());
-
-            setItems(array);
+            setRefreshItems(array);
         }
 
         private int getGroupItemCount() {
             return items == null ? 0 : items.length;
+        }
+
+        @Override
+        public void apply() {
+            setItems(this.refreshItems);
+            this.refreshItems = null;
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -973,7 +973,6 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
         @Override
         public void apply() {
             setItems(this.refreshItems);
-            this.refreshItems = null;
         }
     }
 


### PR DESCRIPTION
fix [After uploading thousands of files, after selecting upload in the drawer, a black screen will appear for several seconds before the upload page can be opened](https://github.com/nextcloud/android/issues/15263)

Disadvantages: There will be a delay in the display of uploaded lists

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


