### PR TITLE
SpotBugs: Fix Method ignores exceptional return value

### DIFF
--- a/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -96,7 +96,11 @@ public final class PushUtils {
         if (!new File(privateKeyPath).exists() && !new File(publicKeyPath).exists()) {
             try {
                 if (!keyPathFile.exists()) {
-                    keyPathFile.mkdir();
+                    try {
+                        Files.createDirectories(keyPathFile.toPath());
+                    } catch (IOException e) {
+                        Log_OC.e(TAG, "Could not create directory: " + keyPathFile.getAbsolutePath(), e);
+                    }
                 }
                 KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
                 keyGen.initialize(2048);
@@ -304,8 +308,12 @@ public final class PushUtils {
         try {
             if (!new File(path).exists()) {
                 File newFile = new File(path);
-                newFile.getParentFile().mkdirs();
-                newFile.createNewFile();
+                try {
+                    Files.createDirectories(newFile.getParentFile().toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not create directory: " + newFile.getParentFile(), e);
+                }
+                Files.create(newFile);
             }
             keyFileOutputStream = new FileOutputStream(path);
             keyFileOutputStream.write(encoded);

--- a/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -97,7 +97,7 @@ public final class PushUtils {
             try {
                 if (!keyPathFile.exists()) {
                     try {
-                        Files.createDirectories(keyPathFile.toPath());
+                        Files.createDirectory(keyPathFile.toPath());
                     } catch (IOException e) {
                         Log_OC.e(TAG, "Could not create directory: " + keyPathFile.getAbsolutePath(), e);
                     }
@@ -313,7 +313,7 @@ public final class PushUtils {
                 } catch (IOException e) {
                     Log_OC.e(TAG, "Could not create directory: " + newFile.getParentFile(), e);
                 }
-                Files.create(newFile);
+                Files.createFile(newFile.toPath());
             }
             keyFileOutputStream = new FileOutputStream(path);
             keyFileOutputStream.write(encoded);

--- a/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
@@ -38,7 +38,9 @@ import com.owncloud.android.utils.FileExportUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -115,7 +117,11 @@ public class DownloadFileOperation extends RemoteOperation {
         if (file.getStoragePath() != null) {
             File parentFile = new File(file.getStoragePath()).getParentFile();
             if (parentFile != null && !parentFile.exists()) {
-                parentFile.mkdirs();
+                try {
+                    Files.createDirectories(parentFile.toPath());
+                } catch (IOException e) {
+                    return FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), file);
+                }
             }
             File path = new File(file.getStoragePath());  // re-downloads should be done over the original file
             if (path.canWrite() || parentFile != null && parentFile.canWrite()) {

--- a/app/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -25,6 +25,7 @@ import com.owncloud.android.utils.MimeTypeUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Remote operation performing the rename of a remote file (or folder?) in the ownCloud server.
@@ -163,24 +164,21 @@ public class RenameFileOperation extends SyncOperation {
         String tmpFolderName = FileStorageUtils.getTemporalPath("");
         File testFile = new File(tmpFolderName + newName);
         File tmpFolder = testFile.getParentFile();
-        if (!tmpFolder.exists() && !tmpFolder.mkdirs()) {
+        if (tmpFolder != null && !tmpFolder.exists() && !tmpFolder.mkdirs()) {
             Log_OC.e(TAG, "Unable to create parent folder " + tmpFolder.getAbsolutePath());
         }
-        if (!tmpFolder.isDirectory()) {
+        if (tmpFolder != null && !tmpFolder.isDirectory()) {
             throw new IOException("Unexpected error: temporal directory could not be created");
         }
         try {
-            testFile.createNewFile();   // return value is ignored; it could be 'false' because
-            // the file already existed, that doesn't invalidate the name
+            Files.createFile(testFile.toPath());
         } catch (IOException e) {
             Log_OC.i(TAG, "Test for validity of name " + newName + " in the file system failed");
             return false;
         }
         boolean result = testFile.exists() && testFile.isFile();
 
-        // cleaning ; result is ignored, since there is not much we could do in case of failure,
-        // but repeat and repeat...
-        testFile.delete();
+        Files.delete(testFile.toPath());
 
         return result;
     }

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -71,8 +71,6 @@ import com.owncloud.android.utils.theme.CapabilityUtils;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.RequestEntity;
-import org.lukhnos.nnio.file.Files;
-import org.lukhnos.nnio.file.Paths;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -82,6 +80,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
@@ -1259,7 +1260,11 @@ public class UploadFileOperation extends SyncOperation {
                                       OwnCloudClient client) {
         switch (mLocalBehaviour) {
             case FileUploadWorker.LOCAL_BEHAVIOUR_DELETE:
-                originalFile.delete();
+                try {
+                    Files.delete(originalFile.toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not delete original file: " + originalFile.getAbsolutePath(), e);
+                }
                 mFile.setStoragePath("");
                 getStorageManager().deleteFileInMediaScan(originalFile.getAbsolutePath());
                 saveUploadedFile(client);
@@ -1563,18 +1568,18 @@ public class UploadFileOperation extends SyncOperation {
 
         if (!targetFile.equals(sourceFile)) {
             File expectedFolder = targetFile.getParentFile();
-            expectedFolder.mkdirs();
+            Files.createDirectories(expectedFolder.toPath());
 
             if (expectedFolder.isDirectory()) {
                 if (!sourceFile.renameTo(targetFile)) {
                     // try to copy and then delete
-                    targetFile.createNewFile();
+                    Files.createFile(targetFile.toPath());
                     try (
                         FileChannel inChannel = new FileInputStream(sourceFile).getChannel();
                         FileChannel outChannel = new FileOutputStream(targetFile).getChannel()
                     ) {
                         inChannel.transferTo(0, inChannel.size(), outChannel);
-                        sourceFile.delete();
+                        Files.delete(sourceFile.toPath());
                     } catch (Exception e) {
                         mFile.setStoragePath(""); // forget the local file
                         // by now, treat this as a success; the file was uploaded

--- a/app/src/main/java/com/owncloud/android/providers/DiskLruImageCacheFileProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DiskLruImageCacheFileProvider.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 
 import javax.inject.Inject;
 
@@ -78,7 +79,7 @@ public class DiskLruImageCacheFileProvider extends ContentProvider {
         // create a file to write bitmap data
         File f = new File(MainApp.getAppContext().getCacheDir(), ocFile.getFileName());
         try {
-            f.createNewFile();
+            Files.createFile(f.toPath());
 
             //Convert bitmap to byte array
             ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/app/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
@@ -29,6 +29,8 @@ import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
@@ -364,10 +366,19 @@ public class StorageMigration {
             try {
                 File dstFile = new File(mStorageTarget + File.separator + MainApp.getDataFolder());
                 deleteRecursive(dstFile);
-                dstFile.delete();
+                try {
+                    Files.delete(dstFile.toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not delete destination file: " + dstFile.getAbsolutePath(), e);
+                }
 
                 File srcFile = new File(mStorageSource + File.separator + MainApp.getDataFolder());
-                srcFile.mkdirs();
+
+                try {
+                    Files.createDirectories(srcFile.toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not create directory: " + srcFile.getAbsolutePath(), e);
+                }
 
                 publishProgress(R.string.file_migration_checking_destination);
 
@@ -466,7 +477,11 @@ public class StorageMigration {
             if (!deleteRecursive(srcFile)) {
                 Log_OC.w(TAG, "Migration cleanup step failed");
             }
-            srcFile.delete();
+            try {
+                Files.delete(srcFile.toPath());
+            } catch (IOException e) {
+                Log_OC.e(TAG, "Could not delete source file: " + srcFile.getAbsolutePath(), e);
+            }
         }
 
         private boolean deleteRecursive(File f) {

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/PrintAsyncTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/PrintAsyncTask.java
@@ -28,6 +28,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.util.Objects;
 
 import static android.content.Context.PRINT_SERVICE;
 
@@ -68,7 +70,11 @@ public class PrintAsyncTask extends AsyncTask<Void, Void, Boolean> {
                     return Boolean.FALSE;
                 }
 
-                file.getParentFile().mkdirs();
+                try {
+                    Files.createDirectories(Objects.requireNonNull(file.getParentFile()).toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not create directory: " + Objects.requireNonNull(file.getParentFile()).getAbsolutePath(), e);
+                }
 
                 if (!file.getParentFile().exists()) {
                     Log_OC.d(TAG, file.getParentFile().getAbsolutePath() + " does not exist");

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1052,7 +1052,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
     private Future<Pair<Integer, OCFile>> getPreviousFile() {
         CompletableFuture<Pair<Integer, OCFile>> completableFuture = new CompletableFuture<>();
 
-        Executors.newCachedThreadPool().submit(() -> {
+        Executors.newCachedThreadPool().execute(() -> {
             var result = new Pair<Integer, OCFile>(null, null);
 
             FileDataStorageManager storageManager = mContainerActivity.getStorageManager();
@@ -1068,7 +1068,6 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
             completableFuture.complete(result);
 
-            return null;
         });
 
         return completableFuture;

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -36,6 +36,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -476,7 +477,11 @@ public final class FileStorageUtils {
         }
 
         storageManager.deleteFileInMediaScan(file.getAbsolutePath());
-        file.delete();
+        try {
+            Files.delete(file.toPath());
+        } catch (IOException e) {
+            Log_OC.e(TAG, "Could not delete file: " + file.getAbsolutePath(), e);
+        }
     }
 
     public static boolean deleteRecursive(File file) {


### PR DESCRIPTION
There are 16 SpotBugs under 

Bad practice:
 RV: Bad use of return value from method (16: 0/16/0/0)
   Method ignores exceptional return value   (16: 0/16/0/0) 

Solution:
Leveraging the more modern java.nio.Files library and conducting these make directory, delete, etc. functions via that. 
Changing a Submit to an Execute function