### PR TITLE
fix: correct query to fetch uploads by IDs and account name

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/dao/UploadDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/UploadDao.kt
@@ -9,6 +9,7 @@ package com.nextcloud.client.database.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import com.nextcloud.client.database.entity.UploadEntity
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
 
 @Dao
@@ -19,4 +20,11 @@ interface UploadDao {
             ProviderTableMeta.UPLOADS_ACCOUNT_NAME + " = :accountName AND _id IS NOT NULL"
     )
     fun getAllIds(status: Int, accountName: String): List<Int>
+
+    @Query(
+        "SELECT * FROM " + ProviderTableMeta.UPLOADS_TABLE_NAME +
+            " WHERE " + ProviderTableMeta._ID + " IN (:ids) AND " +
+            ProviderTableMeta.UPLOADS_ACCOUNT_NAME + " = :accountName"
+    )
+    fun getUploadsByIds(ids: LongArray, accountName: String): List<UploadEntity>
 }

--- a/app/src/main/java/com/nextcloud/client/database/entity/UploadEntity.kt
+++ b/app/src/main/java/com/nextcloud/client/database/entity/UploadEntity.kt
@@ -10,7 +10,13 @@ package com.nextcloud.client.database.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.nextcloud.utils.autoRename.AutoRename
+import com.owncloud.android.datamodel.UploadsStorageManager
+import com.owncloud.android.db.OCUpload
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
+import com.owncloud.android.db.UploadResult
+import com.owncloud.android.files.services.NameCollisionPolicy
+import com.owncloud.android.lib.resources.status.OCCapability
 
 @Entity(tableName = ProviderTableMeta.UPLOADS_TABLE_NAME)
 data class UploadEntity(
@@ -48,3 +54,27 @@ data class UploadEntity(
     @ColumnInfo(name = ProviderTableMeta.UPLOADS_FOLDER_UNLOCK_TOKEN)
     val folderUnlockToken: String?
 )
+
+fun UploadEntity.toOCUpload(capability: OCCapability? = null): OCUpload {
+    val localPath = localPath
+    var remotePath = remotePath
+    if (capability != null && remotePath != null) {
+        remotePath = AutoRename.rename(remotePath, capability)
+    }
+    val upload = OCUpload(localPath, remotePath, accountName)
+
+    fileSize?.let { upload.fileSize = it }
+    id?.let { upload.uploadId = it.toLong() }
+    status?.let { upload.uploadStatus = UploadsStorageManager.UploadStatus.fromValue(it) }
+    localBehaviour?.let { upload.localAction = it }
+    nameCollisionPolicy?.let { upload.nameCollisionPolicy = NameCollisionPolicy.deserialize(it) }
+    isCreateRemoteFolder?.let { upload.isCreateRemoteFolder = it == 1 }
+    uploadEndTimestamp?.let { upload.uploadEndTimestamp = it.toLong() }
+    lastResult?.let { upload.lastResult = UploadResult.fromValue(it) }
+    createdBy?.let { upload.createdBy = it }
+    isWifiOnly?.let { upload.isUseWifiOnly = it == 1 }
+    isWhileChargingOnly?.let { upload.isWhileChargingOnly = it == 1 }
+    folderUnlockToken?.let { upload.folderUnlockToken = it }
+
+    return upload
+}

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -633,13 +633,15 @@ internal class BackgroundJobManagerImpl(
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
 
+            val dataBuilder = Data.Builder()
+                .putBoolean(FileUploadWorker.IS_AUTO_UPLOAD, isAutoUpload)
+                .putString(FileUploadWorker.ACCOUNT, user.accountName)
+                .putInt(FileUploadWorker.TOTAL_UPLOAD_SIZE, uploadIds.size)
+
             val workRequests = batches.mapIndexed { index, batch ->
-                val dataBuilder = Data.Builder()
-                    .putBoolean(FileUploadWorker.IS_AUTO_UPLOAD, isAutoUpload)
-                    .putString(FileUploadWorker.ACCOUNT, user.accountName)
+                dataBuilder
                     .putLongArray(FileUploadWorker.UPLOAD_IDS, batch.toLongArray())
                     .putInt(FileUploadWorker.CURRENT_BATCH_INDEX, index)
-                    .putInt(FileUploadWorker.TOTAL_UPLOAD_SIZE, uploadIds.size)
 
                 oneTimeRequestBuilder(FileUploadWorker::class, JOB_FILES_UPLOAD, user)
                     .addTag(tag)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -158,8 +158,7 @@ class FileUploadWorker(
         }
 
         val previouslyUploadedFileSize = currentBatchIndex * FileUploadHelper.MAX_FILE_COUNT
-
-        val uploads = uploadIds.map { id -> uploadsStorageManager.getUploadById(id) }.filterNotNull()
+        val uploads = uploadsStorageManager.getUploadsByIds(uploadIds, accountName)
 
         for ((index, upload) in uploads.withIndex()) {
             if (preferences.isGlobalUploadPaused) {

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -27,6 +27,8 @@ import com.nextcloud.client.account.CurrentAccountProvider;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.database.NextcloudDatabase;
 import com.nextcloud.client.database.dao.UploadDao;
+import com.nextcloud.client.database.entity.UploadEntity;
+import com.nextcloud.client.database.entity.UploadEntityKt;
 import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.utils.autoRename.AutoRename;
@@ -437,6 +439,20 @@ public class UploadsStorageManager extends Observable {
         return result;
     }
 
+    public List<OCUpload> getUploadsByIds(long[] uploadIds, String accountName) {
+        final List<OCUpload> result = new ArrayList<>();
+
+        final List<UploadEntity> entities = uploadDao.getUploadsByIds(uploadIds, accountName);
+        entities.forEach(uploadEntity -> {
+            OCUpload ocUpload = createOCUploadFromEntity(uploadEntity);
+            if (ocUpload != null) {
+                result.add(ocUpload);
+            }
+        });
+
+        return result;
+    }
+
     private OCUpload[] getUploads(@Nullable String selection, @Nullable String... selectionArgs) {
         final List<OCUpload> uploads = new ArrayList<>();
         long page = 0;
@@ -553,6 +569,15 @@ public class UploadsStorageManager extends Observable {
             c.close();
         }
         return uploads;
+    }
+
+    @Nullable
+    private OCUpload createOCUploadFromEntity(UploadEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        initOCCapability();
+        return UploadEntityKt.toOCUpload(entity, capability);
     }
 
     private OCUpload createOCUploadFromCursor(Cursor c) {

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -636,16 +636,6 @@ public class UploadsStorageManager extends Observable {
     }
 
     /**
-     * Gets a page of uploads after <code>afterId</code>, where uploads are sorted by ascending upload id.
-     * <p>
-     * If <code>afterId</code> is -1, returns the first page
-     */
-    public List<OCUpload> getCurrentAndPendingUploadsForAccountPageAscById(final long afterId, final @NonNull String accountName) {
-        final String selection = getInProgressAndDelayedUploadsSelection();
-        return getUploadPage(QUERY_PAGE_SIZE, afterId, false, selection, accountName);
-    }
-
-    /**
      * Get all failed uploads.
      */
     public OCUpload[] getFailedUploads() {
@@ -681,13 +671,6 @@ public class UploadsStorageManager extends Observable {
                               ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL, user.getAccountName());
     }
 
-    /**
-     * Get all uploads which where successfully completed.
-     */
-    public OCUpload[] getFinishedUploads() {
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_SUCCEEDED.value, (String[]) null);
-    }
-
     public OCUpload[] getFailedButNotDelayedUploadsForCurrentAccount() {
         User user = currentAccountProvider.getUser();
 
@@ -702,25 +685,6 @@ public class UploadsStorageManager extends Observable {
                               ANGLE_BRACKETS + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue() +
                               AND + ProviderTableMeta.UPLOADS_ACCOUNT_NAME + IS_EQUAL,
                           user.getAccountName());
-    }
-
-    /**
-     * Get all failed uploads, except for those that were not performed due to lack of Wifi connection.
-     *
-     * @return Array of failed uploads, except for those that were not performed due to lack of Wifi connection.
-     */
-    public OCUpload[] getFailedButNotDelayedUploads() {
-
-        return getUploads(ProviderTableMeta.UPLOADS_STATUS + EQUAL + UploadStatus.UPLOAD_FAILED.value + AND +
-                              ProviderTableMeta.UPLOADS_LAST_RESULT + ANGLE_BRACKETS + UploadResult.LOCK_FAILED.getValue() +
-                              AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              ANGLE_BRACKETS + UploadResult.DELAYED_FOR_WIFI.getValue() +
-                              AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              ANGLE_BRACKETS + UploadResult.DELAYED_FOR_CHARGING.getValue() +
-                              AND + ProviderTableMeta.UPLOADS_LAST_RESULT +
-                              ANGLE_BRACKETS + UploadResult.DELAYED_IN_POWER_SAVE_MODE.getValue(),
-                          (String[]) null
-                         );
     }
 
     private ContentResolver getDB() {
@@ -846,39 +810,6 @@ public class UploadsStorageManager extends Observable {
             upload.getRemotePath(),
             localPath
                           );
-    }
-
-    /**
-     * Changes the status of any in progress upload from UploadStatus.UPLOAD_IN_PROGRESS to UploadStatus.UPLOAD_FAILED
-     *
-     * @return Number of uploads which status was changed.
-     */
-    public int failInProgressUploads(UploadResult fail) {
-        Log_OC.v(TAG, "Updating state of any killed upload");
-
-        ContentValues cv = new ContentValues();
-        cv.put(ProviderTableMeta.UPLOADS_STATUS, UploadStatus.UPLOAD_FAILED.getValue());
-        cv.put(
-            ProviderTableMeta.UPLOADS_LAST_RESULT,
-            fail != null ? fail.getValue() : UploadResult.UNKNOWN.getValue()
-              );
-        cv.put(ProviderTableMeta.UPLOADS_UPLOAD_END_TIMESTAMP, Calendar.getInstance().getTimeInMillis());
-
-        int result = getDB().update(
-            ProviderTableMeta.CONTENT_URI_UPLOADS,
-            cv,
-            ProviderTableMeta.UPLOADS_STATUS + "=?",
-            new String[]{String.valueOf(UploadStatus.UPLOAD_IN_PROGRESS.getValue())}
-                                   );
-
-        if (result == 0) {
-            Log_OC.v(TAG, "No upload was killed");
-        } else {
-            Log_OC.w(TAG, Integer.toString(result) + " uploads where abruptly interrupted");
-            notifyObserversNow();
-        }
-
-        return result;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Previously, returning incorrect uploads because it did not filter by both IDs and account name properly. This fixes the query to ensure only uploads that match the provided IDs and the given account name are returned.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
