### PR TITLE
fix: save file npe

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -496,6 +496,11 @@ public class FileDataStorageManager {
     }
 
     public boolean saveFile(OCFile ocFile) {
+        if (ocFile == null) {
+            Log_OC.e(TAG, "file is null cannot save");
+            return false;
+        }
+
         boolean overridden = false;
         final ContentValues cv = createContentValuesForFile(ocFile);
         if (ocFile.isFolder()) {
@@ -508,7 +513,9 @@ public class FileDataStorageManager {
 
             if (sameRemotePath) {
                 OCFile oldFile = getFileByPath(ocFile.getRemotePath());
-                ocFile.setFileId(oldFile.getFileId());
+                if (oldFile != null) {
+                    ocFile.setFileId(oldFile.getFileId());
+                }
             }
 
             overridden = true;


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Fixes

```
com.owncloud.android.ui.fragment.GroupfolderListFragmentIT > showGroupfolder[emulator-5554 - 8.1.0] FAILED 
Process: com.***.client, PID: 4882
java.lang.RuntimeException: An error occurred while executing doInBackground()
	at android.os.AsyncTask$3.done(AsyncTask.java:353)
	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
	at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
	at java.util.concurrent.FutureTask.run(FutureTask.java:271)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
	at java.lang.Thread.run(Thread.java:764)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'long com.owncloud.android.datamodel.OCFile.getFileId()' on a null object reference
	at com.owncloud.android.datamodel.FileDataStorageManager.saveFile(FileDataStorageManager.java:511)
	at com.owncloud.android.datamodel.ThumbnailsCacheManager$GalleryImageGenerationTask.getThumbnailFromCache(ThumbnailsCacheManager.java:386)
	at com.owncloud.android.datamodel.ThumbnailsCacheManager$GalleryImageGenerationTask.doInBackground(ThumbnailsCacheManager.java:345)
	at com.owncloud.android.datamodel.ThumbnailsCacheManager$GalleryImageGenerationTask.doInBackground(ThumbnailsCacheManager.java:298)
	at android.os.AsyncTask$2.call(AsyncTask.java:333)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	... 3 more
```