### PR TITLE
Prevent SwipeRefreshLayout from intercepting while list can still scroll up

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -280,6 +280,12 @@ public class OCFileListFragment extends ExtendedListFragment implements
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        // Ensure pull-to-refresh only triggers when the list is truly at top
+        swipeRefreshLayout.setOnChildScrollUpCallback((parent, child) ->{
+            // If the RecyclerView can scroll up, don't allow SwipeRefreshLayout to intercept (no refresh)
+            return recyclerView != null && recyclerView.canScrollVertically(-1);
+        });
+
         setupBackButtonRedirectToAllFiles();
     }
 


### PR DESCRIPTION
This PR fixes an issue where pull-to-refresh could trigger while the files list
was not at the top, causing an unexpected refresh and interrupting scrolling.

Implementation:
- Set a ChildScrollUpCallback on SwipeRefreshLayout to return true when the
  RecyclerView can still scroll up (canScrollVertically(-1) == true). This
  prevents SwipeRefreshLayout from intercepting gestures mid-list.

Fixes #15619.

1) Open the files list screen.
2) Scroll down so the list is not at the very top.
3) Drag using the scrollbar / or perform a slight pull gesture.
   Expected: no refresh is triggered; scrolling remains smooth.
4) Go back to the very top and pull down.
   Expected: pull-to-refresh triggers normally.
