### PR TITLE
fix: extended list fragment on key listener

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -748,13 +748,12 @@ open class ExtendedListFragment :
     }
 
     protected fun setupBackButtonRedirectToAllFiles() {
-        val fda = getTypedActivity(FileActivity::class.java)
-        val currentDir = fda?.currentDir ?: return
-
         view?.isFocusableInTouchMode = true
         view?.requestFocus()
         view?.setOnKeyListener { _: View, keyCode: Int, event: KeyEvent ->
             if (event.action == KeyEvent.ACTION_UP && keyCode == KeyEvent.KEYCODE_BACK) {
+                val fda = getTypedActivity(FileActivity::class.java)
+                val currentDir = fda?.currentDir ?: return@setOnKeyListener false
                 return@setOnKeyListener fda.handleBackButtonEvent(currentDir)
             }
             false


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed


### Issue

`setOnKeyListener` does not receive the latest `currentDir`.