### PR TITLE
fix: show file already exists notification only for manual upload

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -139,7 +139,7 @@ interface BackgroundJobManager {
 
     fun startNotificationJob(subject: String, signature: String)
     fun startAccountRemovalJob(accountName: String, remoteWipe: Boolean)
-    fun startFilesUploadJob(user: User, uploadIds: LongArray, isAutoUpload: Boolean = false)
+    fun startFilesUploadJob(user: User, uploadIds: LongArray, showSameFileAlreadyExistsNotification: Boolean)
     fun getFileUploads(user: User): LiveData<List<JobInfo>>
     fun cancelFilesUploadJob(user: User)
     fun isStartFileUploadJobScheduled(user: User): Boolean

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -623,7 +623,7 @@ internal class BackgroundJobManagerImpl(
      *                  and cannot be determined directly from the account name or a single function
      *                  within the worker.
      */
-    override fun startFilesUploadJob(user: User, uploadIds: LongArray, isAutoUpload: Boolean) {
+    override fun startFilesUploadJob(user: User, uploadIds: LongArray, showSameFileAlreadyExistsNotification: Boolean) {
         defaultDispatcherScope.launch {
             val batchSize = FileUploadHelper.MAX_FILE_COUNT
             val batches = uploadIds.toList().chunked(batchSize)
@@ -634,7 +634,10 @@ internal class BackgroundJobManagerImpl(
                 .build()
 
             val dataBuilder = Data.Builder()
-                .putBoolean(FileUploadWorker.IS_AUTO_UPLOAD, isAutoUpload)
+                .putBoolean(
+                    FileUploadWorker.SHOW_SAME_FILE_ALREADY_EXISTS_NOTIFICATION,
+                    showSameFileAlreadyExistsNotification
+                )
                 .putString(FileUploadWorker.ACCOUNT, user.accountName)
                 .putInt(FileUploadWorker.TOTAL_UPLOAD_SIZE, uploadIds.size)
 

--- a/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/FilesSyncWork.kt
@@ -104,7 +104,7 @@ class FilesSyncWork(
         val user = userAccountManager.getUser(syncedFolder.account)
         if (user.isPresent) {
             var uploadIds = uploadsStorageManager.getCurrentUploadIds(user.get().accountName)
-            backgroundJobManager.startFilesUploadJob(user.get(), uploadIds, isAutoUpload = true)
+            backgroundJobManager.startFilesUploadJob(user.get(), uploadIds, false)
         }
 
         // Get changed files from ContentObserverWork (only images and videos) or by scanning filesystem
@@ -316,7 +316,7 @@ class FilesSyncWork(
             needsWifi,
             needsCharging,
             syncedFolder.nameCollisionPolicy,
-            isAutoUpload = true
+            false
         )
 
         for (path in paths) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -183,7 +183,7 @@ class FileUploadHelper {
         accountNames.forEach { accountName ->
             val user = accountManager.getUser(accountName)
             if (user.isPresent) {
-                backgroundJobManager.startFilesUploadJob(user.get(), failedUploads.getUploadIds())
+                backgroundJobManager.startFilesUploadJob(user.get(), failedUploads.getUploadIds(), false)
             }
         }
 
@@ -202,7 +202,7 @@ class FileUploadHelper {
         requiresWifi: Boolean,
         requiresCharging: Boolean,
         nameCollisionPolicy: NameCollisionPolicy,
-        isAutoUpload: Boolean = false
+        showSameFileAlreadyExistsNotification: Boolean = true
     ) {
         val uploads = localPaths.mapIndexed { index, localPath ->
             OCUpload(localPath, remotePaths[index], user.accountName).apply {
@@ -216,7 +216,7 @@ class FileUploadHelper {
             }
         }
         uploadsStorageManager.storeUploads(uploads)
-        backgroundJobManager.startFilesUploadJob(user, uploads.getUploadIds(), isAutoUpload)
+        backgroundJobManager.startFilesUploadJob(user, uploads.getUploadIds(), showSameFileAlreadyExistsNotification)
     }
 
     fun removeFileUpload(remotePath: String, accountName: String) {
@@ -261,7 +261,7 @@ class FileUploadHelper {
     fun cancelAndRestartUploadJob(user: User, uploadIds: LongArray) {
         backgroundJobManager.run {
             cancelFilesUploadJob(user)
-            startFilesUploadJob(user, uploadIds)
+            startFilesUploadJob(user, uploadIds, false)
         }
     }
 
@@ -377,7 +377,7 @@ class FileUploadHelper {
         }
         uploadsStorageManager.storeUploads(uploads)
         val uploadIds: LongArray = uploads.filterNotNull().map { it.uploadId }.toLongArray()
-        backgroundJobManager.startFilesUploadJob(user, uploadIds)
+        backgroundJobManager.startFilesUploadJob(user, uploadIds, true)
     }
 
     /**
@@ -421,7 +421,7 @@ class FileUploadHelper {
         upload.uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS
         uploadsStorageManager.updateUpload(upload)
 
-        backgroundJobManager.startFilesUploadJob(user, longArrayOf(upload.uploadId))
+        backgroundJobManager.startFilesUploadJob(user, longArrayOf(upload.uploadId), false)
     }
 
     fun cancel(accountName: String) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -63,7 +63,7 @@ class FileUploadWorker(
         const val UPLOAD_IDS = "uploads_ids"
         const val CURRENT_BATCH_INDEX = "batch_index"
         const val TOTAL_UPLOAD_SIZE = "total_upload_size"
-        const val IS_AUTO_UPLOAD = "is_auto_upload"
+        const val SHOW_SAME_FILE_ALREADY_EXISTS_NOTIFICATION = "show_same_file_already_exists_notification"
 
         var currentUploadFileOperation: UploadFileOperation? = null
 
@@ -302,7 +302,8 @@ class FileUploadWorker(
         uploadResult: RemoteOperationResult<Any?>
     ) {
         Log_OC.d(TAG, "NotifyUploadResult with resultCode: " + uploadResult.code)
-        val isAutoUpload = inputData.getBoolean(IS_AUTO_UPLOAD, false)
+        val showSameFileAlreadyExistsNotification =
+            inputData.getBoolean(SHOW_SAME_FILE_ALREADY_EXISTS_NOTIFICATION, false)
 
         if (uploadResult.isSuccess) {
             notificationManager.dismissOldErrorNotification(uploadFileOperation)
@@ -322,7 +323,7 @@ class FileUploadWorker(
                 context
             )
         ) {
-            if (!isAutoUpload) {
+            if (showSameFileAlreadyExistsNotification) {
                 notificationManager.showSameFileAlreadyExistsNotification(uploadFileOperation.fileName)
             }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Previously in [this](https://github.com/nextcloud/android/pull/15383) PR, we showed the "file already exists" notification only for auto uploads. However, since the upload list adapter handles both auto and manual uploads, failed auto uploads would also trigger the "file already exists" dialog.

### Changes

This PR ensures that the notification is shown only for manual uploads.