### PR TITLE
fix: accessing result data

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -345,6 +345,8 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
                     if (!encryptionOperationResult.isSuccess()) {
                         throw new RuntimeException("Error creating encrypted subfolder!");
                     }
+                } else {
+                    throw new RuntimeException("Error creating encrypted subfolder!");
                 }
             } else {
                 // revert to sane state in case of any error

--- a/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -186,21 +186,23 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
                     }
                 }
 
-                RemoteOperationResult remoteFolderOperationResult = new ReadFolderRemoteOperation(encryptedRemotePath)
+                final var remoteFolderOperationResult = new ReadFolderRemoteOperation(encryptedRemotePath)
                     .execute(client);
 
-                createdRemoteFolder = (RemoteFile) remoteFolderOperationResult.getData().get(0);
-                OCFile newDir = createRemoteFolderOcFile(parent, filename, createdRemoteFolder);
-                getStorageManager().saveFile(newDir);
+                if (remoteFolderOperationResult.isSuccess() && remoteFolderOperationResult.getData().get(0) instanceof RemoteFile remoteFile) {
+                    createdRemoteFolder = remoteFile;
+                    OCFile newDir = createRemoteFolderOcFile(parent, filename, createdRemoteFolder);
+                    getStorageManager().saveFile(newDir);
 
-                RemoteOperationResult encryptionOperationResult = new ToggleEncryptionRemoteOperation(
-                    newDir.getLocalId(),
-                    newDir.getRemotePath(),
-                    true)
-                    .execute(client);
+                    final var encryptionOperationResult = new ToggleEncryptionRemoteOperation(
+                        newDir.getLocalId(),
+                        newDir.getRemotePath(),
+                        true)
+                        .execute(client);
 
-                if (!encryptionOperationResult.isSuccess()) {
-                    throw new RuntimeException("Error creating encrypted subfolder!");
+                    if (!encryptionOperationResult.isSuccess()) {
+                        throw new RuntimeException("Error creating encrypted subfolder!");
+                    }
                 }
             } else {
                 // revert to sane state in case of any error
@@ -324,21 +326,23 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
                     throw new RuntimeException("Could not unlock folder!");
                 }
 
-                RemoteOperationResult remoteFolderOperationResult = new ReadFolderRemoteOperation(encryptedRemotePath)
+                final var remoteFolderOperationResult = new ReadFolderRemoteOperation(encryptedRemotePath)
                     .execute(client);
 
-                createdRemoteFolder = (RemoteFile) remoteFolderOperationResult.getData().get(0);
-                OCFile newDir = createRemoteFolderOcFile(parent, filename, createdRemoteFolder);
-                getStorageManager().saveFile(newDir);
+                if (remoteFolderOperationResult.isSuccess() && remoteFolderOperationResult.getData().get(0) instanceof RemoteFile remoteFile) {
+                    createdRemoteFolder = remoteFile;
+                    OCFile newDir = createRemoteFolderOcFile(parent, filename, createdRemoteFolder);
+                    getStorageManager().saveFile(newDir);
 
-                RemoteOperationResult encryptionOperationResult = new ToggleEncryptionRemoteOperation(
-                    newDir.getLocalId(),
-                    newDir.getRemotePath(),
-                    true)
-                    .execute(client);
+                    final var encryptionOperationResult = new ToggleEncryptionRemoteOperation(
+                        newDir.getLocalId(),
+                        newDir.getRemotePath(),
+                        true)
+                        .execute(client);
 
-                if (!encryptionOperationResult.isSuccess()) {
-                    throw new RuntimeException("Error creating encrypted subfolder!");
+                    if (!encryptionOperationResult.isSuccess()) {
+                        throw new RuntimeException("Error creating encrypted subfolder!");
+                    }
                 }
             } else {
                 // revert to sane state in case of any error

--- a/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -203,6 +203,8 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
                     if (!encryptionOperationResult.isSuccess()) {
                         throw new RuntimeException("Error creating encrypted subfolder!");
                     }
+                } else {
+                    throw new RuntimeException("Error creating encrypted subfolder!");
                 }
             } else {
                 // revert to sane state in case of any error

--- a/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.util.UUID;
 
 import androidx.annotation.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
 import static com.owncloud.android.datamodel.OCFile.ROOT_PATH;
@@ -109,6 +110,10 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
         }
     }
 
+    @SuppressFBWarnings(
+        value = "EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS",
+        justification = "Converting checked exception to runtime is acceptable in this context"
+    )
     private RemoteOperationResult encryptedCreateV1(OCFile parent, OwnCloudClient client) {
         ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProviderImpl(context);
         String privateKey = arbitraryDataProvider.getValue(user.getAccountName(), EncryptionUtils.PRIVATE_KEY);
@@ -247,6 +252,10 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
         }
     }
 
+    @SuppressFBWarnings(
+        value = "EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS",
+        justification = "Converting checked exception to runtime is acceptable in this context"
+    )
     private RemoteOperationResult encryptedCreateV2(OCFile parent, OwnCloudClient client) {
         String token = null;
         Boolean metadataExists;

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -436,6 +436,10 @@ public class SynchronizeFolderOperation extends SyncOperation {
     private void updateETag(OwnCloudClient client) {
         ReadFolderRemoteOperation operation = new ReadFolderRemoteOperation(mRemotePath);
         final var result = operation.execute(client);
+        if (!result.isSuccess()) {
+            Log_OC.w(TAG, "Cannot update eTag, read folder operation is failed");
+            return;
+        }
 
         if (result.getData().get(0) instanceof RemoteFile remoteFile) {
             String eTag = remoteFile.getEtag();


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

**Fixes crashes like below**

```
Exception java.lang.RuntimeException: Accessing result data after operation failed!
  at com.owncloud.android.lib.common.operations.RemoteOperationResult.getData (RemoteOperationResult.java:524)
  at com.owncloud.android.operations.SynchronizeFolderOperation.updateETag (SynchronizeFolderOperation.java:440)
  at com.owncloud.android.operations.SynchronizeFolderOperation.syncContents (SynchronizeFolderOperation.java:427)
  at com.owncloud.android.operations.SynchronizeFolderOperation.run (SynchronizeFolderOperation.java:141)
  at com.owncloud.android.lib.common.operations.RemoteOperation.execute (RemoteOperation.java:193)
  at com.owncloud.android.services.SyncFolderHandler.doOperation (SyncFolderHandler.java:106)
  at com.owncloud.android.services.SyncFolderHandler.handleMessage (SyncFolderHandler.java:79)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.os.HandlerThread.run (HandlerThread.java:85)
```