### PR TITLE
fix: read only collection

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -79,6 +79,7 @@ import java.net.IDN;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -828,7 +829,7 @@ public final class DisplayUtils {
 
     private static void setThumbnailFirstTimeForFile(OCFile file, ImageView thumbnailView, FileDataStorageManager storageManager, List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks, boolean gridView, LoaderImageView shimmerThumbnail, User user, AppPreferences preferences, Context context, ViewThemeUtils viewThemeUtils) {
         if (file.getRemoteId() != null) {
-            generateNewThumbnail(file, thumbnailView, user, storageManager, asyncTasks, gridView, context, shimmerThumbnail, preferences, viewThemeUtils);
+            generateNewThumbnail(file, thumbnailView, user, storageManager, new ArrayList<>(asyncTasks), gridView, context, shimmerThumbnail, preferences, viewThemeUtils);
             return;
         }
 
@@ -873,7 +874,7 @@ public final class DisplayUtils {
     private static void setThumbnailFromCache(OCFile file, ImageView thumbnailView, FileDataStorageManager storageManager, List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks, boolean gridView, LoaderImageView shimmerThumbnail, User user, AppPreferences preferences, Context context, ViewThemeUtils viewThemeUtils) {
         final var thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.getRemoteId());
         if (thumbnail == null || file.isUpdateThumbnailNeeded()) {
-            generateNewThumbnail(file, thumbnailView, user, storageManager, asyncTasks, gridView, context, shimmerThumbnail, preferences, viewThemeUtils);
+            generateNewThumbnail(file, thumbnailView, user, storageManager, new ArrayList<>(asyncTasks), gridView, context, shimmerThumbnail, preferences, viewThemeUtils);
             setThumbnailBackgroundForPNGFileIfNeeded(file, context, thumbnailView);
             return;
         }
@@ -901,7 +902,7 @@ public final class DisplayUtils {
                                              ImageView thumbnailView,
                                              User user,
                                              FileDataStorageManager storageManager,
-                                             List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks,
+                                             ArrayList<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks,
                                              boolean gridView,
                                              Context context,
                                              LoaderImageView shimmerThumbnail,
@@ -986,7 +987,7 @@ public final class DisplayUtils {
                                    new ThumbnailsCacheManager.ThumbnailGenerationTaskObject(file,
                                                                                             file.getRemoteId()));
             thumbnailView.invalidate();
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             Log_OC.d(TAG, "ThumbnailGenerationTask : " + e.getMessage());
         }
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Fixes

<img width="882" height="390" alt="Screenshot 2025-10-31 at 15 42 27" src="https://github.com/user-attachments/assets/af8a9f02-42e4-4372-b78a-09a6f28fc69e" />


```
FATAL EXCEPTION: main
Process: com.nextcloud.client, PID: 16378
java.lang.UnsupportedOperationException: Operation is not supported for read-only collection
at com.owncloud.android.utils.DisplayUtils.generateNewThumbnail(DisplayUtils.java:984)
at com.owncloud.android.utils.DisplayUtils.setThumbnailFirstTimeForFile(DisplayUtils.java:831)
at com.owncloud.android.utils.DisplayUtils.setThumbnail(DisplayUtils.java:822)
at com.owncloud.android.ui.adapter.UnifiedSearchCurrentDirItemViewHolder.bind(UnifiedSearchCurrentDirItemViewHolder.kt:46)
at com.owncloud.android.ui.adapter.UnifiedSearchListAdapter.onBindViewHolder(UnifiedSearchListAdapter.kt:192)
```

### Changes

`ArrayList` used instead of `List`.


### How to reproduce?

1. Perform a fresh installation of the application.
2. Query a search (e.g., "a") and submit using the Done action on the keyboard.
3. Repeat the process multiple times in quick succession and press back from toolbar
