### PR TITLE
fix: media folder detection worker

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
+++ b/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
@@ -20,6 +20,7 @@ import com.nextcloud.client.database.dao.FileDao
 import com.nextcloud.client.database.dao.FileSystemDao
 import com.nextcloud.client.database.dao.OfflineOperationDao
 import com.nextcloud.client.database.dao.RecommendedFileDao
+import com.nextcloud.client.database.dao.SyncedFolderDao
 import com.nextcloud.client.database.dao.UploadDao
 import com.nextcloud.client.database.entity.ArbitraryDataEntity
 import com.nextcloud.client.database.entity.CapabilityEntity
@@ -96,6 +97,7 @@ abstract class NextcloudDatabase : RoomDatabase() {
     abstract fun uploadDao(): UploadDao
     abstract fun recommendedFileDao(): RecommendedFileDao
     abstract fun fileSystemDao(): FileSystemDao
+    abstract fun syncedFolderDao(): SyncedFolderDao
 
     companion object {
         const val FIRST_ROOM_DB_VERSION = 65

--- a/app/src/main/java/com/nextcloud/client/database/dao/SyncedFolderDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/SyncedFolderDao.kt
@@ -1,0 +1,26 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import com.nextcloud.client.database.entity.SyncedFolderEntity
+import com.owncloud.android.db.ProviderMeta
+
+@Dao
+interface SyncedFolderDao {
+    @Query(
+        """
+        SELECT * FROM ${ProviderMeta.ProviderTableMeta.SYNCED_FOLDERS_TABLE_NAME}
+        WHERE ${ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH} = :localPath
+          AND ${ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT} = :account
+        LIMIT 1
+        """
+    )
+    fun findByLocalPathAndAccount(localPath: String, account: String): SyncedFolderEntity?
+}

--- a/app/src/main/java/com/nextcloud/client/database/entity/SyncedFolderEntity.kt
+++ b/app/src/main/java/com/nextcloud/client/database/entity/SyncedFolderEntity.kt
@@ -10,6 +10,9 @@ package com.nextcloud.client.database.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.nextcloud.client.preferences.SubFolderRule
+import com.owncloud.android.datamodel.MediaFolderType
+import com.owncloud.android.datamodel.SyncedFolder
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
 
 @Entity(tableName = ProviderTableMeta.SYNCED_FOLDERS_TABLE_NAME)
@@ -49,4 +52,41 @@ data class SyncedFolderEntity(
     val excludeHidden: Int?,
     @ColumnInfo(name = ProviderTableMeta.SYNCED_FOLDER_LAST_SCAN_TIMESTAMP_MS)
     val lastScanTimestampMs: Long?
+)
+
+fun SyncedFolderEntity.toSyncedFolder(): SyncedFolder = SyncedFolder(
+    // id
+    (this.id ?: SyncedFolder.UNPERSISTED_ID).toLong(),
+    // localPath
+    this.localPath ?: "",
+    // remotePath
+    this.remotePath ?: "",
+    // wifiOnly
+    this.wifiOnly == 1,
+    // chargingOnly
+    this.chargingOnly == 1,
+    // existing
+    this.existing == 1,
+    // subfolderByDate
+    this.subfolderByDate == 1,
+    // account
+    this.account ?: "",
+    // uploadAction
+    this.uploadAction ?: 0,
+    // nameCollisionPolicy
+    this.nameCollisionPolicy ?: 0,
+    // enabled
+    this.enabled == 1,
+    // timestampMs
+    (this.enabledTimestampMs ?: SyncedFolder.EMPTY_ENABLED_TIMESTAMP_MS).toLong(),
+    // type
+    MediaFolderType.getById(this.type ?: MediaFolderType.CUSTOM.id),
+    // hidden
+    this.hidden == 1,
+    // subFolderRule
+    this.subFolderRule?.let { SubFolderRule.entries[it] },
+    // excludeHidden
+    this.excludeHidden == 1,
+    // lastScanTimestampMs
+    this.lastScanTimestampMs ?: SyncedFolder.NOT_SCANNED_YET
 )

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolder.java
@@ -108,7 +108,7 @@ public class SyncedFolder implements Serializable, Cloneable {
      *
      * @param id id
      */
-    protected SyncedFolder(long id,
+    public SyncedFolder(long id,
                            String localPath,
                            String remotePath,
                            boolean wifiOnly,

--- a/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/SyncedFolderProvider.java
@@ -15,9 +15,14 @@ import android.net.Uri;
 
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.core.Clock;
+import com.nextcloud.client.database.NextcloudDatabase;
+import com.nextcloud.client.database.dao.SyncedFolderDao;
+import com.nextcloud.client.database.entity.SyncedFolderEntity;
+import com.nextcloud.client.database.entity.SyncedFolderEntityKt;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.client.preferences.AppPreferencesImpl;
 import com.nextcloud.client.preferences.SubFolderRule;
+import com.owncloud.android.MainApp;
 import com.owncloud.android.db.ProviderMeta;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.files.model.ServerFileInterface;
@@ -42,6 +47,7 @@ public class SyncedFolderProvider extends Observable {
     private final ContentResolver mContentResolver;
     private final AppPreferences preferences;
     private final Clock clock;
+    public final SyncedFolderDao dao = NextcloudDatabase.getInstance(MainApp.getAppContext()).syncedFolderDao();
 
     /**
      * constructor.
@@ -183,33 +189,11 @@ public class SyncedFolderProvider extends Observable {
     }
 
     public SyncedFolder findByLocalPathAndAccount(String localPath, User user) {
-        SyncedFolder result = null;
-        Cursor cursor = mContentResolver.query(
-            ProviderMeta.ProviderTableMeta.CONTENT_URI_SYNCED_FOLDERS,
-            null,
-            ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_LOCAL_PATH + " LIKE ? AND " +
-                ProviderMeta.ProviderTableMeta.SYNCED_FOLDER_ACCOUNT + " =? ",
-            new String[]{localPath + "%", user.getAccountName()},
-            null
-        );
-
-        if (cursor != null && cursor.getCount() == 1) {
-            result = createSyncedFolderFromCursor(cursor);
-        } else {
-            if (cursor == null) {
-                Log_OC.e(TAG, "Sync folder db cursor for local path=" + localPath + " in NULL.");
-            } else {
-                Log_OC.e(TAG, cursor.getCount() + " items for local path=" + localPath
-                        + " available in sync folder db. Expected 1. Failed to update sync folder db.");
-            }
+        final SyncedFolderEntity entity = dao.findByLocalPathAndAccount(localPath, user.getAccountName());
+        if (entity == null) {
+            return null;
         }
-
-        if (cursor != null) {
-            cursor.close();
-        }
-
-        return result;
-
+        return SyncedFolderEntityKt.toSyncedFolder(entity);
     }
 
     @Nullable


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Following crash prevents the `recheduleSelf()` thus `ContentObserverWork` not triggers the auto upload again. Because `MediaFoldersDetectionWork` called inside `ContentObserverWork`.

```
E  Work [ 
       id = 12796a33-5fb9-4346-8b7a-e1851c23cce7, 
       tags = { 
           com.nextcloud.client.jobs.MediaFoldersDetectionWork,
           *,
           name: periodic_media_folder_detection,
           timestamp: 1760005357681,
           class: MediaFoldersDetectionWork 
       } 
   ] failed because it threw an exception/error

android.database.CursorIndexOutOfBoundsException: Index -1 requested, with a size of 1
    at android.database.AbstractCursor.checkPosition(AbstractCursor.java:535)
    at android.database.AbstractWindowedCursor.checkPosition(AbstractWindowedCursor.java:139)
    at android.database.AbstractWindowedCursor.getLong(AbstractWindowedCursor.java:77)
    at android.database.CursorWrapper.getLong(CursorWrapper.java:132)
    at com.owncloud.android.datamodel.SyncedFolderProvider.createSyncedFolderFromCursor(SyncedFolderProvider.java:358)
    at com.owncloud.android.datamodel.SyncedFolderProvider.findByLocalPathAndAccount(SyncedFolderProvider.java:197)
    at com.nextcloud.client.jobs.MediaFoldersDetectionWork.doWork(MediaFoldersDetectionWork.kt:143)
    at androidx.work.Worker$startWork$1.invoke(Worker.kt:64)
    at androidx.work.Worker$startWork$1.invoke(Worker.kt:64)
    at androidx.work.WorkerKt.future$lambda$2$lambda$1(Worker.kt:100)
    at androidx.work.WorkerKt.$r8$lambda$06LNzu7McnKR6G06fSbfQ2BCegc(Unknown Source:0)
    at androidx.work.WorkerKt$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
```

