### PR TITLE
fix: empty folder appearance

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
@@ -111,13 +111,4 @@ interface FileDao {
     """
     )
     fun searchFilesInFolder(parentId: Long, fileOwner: String, query: String): List<FileEntity>
-
-    @Query(
-        """
-    SELECT COUNT(*) 
-    FROM filelist 
-    WHERE parent = :parentId
-    """
-    )
-    fun getChildFileCount(parentId: Long): Int
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Since `MetadataWorker` updates the `eTag` newly added files not determined by client any more, thus empty folder may appear.

https://github.com/user-attachments/assets/88348207-ae78-4615-9b31-e5a9b9f4fb52


### Demo

<img width="1745" height="366" alt="Screenshot 2025-10-22 at 15 04 30" src="https://github.com/user-attachments/assets/6b442ed7-ccc1-4e96-8a25-dea35ef0e8b1" />


### Changes

Only updates e-Tag after successful `RefreshFolderOperation` otherwise resets e-Tag.
Only stores new e-Tag after saving child files to storage.

### How to test?

1. Create sub folder in root directory
2. Add one file from web
3. Check metadata worker
4. Create another sub folder from web
5. Add big files to the first sub-folder
6. Open app and navigate to the newly created subfolder
7. Navigate back to the root (so that we can trigger worker to cancel previously unfinished job)
8. Navigate to the newly created subfolder again
9. Navigate back to the root
10. Check new files existence from DB or navigate to the first subfolder