### PR TITLE
make placeholders non translatable

### DIFF
--- a/app/src/main/res/layout/account_item.xml
+++ b/app/src/main/res/layout/account_item.xml
@@ -93,7 +93,7 @@
                 android:text="@string/placeholder_sentence"
                 android:textColor="?android:attr/textColorSecondary"
                 android:visibility="gone"
-                tools:text="☁️ My custom status" />
+                tools:text="@string/placeholder_status" />
 
             <TextView
                 android:id="@+id/account"
@@ -107,7 +107,7 @@
                 android:maxLines="1"
                 android:text="@string/placeholder_sentence"
                 android:textColor="?android:attr/textColorSecondary"
-                tools:text="https://nextcloud.localhost/nextcloud" />
+                tools:text="@string/placeholder_random_link" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/account_item.xml
+++ b/app/src/main/res/layout/account_item.xml
@@ -78,7 +78,7 @@
                 android:maxLines="1"
                 android:text="@string/placeholder_filename"
                 android:textAppearance="?android:attr/textAppearanceListItem"
-                tools:text="Firstname Lastname" />
+                tools:text="@string/placeholder_first_name_last_name" />
 
             <TextView
                 android:id="@+id/status"

--- a/app/src/main/res/layout/account_removal_dialog.xml
+++ b/app/src/main/res/layout/account_removal_dialog.xml
@@ -40,14 +40,14 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="middle"
                 android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
-                tools:text="Alice Muster" />
+                tools:text="@string/placeholder_first_name_last_name" />
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/account"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ellipsize="middle"
-                tools:text="alice@cloud.nextcloud.com" />
+                tools:text="@string/placeholder_random_account" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/conflict_resolve_dialog.xml
+++ b/app/src/main/res/layout/conflict_resolve_dialog.xml
@@ -63,13 +63,13 @@
                 android:id="@+id/left_timestamp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="12. Dec 2020 - 23:10:20" />
+                tools:text="@string/placeholder_date" />
 
             <TextView
                 android:id="@+id/left_file_size"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="5 Mb" />
+                tools:text="@string/placeholder_fileSize_2" />
         </LinearLayout>
 
         <LinearLayout
@@ -97,13 +97,13 @@
                 android:id="@+id/right_timestamp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="10. Dec 2020 - 10:10:10" />
+                tools:text="@string/placeholder_date_2" />
 
             <TextView
                 android:id="@+id/right_file_size"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="3 Mb" />
+                tools:text="@string/placeholder_fileSize_3" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_sso_grant_permission.xml
+++ b/app/src/main/res/layout/dialog_sso_grant_permission.xml
@@ -43,6 +43,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Grant Nextcloud News access to your Nextcloud account incrediblyLong_username_with_123456789_number@Nextcloud_dummy.com?" />
+        tools:text="@string/placeholder_sso" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -46,8 +46,7 @@
             android:textSize="18sp"
             android:textStyle="bold"
             android:visibility="gone"
-            tools:ignore="RtlHardcoded"
-            tools:text="Nextcloud" />
+            tools:ignore="RtlHardcoded" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/etm_background_job_list_item.xml
+++ b/app/src/main/res/layout/etm_background_job_list_item.xml
@@ -27,7 +27,7 @@
             android:id="@+id/etm_background_job_uuid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="d7edb387-0b61-4e4e-a728-ffab3055d700" />
+            tools:text="@string/placeholder_uuid" />
     </TableRow>
 
     <TableRow
@@ -46,7 +46,7 @@
             android:id="@+id/etm_background_job_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="job name" />
+            tools:text="@string/placeholder_job_name" />
 
     </TableRow>
 
@@ -64,7 +64,7 @@
             android:id="@+id/etm_background_job_user"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="user@nextcloud.com" />
+            tools:text="@string/placeholder_random_account" />
 
     </TableRow>
 
@@ -82,7 +82,7 @@
             android:id="@+id/etm_background_job_state"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="ENQUEUED" />
+            tools:text="@string/placeholder_job_state" />
 
     </TableRow>
 
@@ -100,7 +100,7 @@
             android:id="@+id/etm_background_job_started"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="2020-02-15T20:53:15Z" />
+            tools:text="@string/placeholder_date_3" />
 
     </TableRow>
 
@@ -119,7 +119,7 @@
             android:id="@+id/etm_background_job_progress"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="50%" />
+            tools:text="@string/placeholder_progress" />
 
     </TableRow>
 
@@ -139,7 +139,7 @@
             android:id="@+id/etm_background_execution_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="0" />
+            tools:text="@string/placeholder_random_number" />
 
     </TableRow>
 

--- a/app/src/main/res/layout/etm_transfer_list_item.xml
+++ b/app/src/main/res/layout/etm_transfer_list_item.xml
@@ -65,7 +65,7 @@
             android:id="@+id/etm_transfer_uuid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="d7edb387-0b61-4e4e-a728-ffab3055d700" />
+            tools:text="@string/placeholder_uuid" />
     </TableRow>
 
     <TableRow
@@ -82,7 +82,7 @@
             android:id="@+id/etm_transfer_remote_path"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="file path" />
+            tools:text="@string/placeholder_file_path" />
 
     </TableRow>
 
@@ -100,7 +100,7 @@
             android:id="@+id/etm_transfer_user"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="user@nextcloud.com" />
+            tools:text="@string/placeholder_random_account" />
 
     </TableRow>
 
@@ -118,7 +118,7 @@
             android:id="@+id/etm_transfer_state"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="PENDING" />
+            tools:text="@string/placeholder_job_state" />
 
     </TableRow>
 
@@ -137,7 +137,7 @@
             android:id="@+id/etm_transfer_progress"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="50%" />
+            tools:text="@string/placeholder_progress" />
 
     </TableRow>
 

--- a/app/src/main/res/layout/etm_transfer_list_item.xml
+++ b/app/src/main/res/layout/etm_transfer_list_item.xml
@@ -46,7 +46,7 @@
                 app:layout_constraintStart_toEndOf="@+id/etm_transfer_type_icon"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                tools:text="@string/etm_transfer_type_download" />
+                tools:text="@string/placeholder_download" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </TableRow>

--- a/app/src/main/res/layout/file_actions_bottom_sheet_item.xml
+++ b/app/src/main/res/layout/file_actions_bottom_sheet_item.xml
@@ -46,7 +46,7 @@
             android:layout_marginStart="@dimen/bottom_sheet_text_start_margin"
             android:textColor="@color/text_color"
             android:textSize="@dimen/bottom_sheet_text_size"
-            tools:text="Delete file" />
+            tools:text="@string/placeholder_delete_file" />
 
         <TextView
             android:id="@+id/text_line2"
@@ -57,7 +57,7 @@
             android:textColor="@color/secondary_text_color"
             android:textSize="@dimen/bottom_sheet_text_size"
             android:visibility="gone"
-            tools:text="Some additional action info"
+            tools:text="@string/placeholder_action_info"
             tools:visibility="visible" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/file_details_share_group.xml
+++ b/app/src/main/res/layout/file_details_share_group.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="@dimen/two_line_primary_text_size"
-            tools:text="@string/share_internal_link_to_folder_text" />
+            tools:text="@string/placeholder_share_internal_link_text" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/file_details_share_internal_share_link.xml
+++ b/app/src/main/res/layout/file_details_share_internal_share_link.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="@dimen/two_line_primary_text_size"
-            tools:text="@string/share_internal_link_to_folder_text" />
+            tools:text="@string/placeholder_share_internal_folder_text" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/file_details_share_link_share_item.xml
+++ b/app/src/main/res/layout/file_details_share_link_share_item.xml
@@ -56,7 +56,7 @@
             android:gravity="center_vertical"
             android:visibility="gone"
             android:singleLine="true"
-            tools:text="5 downloads remaining"
+            tools:text="@string/placeholder_remaining_downloads"
             tools:visibility="visible"
             android:textColor="@color/text_color"
             android:textSize="@dimen/two_line_primary_text_size" />
@@ -67,7 +67,7 @@
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:singleLine="true"
-            tools:text="View only"
+            tools:text="@string/placeholder_view_only"
             app:drawableEndCompat="@drawable/ic_baseline_arrow_drop_down_24"
             app:drawableTint="@color/primary"
             app:drawableRightCompat="@drawable/ic_baseline_arrow_drop_down_24"

--- a/app/src/main/res/layout/file_details_share_share_item.xml
+++ b/app/src/main/res/layout/file_details_share_share_item.xml
@@ -60,7 +60,7 @@
             app:drawableEndCompat="@drawable/ic_baseline_arrow_drop_down_24"
             app:drawableRightCompat="@drawable/ic_baseline_arrow_drop_down_24"
             app:drawableTint="@color/primary"
-            tools:text="View only" />
+            tools:text="@string/placeholder_view_only" />
     </LinearLayout>
 
     <ImageView

--- a/app/src/main/res/layout/gallery_header.xml
+++ b/app/src/main/res/layout/gallery_header.xml
@@ -23,7 +23,7 @@
         android:layout_marginEnd="@dimen/standard_half_margin"
         android:textAppearance="?android:attr/textAppearanceLarge"
         android:textStyle="bold"
-        tools:text="July" />
+        tools:text="@string/placeholder_month" />
 
     <TextView
         android:id="@+id/year"
@@ -32,5 +32,5 @@
         android:layout_marginTop="@dimen/standard_margin"
         android:layout_marginBottom="@dimen/standard_margin"
         android:textAppearance="?android:attr/textAppearanceLarge"
-        tools:text="2016" />
+        tools:text="@string/placeholder_year" />
 </LinearLayout>

--- a/app/src/main/res/layout/info_box.xml
+++ b/app/src/main/res/layout/info_box.xml
@@ -29,6 +29,6 @@
         android:paddingRight="@dimen/standard_half_padding"
         android:paddingStart="@dimen/standard_half_margin"
         android:textColor="@color/standard_grey"
-        tools:text="@string/offline_mode" />
+        tools:text="@string/placeholder_share_no_internet_connection" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/internal_two_way_sync_view_holder.xml
+++ b/app/src/main/res/layout/internal_two_way_sync_view_holder.xml
@@ -38,7 +38,7 @@
             android:singleLine="true"
             android:textColor="@color/text_color"
             android:textSize="@dimen/two_line_primary_text_size"
-            tools:text="Folder abc" />
+            tools:text="@string/placeholder_filename" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -51,7 +51,7 @@
                 android:gravity="center_vertical"
                 android:textColor="@color/list_item_lastmod_and_filesize_text"
                 android:textSize="@dimen/two_line_secondary_text_size"
-                tools:text="241 Mb" />
+                tools:text="@string/placeholder_fileSize_2" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -70,7 +70,7 @@
                 android:gravity="center_vertical"
                 android:textColor="@color/list_item_lastmod_and_filesize_text"
                 android:textSize="@dimen/two_line_secondary_text_size"
-                tools:text="5 min ago" />
+                tools:text="@string/placeholder_time_ago" />
 
             <TextView
                 android:id="@+id/sync_result_divider"
@@ -90,7 +90,7 @@
                 android:gravity="center_vertical"
                 android:textColor="@color/list_item_lastmod_and_filesize_text"
                 android:textSize="@dimen/two_line_secondary_text_size"
-                tools:text="Success" />
+                tools:text="@string/placeholder_success" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/list_header_open_in.xml
+++ b/app/src/main/res/layout/list_header_open_in.xml
@@ -39,7 +39,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/standard_quarter_margin"
-                tools:text="This folder is best viewed in the Notes app" />
+                tools:text="@string/placeholder_open_in_notes_info" />
 
         </LinearLayout>
 
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/standard_quarter_margin"
-            tools:text="Open in Notes" />
+            tools:text="@string/placeholder_open_in_notes" />
 
         <androidx.constraintlayout.helper.widget.Flow
             android:id="@+id/flow"

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -129,8 +129,7 @@
                     app:chipBackgroundColor="@color/bg_default"
                     app:chipEndPadding="@dimen/zero"
                     app:chipStartPadding="@dimen/zero"
-                    app:ensureMinTouchTargetSize="false"
-                    tools:text="tag1" />
+                    app:ensureMinTouchTargetSize="false" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/secondTag"
@@ -144,8 +143,7 @@
                     app:chipBackgroundColor="@color/bg_default"
                     app:chipEndPadding="@dimen/zero"
                     app:chipStartPadding="@dimen/zero"
-                    app:ensureMinTouchTargetSize="false"
-                    tools:text="tag2" />
+                    app:ensureMinTouchTargetSize="false" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/tag_more"
@@ -159,8 +157,7 @@
                     app:chipBackgroundColor="@color/bg_default"
                     app:chipEndPadding="@dimen/zero"
                     app:chipStartPadding="@dimen/zero"
-                    app:ensureMinTouchTargetSize="false"
-                    tools:text="+3" />
+                    app:ensureMinTouchTargetSize="false" />
 
             </com.google.android.material.chip.ChipGroup>
 

--- a/app/src/main/res/layout/material_list_item_single_line.xml
+++ b/app/src/main/res/layout/material_list_item_single_line.xml
@@ -25,7 +25,7 @@
         android:lines="1"
         android:ellipsize="end"
         android:textColor="?android:attr/textColorPrimary"
-        tools:text="Single line of text"/>
+        tools:text="@string/placeholder_filename"/>
 
     <androidx.appcompat.widget.AppCompatImageView
         style="@style/MaterialListItemSecondaryAction"

--- a/app/src/main/res/layout/passcodelock.xml
+++ b/app/src/main/res/layout/passcodelock.xml
@@ -63,8 +63,7 @@
                     <com.owncloud.android.ui.components.PassCodeEditText
                         android:id="@+id/txt0"
                         style="@style/PassCodeStyle"
-                        android:importantForAutofill="no"
-                        tools:text="123">
+                        android:importantForAutofill="no">
                     </com.owncloud.android.ui.components.PassCodeEditText>
 
                     <com.owncloud.android.ui.components.PassCodeEditText

--- a/app/src/main/res/layout/predefined_status.xml
+++ b/app/src/main/res/layout/predefined_status.xml
@@ -18,7 +18,7 @@
         android:layout_height="match_parent"
         android:gravity="center_vertical"
         android:textSize="25sp"
-        tools:text="📆" />
+        tools:text="@string/placeholder_predefined_status_icon" />
 
     <TextView
         android:id="@+id/name"
@@ -26,7 +26,7 @@
         android:layout_height="match_parent"
         android:gravity="center_vertical"
         android:textAppearance="?android:attr/textAppearanceListItem"
-        tools:text="In a meeting" />
+        tools:text="@string/placeholder_predefined_status_name" />
 
     <TextView
         android:id="@+id/divider"
@@ -45,5 +45,5 @@
         android:gravity="center_vertical"
         android:textAppearance="?android:attr/textAppearanceListItem"
         android:textColor="?android:attr/textColorSecondary"
-        tools:text="an hour" />
+        tools:text="@string/placeholder_predefined_status_clear_at" />
 </LinearLayout>

--- a/app/src/main/res/layout/preview_image_details_fragment.xml
+++ b/app/src/main/res/layout/preview_image_details_fragment.xml
@@ -54,14 +54,14 @@
                         android:layout_height="wrap_content"
                         android:padding="2dp"
                         android:textStyle="bold"
-                        tools:text="Wednesday • 26 Jul 2023 • 12:27" />
+                        tools:text="@string/placeholder_image_detail_date" />
 
                     <TextView
                         android:id="@+id/fileInformation_details"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:padding="2dp"
-                        tools:text="12 MP • 3024 × 4032 • 923 KB" />
+                        tools:text="@string/placeholder_image_details" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -95,14 +95,14 @@
                         android:layout_height="wrap_content"
                         android:padding="2dp"
                         android:textStyle="bold"
-                        tools:text="Camera Phone (4th generation)" />
+                        tools:text="@string/placeholder_image_detail_model" />
 
                     <TextView
                         android:id="@+id/imgTC_conditions"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:padding="2dp"
-                        tools:text="ƒ/1.8 • 1/374 s • 28 mm • ISO 200" />
+                        tools:text="@string/placeholder_image_detail_condition" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -133,7 +133,7 @@
                     android:textAlignment="center"
                     android:textStyle="bold"
                     android:visibility="gone"
-                    tools:text="Mitte, Berlin, Germany"
+                    tools:text="@string/placeholder_image_detail_location"
                     tools:visibility="visible" />
 
                 <FrameLayout
@@ -151,7 +151,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="bottom|end"
                         android:padding="5dp"
-                        tools:text="© OpenStreetMap contributors" />
+                        tools:text="@string/placeholder_image_detail_example_copyright" />
                 </FrameLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/profile_bottom_sheet_action.xml
+++ b/app/src/main/res/layout/profile_bottom_sheet_action.xml
@@ -31,7 +31,7 @@
         android:layout_gravity="center_vertical"
         android:paddingStart="24dp"
         android:paddingEnd="0dp"
-        tools:text="Compose email"
+        tools:text="@string/placeholder_compose_mail"
         android:textColor="@color/text_color"
         android:textSize="@dimen/bottom_sheet_text_size" />
 </LinearLayout>

--- a/app/src/main/res/layout/profile_bottom_sheet_fragment.xml
+++ b/app/src/main/res/layout/profile_bottom_sheet_fragment.xml
@@ -38,7 +38,7 @@
             android:layout_gravity="center_vertical"
             android:paddingTop="@dimen/standard_padding"
             android:paddingBottom="@dimen/standard_padding"
-            tools:text="Christine Scott"
+            tools:text="@string/placeholder_first_name_last_name"
             android:textColor="@color/text_color"
             android:textSize="@dimen/bottom_sheet_text_size" />
     </LinearLayout>

--- a/app/src/main/res/layout/send_button.xml
+++ b/app/src/main/res/layout/send_button.xml
@@ -32,5 +32,5 @@
         android:gravity="center_horizontal"
         android:paddingTop="@dimen/standard_half_padding"
         android:textColor="@color/text_color"
-        tools:text="@string/app_name" />
+        tools:text="@string/placeholder_send_button" />
 </LinearLayout>

--- a/app/src/main/res/layout/setup_encryption_dialog.xml
+++ b/app/src/main/res/layout/setup_encryption_dialog.xml
@@ -32,7 +32,7 @@
         android:padding="5dp"
         android:textIsSelectable="true"
         android:visibility="gone"
-        tools:text="passphrase"
+        tools:text="@string/placeholder_passphrase"
         tools:visibility="visible" />
 
     <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/layout/setup_encryption_dialog.xml
+++ b/app/src/main/res/layout/setup_encryption_dialog.xml
@@ -20,7 +20,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/standard_margin"
-        tools:text="@string/end_to_end_encryption_keywords_description" />
+        tools:text="@string/placeholder_share_internal_e2ee_keyword_description" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/encryption_passphrase"

--- a/app/src/main/res/layout/storage_path_item.xml
+++ b/app/src/main/res/layout/storage_path_item.xml
@@ -17,4 +17,4 @@
     android:text="@string/menu_item_sort_by_name_z_a"
     app:icon="@drawable/ic_user_outline"
     app:iconPadding="@dimen/standard_padding"
-    tools:text="DCIM" />
+    tools:text="@string/placeholder_file_path" />

--- a/app/src/main/res/layout/synced_folders_footer.xml
+++ b/app/src/main/res/layout/synced_folders_footer.xml
@@ -21,7 +21,7 @@
         android:layout_marginBottom="@dimen/min_list_item_size"
         android:gravity="center"
         android:padding="@dimen/standard_padding"
-        tools:text="Show 3 hidden folders"
+        tools:text="@string/placeholder_show_hidden_folders"
         android:textColor="@color/secondary_text_color" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/synced_folders_settings_layout.xml
+++ b/app/src/main/res/layout/synced_folders_settings_layout.xml
@@ -41,7 +41,7 @@
                 android:ellipsize="middle"
                 android:maxLines="2"
                 android:textColor="?android:attr/textColorSecondary"
-                tools:text="For /storage/emulated/0/DCIM/Camera" />
+                tools:text="@string/placeholder_auto_upload_overview_path" />
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/layout/template_button.xml
+++ b/app/src/main/res/layout/template_button.xml
@@ -54,5 +54,5 @@
         android:gravity="center_horizontal"
         android:paddingTop="@dimen/standard_half_padding"
         android:textColor="@color/text_color"
-        tools:text="Template" />
+        tools:text="@string/placeholder_template" />
 </LinearLayout>

--- a/app/src/main/res/layout/toolbar_standard.xml
+++ b/app/src/main/res/layout/toolbar_standard.xml
@@ -200,7 +200,7 @@
                     app:layout_constraintLeft_toRightOf="@id/menu_button"
                     app:layout_constraintRight_toLeftOf="@id/notification_button"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:text="Search in Nextcloud" />
+                    tools:text="@string/placeholder_search_in_nextcloud" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/notification_button"

--- a/app/src/main/res/layout/unified_search_footer.xml
+++ b/app/src/main/res/layout/unified_search_footer.xml
@@ -25,8 +25,7 @@
         android:paddingStart="@dimen/standard_quarter_padding"
         android:paddingEnd="0dp"
         android:text="@string/load_more_results"
-        android:textColor="@color/secondary_text_color"
-        tools:text="Load more results">
+        android:textColor="@color/secondary_text_color">
 
     </TextView>
 </LinearLayout>

--- a/app/src/main/res/layout/unified_search_header.xml
+++ b/app/src/main/res/layout/unified_search_header.xml
@@ -23,5 +23,5 @@
         android:paddingHorizontal="@dimen/standard_padding"
         android:paddingVertical="@dimen/standard_padding"
         android:textColor="@color/color_accent"
-        tools:text="Files" />
+        tools:text="@string/placeholder_files" />
 </RelativeLayout>

--- a/app/src/main/res/layout/unified_search_item.xml
+++ b/app/src/main/res/layout/unified_search_item.xml
@@ -80,7 +80,7 @@
             android:text=""
             android:textColor="@color/text_color"
             android:textSize="@dimen/two_line_primary_text_size"
-            tools:text="Test 123" />
+            tools:text="@string/placeholder_filename" />
 
         <TextView
             android:id="@+id/subline"
@@ -91,7 +91,7 @@
             android:text=""
             android:textColor="@color/list_item_lastmod_and_filesize_text"
             android:textSize="@dimen/two_line_secondary_text_size"
-            tools:text="in TestFolder" />
+            tools:text="@string/placeholder_in_folder" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/upload_file_dialog.xml
+++ b/app/src/main/res/layout/upload_file_dialog.xml
@@ -20,7 +20,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/upload_file_dialog_filename"
-        tools:text="@string/upload_file_dialog_filename"/>
+        tools:text="@string/placeholder_filename"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/user_input_container"
@@ -48,7 +48,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/standard_margin"
         android:text="@string/upload_file_dialog_filetype"
-        tools:text="@string/upload_file_dialog_filetype"/>
+        tools:text="@string/placeholder_file_type"/>
 
     <Spinner
         android:id="@+id/file_type"

--- a/app/src/main/res/layout/upload_list_header.xml
+++ b/app/src/main/res/layout/upload_list_header.xml
@@ -48,7 +48,7 @@
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingBottom="@dimen/standard_half_padding"
         android:textColor="@color/color_accent"
-        tools:text="Current (2)" />
+        tools:text="@string/placeholder_current_2" />
 
     <ImageView
         android:id="@+id/upload_list_action"

--- a/app/src/main/res/layout/user_info_details_table_item.xml
+++ b/app/src/main/res/layout/user_info_details_table_item.xml
@@ -37,6 +37,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/icon"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="+49 123 456 789 12" />
+        tools:text="@string/placeholder_example_phone_number" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/user_info_layout.xml
+++ b/app/src/main/res/layout/user_info_layout.xml
@@ -62,7 +62,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/userinfo_icon"
             app:layout_constraintTop_toTopOf="@id/userinfo_icon"
-            tools:text="John Doe" />
+            tools:text="@string/placeholder_first_name_last_name" />
 
         <TextView
             android:id="@+id/userinfo_username"
@@ -80,7 +80,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/userinfo_fullName"
             app:layout_constraintTop_toBottomOf="@id/userinfo_fullName"
-            tools:text="john@nextcloud.com" />
+            tools:text="@string/placeholder_example_mail" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/version_list_item.xml
+++ b/app/src/main/res/layout/version_list_item.xml
@@ -45,7 +45,7 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:ellipsize="end"
-            tools:text="256 KB"
+            tools:text="@string/placeholder_fileSize"
             android:textColor="?android:attr/textColorSecondary"/>
     </LinearLayout>
 
@@ -67,7 +67,7 @@
         android:layout_weight="1"
         android:ellipsize="end"
         android:textAlignment="textEnd"
-        tools:text="13:24"
+        tools:text="@string/placeholder_media_time"
         android:textColor="?android:attr/textColorSecondary"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/widget_item.xml
+++ b/app/src/main/res/layout/widget_item.xml
@@ -37,7 +37,7 @@
             android:ellipsize="end"
             android:gravity="start"
             android:textColor="@color/black"
-            tools:text="First line" />
+            tools:text="@string/placeholder_widget_first_line" />
 
         <TextView
             android:id="@+id/subtitle"
@@ -47,7 +47,7 @@
             android:textColor="@color/standard_grey"
             android:maxLines="1"
             android:ellipsize="end"
-            tools:text="Subline" />
+            tools:text="@string/placeholder_widget_second_line" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/widget_list_item.xml
+++ b/app/src/main/res/layout/widget_list_item.xml
@@ -29,5 +29,5 @@
         android:layout_height="32dp"
         android:layout_weight="1"
         android:gravity="center_vertical"
-        tools:text="Widget name" />
+        tools:text="@string/placeholder_first_name_last_name" />
 </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -642,12 +642,6 @@
     <string name="picture_set_as_no_app">لم يتم العثور على تطبيق لتعيين صورة به</string>
     <string name="pin_home">ثبِّت في الشاشة الرئيسية</string>
     <string name="pin_shortcut_label">فتح %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 ك.ب</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">تغيرت مؤخرا</string>
-    <string name="placeholder_sentence">هذه مساحة محجوزة</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 مساء</string>
     <string name="player_stop">إيقاف</string>
     <string name="player_toggle">تبديل</string>
     <string name="please_select_a_server">من فضلك، قم بتحديد الخادم...</string>

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -382,12 +382,6 @@
     <string name="permission_deny">Negar</string>
     <string name="permission_storage_access">Ríquense permisos adicionales pa xubir y baxar ficheros.</string>
     <string name="pin_shortcut_label">Abrir «%1$s»</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editóse apocayá</string>
-    <string name="placeholder_sentence">Esto ye un marcador de posición</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="pref_behaviour_entries_delete_file">desanicióse</string>
     <string name="pref_behaviour_entries_keep_file">guardáu en carpeta orixinal</string>
     <string name="pref_behaviour_entries_move">movíu a la carpeta d\'aplicaciones</string>

--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -662,13 +662,6 @@
     <string name="picture_set_as_no_app">No app found to set a picture with</string>
     <string name="pin_home">Pin to home screen</string>
     <string name="pin_shortcut_label">Open %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">placeholder</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Recently edited</string>
-    <string name="placeholder_sentence">This is a placeholder</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stop</string>
     <string name="player_toggle">toggle</string>
     <string name="please_select_a_server">Please select a server…</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -524,12 +524,6 @@
     <string name="permission_storage_access">Изискват се допълнителни права за изтегляне и сваляне на файлове.</string>
     <string name="picture_set_as_no_app">Няма намерени приложения за задаване на снимка</string>
     <string name="pin_shortcut_label">Отваряне на %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Наскоро редактирани</string>
-    <string name="placeholder_sentence">Това е за запазено място</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">стоп</string>
     <string name="player_toggle">превключване</string>
     <string name="power_save_check_dialog_message">Деактивирането на проверката за пестене на енергия може да доведе до качване на файлове, в състояние с ниска батерия!</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -510,11 +510,6 @@
     <string name="permission_deny">Difennet</string>
     <string name="permission_storage_access">Aotreoù ouzhpenn ez eus ezhomp evit pellkas ha pellgargañ restroù.</string>
     <string name="picture_set_as_no_app">Meziant ebet kavet evit lakaat ur skeudenn gant</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Cheñchet n\'eus ket pell zo</string>
-    <string name="placeholder_sentence">Ur lec\'h miret eo</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="power_save_check_dialog_message">Disaotreañ gwiriañ ar saver pod-tredañ a c\'hel lezel an ardivink pellkargañ restroù pa ne vez ket kalz a dredañ kenn !</string>
     <string name="pref_behaviour_entries_delete_file">dilamet</string>
     <string name="pref_behaviour_entries_keep_file">gwarn ar restr orin</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -621,12 +621,6 @@
     <string name="picture_set_as_no_app">No s\'ha trobat cap aplicació per establir-hi la foto</string>
     <string name="pin_home">Fixa-ho a la pantalla d\'inici</string>
     <string name="pin_shortcut_label">Obre %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editat recentment</string>
-    <string name="placeholder_sentence">Això és un marcador de posició</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">atura</string>
     <string name="player_toggle">commuta</string>
     <string name="please_select_a_server">Seleccioneu un servidor…</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Nenalezena žádná aplikace pro nastavení obrázku</string>
     <string name="pin_home">Připnout na domovskou obrazovku</string>
     <string name="pin_shortcut_label">Otevřít %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">výplň</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nedávno upravováno</string>
-    <string name="placeholder_sentence">Toto je zástupný text</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23</string>
     <string name="player_stop">vypnout</string>
     <string name="player_toggle">přepnout</string>
     <string name="please_select_a_server">Vyberte server…</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Ingen apps fundet til at vælge et billede med</string>
     <string name="pin_home">Fastgør til hjemmeskærm</string>
     <string name="pin_shortcut_label">Åbn %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">pladsholder</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nyligt redigeret</string>
-    <string name="placeholder_sentence">Dette er en pladsholder</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stop</string>
     <string name="player_toggle">skift</string>
     <string name="please_select_a_server">Vælg venligst en server...</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Keine App gefunden, mit der ein Bid gesetzt werden könnte</string>
     <string name="pin_home">An Startbildschirm anheften</string>
     <string name="pin_shortcut_label">%1$s öffnen</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">Platzhalter</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Kürzlich bearbeitet</string>
-    <string name="placeholder_sentence">Dies ist ein Platzhalter</string>
-    <string name="placeholder_timestamp">18.5.2012 12:23</string>
     <string name="player_stop">Stopp</string>
     <string name="player_toggle">Umschalten</string>
     <string name="please_select_a_server">Bitte einen Server auswählen…</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -532,12 +532,6 @@
     <string name="permission_storage_access">Επιπλέον διακαιώματα απαιτούνται για μεταφόρτωση και λήψη αρχείων.</string>
     <string name="picture_set_as_no_app">Δεν βρέθηκε εφαρμογή για τον ορισμό φωτογραφίας</string>
     <string name="pin_shortcut_label">Άνοιγμα %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Επεξεργάστηκε πρόσφατα</string>
-    <string name="placeholder_sentence">Αυτό είναι ένα σημείο placeholder</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">Παύση</string>
     <string name="player_toggle">Εναλλαγή</string>
     <string name="power_save_check_dialog_message">Η απενεργοποίηση του έλεγχου εξοικονόμησης ενέργειας ίσως έχει ως αποτέλεσμα το ανέβασμα αρχείων ενώ βρίσκεστε σε κατάσταση χαμηλής μπαταρίας</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -372,11 +372,6 @@
     <string name="permission_deny">Rifuzi</string>
     <string name="permission_storage_access">Pliaj permesoj bezonataj por el- kaj alŝuti dosierojn.</string>
     <string name="picture_set_as_no_app">Neniu aplikaĵo trovita por uzi tiun bildon</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Ĉi tio estas lokokupilo</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23</string>
     <string name="pref_behaviour_entries_delete_file">forigita</string>
     <string name="pref_behaviour_entries_keep_file">konservita en origina dosierujo</string>
     <string name="pref_behaviour_entries_move">movita al aplikaĵa dosierujo</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -566,11 +566,6 @@
     <string name="permission_storage_access">Se requieren permisos adicionales para cargar y descargar archivos. </string>
     <string name="picture_set_as_no_app">No se encontró ninguna aplicación para establecer una imagen con</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editado recientemente</string>
-    <string name="placeholder_sentence">Este es un marcador de posición</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">detener</string>
     <string name="player_toggle">cambiar</string>
     <string name="power_save_check_dialog_message">¡La desactivación de la verificación de ahorro de energía puede provocar la carga de archivos cuando la batería está baja!</string>

--- a/app/src/main/res/values-es-rCL/strings.xml
+++ b/app/src/main/res/values-es-rCL/strings.xml
@@ -369,10 +369,6 @@
     <string name="permission_storage_access">Se requieren permisos adicionales para cargar y descargar archivos. </string>
     <string name="picture_set_as_no_app">No se encontró una aplicación con la cual establecer la imagen</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Este es un marcador de posición</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="pref_behaviour_entries_delete_file">Borrado</string>
     <string name="pref_behaviour_entries_keep_file">mantenido en la carpeta original</string>
     <string name="pref_behaviour_entries_move">movido a la carpeta de la aplicación</string>

--- a/app/src/main/res/values-es-rCO/strings.xml
+++ b/app/src/main/res/values-es-rCO/strings.xml
@@ -514,10 +514,6 @@
     <string name="pass_code_wrong">Código de seguridad incorrecto</string>
     <string name="permission_storage_access">Se requieren permisos adicionales para cargar y descargar archivos. </string>
     <string name="picture_set_as_no_app">No se encontró una aplicación con la cual establecer la imagen</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Este es un marcador de posición</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="pref_behaviour_entries_delete_file">Borrado</string>
     <string name="pref_behaviour_entries_keep_file">mantenido en la carpeta original</string>
     <string name="pref_behaviour_entries_move">movido a la carpeta de la aplicación</string>

--- a/app/src/main/res/values-es-rEC/strings.xml
+++ b/app/src/main/res/values-es-rEC/strings.xml
@@ -525,12 +525,6 @@
     <string name="permission_storage_access">Se requieren permisos adicionales para cargar y descargar archivos. </string>
     <string name="picture_set_as_no_app">No se encontró una aplicación con la cual establecer la imagen</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Recientemente editados</string>
-    <string name="placeholder_sentence">Este es un marcador de posición</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">detener</string>
     <string name="player_toggle">alternar</string>
     <string name="power_save_check_dialog_message">¡Desactivar la comprobación de ahorro de energía podría resultar en la carga de archivos cuando la batería esté baja!</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -572,11 +572,6 @@
     <string name="permission_storage_access">Se requieren permisos adicionales para cargar y descargar archivos. </string>
     <string name="picture_set_as_no_app">No se encontró una aplicación con la cual establecer la imagen</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editado recientemente</string>
-    <string name="placeholder_sentence">Este es un marcador de posición</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">detener</string>
     <string name="player_toggle">alternar</string>
     <string name="power_save_check_dialog_message">¡Desactivar la comprobación de ahorro de energía podría resultar en la carga de archivos cuando la batería esté baja!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">No se ha encontrado una app para establecer con ella la imagen</string>
     <string name="pin_home">Anclar a la pantalla de inicio</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">marcador de posición</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editado recientemente</string>
-    <string name="placeholder_sentence">Esto es un marcador de posición</string>
-    <string name="placeholder_timestamp">18/05/2012 12:23 PM</string>
     <string name="player_stop">parar</string>
     <string name="player_toggle">cambiar</string>
     <string name="please_select_a_server">Por favor, seleccione un servidor…</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Ei leidu rakendust pildi määramiseks</string>
     <string name="pin_home">Kinnita avalehele</string>
     <string name="pin_shortcut_label">Ava %1$s </string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">kohatäitja</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Hiljuti muudetud</string>
-    <string name="placeholder_sentence">See on kohahoidja</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">peata</string>
     <string name="player_toggle">lülita sisse/välja</string>
     <string name="please_select_a_server">Palun vali server…</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -640,12 +640,6 @@
     <string name="picture_set_as_no_app">Ez da aplikaziorik aurkitu irudia ezartzeko</string>
     <string name="pin_home">Finkatu pantaila nagusian</string>
     <string name="pin_shortcut_label">Ireki %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Berriki editatua</string>
-    <string name="placeholder_sentence">Hau leku-marka bat da</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">gelditu</string>
     <string name="player_toggle">txandakatu</string>
     <string name="please_select_a_server">Hautatu zerbitzari bat...</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -552,12 +552,6 @@
     <string name="permission_storage_access">نیاز به مجوزهای اضافی برای بارگذاری و دریافت پرونده‌ها می باشد.</string>
     <string name="picture_set_as_no_app">هیچ برنامه ای برای تنظیم عکس یافت نشد</string>
     <string name="pin_shortcut_label">باز کنید %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">۳۸۹ کیلوبایت</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">اخیراً ویرایش شده</string>
-    <string name="placeholder_sentence">این یک حفره است.</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 بعد از ظهر</string>
     <string name="player_stop">توقف</string>
     <string name="player_toggle">تغییر وضعیت</string>
     <string name="power_save_check_dialog_message">غیرفعال کردن چک مارک صرفه جویی در مصرف برق ممکن است باعث شود بارگذاری پرونده ها در حالت باتری کم باشد!</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -578,12 +578,6 @@
     <string name="permission_storage_access">Tiedostojen lähetys ja lataaminen vaatii lisäoikeuksia.</string>
     <string name="picture_set_as_no_app">Kuvan liittämiseksi ei löytynyt sovellusta</string>
     <string name="pin_shortcut_label">Avaa %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 kt</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Äskettäin muokattu</string>
-    <string name="placeholder_sentence">Tämä on paikkamerkki</string>
-    <string name="placeholder_timestamp">18.05.2012 12:23</string>
     <string name="player_stop">pysäytä</string>
     <string name="player_toggle">vaihda</string>
     <string name="please_select_a_server">Valitse palvelin...</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -662,13 +662,6 @@
     <string name="picture_set_as_no_app">Aucune application trouvée pour utiliser cette image</string>
     <string name="pin_home">Épingler sur l\'écran d\'accueil</string>
     <string name="pin_shortcut_label">Ouvrir %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 Ko</string>
-    <string name="placeholder_filename">exemple</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Modifié récemment</string>
-    <string name="placeholder_sentence">Ceci est un espace réservé</string>
-    <string name="placeholder_timestamp">18/05/2012 12:23 PM</string>
     <string name="player_stop">arrêter</string>
     <string name="player_toggle">inverser</string>
     <string name="please_select_a_server">Veuillez sélectionner un serveur…</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Níor aimsíodh aon aip chun pictiúr a shocrú leis</string>
     <string name="pin_home">Pinn chuig an scáileán baile</string>
     <string name="pin_shortcut_label">Oscail %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">áitchoinneálaí</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Curtha in eagar le déanaí</string>
-    <string name="placeholder_sentence">Is sealbhóir áit é seo</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stad</string>
     <string name="player_toggle">scoránaigh</string>
     <string name="please_select_a_server">Roghnaigh freastalaí le do thoil…</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -433,10 +433,6 @@
     <string name="permission_deny">Diùlt</string>
     <string name="permission_storage_access">Tha feum air barrachd cheadan mus gabh faidhlichean a luchdadh suas is a-nuas.</string>
     <string name="picture_set_as_no_app">Cha deach aplacaid a lorg airson dealbhan a chur leatha</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Seo glèidheadair-àite</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23f</string>
     <string name="player_stop">cuir stad air</string>
     <string name="player_toggle">toglaich</string>
     <string name="power_save_check_dialog_message">Ma chuireas tu à comas dearbhadh caomhnadh cumhachd, dh’fhaoidte gun dèid faidhlichean a luchdadh suas nuair a bhios am bataraidh fann!</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Non se atopou unha aplicación coa que definir unha imaxe</string>
     <string name="pin_home">Fixar na pantalla de Inicio</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">marcador de substitución</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editado recentemente</string>
-    <string name="placeholder_sentence">Isto é un marcador de substitución</string>
-    <string name="placeholder_timestamp">18/05/2012 12:23 p.m.</string>
     <string name="player_stop">parar</string>
     <string name="player_toggle">alternar</string>
     <string name="please_select_a_server">Seleccione un servidor…</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -490,12 +490,6 @@
     <string name="permission_deny">Spriječi</string>
     <string name="permission_storage_access">Potrebna su dodatna dopuštenja za otpremanje i preuzimanje datoteka.</string>
     <string name="picture_set_as_no_app">Nije pronađena nijedna aplikacija za postavljanje slike s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nedavno uređeno</string>
-    <string name="placeholder_sentence">Ovo je prazan prostor</string>
-    <string name="placeholder_timestamp">18. 5. 2012. 12:23</string>
     <string name="player_stop">zaustavi</string>
     <string name="player_toggle">uključi/isključi</string>
     <string name="power_save_check_dialog_message">Onemogućivanje provjere uštede energije može rezultirati otpremanjem datoteka pri niskoj razini napunjenosti baterije!</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Nincs alkalmazás a képbeállításhoz</string>
     <string name="pin_home">Rögzítés a kezdőképernyőre</string>
     <string name="pin_shortcut_label">A(z) %1$s megnyitása</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 kB</string>
-    <string name="placeholder_filename">helykitöltő</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nemrég szerkesztve</string>
-    <string name="placeholder_sentence">Ez egy helykitöltő</string>
-    <string name="placeholder_timestamp">2012.05.18. 12:23</string>
     <string name="player_stop">leállítás</string>
     <string name="player_toggle">átváltás</string>
     <string name="please_select_a_server">Válasszon egy kiszolgálót…</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -640,11 +640,6 @@ Otomatis unggah hanya bekerja dengan baik apabila Anda mengeluarkan aplikasi ini
     <string name="picture_set_as_no_app">Tidak ada aplikasi untuk menyetel gambar yang ditemukan.</string>
     <string name="pin_home">Sematkan ke tampilan beranda</string>
     <string name="pin_shortcut_label">Buka %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Baru saja diedit</string>
-    <string name="placeholder_sentence">Ini adalah placeholder</string>
-    <string name="placeholder_timestamp">18/05/2012 12:23 PM</string>
     <string name="player_stop">hentikan</string>
     <string name="player_toggle">alihkan</string>
     <string name="please_select_a_server">Silahkan pilih server...</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -667,13 +667,6 @@
     <string name="picture_set_as_no_app">Engin forrit fundust til að setja mynd</string>
     <string name="pin_home">Festa á upphafsskjá</string>
     <string name="pin_shortcut_label">Opna %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">KB</string>
-    <string name="placeholder_filename">frátökutákn</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nýlega breytt</string>
-    <string name="placeholder_sentence">Þetta er frátökutákn</string>
-    <string name="placeholder_timestamp">e.h.</string>
     <string name="player_stop">stöðva</string>
     <string name="player_toggle">víxla</string>
     <string name="please_select_a_server">Veldu netþjón…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -623,12 +623,6 @@
     <string name="pick_contact_to_share_with">Seleziona il contatto con cui condividere</string>
     <string name="picture_set_as_no_app">Nessuna applicazione trovata per impostare un\'immagine</string>
     <string name="pin_shortcut_label">Apri %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Modificati di recente</string>
-    <string name="placeholder_sentence">Questo è un segnaposto</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">ferma</string>
     <string name="player_toggle">attiva</string>
     <string name="please_select_a_server">Per favore, seleziona un server...</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -449,11 +449,6 @@
     <string name="permission_deny">לדחות</string>
     <string name="permission_storage_access">נדרשות הרשאות נוספות כדי להעלות ולהוריד קבצים</string>
     <string name="picture_set_as_no_app">לא נמצא יישומון להגדיר אתו תמונה</string>
-    <string name="placeholder_fileSize">389 ק״ב</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">נערכו לאחרונה</string>
-    <string name="placeholder_sentence">זהו ממלא מקום</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="power_save_check_dialog_message">השבתת בדיקת חיסכון בחשמל גורמת להעלאת קבצים כשהסוללה חלשה!</string>
     <string name="pref_behaviour_entries_delete_file">נמחק</string>
     <string name="pref_behaviour_entries_keep_file">נשמר בתיקייה מקורית</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -639,13 +639,6 @@
     <string name="picture_set_as_no_app">画像を設定するアプリが見つかりませんでした</string>
     <string name="pin_home">ホームスクリーンにピン留めする</string>
     <string name="pin_shortcut_label">%1$sを開く</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">プレースホルダー</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">最近編集したもの</string>
-    <string name="placeholder_sentence">これはプレースホルダです</string>
-    <string name="placeholder_timestamp">2012/05/18 PM 12:23</string>
     <string name="player_stop">中止</string>
     <string name="player_toggle">切替え</string>
     <string name="please_select_a_server">サーバを選択してください...</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -532,11 +532,6 @@
     <string name="permission_storage_access">Additional permissions required to upload and download files.</string>
     <string name="picture_set_as_no_app">No app found to set a picture with</string>
     <string name="pin_shortcut_label">Open %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">This is a placeholder</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stop</string>
     <string name="player_toggle">toggle</string>
     <string name="power_save_check_dialog_message">Disabling power save check might result in uploading files when in low battery state!</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -627,11 +627,6 @@
     <string name="pick_contact_to_share_with">공유할 연락처를 선택</string>
     <string name="picture_set_as_no_app">사진을 설정할 앱을 찾을 수 없음</string>
     <string name="pin_shortcut_label">%1$s 열기</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">최근에 편집됨</string>
-    <string name="placeholder_sentence">이것은 자리 비움자입니다</string>
-    <string name="placeholder_timestamp">2012년 05월 18일 오후 12:23</string>
     <string name="player_stop">멈추기</string>
     <string name="player_toggle">토글</string>
     <string name="please_select_a_server">서버를 선택해 주세요...</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -434,10 +434,6 @@
     <string name="permission_deny">ປະຕິເສດ</string>
     <string name="permission_storage_access">ການອະນຸຍາດເພີ່ມເຕີມທີ່ຈໍາເປັນເພື່ອອັບໂຫຼດ ແລະ ດາວໂຫລດຟາຍ</string>
     <string name="picture_set_as_no_app">ບໍ່ພົບແອັບພລິເຄຊັນເພື່ອຕັ້ງຮູບດ້ວຍ</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">ຕົວສຳຮອງ</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">ຢຸດ</string>
     <string name="player_toggle">ສະລັບ</string>
     <string name="power_save_check_dialog_message">ການກວດກາການປະຢັດພະລັງງານອາດຈະສົ່ງຜົນໃນອັບໂຫຼດຟາຍເມື່ອແບັດເຕີຣີຕ່ໍາ!</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -545,11 +545,6 @@
     <string name="permission_storage_access">Papildomos teisės reikalingos įkelti šiuos atsisiųstus failus.</string>
     <string name="picture_set_as_no_app">Nerasta programa, su kuria būtų galima nustatyti nuotrauką</string>
     <string name="pin_shortcut_label">Atverti %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Paskiausiai taisyti</string>
-    <string name="placeholder_sentence">Rezervas</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stabdyti</string>
     <string name="player_toggle">perjungti</string>
     <string name="please_select_a_server">Pasirinkite serverį…</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -397,11 +397,6 @@
     <string name="picture_set_as_no_app">Nav atrasta neviena lietotne, ar ko iestatīt attēlu</string>
     <string name="pin_home">Piespraust sākuma ekrānam</string>
     <string name="pin_shortcut_label">Atvērt %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nesen labots</string>
-    <string name="placeholder_sentence">Šis ir viettura teksts</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">apturēt</string>
     <string name="player_toggle">pārslēgt</string>
     <string name="please_select_a_server">Lūgums atlasīt serveri…</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -459,11 +459,6 @@
     <string name="permission_storage_access">Потебни се дополнителни привилегии за прикачување и превземање на датотеки.</string>
     <string name="picture_set_as_no_app">Не е пронајдена апликација за поставување на слики</string>
     <string name="pin_shortcut_label">Отвори %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Неодамна изменета</string>
-    <string name="placeholder_sentence">Ова е резервирано место</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">стоп</string>
     <string name="player_toggle">вклучи</string>
     <string name="power_save_check_dialog_message">Оневозможување на проверката за заштеда на енергијата може да овозможи прикачување на датотеки и кога батеријата е празна</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -600,12 +600,6 @@
     <string name="permission_storage_access">Flere tillatelser trengs for å laste opp og ned filer.</string>
     <string name="picture_set_as_no_app">Fant ikke noe app å sette bilde med.</string>
     <string name="pin_shortcut_label">Åpne %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nylig redigert</string>
-    <string name="placeholder_sentence">Dette er en plassholder</string>
-    <string name="placeholder_timestamp">18.05.2012 12:23</string>
     <string name="player_stop">stopp</string>
     <string name="player_toggle">av/på</string>
     <string name="please_select_a_server">Vennligst velg en tjener…</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -658,12 +658,6 @@
     <string name="picture_set_as_no_app">Geen app gevonden om afbeelding in te stellen</string>
     <string name="pin_home">Vastzetten op startscherm</string>
     <string name="pin_shortcut_label">Open %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Recent bewerkt</string>
-    <string name="placeholder_sentence">Dit is een plaatshouder</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23</string>
     <string name="player_stop">stop</string>
     <string name="player_toggle">omschakelen</string>
     <string name="please_select_a_server">Selecteer een server...</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Nie znaleziono aplikacji do ustawienia obrazu</string>
     <string name="pin_home">Przypnij do ekranu głównego</string>
     <string name="pin_shortcut_label">Otwórz %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">symbol zastępczy</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Ostatnio edytowane</string>
-    <string name="placeholder_sentence">Tekst zastępczy</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">zatrzymaj</string>
     <string name="player_toggle">przełącz</string>
     <string name="please_select_a_server">Wybierz serwer...</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Nenhum aplicativo encontrado para definir uma imagem</string>
     <string name="pin_home">Fixar na tela inicial</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">espaço reservado</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editado recentemente</string>
-    <string name="placeholder_sentence">Este é um espaço reservado</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">para</string>
     <string name="player_toggle">alternar</string>
     <string name="please_select_a_server">Selecione um servidor…</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -582,11 +582,6 @@
     <string name="permission_storage_access">Necessário permissões adicionais para enviar e transferir ficheiros.</string>
     <string name="picture_set_as_no_app">Nenhuma aplicação encontrada para definir a imagem</string>
     <string name="pin_shortcut_label">Abrir %1$s</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Editado recentemente</string>
-    <string name="placeholder_sentence">Isto é uma variável</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23</string>
     <string name="player_stop">parar</string>
     <string name="player_toggle">alternar</string>
     <string name="power_save_check_dialog_message">Desabilitar a verificação de poupança de energia pode resultar no envio de ficheiros quando a carga da bateria está baixa!</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -599,11 +599,6 @@
     <string name="permission_storage_access">Sunt necesare drepturi adiționale pentru a încărca și descărca fișiere.</string>
     <string name="picture_set_as_no_app">Nu a fost găsită o aplicație pentru a seta imaginea</string>
     <string name="pin_shortcut_label">Deschide %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KO</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Acesta este un substituent</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stop</string>
     <string name="player_toggle">comută</string>
     <string name="power_save_check_dialog_message">Dezactivarea modului de economisire a bateriei ar putea rezulta în încărcarea de fișiere când bateria are un nivel scăzut!</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -663,13 +663,6 @@
     <string name="picture_set_as_no_app">Не найдено приложений для обработки изображений</string>
     <string name="pin_home">Закрепить на главном экране</string>
     <string name="pin_shortcut_label">Открыть %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 Кбайт</string>
-    <string name="placeholder_filename">заполнитель</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Недавно изменено</string>
-    <string name="placeholder_sentence">Это заполнитель</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23</string>
     <string name="player_stop">остановить</string>
     <string name="player_toggle">переключить</string>
     <string name="please_select_a_server">Пожалуйста, выберите сервер...</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -471,12 +471,6 @@
     <string name="permission_deny">Nega</string>
     <string name="permission_storage_access">Sunt rechertos àteros permissos pro carrigare e iscarrigare documentos.</string>
     <string name="picture_set_as_no_app">Peruna aplicatzione agatada pro cunfigurare un\'immàgine</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Modificados dae pagu</string>
-    <string name="placeholder_sentence">Custu est unu sostitutu temporàneu</string>
-    <string name="placeholder_timestamp">18/05/2012 12:23</string>
     <string name="player_stop">firma</string>
     <string name="player_toggle">parti</string>
     <string name="power_save_check_dialog_message">Disativare su controllu de su rispàrmiu de energia podet fàghere chi si carrighent documentos cun sa bateria bàscia!</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -637,12 +637,6 @@
     <string name="picture_set_as_no_app">Aplikácia na nastavenie obrázku sa nenašla</string>
     <string name="pin_home">Pripnúť na domovskú obrazovku</string>
     <string name="pin_shortcut_label">Otvoriť %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nedávno upravené</string>
-    <string name="placeholder_sentence">Toto je \"placeholder\"</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">zastaviť</string>
     <string name="player_toggle">prepnúť</string>
     <string name="please_select_a_server">Prosím vyberte server ...</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -539,12 +539,6 @@
     <string name="permission_storage_access">Za prejemanje oziroma pošiljanje datotek v oblak so zahtevana dodatna dovoljenja.</string>
     <string name="picture_set_as_no_app">Ni najdenega programa za nastavitev slike</string>
     <string name="pin_shortcut_label">Odpri %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nedavno urejano</string>
-    <string name="placeholder_sentence">To je vsebnik predmetov</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">ustavi</string>
     <string name="player_toggle">preklopi</string>
     <string name="power_save_check_dialog_message">Onemogočanje varčevanja lahko povzroči pošiljanje datotek, ko je napetost baterije že nizka!</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -402,10 +402,6 @@
     <string name="permission_deny">Refuzo</string>
     <string name="permission_storage_access">Që të ngarkoni dhe shkarkoni skedar kërkohen leje shtesë.</string>
     <string name="picture_set_as_no_app">Nuk u gjet asnjë aplikacion për të vendosur foton</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Kjo është një vendmbajtëse</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="power_save_check_dialog_message">Çaktivizimi i kontrollit të ruajtjes së energjisë mund të rezultojë në ngarkimin e skedarëve kur gjendeni në gjendje të ulët të baterisë!</string>
     <string name="pref_behaviour_entries_delete_file">të fshira</string>
     <string name="pref_behaviour_entries_keep_file">mbajtur në dosjen origjinale</string>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -391,10 +391,6 @@
     <string name="permission_deny">Odbij</string>
     <string name="permission_storage_access">Dodatne dozvole potrebne da se otpremaju i skidaju fajlovi.</string>
     <string name="picture_set_as_no_app">Nijedna aplikacija nije nađena da se sa njom postavi slika</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Ovo je mestodržač</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PoP</string>
     <string name="power_save_check_dialog_message">Isključivanje provere uštede baterije može da dovede do toga da otpremate fajlove sa praznom baterijom!</string>
     <string name="pref_behaviour_entries_delete_file">obrisano</string>
     <string name="pref_behaviour_entries_keep_file">ostavljen u izvornoj fascikli</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Нема апликације којом се поставља слика</string>
     <string name="pin_home">Закачи на почетни екран</string>
     <string name="pin_shortcut_label">Отвори %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">чувар места</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Недавно уређивано</string>
-    <string name="placeholder_sentence">Ово је местодржач</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 ПоП</string>
     <string name="player_stop">стоп</string>
     <string name="player_toggle">пребацивање</string>
     <string name="please_select_a_server">Молимо вас да изаберете сервер</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Ingen app hittades för att ställa in en bild med</string>
     <string name="pin_home">Fäst på hemskärmen</string>
     <string name="pin_shortcut_label">Öppna %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">platshållare</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Nyligen redigerade</string>
-    <string name="placeholder_sentence">Detta är en platshållare</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">stopp</string>
     <string name="player_toggle">växla</string>
     <string name="please_select_a_server">Välj en server...</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">Hakuna programu iliyopatikana ya kuweka picha nayo</string>
     <string name="pin_home">Bandika kwenye skrini ya nyumbani</string>
     <string name="pin_shortcut_label">Fungua %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">kishika nafasi</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Imehaririwa hivi karibuni</string>
-    <string name="placeholder_sentence">Hiki ni kishikilia nafasi</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">acha</string>
     <string name="player_toggle">geuza</string>
     <string name="please_select_a_server">Tafadhali chagua seva...</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -448,11 +448,6 @@
     <string name="pass_code_reenter_your_pass_code">กรุณากรอกรหัสผ่านของคุณใหม่อีกครั้ง</string>
     <string name="pass_code_stored">รหัสยืนยันที่เก็บไว้</string>
     <string name="pass_code_wrong">รหัสยืนยันไม่ถูกต้อง</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">แก้ไขล่าสุด</string>
-    <string name="placeholder_sentence">นี่คือ placeholder</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="pref_behaviour_entries_keep_file">เก็บไว้ในโฟลเดอร์ต้นฉบับ</string>
     <string name="pref_behaviour_entries_move">ถูกย้ายไปยังโฟลเดอร์แอพพลิเคชัน</string>
     <string name="prefs_add_account">เพิ่มบัญชี</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -427,10 +427,6 @@
     <string name="permission_deny">inkär et</string>
     <string name="permission_storage_access">Faýllary ýüklemek we göçürip almak üçin goşmaça rugsatlar gerek.</string>
     <string name="picture_set_as_no_app">Surat goýmak üçin hiç bir programma tapylmady</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_sentence">Bu bir ýer eýesi</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23</string>
     <string name="player_stop">Dur</string>
     <string name="player_toggle">üýtgetmek</string>
     <string name="power_save_check_dialog_message">Kuwwat tygşytlaýyş barlagyny öçürmek, batareýanyň pes ýagdaýynda faýl ýüklemegine sebäp bolup biler!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -662,13 +662,6 @@
     <string name="picture_set_as_no_app">Görselin ayarlanabileceği bir uygulama bulunamadı</string>
     <string name="pin_home">Ana sayfaya sabitle</string>
     <string name="pin_shortcut_label">%1$s aç</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">yerbelirtici</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Son düzenlenenler</string>
-    <string name="placeholder_sentence">Bu bir yer belirleyicidir</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 ÖS</string>
     <string name="player_stop">durdur</string>
     <string name="player_toggle">değiştir</string>
     <string name="please_select_a_server">Lütfen bir sunucu seçin…</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -598,12 +598,6 @@
     <string name="permission_storage_access">ھۆججەتلەرنى يوللاش ۋە چۈشۈرۈش ئۈچۈن قوشۇمچە ئىجازەتلەر.</string>
     <string name="picture_set_as_no_app">رەسىم ئورنىتىدىغان ھېچقانداق دېتال تېپىلمىدى</string>
     <string name="pin_shortcut_label">%1$s نى ئېچىڭ</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">يېقىندا تەھرىرلەندى</string>
-    <string name="placeholder_sentence">بۇ يەر ئىگىسى</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">توختا</string>
     <string name="player_toggle">toggle</string>
     <string name="please_select_a_server">مۇلازىمېتىرنى تاللاڭ…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -666,12 +666,6 @@
     <string name="picture_set_as_no_app">Не знайдено застосунків для встановлення зображення для</string>
     <string name="pin_home">Закріпити на домівці</string>
     <string name="pin_shortcut_label">Відкрити %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 КБ</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Нещодавно відредаговано</string>
-    <string name="placeholder_sentence">Це заповнювач</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">стоп</string>
     <string name="player_toggle">переключитися</string>
     <string name="please_select_a_server">Виберіть сервер...</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -493,12 +493,6 @@
     <string name="permission_storage_access">Các quyền bổ sung cần thiết để tải lên và tải xuống tệp.</string>
     <string name="picture_set_as_no_app">Không tìm thấy ứng dụng nào để đặt ảnh với</string>
     <string name="pin_shortcut_label">Mở trong %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">Chỉnh sửa gần đây</string>
-    <string name="placeholder_sentence">Vị trí này đã được đặt chỗ trước</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">dừng</string>
     <string name="player_toggle">bật/tắt</string>
     <string name="power_save_check_dialog_message">Việc tắt kiểm tra tiết kiệm năng lượng có thể dẫn đến việc tải tệp lên khi ở trạng thái pin yếu!</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">找不到可以设置图片的应用程序</string>
     <string name="pin_home">固定到主屏幕</string>
     <string name="pin_shortcut_label">打开 1%1$s</string>
-    <string name="placeholder_extension">.txt </string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">占位符</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">最近编辑</string>
-    <string name="placeholder_sentence">这是一个占位符</string>
-    <string name="placeholder_timestamp">2012/05/18 下午12:23 </string>
     <string name="player_stop">停止</string>
     <string name="player_toggle">切换</string>
     <string name="please_select_a_server">请选择服务器…</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -662,13 +662,6 @@
     <string name="picture_set_as_no_app">沒有找到編輯圖片的應用程式</string>
     <string name="pin_home">釘選至主畫面</string>
     <string name="pin_shortcut_label">公開 %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">佔位字串</string>
-    <string name="placeholder_media_time">12：23：45</string>
-    <string name="placeholder_reason">最近編輯</string>
-    <string name="placeholder_sentence">這是佔位內容</string>
-    <string name="placeholder_timestamp">2012/05/18 12：23 PM</string>
     <string name="player_stop">停止</string>
     <string name="player_toggle">切換</string>
     <string name="please_select_a_server">請選擇伺服器 ...</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -666,13 +666,6 @@
     <string name="picture_set_as_no_app">沒有找到圖片可設定的應用程式</string>
     <string name="pin_home">釘選至主畫面</string>
     <string name="pin_shortcut_label">開啟 %1$s</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_filename">佔位字串</string>
-    <string name="placeholder_media_time">12:23:45</string>
-    <string name="placeholder_reason">最近編輯</string>
-    <string name="placeholder_sentence">這是佔位內容</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
     <string name="player_stop">停止</string>
     <string name="player_toggle">切換</string>
     <string name="please_select_a_server">請選取伺服器……</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,6 +451,8 @@
     <string name="ssl_validator_null_cert">The certificate could not be shown.</string>
     <string name="ssl_validator_no_info_about_error">- No information about the error</string>
 
+    <string name="placeholder_timestamp" translatable="false">2012/05/18 12:23 PM</string>
+    <string name="placeholder_media_time" translatable="false">12:23:45</string>
     <string name="placeholder_sentence" translatable="false">This is a placeholder</string>
     <string name="placeholder_filename" translatable="false">Filename</string>
     <string name="placeholder_reason" translatable="false">Recently edited</string>
@@ -459,8 +461,6 @@
     <string name="placeholder_fileSize_2" translatable="false">5 MB</string>
     <string name="placeholder_fileSize_3" translatable="false">3 MB</string>
     <string name="placeholder_current_2" translatable="false">Current (2)</string>
-    <string name="placeholder_timestamp" translatable="false">2012/05/18 12:23 PM</string>
-    <string name="placeholder_media_time" translatable="false">12:23:45</string>
     <string name="placeholder_send_button" translatable="false">Send button</string>
     <string name="placeholder_first_name_last_name" translatable="false">Firstname Lastname</string>
     <string name="placeholder_file_type" translatable="false">Filetype</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,9 @@
     <string name="placeholder_reason" translatable="false">Recently edited</string>
     <string name="placeholder_extension" translatable="false">.txt</string>
     <string name="placeholder_fileSize" translatable="false">389 KB</string>
+    <string name="placeholder_fileSize_2" translatable="false">5 MB</string>
+    <string name="placeholder_fileSize_3" translatable="false">3 MB</string>
+    <string name="placeholder_current_2" translatable="false">Current (2)</string>
     <string name="placeholder_timestamp" translatable="false">2012/05/18 12:23 PM</string>
     <string name="placeholder_media_time" translatable="false">12:23:45</string>
     <string name="placeholder_send_button" translatable="false">Send button</string>
@@ -466,6 +469,50 @@
     <string name="placeholder_share_internal_folder_text" translatable="false">Internal share link only works for users with access to this folder</string>
     <string name="placeholder_share_internal_e2ee_keyword_description" translatable="false">All 12 words together make a very strong password, letting only you view and make use of your encrypted files. Please write it down and keep it somewhere safe.</string>
     <string name="placeholder_share_no_internet_connection" translatable="false">No internet connection</string>
+    <string name="placeholder_status" translatable="false">☁️ My custom status</string>
+    <string name="placeholder_random_link" translatable="false">https://nextcloud.localhost/nextcloud</string>
+    <string name="placeholder_random_account" translatable="false">firstname@example.nextcloud.com</string>
+    <string name="placeholder_date" translatable="false">12. Dec 2020 - 23:10:20</string>
+    <string name="placeholder_date_2" translatable="false">10. Dec 2020 - 10:10:10</string>
+    <string name="placeholder_sso" translatable="false">Grant Nextcloud News access to your Nextcloud account incrediblyLong_username_with_123456789_number@Nextcloud_dummy.com?</string>
+    <string name="placeholder_example_phone_number" translatable="false">+49 123 456 789 12</string>
+    <string name="placeholder_uuid" translatable="false">d7edb387-0b61-4e4e-a728-ffab3055d700</string>
+    <string name="placeholder_job_name" translatable="false">Job name</string>
+    <string name="placeholder_job_state" translatable="false">ENQUEUED</string>
+    <string name="placeholder_date_3" translatable="false">2020-02-15T20:53:15Z</string>
+    <string name="placeholder_progress" translatable="false">50%</string>
+    <string name="placeholder_random_number" translatable="false">0</string>
+    <string name="placeholder_remaining_downloads" translatable="false">5 downloads remaining</string>
+    <string name="placeholder_view_only" translatable="false">View only</string>
+    <string name="placeholder_time_ago" translatable="false">6 min ago</string>
+    <string name="placeholder_success" translatable="false">Success</string>
+    <string name="placeholder_file_path" translatable="false">/abc/example</string>
+    <string name="placeholder_delete_file" translatable="false">Delete file</string>
+    <string name="placeholder_action_info" translatable="false">Some additional action info</string>
+    <string name="placeholder_open_in_notes" translatable="false">Open in Notes</string>
+    <string name="placeholder_open_in_notes_info" translatable="false">This folder is best viewed in the Notes app</string>
+    <string name="placeholder_year" translatable="false">2025</string>
+    <string name="placeholder_month" translatable="false">October</string>
+    <string name="placeholder_auto_upload_overview_path" translatable="false">For /storage/emulated/0/DCIM/Camera</string>
+    <string name="placeholder_predefined_status_icon" translatable="false">📆</string>
+    <string name="placeholder_predefined_status_name" translatable="false">In a meeting</string>
+    <string name="placeholder_predefined_status_clear_at" translatable="false">an hour</string>
+    <string name="placeholder_image_detail_date" translatable="false">Wednesday • 26 Jul 2023 • 12:27</string>
+    <string name="placeholder_image_details" translatable="false">12 MP • 3024 × 4032 • 923 KB</string>
+    <string name="placeholder_image_detail_model" translatable="false">Camera Phone (4th generation)</string>
+    <string name="placeholder_image_detail_condition" translatable="false">ƒ/1.8 • 1/374 s • 28 mm • ISO 200</string>
+    <string name="placeholder_image_detail_location" translatable="false">Mitte, Berlin, Germany</string>
+    <string name="placeholder_image_detail_example_copyright" translatable="false">© OpenStreetMap contributors</string>
+    <string name="placeholder_compose_mail" translatable="false">Compose email</string>
+    <string name="placeholder_passphrase" translatable="false">passphrase</string>
+    <string name="placeholder_show_hidden_folders" translatable="false">Show 3 hidden folders</string>
+    <string name="placeholder_template" translatable="false">Template</string>
+    <string name="placeholder_widget_first_line" translatable="false">First line</string>
+    <string name="placeholder_widget_second_line" translatable="false">Subline</string>
+    <string name="placeholder_search_in_nextcloud" translatable="false">Search in Nextcloud</string>
+    <string name="placeholder_files" translatable="false">Files</string>
+    <string name="placeholder_in_folder" translatable="false">in TestFolder</string>
+    <string name="placeholder_example_mail" translatable="false">example@nextcloud.com</string>
 
     <string name="auto_upload_on_wifi">Only upload on unmetered Wi-Fi</string>
     <string name="instant_upload_on_charging">Only upload when charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,13 +451,21 @@
     <string name="ssl_validator_null_cert">The certificate could not be shown.</string>
     <string name="ssl_validator_no_info_about_error">- No information about the error</string>
 
-    <string name="placeholder_sentence">This is a placeholder</string>
-    <string name="placeholder_filename">placeholder</string>
-    <string name="placeholder_reason">Recently edited</string>
-    <string name="placeholder_extension">.txt</string>
-    <string name="placeholder_fileSize">389 KB</string>
-    <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
-    <string name="placeholder_media_time">12:23:45</string>
+    <string name="placeholder_sentence" translatable="false">This is a placeholder</string>
+    <string name="placeholder_filename" translatable="false">Filename</string>
+    <string name="placeholder_reason" translatable="false">Recently edited</string>
+    <string name="placeholder_extension" translatable="false">.txt</string>
+    <string name="placeholder_fileSize" translatable="false">389 KB</string>
+    <string name="placeholder_timestamp" translatable="false">2012/05/18 12:23 PM</string>
+    <string name="placeholder_media_time" translatable="false">12:23:45</string>
+    <string name="placeholder_send_button" translatable="false">Send button</string>
+    <string name="placeholder_first_name_last_name" translatable="false">Firstname Lastname</string>
+    <string name="placeholder_file_type" translatable="false">Filetype</string>
+    <string name="placeholder_download" translatable="false">Download</string>
+    <string name="placeholder_share_internal_link_text" translatable="false">Internal share link only works for users with access to this folder</string>
+    <string name="placeholder_share_internal_folder_text" translatable="false">Internal share link only works for users with access to this folder</string>
+    <string name="placeholder_share_internal_e2ee_keyword_description" translatable="false">All 12 words together make a very strong password, letting only you view and make use of your encrypted files. Please write it down and keep it somewhere safe.</string>
+    <string name="placeholder_share_no_internet_connection" translatable="false">No internet connection</string>
 
     <string name="auto_upload_on_wifi">Only upload on unmetered Wi-Fi</string>
     <string name="instant_upload_on_charging">Only upload when charging</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Issue: https://github.com/nextcloud/android/issues/15733


Removes placeholder strings from translations.
Adds other hardcoded placeholders into strings.xml as non translatable.

