### PR TITLE
Fix deleting from slideshow

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
@@ -24,7 +24,6 @@ import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.ui.activity.FileActivity
 import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment.ConfirmationDialogFragmentListener
-import com.owncloud.android.ui.preview.PreviewImageActivity
 import javax.inject.Inject
 
 /**
@@ -125,13 +124,10 @@ class RemoveFilesDialogFragment :
             }
 
             finishActionMode()
-            finishPreviewImageActivity()
         }
     }
 
     override fun onNeutral(callerTag: String?) = Unit
-
-    private fun finishPreviewImageActivity() = getTypedActivity(PreviewImageActivity::class.java)?.finish()
 
     private fun setActionMode(actionMode: ActionMode?) {
         this.actionMode = actionMode

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -277,8 +277,6 @@ class PreviewImageActivity :
         super.onRemoteOperationFinish(operation, result)
 
         if (operation is RemoveFileOperation) {
-            val deletePosition = viewPager?.currentItem ?: return
-            val nextPosition = if (deletePosition > 0) deletePosition - 1 else 0
 
             previewImagePagerAdapter?.let {
                 if (it.itemCount <= 1) {
@@ -289,10 +287,12 @@ class PreviewImageActivity :
 
             if (user.isPresent) {
                 initViewPager(user.get())
+            } else {
+                val deletePosition = viewPager?.currentItem ?: return
+                val nextPosition = if (deletePosition > 0) deletePosition - 1 else 0
+                viewPager?.setCurrentItem(nextPosition, true)
+                previewImagePagerAdapter?.delete(deletePosition)
             }
-
-            viewPager?.setCurrentItem(nextPosition, true)
-            previewImagePagerAdapter?.delete(deletePosition)
         } else if (operation is SynchronizeFileOperation) {
             onSynchronizeFileOperationFinish(result)
         }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -286,12 +286,19 @@ class PreviewImageActivity :
             }
 
             if (user.isPresent) {
+                // Re-init the view pager, which will advance to the next image
                 initViewPager(user.get())
-            } else {
+            } else if (result.isSuccess) {
+                // If deletion was successful, update adapter and display next image
                 val deletePosition = viewPager?.currentItem ?: return
-                val nextPosition = if (deletePosition > 0) deletePosition - 1 else 0
-                viewPager?.setCurrentItem(nextPosition, true)
-                previewImagePagerAdapter?.delete(deletePosition)
+                previewImagePagerAdapter?.let { adapter ->
+                    // advance to the next image if possible, since initViewPager() also advances forwards
+                    val nextPosition = if (deletePosition < (adapter.itemCount - 1)) deletePosition + 1 else max(deletePosition - 1, 0)
+                    viewPager?.setCurrentItem(nextPosition, true)
+                    adapter.delete(deletePosition)
+                    // Page needs to be reselected after the adapter has been updated. Otherwise, wrong title is shown
+                    selectPage(nextPosition)
+                }
             }
         } else if (operation is SynchronizeFileOperation) {
             onSynchronizeFileOperationFinish(result)

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.kt
@@ -194,4 +194,10 @@ class PreviewImagePagerAdapter : FragmentStateAdapter {
     override fun createFragment(position: Int): Fragment = getItem(position)
 
     override fun getItemCount(): Int = imageFiles.size
+
+    override fun getItemId(position: Int): Long {
+        // The item ID function is needed to detect whether the deletion of the current item needs a UI update
+        // Use the OCFile id, fallback to position if not available
+        return imageFiles.getOrNull(position)?.fileId?.toLong() ?: position.toLong()
+    }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed

Fixes #15636.

1. The patch added in #14782 prevented that the callback `onRemoteOperationFinish()` was ever called.
The changes were removed. I was not able to reproduce the end-to-end encryption issue, so this seems fine.
    - @alperozturk96 if you could try yourself, as you had originally worked on that issue?
2. the manual update of adapter and pager is only needed if user is not present. When user is present, the `initViewPager()` takes care of everything.
3. The next image was inconsistent between user present yes/no


