### PR TITLE
fix: set current file

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1311,10 +1311,11 @@ class FileDisplayActivity :
         val ocFileListFragment = leftFragment
         syncAndUpdateFolder(ignoreETag = true, ignoreFocus = true)
 
-        var startFile: OCFile? = null
-        if (intent != null) {
-            startFile = getFileFromIntent(intent)
-            file = startFile
+        // Try to get the OCFile from the intent, if one was provided when launching this activity.
+        // 'file' comes from the FileActivity base class and represents the currently opened file or folder.
+        // We update it only when a valid file is found in the intent.
+        val startFile = intent?.let { getFileFromIntent(it) }?.also {
+            file = it
         }
 
         // refresh list of files


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Fixes regression from https://github.com/nextcloud/android/pull/15855.

Current `ocFile` should be set only if valid `ocFile` passed.

**Changes that causing problem:**

<img width="1159" height="344" alt="Screenshot 2025-10-31 at 09 31 01" src="https://github.com/user-attachments/assets/38b20cfc-ab60-48b7-9870-f42856934407" />

**Issue**

https://github.com/user-attachments/assets/76467921-fd14-4ec3-b828-8716d0e8ca6f


