### PR TITLE
fix: rotate bitmap according to the exif

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/extensions/BitmapRotationTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/extensions/BitmapRotationTests.kt
@@ -1,0 +1,90 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.extensions
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.exifinterface.media.ExifInterface
+import com.nextcloud.utils.rotateBitmapViaExif
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class BitmapRotationTests {
+
+    private fun createTestBitmap(): Bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888).apply {
+        setPixel(0, 0, Color.RED)
+        setPixel(1, 0, Color.GREEN)
+        setPixel(0, 1, Color.BLUE)
+        setPixel(1, 1, Color.YELLOW)
+    }
+
+    @Test
+    fun testRotateBitmapViaExifWhenGivenNullBitmapShouldReturnNull() {
+        val rotated = null.rotateBitmapViaExif(ExifInterface.ORIENTATION_ROTATE_90)
+        assertEquals(null, rotated)
+    }
+
+    @Test
+    fun testRotateBitmapViaExifWhenGivenNormalOrientationShouldReturnSameBitmap() {
+        val bmp = createTestBitmap()
+        val rotated = bmp.rotateBitmapViaExif(ExifInterface.ORIENTATION_NORMAL)
+        assertEquals(bmp, rotated)
+    }
+
+    @Test
+    fun testRotateBitmapViaExifWhenGivenRotate90ShouldReturnRotatedBitmap() {
+        val bmp = createTestBitmap()
+        val rotated = bmp.rotateBitmapViaExif(ExifInterface.ORIENTATION_ROTATE_90)!!
+        assertEquals(bmp.width, rotated.height)
+        assertEquals(bmp.height, rotated.width)
+
+        assertEquals(Color.BLUE, rotated.getPixel(0, 0))
+        assertEquals(Color.RED, rotated.getPixel(1, 0))
+        assertEquals(Color.YELLOW, rotated.getPixel(0, 1))
+        assertEquals(Color.GREEN, rotated.getPixel(1, 1))
+    }
+
+    @Test
+    fun testRotateBitmapViaExifWhenGivenRotate180ShouldReturnRotatedBitmap() {
+        val bmp = createTestBitmap()
+        val rotated = bmp.rotateBitmapViaExif(ExifInterface.ORIENTATION_ROTATE_180)!!
+        assertEquals(bmp.width, rotated.width)
+        assertEquals(bmp.height, rotated.height)
+
+        assertEquals(Color.YELLOW, rotated.getPixel(0, 0))
+        assertEquals(Color.BLUE, rotated.getPixel(1, 0))
+        assertEquals(Color.GREEN, rotated.getPixel(0, 1))
+        assertEquals(Color.RED, rotated.getPixel(1, 1))
+    }
+
+    @Test
+    fun testRotateBitmapViaExifWhenGivenFlipHorizontalShouldReturnFlippedBitmap() {
+        val bmp = createTestBitmap()
+        val rotated = bmp.rotateBitmapViaExif(ExifInterface.ORIENTATION_FLIP_HORIZONTAL)!!
+        assertEquals(bmp.width, rotated.width)
+        assertEquals(bmp.height, rotated.height)
+
+        assertEquals(Color.GREEN, rotated.getPixel(0, 0))
+        assertEquals(Color.RED, rotated.getPixel(1, 0))
+        assertEquals(Color.YELLOW, rotated.getPixel(0, 1))
+        assertEquals(Color.BLUE, rotated.getPixel(1, 1))
+    }
+
+    @Test
+    fun testRotateBitmapViaExifWhenGivenFlipVerticalShouldReturnFlippedBitmap() {
+        val bmp = createTestBitmap()
+        val rotated = bmp.rotateBitmapViaExif(ExifInterface.ORIENTATION_FLIP_VERTICAL)!!
+        assertEquals(bmp.width, rotated.width)
+        assertEquals(bmp.height, rotated.height)
+
+        assertEquals(Color.BLUE, rotated.getPixel(0, 0))
+        assertEquals(Color.YELLOW, rotated.getPixel(1, 0))
+        assertEquals(Color.RED, rotated.getPixel(0, 1))
+        assertEquals(Color.GREEN, rotated.getPixel(1, 1))
+    }
+}

--- a/app/src/androidTest/java/com/nextcloud/extensions/GetExifOrientationTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/extensions/GetExifOrientationTests.kt
@@ -19,6 +19,7 @@ class GetExifOrientationTests {
 
     private val tempFiles = mutableListOf<File>()
 
+    @Suppress("MagicNumber")
     private fun createTempImageFile(): File {
         val file = File.createTempFile("test_image", ".jpg")
         tempFiles.add(file)

--- a/app/src/androidTest/java/com/nextcloud/extensions/GetExifOrientationTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/extensions/GetExifOrientationTests.kt
@@ -1,0 +1,77 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.extensions
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.exifinterface.media.ExifInterface
+import com.nextcloud.utils.extensions.getExifOrientation
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Test
+import java.io.File
+
+class GetExifOrientationTests {
+
+    private val tempFiles = mutableListOf<File>()
+
+    private fun createTempImageFile(): File {
+        val file = File.createTempFile("test_image", ".jpg")
+        tempFiles.add(file)
+
+        val bmp = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888).apply {
+            setPixel(0, 0, Color.RED)
+            setPixel(1, 0, Color.GREEN)
+            setPixel(0, 1, Color.BLUE)
+            setPixel(1, 1, Color.YELLOW)
+        }
+
+        file.outputStream().use { out ->
+            bmp.compress(Bitmap.CompressFormat.JPEG, 100, out)
+        }
+
+        return file
+    }
+
+    @After
+    fun cleanup() {
+        tempFiles.forEach { it.delete() }
+    }
+
+    @Test
+    fun testGetExifOrientationWhenExifIsRotate90ShouldReturnRotate90() {
+        val file = createTempImageFile()
+
+        val exif = ExifInterface(file.absolutePath)
+        exif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_ROTATE_90.toString())
+        exif.saveAttributes()
+
+        val orientation = getExifOrientation(file.absolutePath)
+
+        assertEquals(ExifInterface.ORIENTATION_ROTATE_90, orientation)
+    }
+
+    @Test
+    fun testGetExifOrientationWhenExifIsRotate180ShouldReturnRotate180() {
+        val file = createTempImageFile()
+
+        val exif = ExifInterface(file.absolutePath)
+        exif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_ROTATE_180.toString())
+        exif.saveAttributes()
+
+        val orientation = getExifOrientation(file.absolutePath)
+        assertEquals(ExifInterface.ORIENTATION_ROTATE_180, orientation)
+    }
+
+    @Test
+    fun testGetExifOrientationWhenExifIsUndefinedShouldReturnUndefined() {
+        val file = createTempImageFile()
+
+        val orientation = getExifOrientation(file.absolutePath)
+        assertEquals(ExifInterface.ORIENTATION_UNDEFINED, orientation)
+    }
+}

--- a/app/src/main/java/com/nextcloud/utils/BitmapExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/BitmapExtensions.kt
@@ -8,7 +8,10 @@
 package com.nextcloud.utils
 
 import android.graphics.Bitmap
+import android.graphics.Matrix
 import androidx.core.graphics.scale
+import androidx.exifinterface.media.ExifInterface
+import com.owncloud.android.lib.common.utils.Log_OC
 
 @Suppress("MagicNumber")
 fun Bitmap.allocationKilobyte(): Int = allocationByteCount.div(1024)
@@ -37,4 +40,80 @@ fun Bitmap.scaleUntil(targetKB: Int): Bitmap {
 
     val scaledBitmap = scale(width, height)
     return scaledBitmap.scaleUntil(targetKB)
+}
+
+/**
+ * Rotates and/or flips a [Bitmap] according to an EXIF orientation constant.
+ *
+ * Needed because loading bitmaps directly may ignore EXIF metadata with some devices,
+ * resulting in incorrectly displayed images.
+ *
+ * This function uses a [Matrix] transformation to adjust the image so that it
+ * appears upright when displayed. It supports all standard EXIF orientations,
+ * including mirrored and rotated cases.
+ *
+ * The original bitmap will be recycled if a new one is successfully created.
+ * If the device runs out of memory during the transformation, the original bitmap
+ * is returned unchanged.
+ *
+ * @receiver The [Bitmap] to rotate or flip. Can be `null`.
+ * @param orientation One of the [ExifInterface] orientation constants, such as
+ * [ExifInterface.ORIENTATION_ROTATE_90] or [ExifInterface.ORIENTATION_FLIP_HORIZONTAL].
+ * @return The correctly oriented [Bitmap], or `null` if the receiver was `null`.
+ *
+ * @see ExifInterface
+ * @see Matrix
+ */
+@Suppress("MagicNumber", "ReturnCount")
+fun Bitmap?.rotateBitmapViaExif(orientation: Int): Bitmap? {
+    if (this == null) {
+        return null
+    }
+
+    val matrix = Matrix()
+    when (orientation) {
+        ExifInterface.ORIENTATION_NORMAL -> return this
+        ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.setScale(-1f, 1f)
+        ExifInterface.ORIENTATION_ROTATE_180 -> matrix.setRotate(180f)
+        ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
+            matrix.setRotate(180f)
+            matrix.postScale(-1f, 1f)
+        }
+
+        ExifInterface.ORIENTATION_TRANSPOSE -> {
+            matrix.setRotate(90f)
+            matrix.postScale(-1f, 1f)
+        }
+
+        ExifInterface.ORIENTATION_ROTATE_90 -> matrix.setRotate(90f)
+        ExifInterface.ORIENTATION_TRANSVERSE -> {
+            matrix.setRotate(-90f)
+            matrix.postScale(-1f, 1f)
+        }
+
+        ExifInterface.ORIENTATION_ROTATE_270 -> matrix.setRotate(-90f)
+        else -> return this
+    }
+
+    return try {
+        val rotated = Bitmap.createBitmap(
+            this,
+            0,
+            0,
+            this.width,
+            this.height,
+            matrix,
+            true
+        )
+
+        // release original if a new one was created
+        if (rotated != this) {
+            this.recycle()
+        }
+
+        rotated
+    } catch (_: OutOfMemoryError) {
+        Log_OC.e("BitmapExtension", "rotating bitmap, out of memory exception")
+        this
+    }
 }

--- a/app/src/main/java/com/nextcloud/utils/extensions/ThumbnailsCacheManagerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/ThumbnailsCacheManagerExtensions.kt
@@ -1,0 +1,77 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import android.provider.MediaStore
+import androidx.exifinterface.media.ExifInterface
+import androidx.core.net.toUri
+import com.owncloud.android.MainApp
+import com.owncloud.android.lib.common.utils.Log_OC
+
+/**
+ * Retrieves the orientation of an image file from its EXIF metadata or, as a fallback,
+ * from the Android MediaStore.
+ *
+ * This function first attempts to read the orientation using [ExifInterface.TAG_ORIENTATION]
+ * directly from the file at the given [path]. If that fails or returns
+ * [ExifInterface.ORIENTATION_UNDEFINED], it then queries the MediaStore for the image's
+ * stored orientation in degrees (0, 90, 180, or 270), converting that to an EXIF-compatible
+ * orientation constant.
+ *
+ * @param path Absolute file path or content URI (as string) of the image.
+ * @return One of the [ExifInterface] orientation constants, e.g.
+ * [ExifInterface.ORIENTATION_ROTATE_90], or [ExifInterface.ORIENTATION_UNDEFINED]
+ * if the orientation could not be determined.
+ *
+ * @see ExifInterface
+ * @see MediaStore.Images.Media.ORIENTATION
+ */
+@Suppress("TooGenericExceptionCaught", "NestedBlockDepth", "MagicNumber")
+fun getExifOrientation(path: String): Int {
+    val context = MainApp.getAppContext()
+    if (context == null || path.isBlank()) {
+        return ExifInterface.ORIENTATION_UNDEFINED
+    }
+
+    var orientation = ExifInterface.ORIENTATION_UNDEFINED
+
+    try {
+        val exif = ExifInterface(path)
+        orientation = exif.getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_UNDEFINED
+        )
+    } catch (e: Exception) {
+        Log_OC.e("ThumbnailsCacheManager", "getExifOrientation exception: $e")
+    }
+
+    // Fallback: query MediaStore if EXIF is undefined
+    if (orientation == ExifInterface.ORIENTATION_UNDEFINED) {
+        try {
+            val uri = path.toUri()
+            val projection = arrayOf(MediaStore.Images.Media.ORIENTATION)
+
+            context.contentResolver.query(uri, projection, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val orientationIndex = cursor.getColumnIndexOrThrow(projection[0])
+                    val degrees = cursor.getInt(orientationIndex)
+                    orientation = when (degrees) {
+                        90 -> ExifInterface.ORIENTATION_ROTATE_90
+                        180 -> ExifInterface.ORIENTATION_ROTATE_180
+                        270 -> ExifInterface.ORIENTATION_ROTATE_270
+                        else -> ExifInterface.ORIENTATION_NORMAL
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log_OC.e("ThumbnailsCacheManager", "getExifOrientation exception: $e")
+        }
+    }
+
+    return orientation
+}

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -37,6 +37,7 @@ import android.widget.ImageView;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.utils.BitmapExtensionsKt;
+import com.nextcloud.utils.extensions.ThumbnailsCacheManagerExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.OwnCloudAccount;
@@ -76,6 +77,8 @@ import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import static com.nextcloud.utils.extensions.ThumbnailsCacheManagerExtensionsKt.getExifOrientation;
 
 /**
  * Manager for concurrent access to thumbnails cache.
@@ -194,7 +197,8 @@ public final class ThumbnailsCacheManager {
         Bitmap thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
 
         // Rotate image, obeying exif tag
-        thumbnail = BitmapUtils.rotateImage(thumbnail,path);
+        int orientation = getExifOrientation(path);
+        thumbnail = BitmapExtensionsKt.rotateBitmapViaExif(thumbnail, orientation);
 
         // Add thumbnail to cache
         // do not overwrite any pre-existing image

--- a/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -16,7 +16,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.BitmapFactory.Options;
 import android.graphics.Canvas;
 import android.graphics.ImageDecoder;
-import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
@@ -220,74 +219,6 @@ public final class BitmapUtils {
         int w = Math.round(scale * width);
         int h = Math.round(scale * height);
         return Bitmap.createScaledBitmap(bitmap, w, h, true);
-    }
-
-    /**
-     * Rotate bitmap according to EXIF orientation. Cf. http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/
-     *
-     * @param bitmap      Bitmap to be rotated
-     * @param storagePath Path to source file of bitmap. Needed for EXIF information.
-     * @return correctly EXIF-rotated bitmap
-     */
-    public static Bitmap rotateImage(Bitmap bitmap, String storagePath) {
-        Bitmap resultBitmap = bitmap;
-
-        try {
-            ExifInterface exifInterface = new ExifInterface(storagePath);
-            int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
-
-            if (orientation != ExifInterface.ORIENTATION_NORMAL) {
-                Matrix matrix = new Matrix();
-                switch (orientation) {
-                    // 2
-                    case ExifInterface.ORIENTATION_FLIP_HORIZONTAL: {
-                        matrix.postScale(-1.0f, 1.0f);
-                        break;
-                    }
-                    // 3
-                    case ExifInterface.ORIENTATION_ROTATE_180: {
-                        matrix.postRotate(180);
-                        break;
-                    }
-                    // 4
-                    case ExifInterface.ORIENTATION_FLIP_VERTICAL: {
-                        matrix.postScale(1.0f, -1.0f);
-                        break;
-                    }
-                    // 5
-                    case ExifInterface.ORIENTATION_TRANSPOSE: {
-                        matrix.postRotate(-90);
-                        matrix.postScale(1.0f, -1.0f);
-                        break;
-                    }
-                    // 6
-                    case ExifInterface.ORIENTATION_ROTATE_90: {
-                        matrix.postRotate(90);
-                        break;
-                    }
-                    // 7
-                    case ExifInterface.ORIENTATION_TRANSVERSE: {
-                        matrix.postRotate(90);
-                        matrix.postScale(1.0f, -1.0f);
-                        break;
-                    }
-                    // 8
-                    case ExifInterface.ORIENTATION_ROTATE_270: {
-                        matrix.postRotate(270);
-                        break;
-                    }
-                }
-
-                // Rotate the bitmap
-                resultBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-                if (!resultBitmap.equals(bitmap)) {
-                    bitmap.recycle();
-                }
-            }
-        } catch (Exception exception) {
-            Log_OC.e("BitmapUtil", "Could not rotate the image: " + storagePath);
-        }
-        return resultBitmap;
     }
 
     /**


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Issue

On some devices, the orientation of thumbnails and full-size images can be inconsistent, for example:

* On `One UI` devices, thumbnails are rotated 90° left, while the full-size images display correctly.
* On `HarmonyOS` devices, thumbnails are correct, but full-size images appear rotated 90° to the right.

### Changes

* Implemented a fallback mechanism to retrieve image orientation from `MediaStore` when EXIF metadata is unavailable.
* Added unit tests to verify both EXIF-based orientation retrieval and bitmap rotation logic.
* Migrated orientation and rotation logic from Java to Kotlin

### Useful links

[Get correct orientation of image](https://stackoverflow.com/questions/20478765/how-to-get-the-correct-orientation-of-the-image-selected-from-the-default-image)

[Image resizing and preserving exif data](https://stackoverflow.com/questions/13596500/android-image-resizing-and-preserving-exif-data-orientation-rotation-etc)

[Images taken with action image capture](https://stackoverflow.com/questions/8450539/images-taken-with-action-image-capture-always-returns-1-for-exifinterface-tag-or/8864367#8864367)

### Demo

<img width="525" height="330" alt="Screenshot 2025-10-07 at 10 45 12" src="https://github.com/user-attachments/assets/cc370da9-ca6a-4941-baab-86a5685600b7" />


