### PR TITLE
fix: file display activity restart intent handling

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -245,6 +245,7 @@ class FileDisplayActivity :
 
         intent?.let {
             handleCommonIntents(it)
+            handleAccountSwitchIntent(it)
         }
 
         loadSavedInstanceState(savedInstanceState)
@@ -531,6 +532,7 @@ class FileDisplayActivity :
         setIntent(intent)
         handleCommonIntents(intent)
         handleSpecialIntents(intent)
+        handleRestartIntent(intent)
     }
 
     private fun handleSpecialIntents(intent: Intent) {
@@ -570,16 +572,27 @@ class FileDisplayActivity :
                 supportFragmentManager.executePendingTransactions()
                 onOpenFileIntent(intent)
             }
-            RESTART -> {
-                val accountName = accountManager.user.accountName
-                val message = getString(R.string.logged_in_as)
-                val snackBarMessage = String.format(message, accountName)
-                DisplayUtils.showSnackMessage(this, snackBarMessage)
-
-                finish()
-                startActivity(intent)
-            }
         }
+    }
+
+    private fun handleRestartIntent(intent: Intent) {
+        if (intent.action != RESTART) {
+            return
+        }
+
+        finish()
+        startActivity(intent)
+    }
+
+    private fun handleAccountSwitchIntent(intent: Intent) {
+        if (intent.action != RESTART) {
+            return
+        }
+
+        val accountName = accountManager.user.accountName
+        val message = getString(R.string.logged_in_as)
+        val snackBarMessage = String.format(message, accountName)
+        DisplayUtils.showSnackMessage(this, snackBarMessage)
     }
 
     private fun handleSearchIntent(intent: Intent) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The restart Intent for onCreate and onNewIntent is different. For onCreate, only the Snackbar will appear; for onNewIntent, the Intent needs to be restarted. 

Otherwise infinite loop:

```
Timestamp               PID-TID     Activity                Package                  Level  Message
--------------------------------------------------------------------------------------------------------------
2025-08-20 12:30:57.355 17951-17951 FileDisplayActivity     com.nextcloud.client     D      onCreate(Bundle) starting
2025-08-20 12:30:57.443 17951-17951 FileActivity            com.nextcloud.client     D      Operations service connected
2025-08-20 12:30:57.453 17951-17951 FileDisplayActivity     com.nextcloud.client     V      onCreate() start
2025-08-20 12:30:57.472 17951-17951 FileDisplayActivity     com.nextcloud.client     D      onCreate(Bundle) starting
2025-08-20 12:30:57.513 17951-17951 FileActivity            com.nextcloud.client     D      Operations service connected
2025-08-20 12:30:57.522 17951-17951 FileDisplayActivity     com.nextcloud.client     V      onCreate() start
2025-08-20 12:30:57.540 17951-17951 FileDisplayActivity     com.nextcloud.client     D      onCreate(Bundle) starting
2025-08-20 12:30:57.583 17951-17951 FileActivity            com.nextcloud.client     D      Operations service connected
2025-08-20 12:30:57.593 17951-17951 FileDisplayActivity     com.nextcloud.client     V      onCreate() start
2025-08-20 12:30:57.610 17951-17951 FileDisplayActivity     com.nextcloud.client     D      onCreate(Bundle) starting
2025-08-20 12:30:57.655 17951-17951 FileActivity            com.nextcloud.client     D      Operations service connected
2025-08-20 12:30:57.661 17951-17951 FileDisplayActivity     com.nextcloud.client     V      onCreate() start
2025-08-20 12:30:57.689 17951-17951 FileDisplayActivity     com.nextcloud.client     D      onCreate(Bundle) starting
2025-08-20 12:30:57.727 17951-17951 FileActivity            com.nextcloud.client     D      Operations service connected
```


