### PR TITLE
Hide share button in portrait mode to save space

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -14,8 +14,10 @@ import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ComponentCallbacks;
 import android.content.ContentValues;
 import android.content.res.ColorStateList;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
@@ -198,6 +200,16 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         // initialise thumbnails cache on background thread
         ThumbnailsCacheManager.initDiskCacheAsync();
         isRTL = DisplayUtils.isRTL();
+
+        activity.registerComponentCallbacks(new ComponentCallbacks() {
+            @Override
+            public void onConfigurationChanged(@NonNull Configuration newConfig) {
+                notifyDataSetChanged(); // force update of orientation-dependent layout (e.g. share button visibility)
+            }
+            @Override
+            public void onLowMemory() {
+            }
+        });
     }
 
     public boolean isMultiSelect() {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -8,6 +8,7 @@
 package com.owncloud.android.ui.adapter
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import android.os.AsyncTask
 import android.view.View
@@ -261,6 +262,7 @@ class OCFileListDelegate(
         // shares
         val shouldHideShare = (
             hideItemOptions ||
+                context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT ||
                 !file.isFolder &&
                 file.isEncrypted ||
                 file.isEncrypted &&


### PR DESCRIPTION
Spin-off from https://github.com/nextcloud/android/pull/15627

Hides the additional share button in portrait mode, where not much space is available. Note that the three dot menu contains an easily accessible share menu with even more features (local share via other app & various nextcloud share options). 
In landscape mode there is no change, it is still shown as before (e.g. useful for tablets).

|Portrait|Landscape|
|-|-|
|<img width="540" height="1200" alt="portrait" src="https://github.com/user-attachments/assets/1d247eb8-7ffe-49b8-9fb0-7c9b2f40db4d" />|<img width="1200" height="540" alt="landscape" src="https://github.com/user-attachments/assets/c4a9c41f-21b6-4a2d-93d4-7874b62f93be" />


