### PR TITLE
fix: empty list state handling

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/client/FileDisplayActivityScreenshotIT.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/FileDisplayActivityScreenshotIT.kt
@@ -24,7 +24,7 @@ import com.owncloud.android.AbstractIT
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.activity.FileDisplayActivity
-import com.owncloud.android.ui.fragment.SearchType
+import com.owncloud.android.ui.fragment.EmptyListState
 import com.owncloud.android.utils.EspressoIdlingResource
 import com.owncloud.android.utils.ScreenshotTest
 import org.junit.After
@@ -69,7 +69,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
                             listOfFilesFragment?.let {
                                 it.setFabEnabled(false)
                                 resetScrolling(true)
-                                it.setEmptyListMessage(SearchType.LOADING)
+                                it.setEmptyListMessage(EmptyListState.LOADING)
                                 it.isLoading = false
                             }
                         }
@@ -99,7 +99,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
                         val fragment = sut.listOfFilesFragment
                         Assert.assertNotNull(fragment)
                         fragment!!.setFabEnabled(false)
-                        fragment.setEmptyListMessage(SearchType.LOADING)
+                        fragment.setEmptyListMessage(EmptyListState.LOADING)
                         fragment.isLoading = false
                         EspressoIdlingResource.decrement()
 
@@ -114,7 +114,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
 
                         EspressoIdlingResource.increment()
                         fragment.setFabEnabled(false)
-                        fragment.setEmptyListMessage(SearchType.LOADING)
+                        fragment.setEmptyListMessage(EmptyListState.LOADING)
                         fragment.isLoading = false
                         EspressoIdlingResource.decrement()
 
@@ -147,7 +147,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
 
                             listOfFilesFragment?.let {
                                 it.setFabEnabled(false)
-                                it.setEmptyListMessage(SearchType.LOADING)
+                                it.setEmptyListMessage(EmptyListState.LOADING)
                                 it.isLoading = false
                             }
                         }

--- a/app/src/androidTest/java/com/nextcloud/client/FileDisplayActivityScreenshotIT.kt
+++ b/app/src/androidTest/java/com/nextcloud/client/FileDisplayActivityScreenshotIT.kt
@@ -24,6 +24,7 @@ import com.owncloud.android.AbstractIT
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.activity.FileDisplayActivity
+import com.owncloud.android.ui.fragment.SearchType
 import com.owncloud.android.utils.EspressoIdlingResource
 import com.owncloud.android.utils.ScreenshotTest
 import org.junit.After
@@ -68,7 +69,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
                             listOfFilesFragment?.let {
                                 it.setFabEnabled(false)
                                 resetScrolling(true)
-                                it.setEmptyListLoadingMessage()
+                                it.setEmptyListMessage(SearchType.LOADING)
                                 it.isLoading = false
                             }
                         }
@@ -98,7 +99,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
                         val fragment = sut.listOfFilesFragment
                         Assert.assertNotNull(fragment)
                         fragment!!.setFabEnabled(false)
-                        fragment.setEmptyListLoadingMessage()
+                        fragment.setEmptyListMessage(SearchType.LOADING)
                         fragment.isLoading = false
                         EspressoIdlingResource.decrement()
 
@@ -113,7 +114,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
 
                         EspressoIdlingResource.increment()
                         fragment.setFabEnabled(false)
-                        fragment.setEmptyListLoadingMessage()
+                        fragment.setEmptyListMessage(SearchType.LOADING)
                         fragment.isLoading = false
                         EspressoIdlingResource.decrement()
 
@@ -146,7 +147,7 @@ class FileDisplayActivityScreenshotIT : AbstractIT() {
 
                             listOfFilesFragment?.let {
                                 it.setFabEnabled(false)
-                                it.setEmptyListLoadingMessage()
+                                it.setEmptyListMessage(SearchType.LOADING)
                                 it.isLoading = false
                             }
                         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -120,6 +120,7 @@ import com.owncloud.android.ui.dialog.TermsOfServiceDialog
 import com.owncloud.android.ui.events.SearchEvent
 import com.owncloud.android.ui.events.SyncEventFinished
 import com.owncloud.android.ui.events.TokenPushEvent
+import com.owncloud.android.ui.fragment.EmptyListState
 import com.owncloud.android.ui.fragment.FileDetailFragment
 import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.fragment.GalleryFragment
@@ -1601,18 +1602,13 @@ class FileDisplayActivity :
         connectivityService.isNetworkAndServerAvailable { result: Boolean? ->
             when {
                 mSyncInProgress && result == true -> {
-                    ocFileListFragment.setEmptyListLoadingMessage()
+                    ocFileListFragment.setEmptyListMessage(EmptyListState.LOADING)
                 }
                 MainApp.isOnlyOnDevice() -> {
-                    ocFileListFragment.setMessageForEmptyList(
-                        R.string.file_list_empty_headline,
-                        R.string.file_list_empty_on_device,
-                        R.drawable.ic_list_empty_folder,
-                        true
-                    )
+                    ocFileListFragment.setEmptyListMessage(EmptyListState.ONLY_ON_DEVICE)
                 }
                 result == true -> ocFileListFragment.setEmptyListMessage(SearchType.NO_SEARCH)
-                else -> ocFileListFragment.setEmptyListMessage(SearchType.OFFLINE_MODE)
+                else -> ocFileListFragment.setEmptyListMessage(EmptyListState.OFFLINE_MODE)
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -191,7 +191,11 @@ class FileDisplayActivity :
 
     private var mWaitingToPreview: OCFile? = null
 
-    private var mSyncInProgress = false
+    private var mSyncInProgress: Boolean = false
+        set(value) {
+            field = value
+            setBackgroundText()
+        }
 
     private var mWaitingToSend: OCFile? = null
 
@@ -1435,8 +1439,10 @@ class FileDisplayActivity :
                 ) {
                     mLastSslUntrustedServerResult = syncResult
                 }
-            } catch (e: java.lang.RuntimeException) {
+            } catch (_: java.lang.RuntimeException) {
                 safelyDeleteResult(intent)
+            } finally {
+                mSyncInProgress = false
             }
         }
     }
@@ -1486,7 +1492,6 @@ class FileDisplayActivity :
         Log_OC.d(TAG, "Setting progress visibility to $mSyncInProgress")
 
         handleScrollBehaviour(fileListFragment)
-        setBackgroundText()
     }
 
     private fun handleRemovedFileFromServer(currentFile: OCFile?, currentDir: OCFile?): OCFile? {
@@ -1592,36 +1597,23 @@ class FileDisplayActivity :
      * Show a text message on screen view for notifying user if content is loading or folder is empty
      */
     private fun setBackgroundText() {
-        val ocFileListFragment = this.listOfFilesFragment
-        if (ocFileListFragment != null) {
-            if (mSyncInProgress ||
-                file.fileLength > 0 &&
-                storageManager.getFolderContent(
-                    file,
-                    false
-                ).isEmpty()
-            ) {
-                ocFileListFragment.setEmptyListLoadingMessage()
-            } else {
-                if (MainApp.isOnlyOnDevice()) {
+        val ocFileListFragment = listOfFilesFragment ?: return
+        connectivityService.isNetworkAndServerAvailable { result: Boolean? ->
+            when {
+                mSyncInProgress && result == true -> {
+                    ocFileListFragment.setEmptyListLoadingMessage()
+                }
+                MainApp.isOnlyOnDevice() -> {
                     ocFileListFragment.setMessageForEmptyList(
                         R.string.file_list_empty_headline,
                         R.string.file_list_empty_on_device,
                         R.drawable.ic_list_empty_folder,
                         true
                     )
-                } else {
-                    connectivityService.isNetworkAndServerAvailable { result: Boolean? ->
-                        if (result == true) {
-                            ocFileListFragment.setEmptyListMessage(SearchType.NO_SEARCH)
-                        } else {
-                            ocFileListFragment.setEmptyListMessage(SearchType.OFFLINE_MODE)
-                        }
-                    }
                 }
+                result == true -> ocFileListFragment.setEmptyListMessage(SearchType.NO_SEARCH)
+                else -> ocFileListFragment.setEmptyListMessage(SearchType.OFFLINE_MODE)
             }
-        } else {
-            Log_OC.e(TAG, "OCFileListFragment is null")
         }
     }
 
@@ -2379,7 +2371,7 @@ class FileDisplayActivity :
                 if (fragment != null && fragment !is GalleryFragment) {
                     fragment.setLoading(true)
                 }
-                setBackgroundText()
+                mSyncInProgress = false
             }, DELAY_TO_REQUEST_REFRESH_OPERATION_LATER)
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -40,6 +40,7 @@ import com.owncloud.android.syncadapter.FileSyncAdapter
 import com.owncloud.android.ui.dialog.CreateFolderDialogFragment
 import com.owncloud.android.ui.dialog.SortingOrderDialogFragment.OnSortingOrderListener
 import com.owncloud.android.ui.events.SearchEvent
+import com.owncloud.android.ui.fragment.EmptyListState
 import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.fragment.OCFileListFragment
 import com.owncloud.android.utils.DataHolderUtil
@@ -221,15 +222,10 @@ open class FolderPickerActivity :
         }
 
         listFragment?.let {
-            if (!mSyncInProgress) {
-                it.setMessageForEmptyList(
-                    R.string.folder_list_empty_headline,
-                    R.string.file_list_empty_moving,
-                    R.drawable.ic_list_empty_create_folder,
-                    true
-                )
+            if (mSyncInProgress) {
+                it.setEmptyListMessage(EmptyListState.LOADING)
             } else {
-                it.setEmptyListLoadingMessage()
+                it.setEmptyListMessage(EmptyListState.ADD_FOLDER)
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -52,7 +52,6 @@ import com.google.android.material.button.MaterialButton
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.di.Injectable
-import com.nextcloud.client.network.ConnectivityService.GenericCallback
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.client.preferences.AppPreferencesImpl
 import com.nextcloud.utils.extensions.getTypedActivity
@@ -684,17 +683,13 @@ open class ExtendedListFragment :
      */
     fun setEmptyListLoadingMessage() {
         lifecycleScope.launch(Dispatchers.Main) {
-            val fileActivity = getTypedActivity(FileActivity::class.java)
-            fileActivity?.connectivityService?.isNetworkAndServerAvailable(
-                GenericCallback { result: Boolean? ->
-                    if (result == false || mEmptyListContainer == null || mEmptyListMessage == null) {
-                        return@GenericCallback
-                    }
-                    mEmptyListHeadline?.setText(R.string.file_list_loading)
-                    mEmptyListMessage?.text = ""
-                    mEmptyListIcon?.visibility = View.GONE
-                }
-            )
+            if (mEmptyListContainer == null || mEmptyListMessage == null) {
+                return@launch
+            }
+
+            mEmptyListHeadline?.setText(R.string.file_list_loading)
+            mEmptyListMessage?.text = ""
+            mEmptyListIcon?.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -603,120 +603,118 @@ open class ExtendedListFragment :
 
     @Suppress("LongMethod")
     fun setEmptyListMessage(state: Parcelable?) {
-        Handler(Looper.getMainLooper()).post {
-            when (state) {
-                SearchType.NO_SEARCH -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline,
-                        getEmptyListViewTextId(),
-                        R.drawable.ic_list_empty_folder,
-                        true
-                    )
-                }
-                SearchType.FILE_SEARCH -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline_server_search,
-                        R.string.file_list_empty,
-                        R.drawable.ic_search_light_grey
-                    )
-                }
-                SearchType.FAVORITE_SEARCH -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_favorite_headline,
-                        R.string.file_list_empty_favorites_filter_list,
-                        R.drawable.ic_star_light_yellow
-                    )
-                }
-                SearchType.RECENTLY_MODIFIED_SEARCH -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline_server_search,
-                        R.string.file_list_empty_recently_modified,
-                        R.drawable.ic_list_empty_recent
-                    )
-                }
-                SearchType.REGULAR_FILTER -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline_search,
-                        R.string.file_list_empty_search,
-                        R.drawable.ic_search_light_grey
-                    )
-                }
-                SearchType.SHARED_FILTER -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_shared_headline,
-                        R.string.file_list_empty_shared,
-                        R.drawable.ic_list_empty_shared
-                    )
-                }
-                SearchType.GALLERY_SEARCH -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline_server_search,
-                        R.string.file_list_empty_gallery,
-                        R.drawable.file_image
-                    )
-                }
-                SearchType.LOCAL_SEARCH -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline_server_search,
-                        R.string.file_list_empty_local_search,
-                        R.drawable.ic_search_light_grey
-                    )
-                }
-                EmptyListState.OFFLINE_MODE -> {
-                    setMessageForEmptyList(
-                        R.string.offline_mode_info_title,
-                        R.string.offline_mode_info_description,
-                        R.drawable.ic_cloud_sync,
-                        true
-                    )
-                }
-                EmptyListState.LOADING -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_loading,
-                        R.string.empty,
-                        null
-                    )
-                }
-                EmptyListState.ADD_FOLDER -> {
-                    setMessageForEmptyList(
-                        R.string.folder_list_empty_headline,
-                        R.string.file_list_empty_moving,
-                        R.drawable.ic_list_empty_create_folder,
-                        true
-                    )
-                }
-                EmptyListState.ONLY_ON_DEVICE -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline,
-                        R.string.file_list_empty_on_device,
-                        R.drawable.ic_list_empty_folder,
-                        true
-                    )
-                }
-                EmptyListState.LOCAL_FILE_LIST_EMPTY_FILE -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline,
-                        R.string.local_file_list_empty,
-                        R.drawable.ic_list_empty_folder,
-                        true
-                    )
-                }
-                EmptyListState.LOCAL_FILE_LIST_EMPTY_FOLDER -> {
-                    setMessageForEmptyList(
-                        R.string.folder_list_empty_headline,
-                        R.string.local_folder_list_empty,
-                        R.drawable.ic_list_empty_folder,
-                        true
-                    )
-                }
-                else -> {
-                    setMessageForEmptyList(
-                        R.string.file_list_empty_headline,
-                        getEmptyListViewTextId(),
-                        R.drawable.ic_list_empty_folder,
-                        true
-                    )
-                }
+        when (state) {
+            SearchType.NO_SEARCH -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline,
+                    getEmptyListViewTextId(),
+                    R.drawable.ic_list_empty_folder,
+                    true
+                )
+            }
+            SearchType.FILE_SEARCH -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline_server_search,
+                    R.string.file_list_empty,
+                    R.drawable.ic_search_light_grey
+                )
+            }
+            SearchType.FAVORITE_SEARCH -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_favorite_headline,
+                    R.string.file_list_empty_favorites_filter_list,
+                    R.drawable.ic_star_light_yellow
+                )
+            }
+            SearchType.RECENTLY_MODIFIED_SEARCH -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline_server_search,
+                    R.string.file_list_empty_recently_modified,
+                    R.drawable.ic_list_empty_recent
+                )
+            }
+            SearchType.REGULAR_FILTER -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline_search,
+                    R.string.file_list_empty_search,
+                    R.drawable.ic_search_light_grey
+                )
+            }
+            SearchType.SHARED_FILTER -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_shared_headline,
+                    R.string.file_list_empty_shared,
+                    R.drawable.ic_list_empty_shared
+                )
+            }
+            SearchType.GALLERY_SEARCH -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline_server_search,
+                    R.string.file_list_empty_gallery,
+                    R.drawable.file_image
+                )
+            }
+            SearchType.LOCAL_SEARCH -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline_server_search,
+                    R.string.file_list_empty_local_search,
+                    R.drawable.ic_search_light_grey
+                )
+            }
+            EmptyListState.OFFLINE_MODE -> {
+                setMessageForEmptyList(
+                    R.string.offline_mode_info_title,
+                    R.string.offline_mode_info_description,
+                    R.drawable.ic_cloud_sync,
+                    true
+                )
+            }
+            EmptyListState.LOADING -> {
+                setMessageForEmptyList(
+                    R.string.file_list_loading,
+                    R.string.empty,
+                    null
+                )
+            }
+            EmptyListState.ADD_FOLDER -> {
+                setMessageForEmptyList(
+                    R.string.folder_list_empty_headline,
+                    R.string.file_list_empty_moving,
+                    R.drawable.ic_list_empty_create_folder,
+                    true
+                )
+            }
+            EmptyListState.ONLY_ON_DEVICE -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline,
+                    R.string.file_list_empty_on_device,
+                    R.drawable.ic_list_empty_folder,
+                    true
+                )
+            }
+            EmptyListState.LOCAL_FILE_LIST_EMPTY_FILE -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline,
+                    R.string.local_file_list_empty,
+                    R.drawable.ic_list_empty_folder,
+                    true
+                )
+            }
+            EmptyListState.LOCAL_FILE_LIST_EMPTY_FOLDER -> {
+                setMessageForEmptyList(
+                    R.string.folder_list_empty_headline,
+                    R.string.local_folder_list_empty,
+                    R.drawable.ic_list_empty_folder,
+                    true
+                )
+            }
+            else -> {
+                setMessageForEmptyList(
+                    R.string.file_list_empty_headline,
+                    getEmptyListViewTextId(),
+                    R.drawable.ic_list_empty_folder,
+                    true
+                )
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -602,7 +602,7 @@ open class ExtendedListFragment :
     }
 
     @Suppress("LongMethod")
-    fun setEmptyListMessage(state: Parcelable) {
+    fun setEmptyListMessage(state: Parcelable?) {
         Handler(Looper.getMainLooper()).post {
             when (state) {
                 SearchType.NO_SEARCH -> {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -249,7 +249,7 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
 
     private void handleSearchEvent() {
         prepareCurrentSearch(searchEvent);
-        setEmptyListLoadingMessage();
+        setEmptyListMessage(EmptyListState.LOADING);
 
         // always show first stored items
         showAllGalleryItems();

--- a/app/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -90,12 +90,10 @@ public class LocalFileListFragment extends ExtendedListFragment implements
         Log_OC.i(TAG, "onCreateView() start");
         View v = super.onCreateView(inflater, container, savedInstanceState);
 
-        if (!mContainerActivity.isFolderPickerMode()) {
-            setMessageForEmptyList(R.string.file_list_empty_headline, R.string.local_file_list_empty,
-                    R.drawable.ic_list_empty_folder, true);
+        if (mContainerActivity.isFolderPickerMode()) {
+            setEmptyListMessage(EmptyListState.LOCAL_FILE_LIST_EMPTY_FOLDER);
         } else {
-            setMessageForEmptyList(R.string.folder_list_empty_headline, R.string.local_folder_list_empty,
-                    R.drawable.ic_list_empty_folder, true);
+            setEmptyListMessage(EmptyListState.LOCAL_FILE_LIST_EMPTY_FILE);
         }
 
         setSwipeEnabled(false); // Disable pull-to-refresh
@@ -387,7 +385,7 @@ public class LocalFileListFragment extends ExtendedListFragment implements
     public void setLoading(boolean enabled) {
         super.setLoading(enabled);
         if (enabled) {
-            setEmptyListLoadingMessage();
+            setEmptyListMessage(EmptyListState.LOADING);
         } else {
             // ugly hack because setEmptyListLoadingMessage also uses a handler and there's a race condition otherwise
             new Handler().post(() -> {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1196,7 +1196,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         } else {
             // update state and view of this fragment
             searchFragment = false;
-            setEmptyListLoadingMessage();
+            setEmptyListMessage(EmptyListState.LOADING);
             browseToFolder(file, position);
         }
     }
@@ -1886,7 +1886,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
         prepareCurrentSearch(event);
         searchFragment = true;
-        setEmptyListLoadingMessage();
+        setEmptyListMessage(EmptyListState.LOADING);
         mAdapter.setData(new ArrayList<>(),
                          NO_SEARCH,
                          mContainerActivity.getStorageManager(),

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListSearchAsyncTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListSearchAsyncTask.kt
@@ -36,7 +36,7 @@ class OCFileListSearchAsyncTask(
         fragmentReference.get()?.let { fragment ->
             Handler(Looper.getMainLooper()).post {
                 fragment.isLoading = true
-                fragment.setEmptyListLoadingMessage()
+                fragment.setEmptyListMessage(EmptyListState.LOADING)
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/SearchType.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/SearchType.kt
@@ -22,6 +22,15 @@ enum class SearchType : Parcelable {
 
     // not a real filter, but nevertheless
     SHARED_FILTER,
-    GROUPFOLDER,
-    OFFLINE_MODE
+    GROUPFOLDER
+}
+
+@Parcelize
+enum class EmptyListState : Parcelable {
+    OFFLINE_MODE,
+    LOADING,
+    ADD_FOLDER,
+    ONLY_ON_DEVICE,
+    LOCAL_FILE_LIST_EMPTY_FILE,
+    LOCAL_FILE_LIST_EMPTY_FOLDER
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The `setEmptyListLoadingMessage()` function was performing an asynchronous `isNetworkAndServerAvailable()` check before updating the UI. This introduced timing issues where the wrong text message could appear in certain scenarios.

Multiple functions were previously used to set the empty list state, leading to inconsistent behavior.

The same state was sometimes applied consecutively, resulting in redundant operations.

### How to reproduce?

1. Open the app with an empty root directory.
2. Observe that the empty list message may display incorrectly.

### Changes

Removed the internal `isNetworkAndServerAvailable()` check from `setEmptyListLoadingMessage().`
The method now directly updates the UI with the loading message, since network availability is already handled by the calling logic (e.g., `FolderPickerActivity.mSyncInProgress`,` LocalFileListFragment.setLoading`).

Ensured `setBackgroundText()` is called whenever `mSyncInProgress` changes in `FileDisplayActivity`.

Updated `FileDisplayActivity` to set `mSyncInProgress` to false once operations are finished, preventing stale loading messages.

Consolidate empty list state handling into a single function, `setEmptyListMessage(state: Parcelable)`

Consolidate empty list state handling by separating empty list state from search event into distinct `Parcelable` enum classes.


### Before

https://github.com/user-attachments/assets/3dd001e9-34a2-4e76-84d1-04e221ed09c6

### After


https://github.com/user-attachments/assets/4c01cfa8-dc9f-4c6f-95f1-bf00858fc3f9

