### PR TITLE
fix: remove redundant code to prevent unnecessary power management popups

### DIFF
--- a/app/src/main/java/com/nextcloud/client/device/DeviceModule.kt
+++ b/app/src/main/java/com/nextcloud/client/device/DeviceModule.kt
@@ -10,7 +10,6 @@ package com.nextcloud.client.device
 
 import android.content.Context
 import android.os.PowerManager
-import com.nextcloud.client.preferences.AppPreferences
 import dagger.Module
 import dagger.Provides
 
@@ -18,13 +17,11 @@ import dagger.Provides
 class DeviceModule {
 
     @Provides
-    fun powerManagementService(context: Context, preferences: AppPreferences): PowerManagementService {
+    fun powerManagementService(context: Context): PowerManagementService {
         val platformPowerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         return PowerManagementServiceImpl(
             context = context,
-            platformPowerManager = platformPowerManager,
-            deviceInfo = DeviceInfo(),
-            preferences = preferences
+            platformPowerManager = platformPowerManager
         )
     }
 }

--- a/app/src/main/java/com/nextcloud/client/device/PowerManagementService.kt
+++ b/app/src/main/java/com/nextcloud/client/device/PowerManagementService.kt
@@ -22,14 +22,6 @@ interface PowerManagementService {
     val isPowerSavingEnabled: Boolean
 
     /**
-     * Checks if the device vendor requires power saving
-     * exclusion workaround.
-     *
-     * @return true if workaround is required, false otherwise
-     */
-    val isPowerSavingExclusionAvailable: Boolean
-
-    /**
      * Checks current battery status using platform [android.os.BatteryManager]
      */
     val battery: BatteryStatus

--- a/app/src/main/java/com/nextcloud/client/device/PowerManagementServiceImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/device/PowerManagementServiceImpl.kt
@@ -11,45 +11,26 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
 import android.os.PowerManager
-import com.nextcloud.client.preferences.AppPreferences
-import com.nextcloud.client.preferences.AppPreferencesImpl
 import com.nextcloud.utils.extensions.registerBroadcastReceiver
 import com.owncloud.android.datamodel.ReceiverFlag
 
 internal class PowerManagementServiceImpl(
     private val context: Context,
-    private val platformPowerManager: PowerManager,
-    private val preferences: AppPreferences,
-    private val deviceInfo: DeviceInfo = DeviceInfo()
+    private val platformPowerManager: PowerManager
 ) : PowerManagementService {
 
     companion object {
-        /**
-         * Vendors on this list use aggressive power saving methods that might
-         * break application experience.
-         */
-        val OVERLY_AGGRESSIVE_POWER_SAVING_VENDORS = setOf("samsung", "huawei", "xiaomi")
-
         @JvmStatic
         fun fromContext(context: Context): PowerManagementServiceImpl {
             val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-            val preferences = AppPreferencesImpl.fromContext(context)
-
-            return PowerManagementServiceImpl(context, powerManager, preferences, DeviceInfo())
+            return PowerManagementServiceImpl(context, powerManager)
         }
     }
 
     override val isPowerSavingEnabled: Boolean
         get() {
-            if (preferences.isPowerCheckDisabled) {
-                return false
-            }
-
             return platformPowerManager.isPowerSaveMode
         }
-
-    override val isPowerSavingExclusionAvailable: Boolean
-        get() = deviceInfo.vendor in OVERLY_AGGRESSIVE_POWER_SAVING_VENDORS
 
     @Suppress("MagicNumber") // 100% is 100, we're not doing Cobol
     override val battery: BatteryStatus

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
@@ -17,7 +17,6 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.core.Clock
-import com.nextcloud.client.device.DeviceInfo
 import com.nextcloud.client.device.PowerManagementService
 import com.nextcloud.client.documentscan.GeneratePDFUseCase
 import com.nextcloud.client.documentscan.GeneratePdfFromImagesWork
@@ -49,7 +48,6 @@ class BackgroundJobFactory @Inject constructor(
     private val clock: Clock,
     private val powerManagementService: PowerManagementService,
     private val backgroundJobManager: Provider<BackgroundJobManager>,
-    private val deviceInfo: DeviceInfo,
     private val accountManager: UserAccountManager,
     private val resources: Resources,
     private val arbitraryDataProvider: ArbitraryDataProvider,

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -344,10 +344,6 @@ public interface AppPreferences {
 
     long getPhotoSearchTimestamp();
 
-    boolean isPowerCheckDisabled();
-
-    void setPowerCheckDisabled(boolean value);
-
     void increasePinWrongAttempts();
 
     void resetPinWrongAttempts();

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -88,7 +88,6 @@ public final class AppPreferencesImpl implements AppPreferences {
     private static final String PREF__SELECTED_ACCOUNT_NAME = "select_oc_account";
     private static final String PREF__MIGRATED_USER_ID = "migrated_user_id";
     private static final String PREF__PHOTO_SEARCH_TIMESTAMP = "photo_search_timestamp";
-    private static final String PREF__POWER_CHECK_DISABLED = "power_check_disabled";
     private static final String PREF__PIN_BRUTE_FORCE_COUNT = "pin_brute_force_count";
     private static final String PREF__UID_PID = "uid_pid";
 
@@ -687,16 +686,6 @@ public final class AppPreferencesImpl implements AppPreferences {
                                                          FileDataStorageManager.ROOT_PARENT_ID);
 
         return preferenceName + "_" + folderIdString;
-    }
-
-    @Override
-    public boolean isPowerCheckDisabled() {
-        return preferences.getBoolean(PREF__POWER_CHECK_DISABLED, false);
-    }
-
-    @Override
-    public void setPowerCheckDisabled(boolean value) {
-        preferences.edit().putBoolean(PREF__POWER_CHECK_DISABLED, value).apply();
     }
 
     public void increasePinWrongAttempts() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -199,21 +199,6 @@ class SyncedFoldersActivity :
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         val inflater = menuInflater
         inflater.inflate(R.menu.activity_synced_folders, menu)
-        if (powerManagementService.isPowerSavingExclusionAvailable) {
-            val item = menu.findItem(R.id.action_disable_power_save_check)
-            item.isVisible = true
-            item.isChecked = preferences.isPowerCheckDisabled
-            item.setOnMenuItemClickListener { powerCheck -> onDisablePowerSaveCheckClicked(powerCheck) }
-        }
-        return true
-    }
-
-    private fun onDisablePowerSaveCheckClicked(powerCheck: MenuItem): Boolean {
-        if (!powerCheck.isChecked) {
-            showPowerCheckDialog()
-        }
-        preferences.isPowerCheckDisabled = !powerCheck.isChecked
-        powerCheck.isChecked = !powerCheck.isChecked
         return true
     }
 
@@ -835,7 +820,7 @@ class SyncedFoldersActivity :
     }
 
     private fun showBatteryOptimizationInfo() {
-        if (powerManagementService.isPowerSavingExclusionAvailable || checkIfBatteryOptimizationEnabled()) {
+        if (checkIfBatteryOptimizationEnabled()) {
             val alertDialogBuilder = MaterialAlertDialogBuilder(this, R.style.Theme_ownCloud_Dialog)
                 .setTitle(getString(R.string.battery_optimization_title))
                 .setMessage(getString(R.string.battery_optimization_message))

--- a/app/src/test/java/com/nextcloud/client/device/TestPowerManagementService.kt
+++ b/app/src/test/java/com/nextcloud/client/device/TestPowerManagementService.kt
@@ -56,9 +56,7 @@ class TestPowerManagementService {
             MockitoAnnotations.initMocks(this)
             powerManagementService = PowerManagementServiceImpl(
                 context,
-                platformPowerManager,
-                preferences,
-                deviceInfo
+                platformPowerManager
             )
         }
     }
@@ -83,25 +81,10 @@ class TestPowerManagementService {
         }
 
         @Test
-        fun `power saving exclusion is available for flagged vendors`() {
-            for (vendor in PowerManagementServiceImpl.OVERLY_AGGRESSIVE_POWER_SAVING_VENDORS) {
-                whenever(deviceInfo.vendor).thenReturn(vendor)
-                assertTrue("Vendor $vendor check failed", powerManagementService.isPowerSavingExclusionAvailable)
-            }
-        }
-
-        @Test
-        fun `power saving exclusion is not available for other vendors`() {
-            whenever(deviceInfo.vendor).thenReturn("some_other_nice_vendor")
-            assertFalse(powerManagementService.isPowerSavingExclusionAvailable)
-        }
-
-        @Test
         fun `power saving check is disabled`() {
             // GIVEN
             //      a device which falsely returns power save mode enabled
             //      power check is overridden by user
-            whenever(preferences.isPowerCheckDisabled).thenReturn(true)
             whenever(platformPowerManager.isPowerSaveMode).thenReturn(true)
 
             // WHEN

--- a/app/src/test/java/com/nextcloud/client/jobs/BackgroundJobFactoryTest.kt
+++ b/app/src/test/java/com/nextcloud/client/jobs/BackgroundJobFactoryTest.kt
@@ -111,7 +111,6 @@ class BackgroundJobFactoryTest {
             clock,
             powerManagementService,
             { backgroundJobManager },
-            deviceInfo,
             accountManager,
             resources,
             dataProvider,


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

This change simplifies the handling of battery optimization settings for the app. Previously, we included logic to handle `setPowerCheckDisabled` and `isPowerSavingExclusionAvailable`, which were only applicable for certain devices listed under `OVERLY_AGGRESSIVE_POWER_SAVING_VENDORS`.

I tested with`Xiaomi HyperOS 2`, all battery settings can be managed by redirecting to the app's battery optimization page using the `Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` intent. As a result, the previous device-specific logic is no longer necessary and has been removed.


<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/318a217a-d938-4a07-b7fb-42b04869f294" width="300" alt="Image 1"></td>
  </tr>
</table>

