### PR TITLE
perf: improve e2ee file upload performance

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -269,7 +269,6 @@ class FileDisplayActivity :
 
         initSyncBroadcastReceiver()
         observeWorkerState()
-        registerRefreshFolderEventReceiver()
     }
 
     private fun loadSavedInstanceState(savedInstanceState: Bundle?) {
@@ -2816,22 +2815,6 @@ class FileDisplayActivity :
         checkForNewDevVersionNecessary(applicationContext)
     }
 
-    private fun registerRefreshFolderEventReceiver() {
-        val filter = IntentFilter(REFRESH_FOLDER_EVENT_RECEIVER)
-        LocalBroadcastManager.getInstance(this).registerReceiver(refreshFolderEventReceiver, filter)
-    }
-
-    private val refreshFolderEventReceiver: BroadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context?, intent: Intent?) {
-            syncAndUpdateFolder(ignoreETag = true, ignoreFocus = false)
-        }
-    }
-
-    override fun onDestroy() {
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(refreshFolderEventReceiver)
-        super.onDestroy()
-    }
-
     override fun onRestart() {
         super.onRestart()
         checkForNewDevVersionNecessary(applicationContext)
@@ -3050,8 +3033,6 @@ class FileDisplayActivity :
 
         const val KEY_IS_SEARCH_OPEN: String = "IS_SEARCH_OPEN"
         const val KEY_SEARCH_QUERY: String = "SEARCH_QUERY"
-
-        const val REFRESH_FOLDER_EVENT_RECEIVER: String = "REFRESH_FOLDER_EVENT"
 
         @JvmStatic
         fun openFileIntent(context: Context?, user: User?, file: OCFile?): Intent {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Since `FileDisplayActivity.onResume` doing it. No need to send another folder refresh event.


### Demo


https://github.com/user-attachments/assets/caca1acf-3513-4ed3-a7ef-5ffc8f69744c



