### PR TITLE
SpotBugs: Fix Method ignores exceptional return value - PushUtils

### DIFF
--- a/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -96,7 +96,11 @@ public final class PushUtils {
         if (!new File(privateKeyPath).exists() && !new File(publicKeyPath).exists()) {
             try {
                 if (!keyPathFile.exists()) {
-                    keyPathFile.mkdir();
+                    try {
+                        Files.createDirectory(keyPathFile.toPath());
+                    } catch (IOException e) {
+                        Log_OC.e(TAG, "Could not create directory: " + keyPathFile.getAbsolutePath(), e);
+                    }
                 }
                 KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
                 keyGen.initialize(2048);
@@ -304,8 +308,12 @@ public final class PushUtils {
         try {
             if (!new File(path).exists()) {
                 File newFile = new File(path);
-                newFile.getParentFile().mkdirs();
-                newFile.createNewFile();
+                try {
+                    Files.createDirectories(newFile.getParentFile().toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not create directory: " + newFile.getParentFile(), e);
+                }
+                Files.createFile(newFile.toPath());
             }
             keyFileOutputStream = new FileOutputStream(path);
             keyFileOutputStream.write(encoded);

--- a/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
+++ b/app/src/gplay/java/com/owncloud/android/utils/PushUtils.java
@@ -44,6 +44,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactory;


### PR DESCRIPTION
There are 16 SpotBugs under

Bad practice:
RV: Bad use of return value from method (16: 0/16/0/0)
Method ignores exceptional return value (16: 0/16/0/0)

Solution:
Leveraging the more modern java.nio.Files library and conducting these make directory, delete, etc. functions via that.
Changing a Submit to an Execute function

