### PR TITLE
 SpotBugs: Fix Method ignores exceptional return value - StorageMigration

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/StorageMigration.java
@@ -29,6 +29,8 @@ import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
@@ -364,10 +366,19 @@ public class StorageMigration {
             try {
                 File dstFile = new File(mStorageTarget + File.separator + MainApp.getDataFolder());
                 deleteRecursive(dstFile);
-                dstFile.delete();
+                try {
+                    Files.delete(dstFile.toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not delete destination file: " + dstFile.getAbsolutePath(), e);
+                }
 
                 File srcFile = new File(mStorageSource + File.separator + MainApp.getDataFolder());
-                srcFile.mkdirs();
+
+                try {
+                    Files.createDirectories(srcFile.toPath());
+                } catch (IOException e) {
+                    Log_OC.e(TAG, "Could not create directory: " + srcFile.getAbsolutePath(), e);
+                }
 
                 publishProgress(R.string.file_migration_checking_destination);
 
@@ -466,7 +477,11 @@ public class StorageMigration {
             if (!deleteRecursive(srcFile)) {
                 Log_OC.w(TAG, "Migration cleanup step failed");
             }
-            srcFile.delete();
+            try {
+                Files.delete(srcFile.toPath());
+            } catch (IOException e) {
+                Log_OC.e(TAG, "Could not delete source file: " + srcFile.getAbsolutePath(), e);
+            }
         }
 
         private boolean deleteRecursive(File f) {


### PR DESCRIPTION
There are 16 SpotBugs under

Bad practice:
RV: Bad use of return value from method (16: 0/16/0/0)
Method ignores exceptional return value (16: 0/16/0/0)

Solution:
Leveraging the more modern java.nio.Files library and conducting these make directory, delete, etc. functions via that.
Changing a Submit to an Execute function
