### PR TITLE
fix: empty list text

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -52,7 +52,6 @@ import com.google.android.material.button.MaterialButton
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.di.Injectable
-import com.nextcloud.client.network.ConnectivityService.GenericCallback
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.client.preferences.AppPreferencesImpl
 import com.nextcloud.utils.extensions.getTypedActivity
@@ -684,17 +683,13 @@ open class ExtendedListFragment :
      */
     fun setEmptyListLoadingMessage() {
         lifecycleScope.launch(Dispatchers.Main) {
-            val fileActivity = getTypedActivity(FileActivity::class.java)
-            fileActivity?.connectivityService?.isNetworkAndServerAvailable(
-                GenericCallback { result: Boolean? ->
-                    if (result == false || mEmptyListContainer == null || mEmptyListMessage == null) {
-                        return@GenericCallback
-                    }
-                    mEmptyListHeadline?.setText(R.string.file_list_loading)
-                    mEmptyListMessage?.text = ""
-                    mEmptyListIcon?.visibility = View.GONE
-                }
-            )
+            if (mEmptyListContainer == null || mEmptyListMessage == null) {
+                return@launch
+            }
+
+            mEmptyListHeadline?.setText(R.string.file_list_loading)
+            mEmptyListMessage?.text = ""
+            mEmptyListIcon?.visibility = View.GONE
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The `setEmptyListLoadingMessage()` function was performing an asynchronous `isNetworkAndServerAvailable()` check before updating the UI. This introduced timing issues where the wrong text message could appear in certain scenarios.

### How to reproduce?

1. Open the app with an empty root directory.
2. Observe that the empty list message may display incorrectly.

### Changes

Removed the internal `isNetworkAndServerAvailable()` check from `setEmptyListLoadingMessage().`
The method now directly updates the UI with the loading message, since network availability is already handled by the calling logic (e.g., `FolderPickerActivity.mSyncInProgress`,` LocalFileListFragment.setLoading`).

Ensured `setBackgroundText()` is called whenever `mSyncInProgress` changes in `FileDisplayActivity`.

Updated `FileDisplayActivity` to set `mSyncInProgress` to false once operations are finished, preventing stale loading messages.


### Before

https://github.com/user-attachments/assets/3dd001e9-34a2-4e76-84d1-04e221ed09c6

### After

https://github.com/user-attachments/assets/e007ff54-41d6-482b-8329-c226374321c1

