### PR TITLE
fix: saving file for folder download

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobFactory.kt
@@ -292,7 +292,7 @@ class BackgroundJobFactory @Inject constructor(
 
     private fun createFolderDownloadWorker(context: Context, params: WorkerParameters): FolderDownloadWorker =
         FolderDownloadWorker(
-            accountManager.user,
+            accountManager,
             context,
             viewThemeUtils.get(),
             params

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -171,6 +171,6 @@ interface BackgroundJobManager {
     fun scheduleInternal2WaySync(intervalMinutes: Long)
     fun cancelAllFilesDownloadJobs()
     fun startMetadataSyncJob(currentDirPath: String)
-    fun downloadFolder(folder: OCFile)
+    fun downloadFolder(folder: OCFile, accountName: String)
     fun cancelFolderDownload()
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -28,9 +28,9 @@ import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.documentscan.GeneratePdfFromImagesWork
 import com.nextcloud.client.jobs.autoUpload.AutoUploadWorker
 import com.nextcloud.client.jobs.download.FileDownloadWorker
+import com.nextcloud.client.jobs.folderDownload.FolderDownloadWorker
 import com.nextcloud.client.jobs.metadata.MetadataWorker
 import com.nextcloud.client.jobs.offlineOperations.OfflineOperationsWorker
-import com.nextcloud.client.jobs.folderDownload.FolderDownloadWorker
 import com.nextcloud.client.jobs.upload.FileUploadHelper
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.preferences.AppPreferences
@@ -824,7 +824,7 @@ internal class BackgroundJobManagerImpl(
         workManager.enqueueUniquePeriodicWork(JOB_INTERNAL_TWO_WAY_SYNC, ExistingPeriodicWorkPolicy.UPDATE, request)
     }
 
-    override fun downloadFolder(folder: OCFile) {
+    override fun downloadFolder(folder: OCFile, accountName: String) {
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .setRequiresStorageNotLow(true)
@@ -832,6 +832,7 @@ internal class BackgroundJobManagerImpl(
 
         val data = Data.Builder()
             .putLong(FolderDownloadWorker.FOLDER_ID, folder.fileId)
+            .putString(FolderDownloadWorker.ACCOUNT_NAME, accountName)
             .build()
 
         val request = oneTimeRequestBuilder(FolderDownloadWorker::class, JOB_DOWNLOAD_FOLDER)

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadHelper.kt
@@ -139,12 +139,12 @@ class FileDownloadHelper {
         )
     }
 
-    fun downloadFolder(folder: OCFile?) {
+    fun downloadFolder(folder: OCFile?, accountName: String) {
         if (folder == null) {
             Log_OC.e(TAG, "folder cannot be null, cant sync")
             return
         }
-        backgroundJobManager.downloadFolder(folder)
+        backgroundJobManager.downloadFolder(folder, accountName)
     }
 
     fun cancelFolderDownload() = backgroundJobManager.cancelFolderDownload()

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -484,7 +484,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
                 Log_OC.d(TAG, "Exception caught at startDirectDownloads" + e);
             }
         } else {
-            fileDownloadHelper.downloadFolder(mLocalFolder);
+            fileDownloadHelper.downloadFolder(mLocalFolder, user.getAccountName());
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Fixes

1. Correct file saving after download

2. Previously, when downloading large folders for different accounts (e.g., start download for Account A, then switch to Account B and start another), the worker could mix up account contexts because the user was passed through the constructor. Now, the account name is injected via the worker’s input data and resolved inside the worker, ensuring that each download runs under the correct user account — even when switching accounts between downloads.