### PR TITLE
Add forceSync option to auto-upload items

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -127,7 +127,8 @@ interface BackgroundJobManager {
     fun startImmediateFilesSyncJob(
         syncedFolderID: Long,
         overridePowerSaving: Boolean = false,
-        changedFiles: Array<String?> = arrayOf<String?>()
+        changedFiles: Array<String?> = arrayOf<String?>(),
+        forceSync: Boolean = false
     )
 
     fun cancelTwoWaySyncJob()

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -488,12 +488,14 @@ internal class BackgroundJobManagerImpl(
     override fun startImmediateFilesSyncJob(
         syncedFolderID: Long,
         overridePowerSaving: Boolean,
-        changedFiles: Array<String?>
+        changedFiles: Array<String?>,
+        forceSync: Boolean
     ) {
         val arguments = Data.Builder()
             .putBoolean(FilesSyncWork.OVERRIDE_POWER_SAVING, overridePowerSaving)
             .putStringArray(FilesSyncWork.CHANGED_FILES, changedFiles)
             .putLong(FilesSyncWork.SYNCED_FOLDER_ID, syncedFolderID)
+            .putBoolean(FilesSyncWork.FORCE_SYNC, forceSync)
             .build()
 
         val request = oneTimeRequestBuilder(
@@ -505,7 +507,7 @@ internal class BackgroundJobManagerImpl(
 
         workManager.enqueueUniqueWork(
             JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID,
-            ExistingWorkPolicy.APPEND,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
             request
         )
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -10,6 +10,7 @@ package com.owncloud.android.ui.activity
 
 import android.annotation.SuppressLint
 import android.app.NotificationManager
+import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -610,6 +611,26 @@ class SyncedFoldersActivity :
         saveOrUpdateSyncedFolder(syncedFolder)
         adapter.setSyncFolderItem(section, syncedFolder)
         checkAndShowEmptyListContent()
+    }
+
+    override fun onForceSyncClicked(section: Int, syncedFolder: SyncedFolderDisplayItem?) {
+        if (syncedFolder == null) return
+
+        MaterialAlertDialogBuilder(this, R.style.Theme_ownCloud_Dialog)
+            .setTitle(R.string.autoupload_force_sync)
+            .setMessage(R.string.autoupload_force_sync_desc)
+            .setPositiveButton(R.string.common_ok) { dialog: DialogInterface?, _: Int ->
+                Log_OC.d(TAG, "Starting forced sync for item ${syncedFolder.localPath}")
+                backgroundJobManager.startImmediateFilesSyncJob(syncedFolder.id, overridePowerSaving = true, forceSync = true)
+                dialog?.dismiss()
+            }
+            .setNegativeButton(R.string.common_cancel) { dialog: DialogInterface?, _: Int ->
+                dialog?.dismiss()
+            }
+            .setIcon(R.drawable.ic_warning)
+            .setIconAttribute(android.R.attr.alertDialogIcon)
+            .create()
+            .show()
     }
 
     private fun showEmptyContent(headline: String, message: String, action: String) {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.kt
@@ -59,6 +59,9 @@ class SyncedFolderAdapter(
     private var hideItems = true
     private val thumbnailThreadPool: Executor = Executors.newCachedThreadPool()
 
+    @VisibleForTesting
+    internal var popup: PopupMenu? = null
+
     init {
         shouldShowHeadersForEmptySections(true)
         shouldShowFooters(true)
@@ -304,16 +307,24 @@ class SyncedFolderAdapter(
             menu
                 .findItem(R.id.action_auto_upload_folder_toggle_visibility)
                 .setChecked(item.isHidden)
+            menu
+                .findItem(R.id.action_auto_upload_force_sync)
+                .setEnabled(item.isEnabled)
+                .setVisible(item.isEnabled)
         }
 
+        this.popup = popup
         popup.show()
     }
 
-    private fun optionsItemSelected(menuItem: MenuItem, section: Int, item: SyncedFolderDisplayItem): Boolean {
+    @VisibleForTesting
+    internal fun optionsItemSelected(menuItem: MenuItem, section: Int, item: SyncedFolderDisplayItem): Boolean {
         if (menuItem.itemId == R.id.action_auto_upload_folder_toggle_visibility) {
             clickListener.onVisibilityToggleClick(section, item)
+        } else if (menuItem.itemId == R.id.action_auto_upload_force_sync) {
+            clickListener.onForceSyncClicked(section, item)
         } else {
-            // default: R.id.action_create_custom_folder
+            // default: R.id.action_auto_upload_folder_settings
             clickListener.onSyncFolderSettingsClick(section, item)
         }
         return true
@@ -429,6 +440,7 @@ class SyncedFolderAdapter(
         fun onSyncFolderSettingsClick(section: Int, syncedFolderDisplayItem: SyncedFolderDisplayItem?)
         fun onVisibilityToggleClick(section: Int, item: SyncedFolderDisplayItem?)
         fun showSubFolderWarningDialog()
+        fun onForceSyncClicked(section: Int, item: SyncedFolderDisplayItem?)
     }
 
     internal class HeaderViewHolder(var binding: SyncedFoldersItemHeaderBinding) :

--- a/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
+++ b/app/src/main/java/com/owncloud/android/utils/FilesSyncHelper.java
@@ -294,7 +294,7 @@ public final class FilesSyncHelper {
     public static void startFilesSyncForAllFolders(SyncedFolderProvider syncedFolderProvider, BackgroundJobManager jobManager, boolean overridePowerSaving, String[] changedFiles) {
         for (SyncedFolder syncedFolder : syncedFolderProvider.getSyncedFolders()) {
             if (syncedFolder.isEnabled()) {
-                jobManager.startImmediateFilesSyncJob(syncedFolder.getId(),overridePowerSaving,changedFiles);
+                jobManager.startImmediateFilesSyncJob(syncedFolder.getId(),overridePowerSaving,changedFiles,false);
             }
         }
     }

--- a/app/src/main/res/menu/synced_folders_adapter.xml
+++ b/app/src/main/res/menu/synced_folders_adapter.xml
@@ -14,4 +14,8 @@
     <item
         android:id="@+id/action_auto_upload_folder_settings"
         android:title="@string/autoupload_configure" />
+
+    <item
+        android:id="@+id/action_auto_upload_force_sync"
+        android:title="@string/autoupload_force_sync" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -751,6 +751,8 @@
     <string name="autoupload_create_new_custom_folder">Create new custom folder setup</string>
     <string name="autoupload_hide_folder">Hide folder</string>
     <string name="autoupload_configure">Configure</string>
+    <string name="autoupload_force_sync">Force sync</string>
+    <string name="autoupload_force_sync_desc">This action will remove the synced state of all files in this folder and re-sync them.</string>
     <string name="synced_folders_configure_folders">Configure folders</string>
 
     <string name="empty" translatable="false" />


### PR DESCRIPTION
Sometimes files can get missed if they get marked as FILESYSTEM_FILE_SENT_FOR_UPLOAD but then do not get updated for whatever reason, as FilesystemDataProvider#getFilesForUpload only considers files where FILESYSTEM_FILE_SENT_FOR_UPLOAD=0. This change adds an explicit "Force sync" button which can be used to invalidate the client-side cache and re-enumerate all files in a given folder.

Screenshots:
<img width="216" height="480" alt="Screenshot_20250728_122933" src="https://github.com/user-attachments/assets/69ba3b5e-0264-4481-b2d8-645286d8802a" /> <img width="216" height="480" alt="Screenshot_20250728_123043" src="https://github.com/user-attachments/assets/69711d12-4c1c-4f19-af50-c043eb347eb1" />


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
