### PR TITLE
fix: file sort order by size

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.kt
+++ b/app/src/main/java/com/owncloud/android/utils/FileSortOrderBySize.kt
@@ -40,10 +40,14 @@ class FileSortOrderBySize internal constructor(name: String?, ascending: Boolean
     }
 
     override fun sortLocalFiles(files: MutableList<File>): List<File> {
+        val folderSizes =
+            files.associateWith { file -> FileStorageUtils.getFolderSize(file) }
+
         files.sortWith { o1: File, o2: File ->
             when {
-                o1.isDirectory && o2.isDirectory -> sortMultiplier * FileStorageUtils.getFolderSize(o1)
-                    .compareTo(FileStorageUtils.getFolderSize(o2))
+                o1.isDirectory && o2.isDirectory -> sortMultiplier * (folderSizes[o1] ?: 0L).compareTo(
+                    folderSizes[o2] ?: 0L
+                )
                 o1.isDirectory -> -1
                 o2.isDirectory -> 1
                 else -> sortMultiplier * o1.length().compareTo(o2.length())

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -404,23 +404,27 @@ public final class FileStorageUtils {
      * @return Size in bytes
      */
     public static long getFolderSize(File dir) {
-        if (dir.exists() && dir.isDirectory()) {
-            File[] files = dir.listFiles();
-
-            if (files != null) {
-                long result = 0;
-                for (File f : files) {
-                    if (f.isDirectory()) {
-                        result += getFolderSize(f);
-                    } else {
-                        result += f.length();
-                    }
-                }
-                return result;
-            }
+        if (dir == null || !dir.exists() || !dir.isDirectory()) {
+            return 0;
         }
-        return 0;
+
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return 0;
+        }
+
+        long result = 0;
+        for (File f : files) {
+            if (f.isDirectory()) {
+                result += getFolderSize(f);
+                continue;
+            }
+            result += f.length();
+        }
+
+        return result;
     }
+
 
     /**
      * Mimetype String of a file.

--- a/app/src/test/java/com/nextcloud/client/utils/FileSortOrderBySizeTests.kt
+++ b/app/src/test/java/com/nextcloud/client/utils/FileSortOrderBySizeTests.kt
@@ -1,0 +1,165 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.utils
+
+import com.owncloud.android.utils.FileSortOrderBySize
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+import org.junit.Before
+import org.junit.After
+import java.io.File
+
+@Suppress("TooManyFunctions", "MagicNumber")
+class FileSortOrderBySizeTests {
+    private lateinit var tempDir: File
+
+    @Before
+    fun setup() {
+        tempDir = File(System.getProperty("java.io.tmpdir"), "test_sort_${System.currentTimeMillis()}")
+        tempDir.mkdirs()
+    }
+
+    @After
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun testSortAscendingWhenGivenFilesWithDifferentSizes() {
+        val smallFile = File(tempDir, "small.txt").apply {
+            writeText("x")
+        }
+        val mediumFile = File(tempDir, "medium.txt").apply {
+            writeText("x".repeat(100))
+        }
+        val largeFile = File(tempDir, "large.txt").apply {
+            writeText("x".repeat(1000))
+        }
+
+        val files = mutableListOf(largeFile, smallFile, mediumFile)
+        val sortOrder = FileSortOrderBySize("test", true)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertEquals("small.txt", sorted[0].name)
+        assertEquals("medium.txt", sorted[1].name)
+        assertEquals("large.txt", sorted[2].name)
+    }
+
+    @Test
+    fun testSortDescendingWhenGivenFilesWithDifferentSizes() {
+        val smallFile = File(tempDir, "small.txt").apply {
+            writeText("a")
+        }
+        val mediumFile = File(tempDir, "medium.txt").apply {
+            writeText("a".repeat(50))
+        }
+        val largeFile = File(tempDir, "large.txt").apply {
+            writeText("a".repeat(500))
+        }
+
+        val files = mutableListOf(smallFile, largeFile, mediumFile)
+        val sortOrder = FileSortOrderBySize("test", false)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertEquals("large.txt", sorted[0].name)
+        assertEquals("medium.txt", sorted[1].name)
+        assertEquals("small.txt", sorted[2].name)
+    }
+
+    @Test
+    fun testFoldersComesFirstWhenGivenMixedFilesAndFolders() {
+        val folder1 = File(tempDir, "folderA").apply { mkdirs() }
+        val folder2 = File(tempDir, "folderB").apply { mkdirs() }
+        val file1 = File(tempDir, "file1.txt").apply { writeText("content") }
+        val file2 = File(tempDir, "file2.txt").apply { writeText("data") }
+
+        val files = mutableListOf(file1, folder1, file2, folder2)
+        val sortOrder = FileSortOrderBySize("test", true)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertTrue(sorted[0].isDirectory)
+        assertTrue(sorted[1].isDirectory)
+        assertFalse(sorted[2].isDirectory)
+        assertFalse(sorted[3].isDirectory)
+    }
+
+    @Test
+    fun testSortByFolderSizeWhenGivenFoldersWithDifferentContent() {
+        val smallFolder = File(tempDir, "smallFolder").apply {
+            mkdirs()
+            File(this, "file.txt").writeText("x")
+        }
+
+        val largeFolder = File(tempDir, "largeFolder").apply {
+            mkdirs()
+            File(this, "file1.txt").writeText("x".repeat(100))
+            File(this, "file2.txt").writeText("x".repeat(100))
+        }
+
+        val files = mutableListOf(largeFolder, smallFolder)
+        val sortOrder = FileSortOrderBySize("test", true)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertEquals("smallFolder", sorted[0].name)
+        assertEquals("largeFolder", sorted[1].name)
+    }
+
+    @Test
+    fun testEmptyListWhenGivenNoFiles() {
+        val files = mutableListOf<File>()
+        val sortOrder = FileSortOrderBySize("test", true)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertTrue(sorted.isEmpty())
+    }
+
+    @Test
+    fun testSingleFileWhenGivenOnlyOneFile() {
+        val file = File(tempDir, "single.txt").apply {
+            writeText("content")
+        }
+
+        val files = mutableListOf(file)
+        val sortOrder = FileSortOrderBySize("test", true)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertEquals(1, sorted.size)
+        assertEquals("single.txt", sorted[0].name)
+    }
+
+    @Test
+    fun testSameOrderWhenGivenFilesWithSameSize() {
+        val file1 = File(tempDir, "file1.txt").apply {
+            writeText("same")
+        }
+        val file2 = File(tempDir, "file2.txt").apply {
+            writeText("same")
+        }
+        val file3 = File(tempDir, "file3.txt").apply {
+            writeText("same")
+        }
+
+        val files = mutableListOf(file1, file2, file3)
+        val sortOrder = FileSortOrderBySize("test", true)
+
+        val sorted = sortOrder.sortLocalFiles(files)
+
+        assertEquals(3, sorted.size)
+
+        // All files have same size, so order should be stable
+        sorted.forEach { assertTrue(it.length() == 4L) }
+    }
+}

--- a/app/src/test/java/com/nextcloud/client/utils/FolderSizeCalculationTests.kt
+++ b/app/src/test/java/com/nextcloud/client/utils/FolderSizeCalculationTests.kt
@@ -1,0 +1,196 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.utils
+
+import com.owncloud.android.utils.FileStorageUtils
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+@Suppress("TooManyFunctions", "MagicNumber")
+class FolderSizeCalculationTests {
+
+    private lateinit var testDir: File
+
+    @Before
+    fun setUp() {
+        testDir = File(System.getProperty("java.io.tmpdir"), "test_folder_${System.currentTimeMillis()}")
+        testDir.mkdirs()
+    }
+
+    @After
+    fun tearDown() {
+        testDir.deleteRecursively()
+    }
+
+    @Test
+    fun testReturnZeroWhenGivenNullDirectory() {
+        val result = FileStorageUtils.getFolderSize(null)
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun testReturnZeroWhenGivenNonExistentDirectory() {
+        val nonExistent = File(testDir, "does_not_exist")
+        val result = FileStorageUtils.getFolderSize(nonExistent)
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun testReturnZeroWhenGivenRegularFile() {
+        val file = File(testDir, "regular_file.txt")
+        file.writeText("content")
+
+        val result = FileStorageUtils.getFolderSize(file)
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun testReturnZeroWhenGivenEmptyDirectory() {
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeForSingleFile() {
+        val file = File(testDir, "file.txt")
+        file.writeText("12345") // 5 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(5L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeForMultipleFiles() {
+        File(testDir, "file1.txt").writeText("123") // 3 bytes
+        File(testDir, "file2.txt").writeText("12345") // 5 bytes
+        File(testDir, "file3.txt").writeText("1234567") // 7 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(15L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithSubdirectory() {
+        File(testDir, "file1.txt").writeText("123") // 3 bytes
+
+        val subDir = File(testDir, "subdir")
+        subDir.mkdirs()
+        File(subDir, "file2.txt").writeText("12345") // 5 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(8L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithNestedSubdirectories() {
+        File(testDir, "file1.txt").writeText("12") // 2 bytes
+
+        val subDir1 = File(testDir, "subdir1")
+        subDir1.mkdirs()
+        File(subDir1, "file2.txt").writeText("123") // 3 bytes
+
+        val subDir2 = File(subDir1, "subdir2")
+        subDir2.mkdirs()
+        File(subDir2, "file3.txt").writeText("1234") // 4 bytes
+
+        val subDir3 = File(subDir2, "subdir3")
+        subDir3.mkdirs()
+        File(subDir3, "file4.txt").writeText("12345") // 5 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(14L, result) // 2 + 3 + 4 + 5
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithEmptySubdirectories() {
+        File(testDir, "file1.txt").writeText("123") // 3 bytes
+
+        val emptyDir1 = File(testDir, "empty1")
+        emptyDir1.mkdirs()
+
+        val emptyDir2 = File(testDir, "empty2")
+        emptyDir2.mkdirs()
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(3L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithLargeFile() {
+        val file = File(testDir, "large_file.txt")
+        val content = "x".repeat(10000) // 10000 bytes
+        file.writeText(content)
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(10000L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithMixedFilesAndDirectories() {
+        // Root level files
+        File(testDir, "root1.txt").writeText("12") // 2 bytes
+        File(testDir, "root2.txt").writeText("123") // 3 bytes
+
+        // First subdirectory
+        val subDir1 = File(testDir, "sub1")
+        subDir1.mkdirs()
+        File(subDir1, "sub1_file1.txt").writeText("1234") // 4 bytes
+        File(subDir1, "sub1_file2.txt").writeText("12345") // 5 bytes
+
+        // Second subdirectory
+        val subDir2 = File(testDir, "sub2")
+        subDir2.mkdirs()
+        File(subDir2, "sub2_file.txt").writeText("123456") // 6 bytes
+
+        // Nested subdirectory
+        val nestedDir = File(subDir1, "nested")
+        nestedDir.mkdirs()
+        File(nestedDir, "nested_file.txt").writeText("1234567") // 7 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(27L, result) // 2 + 3 + 4 + 5 + 6 + 7
+    }
+
+    @Test
+    fun testReturnZeroForDirectoryWithOnlyEmptySubdirectories() {
+        val sub1 = File(testDir, "sub1")
+        sub1.mkdirs()
+
+        val sub2 = File(testDir, "sub2")
+        sub2.mkdirs()
+
+        val nested = File(sub1, "nested")
+        nested.mkdirs()
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithSpecialCharactersInFilenames() {
+        File(testDir, "file with spaces.txt").writeText("12") // 2 bytes
+        File(testDir, "file-with-dashes.txt").writeText("123") // 3 bytes
+        File(testDir, "file_with_underscores.txt").writeText("1234") // 4 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(9L, result)
+    }
+
+    @Test
+    fun testReturnCorrectSizeWithEmptyFiles() {
+        File(testDir, "empty1.txt").writeText("") // 0 bytes
+        File(testDir, "empty2.txt").writeText("") // 0 bytes
+        File(testDir, "nonempty.txt").writeText("123") // 3 bytes
+
+        val result = FileStorageUtils.getFolderSize(testDir)
+        assertEquals(3L, result)
+    }
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

`getFolderSize()` may change during sorting, especially with slow server, thus sorting logic will throw following exception.

`com.owncloud.android.utils.FileSortOrderBySize.sortLocalFiles(FileSortOrderBySize.kt:43)errorStack: java.lang.IllegalArgumentException: Comparison method violates its general contract!`

### Changes

First calculates folder sizes and store in variable, then compares.

Tests are added for `getFolderSize()` and `sortLocalFiles()`