### PR TITLE
fix: local file list adapter scroll to top

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -274,6 +274,11 @@ public class LocalFileListFragment extends ExtendedListFragment implements
         mAdapter.swapDirectory(directory);
 
         mDirectory = directory;
+
+        final var recyclerView = getRecyclerView();
+        if (recyclerView != null) {
+            recyclerView.scrollToPosition(0);
+        }
     }
 
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Fixes

The subfolder opens with the view already scrolled down, without any user interaction.

### How to reproduce?

1. Tap the plus (+) button.
2. Select the option to upload files.
3. Scroll down the list of folders.
4. Open a subfolder.