### PR TITLE
fix: unified search filter

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -445,7 +445,9 @@ class UnifiedSearchFragment :
 
     private fun searchInCurrentDirectory(query: String) {
         currentDir?.run {
-            val files = storageManager.searchFilesByName(this, accountManager.user.accountName, query)
+            val files = storageManager
+                .searchFilesByName(this, accountManager.user.accountName, query)
+                .filter { !it.isEncrypted }
             adapter.setDataCurrentDirItems(files)
         }
     }
@@ -462,6 +464,6 @@ class UnifiedSearchFragment :
 
     override fun openFile(remotePath: String, showMoreActions: Boolean) {
         this.showMoreActions = showMoreActions
-        vm.openFile(remotePath)
+        vm.getRemoteFile(remotePath)
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/IUnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/IUnifiedSearchViewModel.kt
@@ -24,4 +24,5 @@ interface IUnifiedSearchViewModel {
     fun openResult(result: SearchResultEntry)
     fun setQuery(query: String)
     fun openFile(remotePath: String)
+    fun getRemoteFile(remotePath: String)
 }

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -159,16 +159,20 @@ class UnifiedSearchViewModel(application: Application) :
     override fun openFile(remotePath: String) {
         if (isLoading.value == false) {
             isLoading.value = true
-            val user = currentAccountProvider.user
-            val task = GetRemoteFileTask(
-                context,
-                remotePath,
-                clientFactory.create(currentAccountProvider.user),
-                FileDataStorageManager(user, context.contentResolver),
-                user
-            )
-            runner.postQuickTask(task, onResult = this::onFileRequestResult)
+            getRemoteFile(remotePath)
         }
+    }
+
+    override fun getRemoteFile(remotePath: String) {
+        val user = currentAccountProvider.user
+        val task = GetRemoteFileTask(
+            context,
+            remotePath,
+            clientFactory.create(user),
+            FileDataStorageManager(user, context.contentResolver),
+            user
+        )
+        runner.postQuickTask(task, onResult = this::onFileRequestResult)
     }
 
     fun onError(error: Throwable) {

--- a/app/src/main/res/layout/unified_search_current_directory_item.xml
+++ b/app/src/main/res/layout/unified_search_current_directory_item.xml
@@ -64,7 +64,7 @@
 
     <ImageButton
         android:id="@+id/more"
-        android:layout_marginEnd="@dimen/standard_double_margin"
+        android:layout_marginEnd="@dimen/drawer_content_horizontal_padding"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:clickable="true"


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed


### Changes in this PR

1. **Instant Search & Encrypted Files**

   * Encrypted files appearing in the "Instant Search" section (search in this folder) are tricky to handle. This will be addressed in a separate PR. @tobiasKaminsky What do you think?

2. **File Opening Logic**

   * Removed the `isLoading.value` check when opening files from in this folder section. This change allows files to be opened immediately from the search results without being blocked, as the loading state is mainly intended for remote files.

3. **UI Fixes**

   * Fixed alignment issues for the "more" icon.


