### PR TITLE
fix: unnecessary refresh folder event triggers

### DIFF
--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -395,4 +395,7 @@ public interface AppPreferences {
 
     int getPassCodeDelay();
     void setPassCodeDelay(int value);
+
+    String getLastDisplayedAccountName();
+    void setLastDisplayedAccountName(String lastDisplayedAccountName);
 }

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -110,6 +110,8 @@ public final class AppPreferencesImpl implements AppPreferences {
     
     private static final String PREF__PASSCODE_DELAY_IN_SECONDS = "passcode_delay_in_seconds";
 
+    private static final String PREF_LAST_DISPLAYED_ACCOUNT_NAME = "last_displayed_user";
+
     private static final String LOG_ENTRY = "log_entry";
 
     private final Context context;
@@ -831,5 +833,15 @@ public final class AppPreferencesImpl implements AppPreferences {
     @Override
     public void setPassCodeDelay(int value) {
         preferences.edit().putInt(PREF__PASSCODE_DELAY_IN_SECONDS, value).apply();
+    }
+
+    @Override
+    public String getLastDisplayedAccountName() {
+        return preferences.getString(PREF_LAST_DISPLAYED_ACCOUNT_NAME, null);
+    }
+
+    @Override
+    public void setLastDisplayedAccountName(String lastDisplayedAccountName) {
+        preferences.edit().putString(PREF_LAST_DISPLAYED_ACCOUNT_NAME, lastDisplayedAccountName).apply();
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -166,6 +166,7 @@ public abstract class FileActivity extends DrawerActivity
 
     protected FileDownloadWorker.FileDownloadProgressListener fileDownloadProgressListener;
     protected FileUploadHelper fileUploadHelper = FileUploadHelper.Companion.instance();
+    protected boolean isFileDisplayActivityResumed = false;
 
     @Inject
     UserAccountManager accountManager;
@@ -254,7 +255,11 @@ public abstract class FileActivity extends DrawerActivity
     public void networkAndServerConnectionListener(boolean isNetworkAndServerAvailable) {
         if (isNetworkAndServerAvailable) {
             hideInfoBox();
-            refreshList();
+
+            // No need to refresh the file list again since file display activity doing it.
+            if (!isFileDisplayActivityResumed) {
+                refreshList();
+            }
         } else {
             if (this instanceof PreviewMediaActivity) {
                 hideInfoBox();

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -30,7 +30,9 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.os.Parcelable
 import android.text.TextUtils
 import android.view.Menu
@@ -1232,6 +1234,8 @@ class FileDisplayActivity :
     override fun onResume() {
         Log_OC.v(TAG, "onResume() start")
         super.onResume()
+        isFileDisplayActivityResumed = true
+
         // Instead of onPostCreate, starting the loading in onResume for children fragments
         val leftFragment = this.leftFragment
 
@@ -1299,6 +1303,10 @@ class FileDisplayActivity :
         checkNotifications()
 
         Log_OC.v(TAG, "onResume() end")
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            isFileDisplayActivityResumed = false
+        }, ON_RESUMED_RESET_DELAY)
     }
 
     private fun checkAndSetMenuItemId() {
@@ -3012,6 +3020,8 @@ class FileDisplayActivity :
         private const val KEY_SYNC_IN_PROGRESS = "SYNC_IN_PROGRESS"
         private const val KEY_WAITING_TO_SEND = "WAITING_TO_SEND"
         private const val DIALOG_TAG_SHOW_TOS = "DIALOG_TAG_SHOW_TOS"
+
+        private const val ON_RESUMED_RESET_DELAY = 10000L
 
         const val ACTION_DETAILS: String = "com.owncloud.android.ui.activity.action.DETAILS"
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -273,10 +273,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
             handleSearchEvent(searchEvent);
         }
 
-        if (getActivity() instanceof FileDisplayActivity fda) {
-            fda.startSyncFolderOperation(getCurrentFile(), true);
-        }
-
         super.onResume();
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed

### Issue

This PR addresses multiple redundant calls to `startSyncFolderOperation` across different execution flows, optimizing folder synchronization and improving performance. The following issues have been resolved:

**Initial App Launch after File Permission Grant**
When the app is opened for the first time after granting `REQUEST_CODE_MANAGE_ALL_FILES`, a full folder refresh is unnecessary. The `FileDisplayActivity` already triggers `onResume`, which handles folder synchronization.

**Persistent Account Tracking**
The `lastDisplayedUser` was previously stored only in memory, causing redundant refreshes on subsequent app launches. Now, the account name is stored in `SharedPreferences` and compared at startup to prevent unnecessary sync operations.

**Network Change Listener Overlap**
The `NetworkChangeListener` previously triggered folder refresh immediately after internet access was restored and app start, overlapping with the refresh already performed in `FileDisplayActivity.onResume`. To prevent this, a flag is set in `onResume` to temporarily suppress the network-triggered refresh. The network refresh will resume automatically after 10 seconds if required.

**Move File Operation Completion and OCFileListFragment onResume**
Refreshing the folder after a file move operation is no longer necessary and `OCFileListFragment.onResume`, as `FileDisplayActivity` already handles folder synchronization on operation completion.
