### PR TITLE
fix: preview media activity layout

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -29,7 +29,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import android.widget.LinearLayout
 import androidx.annotation.OptIn
 import androidx.annotation.StringRes
 import androidx.appcompat.content.res.AppCompatResources
@@ -78,7 +77,6 @@ import com.nextcloud.ui.fileactions.FileActionsBottomSheet.ResultListener
 import com.nextcloud.utils.extensions.getParcelableArgument
 import com.nextcloud.utils.extensions.logFileSize
 import com.nextcloud.utils.extensions.setTitleColor
-import com.nextcloud.utils.extensions.statusBarHeight
 import com.owncloud.android.R
 import com.owncloud.android.databinding.ActivityPreviewMediaBinding
 import com.owncloud.android.datamodel.OCFile
@@ -158,7 +156,6 @@ class PreviewMediaActivity :
 
         binding = ActivityPreviewMediaBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
         setSupportActionBar(binding.materialToolbar)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         applyWindowInsets()
@@ -178,7 +175,6 @@ class PreviewMediaActivity :
         configureSystemBars()
         emptyListView = binding.emptyView.emptyListView
         showProgressLayout()
-        addMarginForEmptyView()
         if (file == null) {
             return
         }
@@ -193,21 +189,6 @@ class PreviewMediaActivity :
             setPackage(packageName)
         }
         sendBroadcast(intent)
-    }
-
-    private fun addMarginForEmptyView() {
-        val layoutParams = emptyListView?.layoutParams ?: return
-        val statusBarHeight = statusBarHeight().toFloat()
-        val marginTop = DisplayUtils.convertDpToPixel(statusBarHeight, this)
-        when (layoutParams) {
-            is LinearLayout.LayoutParams -> layoutParams.setMargins(0, marginTop, 0, 0)
-            is FrameLayout.LayoutParams -> layoutParams.setMargins(0, marginTop, 0, 0)
-            else -> {
-                Log_OC.e(TAG, "Unsupported LayoutParams type: ${layoutParams::class.java.simpleName}")
-                return
-            }
-        }
-        emptyListView?.layoutParams = layoutParams
     }
 
     private fun initArguments(savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/activity_preview_media.xml
+++ b/app/src/main/res/layout/activity_preview_media.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Nextcloud - Android Client
-  ~
+  ~ SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
   ~ SPDX-FileCopyrightText: 2023 Parneet Singh <gurayaparneet@gmail.com>
   ~ SPDX-FileCopyrightText: 2020 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/top"
+    android:id="@+id/preview_media_activity_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
     tools:context=".ui.preview.PreviewMediaActivity">
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -20,56 +20,63 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:elevation="@dimen/standard_quarter_margin"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_gravity="center"
         android:layout_margin="@dimen/standard_margin"
         android:contentDescription="@string/preview_image_description"
-        android:src="@drawable/logo" />
+        android:src="@drawable/logo"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 
     <androidx.media3.ui.PlayerView
         android:id="@+id/exoplayer_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:show_buffering="always" />
 
     <com.owncloud.android.media.MediaControlView
         android:id="@+id/audio_controller_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/standard_margin"
-        android:visibility="gone" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="gone"
+        tools:visibility="visible"/>
 
-    <FrameLayout
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progress"
-        android:background="@color/color_dark_transparent"
+        android:layout_width="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true" />
+
+    <include
+        android:id="@+id/empty_view"
+        tools:visibility="visible"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        layout="@layout/empty_list" />
 
-        <com.google.android.material.progressindicator.CircularProgressIndicator
-            android:layout_width="wrap_content"
-            android:layout_gravity="center"
-            android:layout_height="wrap_content"
-            android:indeterminate="true" />
-
-    </FrameLayout>
-
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <include
-            android:id="@+id/empty_view"
-            layout="@layout/empty_list" />
-    </FrameLayout>
-
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Issue

The empty list view is not centered. Instead of using a child `FrameLayout` with a `ConstraintLayout`, we can achieve proper centering of child views more easily and accurately. 

This change can also enhance performance by reducing unnecessary layout nesting and removing the programmatic shifting logic.


### Before


<table>
  <tr>
    <th>Small Screen Device</th>
    <th>Large Screen Device</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/744a4d93-8408-47a8-9deb-e8a31ba3b4c8" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/d77848a0-92e0-4da2-9c65-f97e6acf6bbd" width="300" alt="after"></td>
  </tr>
</table>



### After


<table>
  <tr>
    <th>Small Screen Device</th>
    <th>Large Screen Device</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8e7d9b27-32cc-4d1b-9fd7-b5cf27a789fe" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/8b0d2d21-0eb9-4a9a-9373-05f786e75088" width="300" alt="after"></td>
  </tr>
</table>
