### PR TITLE
fix: inform user for same file upload

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -139,7 +139,7 @@ interface BackgroundJobManager {
 
     fun startNotificationJob(subject: String, signature: String)
     fun startAccountRemovalJob(accountName: String, remoteWipe: Boolean)
-    fun startFilesUploadJob(user: User, uploadIds: LongArray)
+    fun startFilesUploadJob(user: User, uploadIds: LongArray, isAutoUpload: Boolean = false)
     fun getFileUploads(user: User): LiveData<List<JobInfo>>
     fun cancelFilesUploadJob(user: User)
     fun isStartFileUploadJobScheduled(user: User): Boolean

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -600,7 +600,7 @@ internal class BackgroundJobManagerImpl(
      *                  and cannot be determined directly from the account name or a single function
      *                  within the worker.
      */
-    override fun startFilesUploadJob(user: User, uploadIds: LongArray) {
+    override fun startFilesUploadJob(user: User, uploadIds: LongArray, isAutoUpload: Boolean) {
         defaultDispatcherScope.launch {
             val batchSize = FileUploadHelper.MAX_FILE_COUNT
             val batches = uploadIds.toList().chunked(batchSize)
@@ -612,6 +612,7 @@ internal class BackgroundJobManagerImpl(
 
             val workRequests = batches.mapIndexed { index, batch ->
                 val dataBuilder = Data.Builder()
+                    .putBoolean(FileUploadWorker.IS_AUTO_UPLOAD, isAutoUpload)
                     .putString(FileUploadWorker.ACCOUNT, user.accountName)
                     .putLongArray(FileUploadWorker.UPLOAD_IDS, batch.toLongArray())
                     .putInt(FileUploadWorker.CURRENT_BATCH_INDEX, index)

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -104,7 +104,7 @@ class FilesSyncWork(
         val user = userAccountManager.getUser(syncedFolder.account)
         if (user.isPresent) {
             var uploadIds = uploadsStorageManager.getCurrentUploadIds(user.get().accountName)
-            backgroundJobManager.startFilesUploadJob(user.get(), uploadIds)
+            backgroundJobManager.startFilesUploadJob(user.get(), uploadIds, isAutoUpload = true)
         }
 
         // Get changed files from ContentObserverWork (only images and videos) or by scanning filesystem
@@ -315,7 +315,8 @@ class FilesSyncWork(
             UploadFileOperation.CREATED_AS_INSTANT_PICTURE,
             needsWifi,
             needsCharging,
-            syncedFolder.nameCollisionPolicy
+            syncedFolder.nameCollisionPolicy,
+            isAutoUpload = true
         )
 
         for (path in paths) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -190,6 +190,7 @@ class FileUploadHelper {
         return showNotExistMessage
     }
 
+    @JvmOverloads
     @Suppress("LongParameterList")
     fun uploadNewFiles(
         user: User,
@@ -200,7 +201,8 @@ class FileUploadHelper {
         createdBy: Int,
         requiresWifi: Boolean,
         requiresCharging: Boolean,
-        nameCollisionPolicy: NameCollisionPolicy
+        nameCollisionPolicy: NameCollisionPolicy,
+        isAutoUpload: Boolean = false
     ) {
         val uploads = localPaths.mapIndexed { index, localPath ->
             OCUpload(localPath, remotePaths[index], user.accountName).apply {
@@ -214,7 +216,7 @@ class FileUploadHelper {
             }
         }
         uploadsStorageManager.storeUploads(uploads)
-        backgroundJobManager.startFilesUploadJob(user, uploads.getUploadIds())
+        backgroundJobManager.startFilesUploadJob(user, uploads.getUploadIds(), isAutoUpload)
     }
 
     fun removeFileUpload(remotePath: String, accountName: String) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -57,10 +57,13 @@ class FileUploadWorker(
         val TAG: String = FileUploadWorker::class.java.simpleName
 
         const val NOTIFICATION_ERROR_ID: Int = 413
+
         const val ACCOUNT = "data_account"
         const val UPLOAD_IDS = "uploads_ids"
         const val CURRENT_BATCH_INDEX = "batch_index"
         const val TOTAL_UPLOAD_SIZE = "total_upload_size"
+        const val IS_AUTO_UPLOAD = "is_auto_upload"
+
         var currentUploadFileOperation: UploadFileOperation? = null
 
         private const val UPLOADS_ADDED_MESSAGE = "UPLOADS_ADDED"
@@ -277,6 +280,7 @@ class FileUploadWorker(
         uploadResult: RemoteOperationResult<Any?>
     ) {
         Log_OC.d(TAG, "NotifyUploadResult with resultCode: " + uploadResult.code)
+        val isAutoUpload = inputData.getBoolean(IS_AUTO_UPLOAD, false)
 
         if (uploadResult.isSuccess) {
             notificationManager.dismissOldErrorNotification(uploadFileOperation)
@@ -296,6 +300,10 @@ class FileUploadWorker(
                 context
             )
         ) {
+            if (!isAutoUpload) {
+                notificationManager.showSameFileAlreadyExistsNotification(uploadFileOperation.fileName)
+            }
+
             uploadFileOperation.handleLocalBehaviour()
             return
         }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -151,6 +151,23 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
         )
     }
 
+    fun showSameFileAlreadyExistsNotification(filename: String) {
+        notificationBuilder.run {
+            setAutoCancel(true)
+            clearActions()
+            setContentText("")
+            setProgress(0, 0, false)
+            setContentTitle(context.getString(R.string.file_upload_worker_same_file_already_exists, filename))
+        }
+
+        val notificationId = filename.hashCode()
+
+        notificationManager.notify(
+            notificationId,
+            notificationBuilder.build()
+        )
+    }
+
     fun showConnectionErrorNotification() {
         notificationManager.cancel(getId())
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,7 @@
     <string name="uploader_error_message_source_file_not_copied">Could not copy file to a temporary folder. Try to resend it.</string>
     <string name="uploader_upload_files_behaviour">Upload option:</string>
     <string name="max_file_count_warning_message">You have reached the maximum file upload limit. Please upload fewer than 500 files at a time.</string>
+    <string name="file_upload_worker_same_file_already_exists">%s already exists, no conflict detected</string>
     <string name="uploader_upload_files_behaviour_move_to_nextcloud_folder">Move file to %1$s folder</string>
     <string name="uploader_upload_files_behaviour_only_upload">Keep file in source folder</string>
     <string name="uploader_upload_files_behaviour_upload_and_delete_from_source">Delete file from source folder</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

When a user attempts to upload a file that already exists, the app currently skips the upload process without notifying the user.

### Steps to Reproduce

1. Create a folder and upload a file.
2. Attempt to upload the same file again.

### Rationale for isAutoUpload Check

The AutoUpload logic is not fully reliable due to [these reasons](https://github.com/nextcloud/android/issues/15214#issuecomment-3101884063). Without this check, failed uploads may show previously dismissed notifications again.

Example issue: https://github.com/nextcloud/android/issues/14402

### Demo

https://github.com/user-attachments/assets/94a5b509-d15f-4ea8-a815-99446ab623c7



