### PR TITLE
fix: file display activity intent handling

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -584,7 +584,8 @@ class FileDisplayActivity :
 
     private fun handleSearchIntent(intent: Intent) {
         val searchEvent = intent.getParcelableArgument(
-            OCFileListFragment.SEARCH_EVENT, SearchEvent::class.java
+            OCFileListFragment.SEARCH_EVENT,
+            SearchEvent::class.java
         ) ?: return
 
         when (searchEvent.searchType) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Some intent actions must be handled within `FileDisplayActivity`. The `onPostCreate()` method is not a suitable location for this logic. Instead, `onCreate()` and `onNewIntent()` should be used. However, only actions that are common to both scenarios should be handled in both methods. Actions specific to one case should remain in their respective method.

Additionally, a missing call to `getSupportFragmentManager().executePendingTransactions()` for the `OPEN_FILE` action in the `onNewIntent()` method was causing a crash, and should be included to ensure the fragment transaction is completed before the action is processed.

```
Exception in thread "main" java.lang.NullPointerException: Attempt to invoke virtual method 'void com.owncloud.android.ui.activity.FileDisplayActivity.startTextPreview(com.owncloud.android.datamodel.OCFile, boolean)' on a null object reference
    at com.owncloud.android.ui.fragment.OCFileListFragment.fileOnItemClick(OCFileListFragment.java:1262)
    at com.owncloud.android.ui.fragment.OCFileListFragment.onItemClicked(OCFileListFragment.java:1308)
    at com.owncloud.android.ui.activity.FileDisplayActivity.onOpenFileIntent(FileDisplayActivity.java:613)
    at com.owncloud.android.ui.activity.FileDisplayActivity.onNewIntent(FileDisplayActivity.java:550)
    at android.app.Activity.onNewIntent(Activity.java:2469)
    at android.app.Activity.performNewIntent(Activity.java:9182)
    at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1641)
    at android.app.Instrumentation.internalCallActivityOnNewIntent(Instrumentation.java:1662)
    at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1650)
    at android.app.ActivityThread.deliverNewIntents(ActivityThread.java:4512)
    at android.app.ActivityThread.handleNewIntent(ActivityThread.java:4522)
    at android.app.servertransaction.NewIntentItem.execute(NewIntentItem.java:69)
    at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:63)
    at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:133)
    at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:103)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2823)
    at android.os.Handler.dispatchMessage(Handler.java:110)
    at android.os.Looper.loopOnce(Looper.java:248)
    at android.os.Looper.loop(Looper.java:338)
    at android.app.ActivityThread.main(ActivityThread.java:9067)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)

```


### How to reproduce?

1. Download a file
2. Add shortcut to home screen
3. Activate `Don't keep activities` from developer settings
4. Try to open home shortcut item
