### PR TITLE
fix: manage space activity screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -616,8 +616,7 @@
         <activity
             android:name=".ui.activity.ManageSpaceActivity"
             android:exported="false"
-            android:label="@string/manage_space_title"
-            android:theme="@style/Theme.ownCloud" />
+            android:label="@string/manage_space_title" />
 
         <service
             android:name=".services.AccountManagerService"

--- a/app/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.kt
@@ -1,23 +1,30 @@
 /*
  * Nextcloud - Android Client
  *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-FileCopyrightText: 2022 Álvaro Brey <alvaro@alvarobrey.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.owncloud.android.ui.activity
 
-import android.os.AsyncTask
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
+import com.nextcloud.android.common.ui.util.extensions.applyEdgeToEdgeWithSystemBarPadding
+import com.nextcloud.android.common.ui.util.extensions.initStatusBar
 import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.preferences.AppPreferences
 import com.owncloud.android.R
 import com.owncloud.android.lib.common.utils.Log_OC
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 import kotlin.system.exitProcess
@@ -33,43 +40,23 @@ class ManageSpaceActivity :
     lateinit var userAccountManager: UserAccountManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        initStatusBar(ContextCompat.getColor(this, R.color.appbar))
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_manage_space)
-        val actionBar = supportActionBar
-        if (actionBar != null) {
-            actionBar.setDisplayHomeAsUpEnabled(true)
-            actionBar.setTitle(R.string.manage_space_title)
-        }
+
         val descriptionTextView = findViewById<TextView>(R.id.general_description)
         descriptionTextView.text = getString(R.string.manage_space_description, getString(R.string.app_name))
+
         val clearDataButton = findViewById<Button>(R.id.clearDataButton)
         clearDataButton.setOnClickListener {
-            val clearDataTask = ClearDataAsyncTask()
-            clearDataTask.execute()
-        }
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        var retval = true
-        when (item.itemId) {
-            android.R.id.home -> finish()
-            else -> {
-                Log_OC.w(TAG, "Unknown menu item triggered")
-                retval = super.onOptionsItemSelected(item)
+            lifecycleScope.launch {
+                clearData()
             }
         }
-        return retval
     }
 
-    /**
-     * AsyncTask for Clear Data, saving the passcode
-     */
-    private inner class ClearDataAsyncTask : AsyncTask<Void, Void, Boolean>() {
-        private val preferences = this@ManageSpaceActivity.preferences
-        private val userAccountManager = this@ManageSpaceActivity.userAccountManager
-
-        @Suppress("MagicNumber")
-        override fun doInBackground(vararg params: Void): Boolean {
+    private suspend fun clearData() {
+        withContext(Dispatchers.IO) {
             val lockPref = preferences.lockPreference
             val passCodeEnable = SettingsActivity.LOCK_PASSCODE == lockPref
             var passCodeDigits = arrayOfNulls<String>(4)
@@ -92,56 +79,66 @@ class ManageSpaceActivity :
             }
             preferences.lockPreference = lockPref
             userAccountManager.removeAllAccounts()
-            return result
-        }
 
-        override fun onPostExecute(result: Boolean) {
-            super.onPostExecute(result)
-            if (!result) {
-                Snackbar.make(
-                    findViewById(android.R.id.content),
-                    R.string.manage_space_clear_data,
-                    Snackbar.LENGTH_LONG
-                ).show()
-            } else {
-                finishAndRemoveTask()
-                exitProcess(0)
-            }
-        }
-
-        fun clearApplicationData(): Boolean {
-            var clearResult = true
-            val appDir = File(cacheDir.parent!!)
-            if (appDir.exists()) {
-                val children = appDir.list()
-                if (children != null) {
-                    children.filter { it != LIB_FOLDER }.forEach { s ->
-                        val fileToDelete = File(appDir, s)
-                        clearResult = clearResult && deleteDir(fileToDelete)
-                        Log_OC.d(TAG, "Clear Application Data, File: " + fileToDelete.name + " DELETED *****")
-                    }
+            withContext(Dispatchers.Main) {
+                if (result) {
+                    finishAndRemoveTask()
+                    exitProcess(0)
                 } else {
-                    clearResult = false
+                    Snackbar.make(
+                        findViewById(android.R.id.content),
+                        R.string.manage_space_clear_data,
+                        Snackbar.LENGTH_LONG
+                    ).show()
                 }
             }
-            return clearResult
         }
+    }
 
-        @Suppress("ReturnCount")
-        fun deleteDir(dir: File?): Boolean {
-            if (dir != null && dir.isDirectory) {
-                dir.list()?.forEach { child ->
-                    val success = deleteDir(File(dir, child))
-                    if (!success) {
-                        Log_OC.w(TAG, "File NOT deleted $child")
-                        return false
-                    } else {
-                        Log_OC.d(TAG, "File deleted $child")
-                    }
-                } ?: return false
+    private fun clearApplicationData(): Boolean {
+        var clearResult = true
+        val appDir = File(cacheDir.parent!!)
+        if (appDir.exists()) {
+            val children = appDir.list()
+            if (children != null) {
+                children.filter { it != LIB_FOLDER }.forEach { s ->
+                    val fileToDelete = File(appDir, s)
+                    clearResult = clearResult && deleteDir(fileToDelete)
+                    Log_OC.d(TAG, "Clear Application Data, File: " + fileToDelete.name + " DELETED *****")
+                }
+            } else {
+                clearResult = false
             }
-            return dir?.delete() ?: false
         }
+        return clearResult
+    }
+
+    @Suppress("ReturnCount")
+    private fun deleteDir(dir: File?): Boolean {
+        if (dir != null && dir.isDirectory) {
+            dir.list()?.forEach { child ->
+                val success = deleteDir(File(dir, child))
+                if (!success) {
+                    Log_OC.w(TAG, "File NOT deleted $child")
+                    return false
+                } else {
+                    Log_OC.d(TAG, "File deleted $child")
+                }
+            } ?: return false
+        }
+        return dir?.delete() ?: false
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        var retval = true
+        when (item.itemId) {
+            android.R.id.home -> finish()
+            else -> {
+                Log_OC.w(TAG, "Unknown menu item triggered")
+                retval = super.onOptionsItemSelected(item)
+            }
+        }
+        return retval
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_manage_space.xml
+++ b/app/src/main/res/layout/activity_manage_space.xml
@@ -7,15 +7,30 @@
   ~ SPDX-FileCopyrightText: 2016 ownCloud Inc.
   ~ SPDX-License-Identifier: GPL-2.0-only AND (AGPL-3.0-or-later OR GPL-2.0-only)
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        app:titleTextColor="@color/text_color"
+        app:title="@string/manage_space_title"
+        android:background="@color/appbar" />
 
     <TextView
         android:id="@+id/general_description"
         style="?android:attr/editTextPreferenceStyle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
@@ -28,10 +43,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/general_description"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:layout_margin="@dimen/standard_margin"
         android:contentDescription="@string/manage_space_clear_data"
         android:text="@string/manage_space_clear_data"
         android:theme="@style/Button.Primary"
         app:cornerRadius="@dimen/button_corner_radius" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Changes

Remove deprecated `AsyncTask` use instead `Coroutines`.
Replace `LinearLayout` with `ConstraintLayout`.
Fix status bar alignment
Check nullable cache parent dir path


### Note

Since this screen is accessed through the app settings and functions more as an integration point rather than a core part of our app, I didn’t apply `viewThemeUtils` for branding. However, I can update it to use the `viewThemeUtils` if needed.


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/96d488fc-d5b4-4f84-9fe5-9ec3dc9d2204" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/1d9ee8c1-ba2b-4c89-8a5e-7244f3e77138" width="300" alt="after"></td>
  </tr>
</table>

