### PR TITLE
fix: incomplete trailing space during decoding filename

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -80,8 +80,8 @@ public final class FileStorageUtils {
         String decoded;
         try {
             decoded = URLDecoder.decode(filename, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException e) {
-            return false;
+        } catch (Exception e) {
+            decoded = filename;
         }
 
         int[] bidiControlCharacters = {

--- a/app/src/test/java/com/nextcloud/client/utils/FileStorageUtilsTest.kt
+++ b/app/src/test/java/com/nextcloud/client/utils/FileStorageUtilsTest.kt
@@ -304,4 +304,22 @@ class FileStorageUtilsTest {
         val result = FileStorageUtils.containsBidiControlCharacters("/Foo%e2%80%aedm.exe")
         assertTrue(result)
     }
+
+    @Test
+    fun testContainsBidiControlCharactersWhenGivenMalformedEncodedSequenceShouldNotThrowAndReturnFalse() {
+        val result = FileStorageUtils.containsBidiControlCharacters("file%")
+        assertFalse(result)
+    }
+
+    @Test
+    fun testContainsBidiControlCharactersWhenGivenBrokenUrlEncodedPatternShouldHandleGracefully() {
+        val result = FileStorageUtils.containsBidiControlCharacters("file%2")
+        assertFalse(result)
+    }
+
+    @Test
+    fun testContainsBidiControlCharactersWhenGivenMultipleBidiCharactersShouldReturnTrue() {
+        val result = FileStorageUtils.containsBidiControlCharacters("safe\u202Ebad\u202Bname.txt")
+        assertTrue(result)
+    }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Fixes

```
Exception in thread "main"
java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern
    at java.net.URLDecoder.decode(URLDecoder.java:196)
    at com.owncloud.android.utils.FileStorageUtils.containsBidiControlCharacters(FileStorageUtils.java:82)
    at com.owncloud.android.ui.adapter.OCFileListAdapter.handleGridMode(OCFileListAdapter.java:588)
    at com.owncloud.android.ui.adapter.OCFileListAdapter.setFilenameAndExtension(OCFileListAdapter.java:581)
    at com.owncloud.android.ui.adapter.OCFileListAdapter.bindHolder(OCFileListAdapter.java:496)
    at com.owncloud.android.ui.adapter.OCFileListAdapter.onBindViewHolder(OCFileListAdapter.java:479)
    at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:7747)
    at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:7847)
    at androidx.recyclerview.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:6646)
    at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6917)
    at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6757)
    at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6753)
```
