### PR TITLE
fix: share updating

### DIFF
--- a/app/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/app/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -629,7 +629,7 @@ public class OperationsService extends Service {
                         shareId = operationIntent.getLongExtra(EXTRA_SHARE_ID, -1);
                         long shareRemoteId = operationIntent.getLongExtra(EXTRA_SHARE_REMOTE_ID, -1);
 
-                        if (shareId > 0) {
+                        if (shareId > 0 || shareRemoteId > 0) {
                             UpdateShareInfoOperation updateShare = new UpdateShareInfoOperation(shareId,
                                                                                                 shareRemoteId,
                                                                                                 fileDataStorageManager);

--- a/app/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/app/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -98,6 +98,7 @@ public class OperationsService extends Service {
     public static final String EXTRA_SHARE_PUBLIC_LABEL = "SHARE_PUBLIC_LABEL";
     public static final String EXTRA_SHARE_HIDE_FILE_DOWNLOAD = "HIDE_FILE_DOWNLOAD";
     public static final String EXTRA_SHARE_ID = "SHARE_ID";
+    public static final String EXTRA_SHARE_REMOTE_ID = "SHARE_REMOTE_ID";
     public static final String EXTRA_SHARE_NOTE = "SHARE_NOTE";
     public static final String EXTRA_IN_BACKGROUND = "IN_BACKGROUND";
     public static final String EXTRA_FILES_DOWNLOAD_LIMIT = "FILES_DOWNLOAD_LIMIT";
@@ -626,9 +627,11 @@ public class OperationsService extends Service {
 
                     case ACTION_UPDATE_SHARE_INFO:
                         shareId = operationIntent.getLongExtra(EXTRA_SHARE_ID, -1);
+                        long shareRemoteId = operationIntent.getLongExtra(EXTRA_SHARE_REMOTE_ID, -1);
 
                         if (shareId > 0) {
                             UpdateShareInfoOperation updateShare = new UpdateShareInfoOperation(shareId,
+                                                                                                shareRemoteId,
                                                                                                 fileDataStorageManager);
 
                             int permissionsToChange = operationIntent.getIntExtra(EXTRA_SHARE_PERMISSIONS, -1);

--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -773,6 +773,7 @@ public class FileOperationsHelper {
         updateShareIntent.setAction(OperationsService.ACTION_UPDATE_SHARE_INFO);
         updateShareIntent.putExtra(OperationsService.EXTRA_ACCOUNT, fileActivity.getAccount());
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_ID, id);
+        updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_REMOTE_ID, share.getRemoteId());
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PERMISSIONS, permissions);
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_HIDE_FILE_DOWNLOAD, hideFileDownload);
         updateShareIntent.putExtra(OperationsService.EXTRA_SHARE_PASSWORD, (password == null) ? "" : password);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

When creating a new folder and attempting to share it via a link, the "Set password" and "Link label" fields do not save changes the first time. The changes are only saved on subsequent attempts, and occasionally even multiple attempts do not work until a full refresh of "All Files" is performed.

### Steps to Reproduce:

1. Tap the "+" button and create a new folder.
2. Tap the share icon for the newly created folder.
3. Tap "Create link".
4. Tap on link details and navigate to Settings.
5. Enter a value in Set password and Link label fields.
6. Tap the confirm button.
7. Observe that the changes are not saved on the first attempt.