### PR TITLE
SpotBugs: Fix Method ignores exceptional return value - DiskLRUImageCacheFileProvider

### DIFF
--- a/app/src/main/java/com/owncloud/android/providers/DiskLruImageCacheFileProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DiskLruImageCacheFileProvider.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 
 import javax.inject.Inject;
 
@@ -78,7 +79,7 @@ public class DiskLruImageCacheFileProvider extends ContentProvider {
         // create a file to write bitmap data
         File f = new File(MainApp.getAppContext().getCacheDir(), ocFile.getFileName());
         try {
-            f.createNewFile();
+            Files.createFile(f.toPath());
 
             //Convert bitmap to byte array
             ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
There are 16 SpotBugs under

Bad practice:
RV: Bad use of return value from method (16: 0/16/0/0)
Method ignores exceptional return value (16: 0/16/0/0)

Solution:
Leveraging the more modern java.nio.Files library and conducting these make directory, delete, etc. functions via that.
Changing a Submit to an Execute function
