### PR TITLE
fix: file upload limit message visibility

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -7,6 +7,7 @@
  */
 package com.nextcloud.client.jobs.upload
 
+import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -20,6 +21,7 @@ import com.nextcloud.client.network.Connectivity
 import com.nextcloud.client.network.ConnectivityService
 import com.nextcloud.utils.extensions.getUploadIds
 import com.owncloud.android.MainApp
+import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.UploadsStorageManager
@@ -35,6 +37,7 @@ import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation
 import com.owncloud.android.lib.resources.files.model.RemoteFile
 import com.owncloud.android.operations.RemoveFileOperation
 import com.owncloud.android.operations.UploadFileOperation
+import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.FileUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -421,6 +424,14 @@ class FileUploadHelper {
                 remoteFile.modifiedTimestamp == localLastModifiedTimestamp * 1000
         }
         return false
+    }
+
+    fun showFileUploadLimitMessage(activity: Activity) {
+        val message = activity.getString(
+            R.string.file_upload_limit_message,
+            MAX_FILE_COUNT
+        )
+        DisplayUtils.showSnackMessage(activity, message)
     }
 
     class UploadNotificationActionReceiver : BroadcastReceiver() {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -952,7 +952,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         }
 
         if (mStreamsToUpload.size() > FileUploadHelper.MAX_FILE_COUNT) {
-            DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+            FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
             return;
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -503,7 +503,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             } else {
                 final var chosenFiles = mFileListFragment.getCheckedFilePaths();
                 if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
-                    DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+                    FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
                     return;
                 }
 
@@ -670,7 +670,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
                 } else {
                     final var chosenFiles = mFileListFragment.getCheckedFilePaths();
                     if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
-                        DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+                        FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
                         return;
                     }
                     boolean isPositionZero = (binding.uploadFilesSpinnerBehaviour.getSelectedItemPosition() == 0);
@@ -720,7 +720,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
         Log_OC.d(TAG, "Positive button in dialog was clicked; dialog tag is " + callerTag);
         final var chosenFiles = mFileListFragment.getCheckedFilePaths();
         if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
-            DisplayUtils.showSnackMessage(this, R.string.max_file_count_warning_message);
+            FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
             return;
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,7 +172,7 @@
     <string name="uploader_error_message_source_file_not_found">File selected for upload not found. Please check whether the file exists.</string>
     <string name="uploader_error_message_source_file_not_copied">Could not copy file to a temporary folder. Try to resend it.</string>
     <string name="uploader_upload_files_behaviour">Upload option:</string>
-    <string name="max_file_count_warning_message">You have reached the maximum file upload limit. Please upload fewer than 500 files at a time.</string>
+    <string name="file_upload_limit_message">You can upload up to %d files at once."</string>
     <string name="file_upload_worker_same_file_already_exists">%s already exists, no conflict detected</string>
     <string name="uploader_upload_files_behaviour_move_to_nextcloud_folder">Move file to %1$s folder</string>
     <string name="uploader_upload_files_behaviour_only_upload">Keep file in source folder</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

In some translations, the original message is too long to fit within the `Snackbar`, preventing users from seeing the full content. This shorter version ensures translations remain concise, allowing the complete message to be displayed to the user.



<table>
  <tr>
    <th>Before Small Screen Device</th>
    <th>After Small Screen Device</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/cfb375fd-95f1-4c0b-9315-157956382ff4" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/8bb2df0a-0701-4181-8c71-872d3a82ace7" width="300" alt="after"></td>
  </tr>
</table>

<table>
  <tr>
    <th>Before Large Screen Device</th>
    <th>After Large Screen Device</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/893ad473-980e-4f4c-b518-c196cbb49c11" width="300" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/433b92b2-0f5d-4125-8516-de4301b3c5da" width="300" alt="after"></td>
  </tr>
</table>