### PR TITLE
fix: npe left fragment adapter

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1221,9 +1221,10 @@ class FileDisplayActivity :
 
         if (isRoot(getCurrentDir()) && leftFragment is OCFileListFragment) {
             // Remove the list to the original state
-
-            val listOfHiddenFiles = leftFragment.adapter.listOfHiddenFiles
-            leftFragment.performSearch("", listOfHiddenFiles, true)
+            leftFragment.adapter?.let { adapter ->
+                val listOfHiddenFiles = adapter.listOfHiddenFiles
+                leftFragment.performSearch("", listOfHiddenFiles, true)
+            }
 
             hideSearchView(getCurrentDir())
             setDrawerIndicatorEnabled(isDrawerIndicatorAvailable)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Fixes

```
E  FATAL EXCEPTION: main
Process: com.nextcloud.client, PID: 21488
java.lang.NullPointerException: Attempt to read from field 'java.util.ArrayList com.owncloud.android.ui.adapter.OCFileListAdapter.listOfHiddenFiles' on a null object reference in method 'void com.owncloud.android.ui.activity.FileDisplayActivity.resetSearchAction()'
at com.owncloud.android.ui.activity.FileDisplayActivity.resetSearchAction(FileDisplayActivity.kt:1225)
at com.owncloud.android.ui.activity.FileDisplayActivity.access$resetSearchAction(FileDisplayActivity.kt:173)
at com.owncloud.android.ui.activity.FileDisplayActivity$handleBackPress$1.handleOnBackPressed(FileDisplayActivity.kt:1165)
at androidx.activity.OnBackPressedDispatcher.onBackPressed(OnBackPressedDispatcher.kt:279)
at com.owncloud.android.ui.activity.FileDisplayActivity.onOptionsItemSelected(FileDisplayActivity.kt:940)
at android.app.Activity.onMenuItemSelected(Activity.java:4783)
at androidx.activity.ComponentActivity.onMenuItemSelected(ComponentActivity.kt:477)
at androidx.fragment.app.FragmentActivity.onMenuItemSelected(FragmentActivity.kt:264)
at androidx.appcompat.app.AppCompatActivity.onMenuItemSelected(AppCompatActivity.kt:256)
at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(WindowCallbackWrapper.java:109)
at androidx.appcompat.widget.ToolbarWidgetWrapper$1.onClick(ToolbarWidgetWrapper.java:187)
at android.view.View.performClick(View.java:8209)
at android.view.View.performClickInternal(View.java:8186)
at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
at android.view.View$PerformClick.run(View.java:31889)
at android.os.Handler.handleCallback(Handler.java:1070)
at android.os.Handler.dispatchMessage(Handler.java:125)
at android.os.Looper.dispatchMessage(Looper.java:333)
at android.os.Looper.loopOnce(Looper.java:263)
at android.os.Looper.loop(Looper.java:367)
at android.app.ActivityThread.main(ActivityThread.java:9227)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

