### PR TITLE
Previously directory was assigned on registerFabListener, thus it was always "/"

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -508,16 +508,17 @@ public class OCFileListFragment extends ExtendedListFragment implements
             return;
         }
 
-        final var currentDir = getCurrentFile();
-        if (currentDir == null) {
-            Log_OC.w(TAG, "currentDir is null cannot register fab listener");
-            return;
-        }
-
         // is not available in FolderPickerActivity
         viewThemeUtils.material.themeFAB(mFabMain);
         mFabMain.setOnClickListener(v -> {
             PermissionUtil.requestMediaLocationPermission(fileActivity);
+
+            var currentDir = getCurrentFile();
+            if (currentDir == null) {
+                Log_OC.w(TAG, "currentDir is null cannot open bottom sheet dialog");
+                return;
+            }
+            
             final OCFileListBottomSheetDialog dialog = new OCFileListBottomSheetDialog(fileActivity,
                                                                                        this,
                                                                                        deviceInfo,


### PR DESCRIPTION


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
