### PR TITLE
fix: initial thumbnail generation

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -928,6 +928,8 @@ public final class DisplayUtils {
             }
         }
 
+        thumbnailView.setTag(file.getFileId());
+
         try {
             final ThumbnailsCacheManager.ThumbnailGenerationTask task =
                 new ThumbnailsCacheManager.ThumbnailGenerationTask(thumbnailView,
@@ -983,6 +985,7 @@ public final class DisplayUtils {
             task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
                                    new ThumbnailsCacheManager.ThumbnailGenerationTaskObject(file,
                                                                                             file.getRemoteId()));
+            thumbnailView.invalidate();
         } catch (IllegalArgumentException e) {
             Log_OC.d(TAG, "ThumbnailGenerationTask : " + e.getMessage());
         }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

On the first launch, the thumbnail does not appear in the `FileActionsBottomSheet`.

### How to Reproduce?

Ensure the cache is empty.
Open the media tab.
Tap the “More” button.
Observe that the thumbnail does not appear in the `FileActionsBottomSheet`.
