### PR TITLE
Fix: Make "open in notes" banner honour ecosystem app preference

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -505,6 +505,9 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean shouldShowOpenInNotes() {
+        if (!preferences.isShowEcosystemApps()) {
+            return false;
+        }
         String notesFolderPath = capability.getNotesFolderPath();
         String currentPath = currentDirectory.getDecryptedRemotePath();
         return notesFolderPath != null && currentPath != null && currentPath.startsWith(notesFolderPath);


### PR DESCRIPTION
This hides the "open in notes" banner when the user decides to hide links to ecosystem apps via the respective switch in the app preferences.

Before: The banner was always shown, ignoring the user preference "Show app switcher (Nextcloud app suggestions)".

After: The banner takes the user preference into account

Fixes #15614

| Banner | Switch in preferences |
|-|-|
|<img width="532" height="264" alt="grafik" src="https://github.com/user-attachments/assets/718d0d8d-92d1-4ef6-b4db-74f122d213ad" />|<img width="535" height="159" alt="grafik" src="https://github.com/user-attachments/assets/0d2749e3-92c2-41ac-be9c-3c856bdc52b2" />


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed
