### PR TITLE
fix: sync icon logic for folder item download

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadHelper.kt
@@ -50,7 +50,7 @@ class FileDownloadHelper {
         val isJobScheduled = backgroundJobManager.isStartFileDownloadJobScheduled(user, file.fileId)
         return isJobScheduled ||
             if (file.isFolder) {
-                FileDownloadWorker.isDownloadingFolder(file.fileId) ||
+                FileDownloadWorker.isDownloadingFolder(file.fileId) &&
                     backgroundJobManager.isStartFileDownloadJobScheduled(user, topParentId)
             } else {
                 FileDownloadWorker.isDownloading(user.accountName, file.fileId)

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -328,6 +328,7 @@ class FileDownloadWorker(
             currentDownload?.user?.accountName,
             currentDownload?.remotePath
         )
+        pendingFolderDownloads.remove(currentDownload?.file?.parentId)
 
         val downloadResult = result ?: RemoteOperationResult<Any?>(RuntimeException("Error downloading…"))
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed

### Issue

When a file is downloaded, the folder status still shows as "In Sync."

### How to reproduce?

1. Have a folder that contains multiple files.
2. Try to download one file.
3. Sync icon should not be visible for folder after completion of the one file download.
