### PR TITLE
fix: stuck sync dialog

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -78,7 +78,8 @@ class OfflineSyncWork(
                     true,
                     context,
                     storageManager,
-                    true
+                    true,
+                    false
                 )
                 synchronizeFileOperation.execute(context)
             }

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -30,7 +30,11 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation;
 import com.owncloud.android.lib.resources.files.model.RemoteFile;
 import com.owncloud.android.operations.common.SyncOperation;
+import com.owncloud.android.ui.events.DialogEvent;
+import com.owncloud.android.ui.events.DialogEventType;
 import com.owncloud.android.utils.FileStorageUtils;
+
+import org.greenrobot.eventbus.EventBus;
 
 /**
  * Remote operation performing the read of remote file in the ownCloud server.
@@ -47,6 +51,7 @@ public class SynchronizeFileOperation extends SyncOperation {
     private Context mContext;
     private boolean mTransferWasRequested;
     private final boolean syncInBackgroundWorker;
+    private boolean postDialogEvent = true;
 
 
     /**
@@ -77,7 +82,8 @@ public class SynchronizeFileOperation extends SyncOperation {
         boolean syncFileContents,
         Context context,
         FileDataStorageManager storageManager,
-        boolean syncInBackgroundWorker) {
+        boolean syncInBackgroundWorker,
+        boolean postDialogEvent) {
         super(storageManager);
 
         mRemotePath = remotePath;
@@ -88,6 +94,7 @@ public class SynchronizeFileOperation extends SyncOperation {
         mContext = context;
         mAllowUploads = true;
         this.syncInBackgroundWorker = syncInBackgroundWorker;
+        this.postDialogEvent = postDialogEvent;
     }
 
 
@@ -281,6 +288,9 @@ public class SynchronizeFileOperation extends SyncOperation {
         Log_OC.i(TAG, "Synchronizing " + mUser.getAccountName() + ", file " + mLocalFile.getRemotePath() +
             ": " + result.getLogMessage());
 
+        if (postDialogEvent) {
+            EventBus.getDefault().post(new DialogEvent(DialogEventType.SYNC));
+        }
         return result;
     }
 

--- a/app/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/app/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -82,6 +82,7 @@ public class OperationsService extends Service {
     private static final String TAG = OperationsService.class.getSimpleName();
 
     public static final String EXTRA_ACCOUNT = "ACCOUNT";
+    public static final String EXTRA_POST_DIALOG_EVENT = "EXTRA_POST_DIALOG_EVENT";
     public static final String EXTRA_SERVER_URL = "SERVER_URL";
     public static final String EXTRA_REMOTE_PATH = "REMOTE_PATH";
     public static final String EXTRA_NEWNAME = "NEWNAME";
@@ -715,13 +716,15 @@ public class OperationsService extends Service {
 
                     case ACTION_SYNC_FILE:
                         remotePath = operationIntent.getStringExtra(EXTRA_REMOTE_PATH);
+                        boolean postDialogEvent = operationIntent.getBooleanExtra(EXTRA_POST_DIALOG_EVENT, true);
                         boolean syncFileContents = operationIntent.getBooleanExtra(EXTRA_SYNC_FILE_CONTENTS, true);
                         operation = new SynchronizeFileOperation(remotePath,
                                                                  user,
                                                                  syncFileContents,
                                                                  getApplicationContext(),
                                                                  fileDataStorageManager,
-                                                                 false);
+                                                                 false,
+                                                                 postDialogEvent);
                         break;
 
                     case ACTION_SYNC_FOLDER:

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -85,6 +85,9 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.ui.dialog.ShareLinkToDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
+import com.owncloud.android.ui.events.DialogEvent;
+import com.owncloud.android.ui.events.DialogEventType;
+import com.owncloud.android.ui.events.FavoriteEvent;
 import com.owncloud.android.ui.fragment.FileDetailFragment;
 import com.owncloud.android.ui.fragment.FileDetailSharingFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
@@ -98,6 +101,9 @@ import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.ErrorMessageAdapter;
 import com.owncloud.android.utils.FilesSyncHelper;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -999,5 +1005,20 @@ public abstract class FileActivity extends DrawerActivity
 
     public FilesRepository getFilesRepository() {
         return filesRepository;
+    }
+
+    public void showSyncLoadingDialog(boolean isFolder) {
+        if (isFolder) {
+            return;
+        }
+
+        showLoadingDialog(getApplicationContext().getString(R.string.wait_a_moment));
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void handleSyncDialogEvent(DialogEvent event) {
+        if (event.getType() == DialogEventType.SYNC) {
+            dismissLoadingDialog();
+        }
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2107,6 +2107,7 @@ class FileDisplayActivity :
                 fileOperationsHelper.removeFiles(list, true, true)
 
                 // download new version, only if file was previously download
+                showSyncLoadingDialog(file.isFolder)
                 fileOperationsHelper.syncFile(file)
             }
 

--- a/app/src/main/java/com/owncloud/android/ui/events/DialogEvent.kt
+++ b/app/src/main/java/com/owncloud/android/ui/events/DialogEvent.kt
@@ -1,0 +1,14 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.ui.events
+
+data class DialogEvent(val type: DialogEventType)
+
+enum class DialogEventType {
+    SYNC
+}

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -54,6 +54,7 @@ import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.lib.resources.tags.Tag;
 import com.owncloud.android.ui.activity.DrawerActivity;
+import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.activity.ToolbarActivity;
 import com.owncloud.android.ui.adapter.FileDetailTabAdapter;
@@ -459,6 +460,9 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         } else if (itemId == R.id.action_cancel_sync) {
             ((FileDisplayActivity) containerActivity).cancelTransference(getFile());
         } else if (itemId == R.id.action_download_file || itemId == R.id.action_sync_file) {
+            if (containerActivity instanceof FileActivity activity) {
+                activity.showSyncLoadingDialog(getFile().isFolder());
+            }
             containerActivity.getFileOperationsHelper().syncFile(getFile());
         } else if (itemId == R.id.action_export_file) {
             ArrayList<OCFile> list = new ArrayList<>();

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -122,11 +122,13 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
@@ -2182,12 +2184,27 @@ public class OCFileListFragment extends ExtendedListFragment implements
     }
 
     private void syncAndCheckFiles(Collection<OCFile> files) {
-        for (OCFile file : files) {
-            // Get the remaining space on device
+        boolean isAnyFileFolder = false;
+        for (OCFile file: files) {
+            if (file.isFolder()) {
+                isAnyFileFolder = true;
+                break;
+            }
+        }
+
+        if (mContainerActivity instanceof FileActivity activity && !files.isEmpty()) {
+            activity.showSyncLoadingDialog(isAnyFileFolder);
+        }
+
+        Iterator<OCFile> iterator = files.iterator();
+        while (iterator.hasNext()) {
+            OCFile file = iterator.next();
+
             long availableSpaceOnDevice = FileOperationsHelper.getAvailableSpaceOnDevice();
 
             if (FileStorageUtils.checkIfEnoughSpace(file)) {
-                mContainerActivity.getFileOperationsHelper().syncFile(file);
+                boolean isLastItem = !iterator.hasNext();
+                mContainerActivity.getFileOperationsHelper().syncFile(file, isLastItem);
             } else {
                 showSpaceErrorDialog(file, availableSpaceOnDevice);
             }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -59,6 +59,7 @@ import com.owncloud.android.datamodel.ThumbnailsCacheManager
 import com.owncloud.android.datamodel.ThumbnailsCacheManager.AsyncResizedImageDrawable
 import com.owncloud.android.datamodel.ThumbnailsCacheManager.ResizedImageGenerationTask
 import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.ui.activity.FileActivity
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment
 import com.owncloud.android.ui.fragment.FileFragment
@@ -415,6 +416,10 @@ class PreviewImageFragment :
         } else if (itemId == R.id.action_see_details) {
             seeDetails()
         } else if (itemId == R.id.action_download_file || itemId == R.id.action_sync_file) {
+            if (containerActivity is FileActivity) {
+                val activity = containerActivity as FileActivity
+                activity.showSyncLoadingDialog(file.isFolder)
+            }
             containerActivity.fileOperationsHelper.syncFile(file)
         } else if (itemId == R.id.action_cancel_sync) {
             containerActivity.fileOperationsHelper.cancelTransference(file)

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -572,6 +572,7 @@ class PreviewMediaActivity :
             }
 
             R.id.action_sync_file -> {
+                showSyncLoadingDialog(file.isFolder)
                 fileOperationsHelper.syncFile(file)
             }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -56,6 +56,7 @@ import com.nextcloud.common.NextcloudClient
 import com.nextcloud.ui.fileactions.FileAction
 import com.nextcloud.ui.fileactions.FileActionsBottomSheet.Companion.newInstance
 import com.nextcloud.utils.extensions.getParcelableArgument
+import com.nextcloud.utils.extensions.getTypedActivity
 import com.nextcloud.utils.extensions.logFileSize
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
@@ -65,6 +66,7 @@ import com.owncloud.android.files.StreamMediaFileOperation
 import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.activity.DrawerActivity
+import com.owncloud.android.ui.activity.FileActivity
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment
 import com.owncloud.android.ui.fragment.FileFragment
@@ -362,6 +364,7 @@ class PreviewMediaFragment :
             }
 
             R.id.action_sync_file -> {
+                getTypedActivity(FileActivity::class.java)?.showSyncLoadingDialog(file.isFolder)
                 containerActivity.fileOperationsHelper.syncFile(file)
             }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFileFragment.java
@@ -25,6 +25,7 @@ import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.utils.DisplayUtils;
@@ -300,6 +301,9 @@ public class PreviewTextFileFragment extends PreviewTextFragment {
         } else if (itemId == R.id.action_see_details) {
             seeDetails();
         } else if (itemId == R.id.action_sync_file) {
+            if (containerActivity instanceof FileActivity activity) {
+                activity.showSyncLoadingDialog(getFile().isFolder());
+            }
             containerActivity.getFileOperationsHelper().syncFile(getFile());
         } else if(itemId == R.id.action_cancel_sync){
             containerActivity.getFileOperationsHelper().cancelTransference(getFile());


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The `showLoadingDialog` method is being called directly from the networking layer for every file.
This results in multiple loading dialogs being triggered. If the dialog state is not managed correctly, it can remain stuck or cause UI inconsistencies.

### Changes

Separated dialog handling from networking logic.
Ensured that the loading dialog is shown only once and dismissed only once, regardless of the number of files being processed.


### Before


https://github.com/user-attachments/assets/bfa2c9fb-c66c-4fcb-857e-15aa69c43743



### After

https://github.com/user-attachments/assets/4b84a513-4cb8-4122-863a-ceaf8d06fa6f


