### PR TITLE
fix: sync folder layout shimmer order

### DIFF
--- a/app/src/main/res/layout/synced_folders_layout.xml
+++ b/app/src/main/res/layout/synced_folders_layout.xml
@@ -39,10 +39,6 @@
                 android:scrollbars="vertical"
                 android:visibility="visible" />
 
-            <include
-                android:id="@+id/emptyList"
-                layout="@layout/empty_list" />
-
             <LinearLayout
                 android:id="@+id/loading_content"
                 android:layout_width="match_parent"
@@ -54,6 +50,11 @@
                 <include layout="@layout/synced_folders_list_item_shimmer" />
 
             </LinearLayout>
+
+            <include
+                android:id="@+id/emptyList"
+                layout="@layout/empty_list" />
+
         </FrameLayout>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Due to wrong order of the sync folder layout, loading content's text was behind the shimmering layout.

### Before

**Order**

0. list
1. empty list
2. loading content

[before.webm](https://github.com/user-attachments/assets/ce6ee62c-d88b-4f93-8049-99146622c470)


### After

**Order**

0. list
1. loading content
2. empty list


[after.webm](https://github.com/user-attachments/assets/69e7c139-ed50-4586-950c-5d40c769074e)
