### PR TITLE
BugFix - E2EE Local File Deletion

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -764,16 +764,20 @@ public class UploadFileOperation extends SyncOperation {
         return result;
     }
 
-    private E2EData getE2EData(Object object) throws InvalidAlgorithmParameterException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, InvalidParameterSpecException, IOException {
+    private E2EData getE2EData(Object object) throws InvalidAlgorithmParameterException, IllegalStateException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, InvalidParameterSpecException, IOException {
         byte[] key = EncryptionUtils.generateKey();
         byte[] iv = EncryptionUtils.randomBytes(EncryptionUtils.ivLength);
         Cipher cipher = EncryptionUtils.getCipher(Cipher.ENCRYPT_MODE, key, iv);
-        File file = new File(mFile.getStoragePath());
-        EncryptedFile encryptedFile = EncryptionUtils.encryptFile(user.getAccountName(), file, cipher);
+        File originalFile = new File(mFile.getStoragePath());
+        EncryptedFile encryptedFile = EncryptionUtils.encryptFile(user.getAccountName(), originalFile, cipher);
         String encryptedFileName = getEncryptedFileName(object);
 
         if (key == null) {
             throw new NullPointerException("key cannot be null");
+        }
+
+        if (originalFile.getAbsolutePath().equals(encryptedFile.getEncryptedFile().getAbsolutePath())) {
+            throw new IllegalStateException("The encrypted file path cannot be the same as the original file path.");
         }
 
         return new E2EData(key, iv, encryptedFile, encryptedFileName);

--- a/app/src/main/java/com/owncloud/android/operations/e2e/E2EFiles.kt
+++ b/app/src/main/java/com/owncloud/android/operations/e2e/E2EFiles.kt
@@ -21,12 +21,22 @@ data class E2EFiles(
     private val tag = "E2EFiles"
 
     fun deleteTemporalFile() {
+        if (temporalFile == null) {
+            Log_OC.d(tag, "Could not delete temporal file, temporal file is null")
+            return
+        }
+
         if (temporalFile?.exists() == true && temporalFile?.delete() == false) {
             Log_OC.e(tag, "Could not delete temporal file " + temporalFile?.absolutePath)
         }
     }
 
     fun deleteTemporalFileWithOriginalFileComparison() {
+        if (temporalFile == null) {
+            Log_OC.d(tag, "Could not delete temporal file, temporal file is null")
+            return
+        }
+
         if (originalFile == temporalFile) {
             return
         }
@@ -38,9 +48,9 @@ data class E2EFiles(
     fun deleteEncryptedTempFile() {
         if (encryptedTempFile != null) {
             val isTempEncryptedFileDeleted = encryptedTempFile?.delete()
-            Log_OC.e(tag, "isTempEncryptedFileDeleted: $isTempEncryptedFileDeleted")
+            Log_OC.d(tag, "isTempEncryptedFileDeleted: $isTempEncryptedFileDeleted")
         } else {
-            Log_OC.e(tag, "Encrypted temp file cannot be found")
+            Log_OC.d(tag, "Encrypted temp file cannot be found")
         }
     }
 }

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -546,10 +546,12 @@ public final class EncryptionUtils {
     }
 
     public static EncryptedFile encryptFile(String accountName, File file, Cipher cipher) throws InvalidParameterSpecException, IOException {
-        File tempEncryptedFolder = FileDataStorageManager.createTempEncryptedFolder(accountName);
-        File tempEncryptedFile = File.createTempFile(file.getName(), null, tempEncryptedFolder);
+        final File tempEncryptedFolder = FileDataStorageManager.createTempEncryptedFolder(accountName);
+        final String randomFileName = UUID.randomUUID().toString();
+        final String suffix = String.valueOf(System.currentTimeMillis());
+        final File tempEncryptedFile = File.createTempFile(randomFileName, suffix, tempEncryptedFolder);
         encryptFileWithGivenCipher(file, tempEncryptedFile, cipher);
-        String authenticationTagString = getAuthenticationTag(cipher);
+        final String authenticationTagString = getAuthenticationTag(cipher);
         return new EncryptedFile(tempEncryptedFile, authenticationTagString);
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed

### How to reproduce?

1. Tap the “+” button and create a new folder.
2. Encrypt the folder.
3. Upload a file named “A” from one location on the device.
4. Upload another file with the same name “A” from a different location on the device.
5. From the notification tray, tap the conflict notification and choose “Keep local” in the file conflict popup.
6. Local file gets deleted

### Issue?

`UploadFileOperation.cleanupE2EUpload` line 910 local file exists, line 920 local file not exists. How come unlock folder operation can delete the local file? You can use Debug → Evaluation expression field to check file existence. @tobiasKaminsky 

<img width="1368" height="906" alt="Screenshot 2025-08-20 at 12 14 02" src="https://github.com/user-attachments/assets/d20e695e-943f-4d7e-b463-7edeafcf7dbb" />