### PR TITLE
SpotBugs: Fix Method ignores exceptional return value - RenameFileOperation

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -185,7 +185,7 @@ public class RenameFileOperation extends SyncOperation {
         boolean result = Files.exists(testFile) && Files.isRegularFile(testFile);
 
         try {
-            Files.delete(testFile);
+            Files.deleteIfExists(testFile);
         } catch (Exception e) {
             Log_OC.e("Error deleting file: ", e.getMessage());
             return true;


### PR DESCRIPTION
There are 16 SpotBugs under

Bad practice:
RV: Bad use of return value from method (16: 0/16/0/0)
Method ignores exceptional return value (16: 0/16/0/0)

Solution:
Leveraging the more modern java.nio.Files library and conducting these make directory, delete, etc. functions via that.
Changing a Submit to an Execute function
