### PR TITLE
fix: empty user input checks

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/utils/FileNameValidatorTests.kt
@@ -98,6 +98,12 @@ class FileNameValidatorTests : AbstractOnServerIT() {
     }
 
     @Test
+    fun testBlankFileName() {
+        val result = FileNameValidator.checkFileName("      ", capability, targetContext)
+        assertEquals(targetContext.getString(R.string.filename_empty), result)
+    }
+
+    @Test
     fun testFileAlreadyExists() {
         val existingFiles = setOf("existingFile")
         val result = FileNameValidator.checkFileName("existingFile", capability, targetContext, existingFiles)

--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
@@ -39,7 +39,7 @@ object FileNameValidator {
         context: Context,
         existedFileNames: Set<String>? = null
     ): String? {
-        if (TextUtils.isEmpty(filename)) {
+        if (filename.isBlank()) {
             return context.getString(R.string.filename_empty)
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
@@ -141,7 +141,7 @@ class CreateFolderDialogFragment :
             FileNameValidator.checkFileName(newFileName, getOCCapability(), requireContext(), fileNames)
 
         val errorMessage = when {
-            newFileName.isEmpty() -> getString(R.string.folder_name_empty)
+            newFileName.isBlank() -> getString(R.string.folder_name_empty)
             fileNameValidatorResult != null -> fileNameValidatorResult
             else -> null
         }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenamePublicShareDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenamePublicShareDialogFragment.kt
@@ -10,7 +10,6 @@ package com.owncloud.android.ui.dialog
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
@@ -94,7 +93,7 @@ class RenamePublicShareDialogFragment :
                     newName = binding.userInput.text.toString().trim()
                 }
 
-                if (TextUtils.isEmpty(newName)) {
+                if (newName.isBlank()) {
                     DisplayUtils.showSnackMessage(requireActivity(), R.string.label_empty)
                     return
                 }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.kt
@@ -14,7 +14,6 @@ package com.owncloud.android.ui.dialog
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.text.TextUtils
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
@@ -69,7 +68,7 @@ class SharePasswordDialogFragment :
 
                     if (sharePassword != null) {
                         val password = sharePassword.toString()
-                        if (!askForPassword && TextUtils.isEmpty(password)) {
+                        if (!askForPassword && password.isBlank()) {
                             DisplayUtils.showSnackMessage(binding?.root, R.string.share_link_empty_password)
                             return@setOnClickListener
                         }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -768,21 +768,21 @@ class FileDetailsSharingProcessFragment :
         }
 
         if (binding.shareProcessSetPasswordSwitch.isChecked &&
-            binding.shareProcessEnterPassword.text?.trim().isNullOrEmpty()
+            binding.shareProcessEnterPassword.text?.isBlank() == true
         ) {
             DisplayUtils.showSnackMessage(binding.root, R.string.share_link_empty_password)
             return
         }
 
         if (binding.shareProcessSetExpDateSwitch.isChecked &&
-            binding.shareProcessSelectExpDate.text?.trim().isNullOrEmpty()
+            binding.shareProcessSelectExpDate.text?.isBlank() == true
         ) {
             showExpirationDateDialog()
             return
         }
 
         if (binding.shareProcessChangeNameSwitch.isChecked &&
-            binding.shareProcessChangeName.text?.trim().isNullOrEmpty()
+            binding.shareProcessChangeName.text?.isBlank() == true
         ) {
             DisplayUtils.showSnackMessage(binding.root, R.string.label_empty)
             return


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Currently, we are using `isEmpty()` to validate user input. However, this check does not prevent inputs that consist only of whitespace. For example, a user could try to create a folder with the name " " (spaces), which passes the `isEmpty()` check but is clearly invalid.


