### PR TITLE
File Upload Worker Batch Support

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/migrations/Migration88to89.kt
+++ b/app/src/main/java/com/nextcloud/client/database/migrations/Migration88to89.kt
@@ -12,6 +12,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.nextcloud.client.database.migrations.model.SQLiteColumnType
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
 
+@Suppress("MagicNumber")
 val MIGRATION_88_89 = object : Migration(88, 89) {
     override fun migrate(database: SupportSQLiteDatabase) {
         DatabaseMigrationUtil.addColumnIfNotExists(

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -596,7 +596,7 @@ internal class BackgroundJobManagerImpl(
      *                  within the worker.
      */
     override fun startFilesUploadJob(user: User, uploadIds: LongArray) {
-        val batchSize = 100
+        val batchSize = FileUploadWorker.BATCH_SIZE
         val batches = uploadIds.toList().chunked(batchSize)
         val tag = startFileUploadJobTag(user)
 

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -66,7 +66,6 @@ internal class BackgroundJobManagerImpl(
     Injectable {
 
     companion object {
-        private const val TAG = "BackgroundJobManagerImpl"
         const val TAG_ALL = "*" // This tag allows us to retrieve list of all jobs run by Nextcloud client
         const val JOB_CONTENT_OBSERVER = "content_observer"
         const val JOB_PERIODIC_CONTACTS_BACKUP = "periodic_contacts_backup"

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -604,12 +604,11 @@ internal class BackgroundJobManagerImpl(
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
 
-        val workRequests = batches.mapIndexed { batchIndex, batch ->
+        val workRequests = batches.mapIndexed { index, batch ->
             val dataBuilder = Data.Builder()
                 .putString(FileUploadWorker.ACCOUNT, user.accountName)
                 .putLongArray(FileUploadWorker.UPLOAD_IDS, batch.toLongArray())
-                .putInt(FileUploadWorker.BATCH_INDEX, batchIndex)
-                .putInt(FileUploadWorker.TOTAL_BATCHES, batches.size)
+                .putInt(FileUploadWorker.CURRENT_BATCH_INDEX, index)
                 .putInt(FileUploadWorker.TOTAL_UPLOAD_SIZE, uploadIds.size)
 
             oneTimeRequestBuilder(FileUploadWorker::class, JOB_FILES_UPLOAD, user)
@@ -619,6 +618,7 @@ internal class BackgroundJobManagerImpl(
                 .build()
         }
 
+        // Chain the work requests sequentially
         if (workRequests.isNotEmpty()) {
             var workChain = workManager.beginUniqueWork(
                 tag,

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -28,6 +28,7 @@ import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.documentscan.GeneratePdfFromImagesWork
 import com.nextcloud.client.jobs.download.FileDownloadWorker
 import com.nextcloud.client.jobs.offlineOperations.OfflineOperationsWorker
+import com.nextcloud.client.jobs.upload.FileUploadHelper
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.utils.extensions.isWorkRunning
@@ -596,7 +597,7 @@ internal class BackgroundJobManagerImpl(
      *                  within the worker.
      */
     override fun startFilesUploadJob(user: User, uploadIds: LongArray) {
-        val batchSize = FileUploadWorker.BATCH_SIZE
+        val batchSize = FileUploadHelper.MAX_FILE_COUNT
         val batches = uploadIds.toList().chunked(batchSize)
         val tag = startFileUploadJobTag(user)
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -57,7 +57,6 @@ class FileUploadWorker(
         val TAG: String = FileUploadWorker::class.java.simpleName
 
         const val NOTIFICATION_ERROR_ID: Int = 413
-        const val BATCH_SIZE = 100
         const val ACCOUNT = "data_account"
         const val UPLOAD_IDS = "uploads_ids"
         const val CURRENT_BATCH_INDEX = "batch_index"
@@ -153,7 +152,7 @@ class FileUploadWorker(
             return Result.failure()
         }
 
-        val previouslyUploadedFileSize = currentBatchIndex * BATCH_SIZE
+        val previouslyUploadedFileSize = currentBatchIndex * FileUploadHelper.MAX_FILE_COUNT
 
         val uploads = uploadIds.map { id -> uploadsStorageManager.getUploadById(id) }.filterNotNull()
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -126,7 +126,7 @@ class FileUploadWorker(
         WorkerStateLiveData.instance().setWorkState(WorkerState.UploadFinished(currentUploadFileOperation?.file))
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "LongMethod")
     private fun uploadFiles(): Result {
         val accountName = inputData.getString(ACCOUNT)
         if (accountName == null) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -59,6 +59,9 @@ class FileUploadWorker(
         const val NOTIFICATION_ERROR_ID: Int = 413
         const val ACCOUNT = "data_account"
         const val UPLOAD_IDS = "uploads_ids"
+        const val BATCH_INDEX = "batch_index"
+        const val TOTAL_BATCHES = "total_batches"
+        const val TOTAL_UPLOAD_SIZE = "total_upload_size"
         var currentUploadFileOperation: UploadFileOperation? = null
 
         private const val UPLOADS_ADDED_MESSAGE = "UPLOADS_ADDED"
@@ -128,8 +131,22 @@ class FileUploadWorker(
     private fun uploadFiles(): Result {
         val accountName = inputData.getString(ACCOUNT) ?: return Result.failure()
         val uploadIds = inputData.getLongArray(UPLOAD_IDS) ?: return Result.success()
+        val totalBatches = inputData.getInt(TOTAL_BATCHES, -1)
+        if (totalBatches == -1) {
+            return Result.failure()
+        }
+
+        val batchIndex = inputData.getInt(BATCH_INDEX, -1)
+        if (batchIndex == -1) {
+            return Result.failure()
+        }
+
+        val totalUploadSize = inputData.getInt(TOTAL_UPLOAD_SIZE, -1)
+        if (totalUploadSize == -1) {
+            return Result.failure()
+        }
+
         val uploads = uploadIds.map { id -> uploadsStorageManager.getUploadById(id) }.filterNotNull()
-        val totalUploadSize = uploadIds.size
 
         for ((index, upload) in uploads.withIndex()) {
             if (preferences.isGlobalUploadPaused) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -501,7 +501,13 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
 
                 preferences.setUploaderBehaviour(FileUploadWorker.LOCAL_BEHAVIOUR_DELETE);
             } else {
-                data.putExtra(EXTRA_CHOSEN_FILES, mFileListFragment.getCheckedFilePaths());
+                final var chosenFiles = mFileListFragment.getCheckedFilePaths();
+                if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
+                    DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+                    return;
+                }
+
+                data.putExtra(EXTRA_CHOSEN_FILES, chosenFiles);
                 data.putExtra(LOCAL_BASE_PATH, mCurrentDir.getAbsolutePath());
 
                 // set result code
@@ -662,9 +668,13 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
                         finish();
                     }
                 } else {
-                    String[] selectedFilePaths = mFileListFragment.getCheckedFilePaths();
+                    final var chosenFiles = mFileListFragment.getCheckedFilePaths();
+                    if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
+                        DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+                        return;
+                    }
                     boolean isPositionZero = (binding.uploadFilesSpinnerBehaviour.getSelectedItemPosition() == 0);
-                    new CheckAvailableSpaceTask(this, selectedFilePaths).execute(isPositionZero);
+                    new CheckAvailableSpaceTask(this, chosenFiles).execute(isPositionZero);
                 }
             } else {
                 requestPermissions();
@@ -708,7 +718,8 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     @Override
     public void onConfirmation(String callerTag) {
         Log_OC.d(TAG, "Positive button in dialog was clicked; dialog tag is " + callerTag);
-        if (mFileListFragment.getCheckedFilePaths().length > FileUploadHelper.MAX_FILE_COUNT) {
+        final var chosenFiles = mFileListFragment.getCheckedFilePaths();
+        if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
             DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
             return;
         }
@@ -717,7 +728,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             // return the list of selected files to the caller activity (success),
             // signaling that they should be moved to the ownCloud folder, instead of copied
             Intent data = new Intent();
-            data.putExtra(EXTRA_CHOSEN_FILES, mFileListFragment.getCheckedFilePaths());
+            data.putExtra(EXTRA_CHOSEN_FILES, chosenFiles);
             data.putExtra(LOCAL_BASE_PATH, mCurrentDir.getAbsolutePath());
             setResult(RESULT_OK_AND_MOVE, data);
             finish();


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Issue

The current file upload implementation can fail silently when processing large batches of files due to WorkManager's data size limitations or passing thousands of String paths to the intent.

**Failed upload recovery:** When users retry failed uploads, the accumulated file IDs can exceed WorkManager's data limits.

**Large folder uploads:** Users uploading folders containing thousands of images (e.g., 7,000+ files) encounters app freeze or crash.


```
Exception in thread "main" java.lang.IllegalStateException: Data cannot occupy more than 10240 bytes when serialized
    at androidx.work.Data$Companion.toByteArrayInternalV1(Data_.kt:703)
    at androidx.work.Data$Builder.build(Data_.kt:525)
    at com.nextcloud.client.jobs.BackgroundJobManagerImpl.startFilesUploadJob(BackgroundJobManagerImpl.kt:610)
    at com.nextcloud.client.jobs.upload.FileUploadHelper.cancelAndRestartUploadJob(FileUploadHelper.kt:262)
    at com.owncloud.android.ui.activity.UploadListActivity.toggleGlobalPause(UploadListActivity.java:281)
    at com.owncloud.android.ui.activity.UploadListActivity.onOptionsItemSelected(UploadListActivity.java:300)
    at android.app.Activity.onMenuItemSelected(Activity.java:4760)
    at androidx.activity.ComponentActivity.onMenuItemSelected(ComponentActivity.kt:477)
    at androidx.fragment.app.FragmentActivity.onMenuItemSelected(FragmentActivity.java:264)
    at androidx.appcompat.app.AppCompatActivity.onMenuItemSelected(AppCompatActivity.java:256)
    at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(WindowCallbackWrapper.java:109)
    at androidx.appcompat.app.ToolbarActionBar$2.onMenuItemClick(ToolbarActionBar.java:66)
    at androidx.appcompat.widget.Toolbar$1.onMenuItemClick(Toolbar.java:224)
    at androidx.appcompat.widget.ActionMenuView$MenuBuilderCallback.onMenuItemSelected(ActionMenuView.java:769)
    at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:833)
    at androidx.appcompat.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:157)
    at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:984)
    at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:974)
    at androidx.appcompat.widget.ActionMenuView.invokeItem(ActionMenuView.java:620)
    at androidx.appcompat.view.menu.ActionMenuItemView.onClick(ActionMenuItemView.java:155)
    at android.view.View.performClick(View.java:8083)
    at android.view.View.performClickInternal(View.java:8060)
    at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
    at android.view.View$PerformClick.run(View.java:31549)
    at android.os.Handler.handleCallback(Handler.java:995)
    at android.os.Handler.dispatchMessage(Handler.java:103)
    at android.os.Looper.loopOnce(Looper.java:248)
    at android.os.Looper.loop(Looper.java:338)
    at android.app.ActivityThread.main(ActivityThread.java:9106)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
    at com.android.internal.os.ExecInit.main(ExecInit.java:50)
    at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
    at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:371)
```

### Changes

Splits large upload queues into manageable chunks (recommended: 500 files per batch).

Adds remaining bounds checking to prevent crashes or silent failures for intent argument passing and inform user.

Starts the `FileUploadWorker` job in default dispatchers.

### Demo


https://github.com/user-attachments/assets/c63b3b8d-2c27-4f83-89a3-3914a1aad273


