### PR TITLE
feat: indicate skipped auto upload due to battery saver mode

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -230,7 +230,8 @@ class SyncedFoldersActivity :
             gridWidth,
             this,
             lightVersion,
-            viewThemeUtils
+            viewThemeUtils,
+            powerManagementService
         )
         binding.emptyList.emptyListIcon.setImageResource(R.drawable.nav_synced_folders)
         viewThemeUtils.material.colorMaterialButtonPrimaryFilled(binding.emptyList.emptyListViewAction)

--- a/app/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.kt
@@ -21,6 +21,7 @@ import com.afollestad.sectionedrecyclerview.SectionedRecyclerViewAdapter
 import com.afollestad.sectionedrecyclerview.SectionedViewHolder
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.core.Clock
+import com.nextcloud.client.device.PowerManagementService
 import com.nextcloud.utils.extensions.filterEnabledOrWithoutEnabledParent
 import com.nextcloud.utils.extensions.hasEnabledParent
 import com.nextcloud.utils.extensions.setVisibleIf
@@ -50,7 +51,8 @@ class SyncedFolderAdapter(
     private val gridWidth: Int,
     private val clickListener: ClickListener,
     private val light: Boolean,
-    private val viewThemeUtils: ViewThemeUtils
+    private val viewThemeUtils: ViewThemeUtils,
+    private val powerManagementService: PowerManagementService
 ) : SectionedRecyclerViewAdapter<SectionedViewHolder>() {
 
     private val gridTotal = gridWidth * 2
@@ -238,6 +240,13 @@ class SyncedFolderAdapter(
         if (section < filteredSyncFolderItems.size) {
             val holder = commonHolder as HeaderViewHolder
             holder.binding.headerContainer.visibility = View.VISIBLE
+
+            if (section == 0) {
+                holder.binding.autoUploadBatterySaverWarningCard.root.run {
+                    setVisibleIf(powerManagementService.isPowerSavingEnabled)
+                    viewThemeUtils.material.themeCardView(this)
+                }
+            }
 
             holder.binding.title.text = filteredSyncFolderItems[section].folderName
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/SyncedFolderAdapter.kt
@@ -13,12 +13,13 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
 import android.widget.PopupMenu
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.afollestad.sectionedrecyclerview.SectionedRecyclerViewAdapter
 import com.afollestad.sectionedrecyclerview.SectionedViewHolder
+import com.google.android.material.button.MaterialButton
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.device.PowerManagementService
@@ -298,7 +299,6 @@ class SyncedFolderAdapter(
         holder.binding.subFolderWarningButton.run {
             setVisibleIf(isGivenLocalPathHasEnabledParent)
             if (isVisible) {
-                viewThemeUtils.platform.themeImageButton(this)
                 setOnClickListener {
                     clickListener.showSubFolderWarningDialog()
                 }
@@ -457,13 +457,12 @@ class SyncedFolderAdapter(
             binding.root
         )
 
-    private fun setSyncButtonActiveIcon(syncStatusButton: ImageButton, enabled: Boolean) {
+    private fun setSyncButtonActiveIcon(syncStatusButton: MaterialButton, enabled: Boolean) {
         if (enabled) {
-            syncStatusButton.setImageDrawable(
+            syncStatusButton.icon =
                 viewThemeUtils.platform.tintDrawable(context, R.drawable.ic_cloud_sync_on, ColorRole.PRIMARY)
-            )
         } else {
-            syncStatusButton.setImageResource(R.drawable.ic_cloud_sync_off)
+            syncStatusButton.icon = ContextCompat.getDrawable(context, R.drawable.ic_cloud_sync_off)
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -30,6 +30,7 @@ import com.nextcloud.client.device.PowerManagementService;
 import com.nextcloud.client.jobs.upload.FileUploadHelper;
 import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.network.ConnectivityService;
+import com.nextcloud.utils.extensions.ViewExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.databinding.UploadListHeaderBinding;
@@ -126,6 +127,9 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
                 headerViewHolder.binding.uploadListAction.setImageResource(R.drawable.ic_dots_vertical);
 
         }
+
+        ViewExtensionsKt.setVisibleIf(headerViewHolder.binding.autoUploadBatterySaverWarningCard, powerManagementService.isPowerSavingEnabled());
+        viewThemeUtils.material.themeCardView(headerViewHolder.binding.autoUploadBatterySaverWarningCard);
 
         headerViewHolder.binding.uploadListAction.setOnClickListener(v -> {
             switch (group.type) {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UploadListAdapter.java
@@ -128,8 +128,8 @@ public class UploadListAdapter extends SectionedRecyclerViewAdapter<SectionedVie
 
         }
 
-        ViewExtensionsKt.setVisibleIf(headerViewHolder.binding.autoUploadBatterySaverWarningCard, powerManagementService.isPowerSavingEnabled());
-        viewThemeUtils.material.themeCardView(headerViewHolder.binding.autoUploadBatterySaverWarningCard);
+        ViewExtensionsKt.setVisibleIf(headerViewHolder.binding.autoUploadBatterySaverWarningCard.root, powerManagementService.isPowerSavingEnabled());
+        viewThemeUtils.material.themeCardView(headerViewHolder.binding.autoUploadBatterySaverWarningCard.root);
 
         headerViewHolder.binding.uploadListAction.setOnClickListener(v -> {
             switch (group.type) {

--- a/app/src/main/res/layout/auto_upload_battery_saver_warning_card.xml
+++ b/app/src/main/res/layout/auto_upload_battery_saver_warning_card.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Nextcloud - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+  ~ SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+<com.google.android.material.card.MaterialCardView
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/rounded_rect_8dp"
+    android:layout_marginTop="@dimen/standard_half_margin"
+    android:layout_marginHorizontal="@dimen/standard_half_margin"
+    android:backgroundTint="@color/grey_200"
+    android:elevation="4dp"
+    android:padding="@dimen/standard_double_margin"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/standard_padding"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:layout_width="@dimen/standard_icon_size"
+            android:layout_height="@dimen/standard_icon_size"
+            android:contentDescription="@string/auto_upload_battery_saver_mode_warning"
+            android:src="@drawable/ic_warning"
+            app:tint="@color/log_level_warning" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:text="@string/auto_upload_battery_saver_mode_warning"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="@color/text_color" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/synced_folders_item_header.xml
+++ b/app/src/main/res/layout/synced_folders_item_header.xml
@@ -7,102 +7,95 @@
   ~ SPDX-FileCopyrightText: 2016 Nextcloud GmbH
   ~ SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
 -->
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/header_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/alternate_half_padding">
+    android:padding="@dimen/standard_half_padding">
 
     <include
         android:id="@+id/auto_upload_battery_saver_warning_card"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:layout_gravity="center"
-        tools:visibility="visible"
         layout="@layout/auto_upload_battery_saver_warning_card"
-        android:layout_marginBottom="@dimen/standard_double_margin" />
-
-    <LinearLayout
-        android:id="@+id/header_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:baselineAligned="false"
-        android:orientation="horizontal">
+        android:layout_gravity="center"
+        android:layout_marginBottom="@dimen/standard_quadruple_margin"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/type"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
 
-        <LinearLayout
-            android:id="@+id/title_container"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            android:layout_gravity="center"
-            tools:ignore="UseCompoundDrawables">
+    <ImageView
+        android:id="@+id/type"
+        android:layout_width="@dimen/minimum_size_for_touchable_area"
+        android:layout_height="@dimen/minimum_size_for_touchable_area"
+        android:contentDescription="@string/synced_folders_type"
+        android:padding="@dimen/standard_half_padding"
+        android:src="@drawable/image_32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-            <ImageView
-                android:id="@+id/type"
-                android:layout_width="@dimen/synced_folders_item_type_layout_width"
-                android:layout_height="@dimen/synced_folders_item_type_layout_height"
-                android:layout_marginEnd="@dimen/synced_folders_item_type_layout_right_end_margin"
-                android:contentDescription="@string/synced_folders_type"
-                android:src="@drawable/image_32dp" />
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/minimum_size_for_touchable_area"
+        android:layout_marginStart="@dimen/standard_margin"
+        android:ellipsize="middle"
+        android:gravity="center|start"
+        android:text="@string/placeholder_filename"
+        android:textAlignment="center"
+        android:textColor="?android:textColorPrimary"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/type" />
 
-            <TextView
-                android:id="@+id/title"
-                android:gravity="center|start"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:ellipsize="middle"
-                android:text="@string/placeholder_filename"
-                android:textColor="?android:textColorPrimary"
-                android:textStyle="bold" />
-        </LinearLayout>
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/subFolderWarningButton"
+        style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+        android:layout_width="@dimen/minimum_size_for_touchable_area"
+        android:layout_height="@dimen/minimum_size_for_touchable_area"
+        android:clickable="true"
+        android:contentDescription="@string/sync_warning_button"
+        android:focusable="true"
+        android:visibility="gone"
+        app:backgroundTint="@color/transparent"
+        app:cornerRadius="@dimen/button_corner_radius"
+        app:icon="@drawable/ic_info"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/syncStatusButton"
+        tools:layout_editor_absoluteY="5dp"
+        tools:visibility="visible" />
 
-        <LinearLayout
-            android:id="@+id/buttonBar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/syncStatusButton"
+        style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+        android:layout_width="@dimen/minimum_size_for_touchable_area"
+        android:layout_height="@dimen/minimum_size_for_touchable_area"
+        android:clickable="true"
+        android:contentDescription="@string/sync_status_button"
+        android:focusable="true"
+        app:backgroundTint="@color/transparent"
+        app:cornerRadius="@dimen/button_corner_radius"
+        app:icon="@drawable/ic_cloud_sync_off"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/settingsButton" />
 
-            <ImageButton
-                android:id="@+id/subFolderWarningButton"
-                android:visibility="gone"
-                tools:visibility="visible"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/transparent"
-                android:clickable="true"
-                android:contentDescription="@string/sync_warning_button"
-                android:focusable="true"
-                android:padding="@dimen/standard_half_padding"
-                android:src="@drawable/ic_info" />
-
-            <ImageButton
-                android:id="@+id/syncStatusButton"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/transparent"
-                android:clickable="true"
-                android:contentDescription="@string/sync_status_button"
-                android:focusable="true"
-                android:padding="@dimen/standard_half_padding"
-                android:src="@drawable/ic_cloud_sync_off" />
-
-            <ImageButton
-                android:id="@+id/settingsButton"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/transparent"
-                android:clickable="true"
-                android:contentDescription="@string/synced_folder_settings_button"
-                android:focusable="true"
-                android:paddingStart="@dimen/standard_half_padding"
-                android:paddingEnd="@dimen/synced_folder_padding_end"
-                android:src="@drawable/ic_dots_vertical"/>
-        </LinearLayout>
-    </LinearLayout>
-</LinearLayout>
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/settingsButton"
+        style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+        android:layout_width="@dimen/minimum_size_for_touchable_area"
+        android:layout_height="@dimen/minimum_size_for_touchable_area"
+        android:clickable="true"
+        android:contentDescription="@string/synced_folder_settings_button"
+        android:focusable="true"
+        app:backgroundTint="@color/transparent"
+        app:cornerRadius="@dimen/button_corner_radius"
+        app:icon="@drawable/ic_dots_vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/synced_folders_item_header.xml
+++ b/app/src/main/res/layout/synced_folders_item_header.xml
@@ -14,7 +14,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/standard_half_padding">
+    android:paddingBottom="@dimen/alternate_half_padding"
+    android:paddingEnd="@dimen/zero"
+    android:paddingStart="@dimen/standard_padding"
+    android:paddingTop="@dimen/alternate_half_padding">
 
     <include
         android:id="@+id/auto_upload_battery_saver_warning_card"
@@ -24,6 +27,7 @@
         android:layout_gravity="center"
         android:layout_marginBottom="@dimen/standard_quadruple_margin"
         android:visibility="gone"
+        android:layout_marginEnd="@dimen/standard_margin"
         app:layout_constraintBottom_toBottomOf="@id/type"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/synced_folders_item_header.xml
+++ b/app/src/main/res/layout/synced_folders_item_header.xml
@@ -2,91 +2,107 @@
 <!--
   ~ Nextcloud - Android Client
   ~
+  ~ SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
   ~ SPDX-FileCopyrightText: 2016 Andy Scherzinger <info@andy-scherzinger>
   ~ SPDX-FileCopyrightText: 2016 Nextcloud GmbH
   ~ SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/header_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="@dimen/alternate_half_padding"
-    android:paddingEnd="@dimen/zero"
-    android:paddingStart="@dimen/standard_padding"
-    android:paddingTop="@dimen/alternate_half_padding">
+    android:orientation="vertical"
+    android:padding="@dimen/alternate_half_padding">
+
+    <include
+        android:id="@+id/auto_upload_battery_saver_warning_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_gravity="center"
+        tools:visibility="visible"
+        layout="@layout/auto_upload_battery_saver_warning_card"
+        android:layout_marginBottom="@dimen/standard_double_margin" />
 
     <LinearLayout
-        android:id="@+id/title_container"
-        android:layout_width="wrap_content"
+        android:id="@+id/header_row"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignBottom="@+id/buttonBar"
-        android:layout_alignParentStart="true"
-        android:layout_alignTop="@+id/buttonBar"
-        android:layout_toStartOf="@+id/buttonBar"
-        tools:ignore="UseCompoundDrawables">
+        android:baselineAligned="false"
+        android:orientation="horizontal">
 
-        <ImageView
-            android:id="@+id/type"
-            android:layout_width="@dimen/synced_folders_item_type_layout_width"
-            android:layout_height="@dimen/synced_folders_item_type_layout_height"
-            android:layout_gravity="start|center_vertical"
-            android:layout_marginEnd="@dimen/synced_folders_item_type_layout_right_end_margin"
-            android:contentDescription="@string/synced_folders_type"
-            android:src="@drawable/image_32dp" />
+        <LinearLayout
+            android:id="@+id/title_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_gravity="center"
+            tools:ignore="UseCompoundDrawables">
 
-        <TextView
-            android:id="@+id/title"
-            android:layout_width="match_parent"
+            <ImageView
+                android:id="@+id/type"
+                android:layout_width="@dimen/synced_folders_item_type_layout_width"
+                android:layout_height="@dimen/synced_folders_item_type_layout_height"
+                android:layout_marginEnd="@dimen/synced_folders_item_type_layout_right_end_margin"
+                android:contentDescription="@string/synced_folders_type"
+                android:src="@drawable/image_32dp" />
+
+            <TextView
+                android:id="@+id/title"
+                android:gravity="center|start"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:ellipsize="middle"
+                android:text="@string/placeholder_filename"
+                android:textColor="?android:textColorPrimary"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/buttonBar"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            android:ellipsize="middle"
-            android:text="@string/placeholder_filename"
-            android:textColor="?android:textColorPrimary"
-            android:textStyle="bold" />
+            android:orientation="horizontal">
 
+            <ImageButton
+                android:id="@+id/subFolderWarningButton"
+                android:visibility="gone"
+                tools:visibility="visible"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/transparent"
+                android:clickable="true"
+                android:contentDescription="@string/sync_warning_button"
+                android:focusable="true"
+                android:padding="@dimen/standard_half_padding"
+                android:src="@drawable/ic_info" />
+
+            <ImageButton
+                android:id="@+id/syncStatusButton"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/transparent"
+                android:clickable="true"
+                android:contentDescription="@string/sync_status_button"
+                android:focusable="true"
+                android:padding="@dimen/standard_half_padding"
+                android:src="@drawable/ic_cloud_sync_off" />
+
+            <ImageButton
+                android:id="@+id/settingsButton"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/transparent"
+                android:clickable="true"
+                android:contentDescription="@string/synced_folder_settings_button"
+                android:focusable="true"
+                android:paddingStart="@dimen/standard_half_padding"
+                android:paddingEnd="@dimen/synced_folder_padding_end"
+                android:src="@drawable/ic_dots_vertical"/>
+        </LinearLayout>
     </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/buttonBar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true">
-
-        <ImageButton
-            android:id="@+id/subFolderWarningButton"
-            android:visibility="gone"
-            tools:visibility="visible"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@color/transparent"
-            android:clickable="true"
-            android:contentDescription="@string/sync_warning_button"
-            android:focusable="true"
-            android:padding="@dimen/standard_half_padding"
-            android:src="@drawable/ic_info" />
-
-        <ImageButton
-            android:id="@+id/syncStatusButton"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@color/transparent"
-            android:clickable="true"
-            android:contentDescription="@string/sync_status_button"
-            android:focusable="true"
-            android:padding="@dimen/standard_half_padding"
-            android:src="@drawable/ic_cloud_sync_off" />
-
-        <ImageButton
-            android:id="@+id/settingsButton"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@color/transparent"
-            android:clickable="true"
-            android:contentDescription="@string/synced_folder_settings_button"
-            android:focusable="true"
-            android:paddingEnd="@dimen/synced_folder_padding_end"
-            android:paddingStart="@dimen/standard_half_padding"
-            android:src="@drawable/ic_dots_vertical"/>
-    </LinearLayout>
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/upload_list_header.xml
+++ b/app/src/main/res/layout/upload_list_header.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Nextcloud - Android Client
-  ~
+  ~ SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
   ~ SPDX-FileCopyrightText: 2024 Jonas Mayer
   ~ SPDX-FileCopyrightText: 2018 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2018 Tobias Kaminsky <tobias@kaminsky.me>
   ~ SPDX-FileCopyrightText: 2018 Nextcloud
   ~ SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/ListItemLayout"
     android:layout_width="match_parent"
@@ -59,4 +61,41 @@
         android:paddingEnd="@dimen/zero"
         android:paddingBottom="@dimen/standard_half_padding"
         android:src="@drawable/nav_trashbin" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/auto_upload_battery_saver_warning_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/upload_list_title"
+        android:background="@drawable/rounded_rect_8dp"
+        android:layout_marginTop="@dimen/standard_half_margin"
+        android:layout_marginHorizontal="@dimen/standard_half_margin"
+        android:backgroundTint="@color/grey_200"
+        android:elevation="4dp"
+        android:padding="@dimen/standard_double_margin">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/standard_padding"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="@dimen/standard_icon_size"
+                android:layout_height="@dimen/standard_icon_size"
+                android:contentDescription="@string/auto_upload_battery_saver_mode_warning"
+                android:src="@drawable/ic_warning"
+                app:tint="@color/log_level_warning" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/auto_upload_battery_saver_mode_warning"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+                android:textColor="@color/text_color" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 </RelativeLayout>

--- a/app/src/main/res/layout/upload_list_header.xml
+++ b/app/src/main/res/layout/upload_list_header.xml
@@ -62,40 +62,10 @@
         android:paddingBottom="@dimen/standard_half_padding"
         android:src="@drawable/nav_trashbin" />
 
-    <com.google.android.material.card.MaterialCardView
+    <include
         android:id="@+id/auto_upload_battery_saver_warning_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/upload_list_title"
-        android:background="@drawable/rounded_rect_8dp"
-        android:layout_marginTop="@dimen/standard_half_margin"
-        android:layout_marginHorizontal="@dimen/standard_half_margin"
-        android:backgroundTint="@color/grey_200"
-        android:elevation="4dp"
-        android:padding="@dimen/standard_double_margin">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/standard_padding"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <ImageView
-                android:layout_width="@dimen/standard_icon_size"
-                android:layout_height="@dimen/standard_icon_size"
-                android:contentDescription="@string/auto_upload_battery_saver_mode_warning"
-                android:src="@drawable/ic_warning"
-                app:tint="@color/log_level_warning" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_weight="1"
-                android:text="@string/auto_upload_battery_saver_mode_warning"
-                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-                android:textColor="@color/text_color" />
-        </LinearLayout>
-    </com.google.android.material.card.MaterialCardView>
+        layout="@layout/auto_upload_battery_saver_warning_card" />
 </RelativeLayout>

--- a/app/src/main/res/values/dims.xml
+++ b/app/src/main/res/values/dims.xml
@@ -29,6 +29,7 @@
     <dimen name="standard_double_padding">32dp</dimen>
     <dimen name="standard_half_padding">8dp</dimen>
     <dimen name="standard_quarter_padding">4dp</dimen>
+    <dimen name="standard_icon_size">32dp</dimen>
     <dimen name="standard_eight_padding">2dp</dimen>
     <dimen name="standard_margin">16dp</dimen>
     <dimen name="standard_double_margin">32dp</dimen>

--- a/app/src/main/res/values/dims.xml
+++ b/app/src/main/res/values/dims.xml
@@ -33,6 +33,7 @@
     <dimen name="standard_eight_padding">2dp</dimen>
     <dimen name="standard_margin">16dp</dimen>
     <dimen name="standard_double_margin">32dp</dimen>
+    <dimen name="standard_quadruple_margin">64dp</dimen>
     <dimen name="standard_half_margin">8dp</dimen>
     <dimen name="floating_action_button_bottom_margin">100dp</dimen>
     <dimen name="bottom_navigation_view_margin">100dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1356,6 +1356,7 @@
     <string name="create_link">Create link</string>
     <string name="folder_best_viewed_in">This folder is best viewed in %1$s.</string>
     <string name="open_in_app">Open in %1$s</string>
+    <string name="auto_upload_battery_saver_mode_warning">Auto-upload is paused because Battery Saver is on.</string>
     <string name="auto_upload_sub_folder_warning">This folder is already included in the parent folder’s sync, which may cause duplicate uploads</string>
     <string name="sync_anyway">Sync anyway</string>
     <string name="sync_duplication">Sync duplication</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

<table>
  <tr>
    <th>Light</th>
    <th>Dark</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0176f6f6-7fa3-4c77-a242-c72f198eba78" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/29140e92-cd85-4220-a836-56da5653513d" width="300" alt="after"></td>
  </tr>
</table>

<table>
  <tr>
    <th>Before Light Auto Upload Overview</th>
    <th>After Light Auto Upload Overview</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/c2bad088-83f6-41df-ac24-80946a545f1f" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/9123b700-9e4c-41d5-bd12-95ba5018263c" width="300" alt="after light"></td>
  </tr>
</table>


<table>
  <tr>
    <th>Before Dark Auto Upload Overview</th>
    <th>After Dark Auto Upload Overview</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/9a7fd133-f0ee-4650-a5d8-bf14eccf896e" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/f8dedf9d-306a-428c-8fc3-c965eb28140b" width="300" alt="after dark"></td>
  </tr>
</table>