### PR TITLE
fix: settings activity back button behaviour

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -51,6 +51,7 @@ import com.google.android.material.progressindicator.LinearProgressIndicator;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.files.DeepLinkConstants;
+import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.network.ClientFactory;
 import com.nextcloud.client.onboarding.FirstRunActivity;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -606,7 +607,14 @@ public abstract class DrawerActivity extends ToolbarActivity
             startActivity(ActivitiesActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP);
         } else if (itemId == R.id.nav_settings) {
             resetOnlyPersonalAndOnDevice();
-            startActivity(SettingsActivity.class);
+
+            /**
+             * Since back button of SettingsActivity always shows all files we can clear the stack.
+             * {@link SettingsActivity#onBackPressed()
+             */
+            final Intent intent = new Intent(this, SettingsActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            startActivity(intent);
         } else if (itemId == R.id.nav_community) {
             resetOnlyPersonalAndOnDevice();
             startActivity(CommunityActivity.class);

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -609,7 +609,7 @@ public abstract class DrawerActivity extends ToolbarActivity
             resetOnlyPersonalAndOnDevice();
 
             /**
-             * Since back button of SettingsActivity always shows all files we can clear the stack.
+             * Since pressing the back button in SettingsActivity always returns to the all file list, we can clear the stack.
              * {@link SettingsActivity#onBackPressed()
              */
             final Intent intent = new Intent(this, SettingsActivity.class);

--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -356,8 +356,9 @@ public class SettingsActivity extends PreferenceActivity
 
     @Override
     public void onBackPressed() {
+        DrawerActivity.menuItemId = R.id.nav_all_files;
         Intent i = new Intent(this, FileDisplayActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         i.setAction(FileDisplayActivity.ALL_FILES);
         startActivity(i);
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Empty all files screen, appears when user presses the back button from the `SettingsActivity`. Additionally, wrong navigation item is selected.

https://github.com/user-attachments/assets/0346e84e-1bdf-481b-9c10-34a4bd4f441d

### After

https://github.com/user-attachments/assets/ec2a50fb-bec8-4f18-84a8-70c74495d064


