### PR TITLE
SpotBugs: Fix Method ignores exceptional return value - DownloadFileOperation

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
@@ -38,7 +38,9 @@ import com.owncloud.android.utils.FileExportUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -115,7 +117,11 @@ public class DownloadFileOperation extends RemoteOperation {
         if (file.getStoragePath() != null) {
             File parentFile = new File(file.getStoragePath()).getParentFile();
             if (parentFile != null && !parentFile.exists()) {
-                parentFile.mkdirs();
+                try {
+                    Files.createDirectories(parentFile.toPath());
+                } catch (IOException e) {
+                    return FileStorageUtils.getDefaultSavePathFor(user.getAccountName(), file);
+                }
             }
             File path = new File(file.getStoragePath());  // re-downloads should be done over the original file
             if (path.canWrite() || parentFile != null && parentFile.canWrite()) {


### PR DESCRIPTION
There are 16 SpotBugs under

Bad practice:
RV: Bad use of return value from method (16: 0/16/0/0)
Method ignores exceptional return value (16: 0/16/0/0)

Solution:
Leveraging the more modern java.nio.Files library and conducting these make directory, delete, etc. functions via that.
Changing a Submit to an Execute function
