### PR TITLE
handle nullable current file

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -334,6 +334,7 @@ public abstract class FileActivity extends DrawerActivity
      *
      * @return  Main {@link OCFile} handled by the activity.
      */
+    @Nullable
     public OCFile getFile() {
         return mFile;
     }
@@ -654,6 +655,7 @@ public abstract class FileActivity extends DrawerActivity
         return fileUploadHelper;
     }
 
+    @Nullable
     public OCFile getCurrentDir() {
         OCFile file = getFile();
         if (file != null) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -409,10 +409,10 @@ open class FolderPickerActivity :
         file?.isFolder != true -> true
 
         // all of the target files are already in the selected directory
-        targetFilePaths?.all { PathUtils.isDirectParent(file.remotePath, it) } == true -> false
+        targetFilePaths?.all { PathUtils.isDirectParent(file?.remotePath ?: "", it) } == true -> false
 
         // some of the target files are parents of the selected folder
-        targetFilePaths?.any { PathUtils.isAncestor(it, file.remotePath) } == true -> false
+        targetFilePaths?.any { PathUtils.isAncestor(it, file?.remotePath ?: "") } == true -> false
         else -> true
     }
 
@@ -429,7 +429,7 @@ open class FolderPickerActivity :
     }
 
     private fun getSelectedFolderPathTitle(): String? {
-        val atRoot = (currentDir == null || currentDir.parentId == 0L)
+        val atRoot = (currentDir == null || currentDir?.parentId == 0L)
         return if (atRoot) captionText ?: "" else currentDir?.fileName
     }
 
@@ -555,7 +555,7 @@ open class FolderPickerActivity :
                     if (currentDir == null) {
                         browseRootForRemovedFolder()
                     } else {
-                        if (currentFile == null && !file.isFolder) {
+                        if (currentFile == null && file?.isFolder == false) {
                             // currently selected file was removed in the server, and now we know it
                             currentFile = currentDir
                         }
@@ -580,8 +580,7 @@ open class FolderPickerActivity :
         }
 
         private fun getCurrentFileAndDirectory(): Pair<OCFile?, OCFile?> {
-            val currentFile =
-                if (file == null) null else storageManager.getFileByEncryptedRemotePath(file.remotePath)
+            val currentFile = file?.let { storageManager.getFileByEncryptedRemotePath(it.remotePath) }
 
             val currentDir = if (currentFolder == null) {
                 null

--- a/app/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/RichDocumentsEditorWebView.kt
@@ -185,7 +185,7 @@ class RichDocumentsEditorWebView : EditorWebView() {
                 renameString ?: return
                 val renameJson = JSONObject(renameString)
                 val newName = renameJson.getString(NEW_NAME)
-                file.fileName = newName
+                file?.fileName = newName
             } catch (e: JSONException) {
                 Log_OC.e(this, "Failed to parse rename json message: $e")
             }

--- a/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/TextEditorWebView.kt
@@ -43,7 +43,7 @@ class TextEditorWebView : EditorWebView() {
             finish()
         }
 
-        val editor = editorUtils.getEditor(user.get(), file.mimeType)
+        val editor = editorUtils.getEditor(user.get(), file?.mimeType)
 
         if (editor != null && editor.id == "onlyoffice") {
             webView.settings.userAgentString = generateOnlyOfficeUserAgent()

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -177,7 +177,7 @@ class PreviewImageActivity :
             )
         } else {
             // get parent from path
-            var parentFolder = storageManager.getFileById(file.parentId)
+            var parentFolder = file?.let { storageManager.getFileById(it.parentId) }
 
             if (parentFolder == null) {
                 // should not be necessary
@@ -197,7 +197,13 @@ class PreviewImageActivity :
 
         viewPager = findViewById(R.id.fragmentPager)
 
-        var position = if (savedPosition != null) savedPosition else previewImagePagerAdapter?.getFilePosition(file)
+        var position = if (savedPosition !=
+            null
+        ) {
+            savedPosition
+        } else {
+            file?.let { previewImagePagerAdapter?.getFilePosition(it) }
+        }
         position = position?.toDouble()?.let { max(it, 0.0).toInt() }
 
         viewPager?.adapter = previewImagePagerAdapter
@@ -210,7 +216,7 @@ class PreviewImageActivity :
             viewPager?.setCurrentItem(position, false)
         }
 
-        if (position == 0 && !file.isDown) {
+        if (position == 0 && file?.isDown == false) {
             // this is necessary because mViewPager.setCurrentItem(0) just after setting the
             // adapter does not result in a call to #onPageSelected(0)
             screenState = PreviewImageActivityState.WaitingForBinder
@@ -275,7 +281,7 @@ class PreviewImageActivity :
             if (file != null) {
                 // / Refresh the activity according to the Account and OCFile set
                 setFile(file) // reset after getting it fresh from storageManager
-                updateActionBarTitle(getFile().fileName)
+                updateActionBarTitle(getFile()?.fileName)
                 // if (!stateWasRecovered) {
                 initViewPager(optionalUser.get())
 
@@ -353,8 +359,10 @@ class PreviewImageActivity :
         savedPosition?.let { position ->
 
             previewImagePagerAdapter?.run {
-                updateFile(position, file)
-                notifyItemChanged(position)
+                file?.let {
+                    updateFile(position, it)
+                    notifyItemChanged(position)
+                }
             }
 
             if (user.isPresent) {
@@ -378,7 +386,9 @@ class PreviewImageActivity :
         dismissLoadingDialog()
         screenState = PreviewImageActivityState.Idle
         file = downloadedFile
-        startEditImageActivity(file)
+        file?.let {
+            startEditImageActivity(it)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -384,18 +384,19 @@ class PreviewMediaActivity :
 
     @Suppress("TooGenericExceptionCaught")
     private fun playAudio() {
-        if (file.isDown) {
-            prepareAudioPlayer(file.storageUri)
+        if (file?.isDown == true) {
+            prepareAudioPlayer(file?.storageUri)
         } else {
             try {
-                LoadStreamUrl(this, user, clientFactory).execute(file.localId)
+                LoadStreamUrl(this, user, clientFactory).execute(file?.localId)
             } catch (e: Exception) {
                 Log_OC.e(TAG, "Loading stream url for Audio not possible: $e")
             }
         }
     }
 
-    private fun prepareAudioPlayer(uri: Uri) {
+    private fun prepareAudioPlayer(uri: Uri?) {
+        uri ?: return
         audioMediaController?.let { audioPlayer ->
             audioPlayer.addListener(object : Player.Listener {
 
@@ -434,7 +435,7 @@ class PreviewMediaActivity :
             })
             val mediaItem = MediaItem.Builder()
                 .setUri(uri)
-                .setMediaMetadata(MediaMetadata.Builder().setTitle(file.fileName).build())
+                .setMediaMetadata(MediaMetadata.Builder().setTitle(file?.fileName).build())
                 .build()
             audioPlayer.setMediaItem(mediaItem)
             audioPlayer.playWhenReady = autoplay
@@ -563,8 +564,8 @@ class PreviewMediaActivity :
 
             R.id.action_remove_file -> {
                 videoPlayer?.pause()
-                val dialog = RemoveFilesDialogFragment.newInstance(file)
-                dialog.show(supportFragmentManager, ConfirmationDialogFragment.FTAG_CONFIRMATION)
+                val dialog = file?.let { RemoveFilesDialogFragment.newInstance(it) }
+                dialog?.show(supportFragmentManager, ConfirmationDialogFragment.FTAG_CONFIRMATION)
             }
 
             R.id.action_see_details -> {
@@ -572,7 +573,7 @@ class PreviewMediaActivity :
             }
 
             R.id.action_sync_file -> {
-                showSyncLoadingDialog(file.isFolder)
+                showSyncLoadingDialog(file?.isFolder == true)
                 fileOperationsHelper.syncFile(file)
             }
 
@@ -586,7 +587,7 @@ class PreviewMediaActivity :
 
             R.id.action_export_file -> {
                 val list = ArrayList<OCFile>()
-                list.add(file)
+                file?.let { list.add(it) }
                 fileOperationsHelper.exportFiles(
                     list,
                     this,
@@ -673,18 +674,19 @@ class PreviewMediaActivity :
     private fun playVideo() {
         setupVideoView()
 
-        if (file.isDown) {
-            prepareVideoPlayer(file.storageUri)
+        if (file?.isDown == true) {
+            prepareVideoPlayer(file?.storageUri)
         } else {
             try {
-                LoadStreamUrl(this, user, clientFactory).execute(file.localId)
+                LoadStreamUrl(this, user, clientFactory).execute(file?.localId)
             } catch (e: Exception) {
                 Log_OC.e(TAG, "Loading stream url for Video not possible: $e")
             }
         }
     }
 
-    private fun prepareVideoPlayer(uri: Uri) {
+    private fun prepareVideoPlayer(uri: Uri?) {
+        uri ?: return
         binding.progress.visibility = View.GONE
         val videoMediaItem = MediaItem.fromUri(uri)
         videoPlayer?.run {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Issue

`FileActivity`'s `mFile` used in subclasses and this field can be null, thus consumers must be aware of it and handle it properly.

Otherwise, crashes like this can occur. For example, in this case, `currentDir` can be null and `UnifiedSearch` can use for quick scan `ROOT_PATH` because user not in child directory at that moment.

```
Event Type:    FATAL EXCEPTION
Process:       com.nextcloud.client
PID:           16762
Thread:        main

Exception:     java.lang.NullPointerException
Message:       Attempt to invoke virtual method 
               'java.lang.String com.owncloud.android.datamodel.OCFile.getDecryptedRemotePath()' 
               on a null object reference

Stack Trace:
    at com.owncloud.android.ui.activity.FileDisplayActivity.performUnifiedSearch(FileDisplayActivity.kt:2980)
    at com.owncloud.android.ui.fragment.ExtendedListFragment.performSearch$lambda$0(ExtendedListFragment.kt:266)
    at com.owncloud.android.ui.fragment.ExtendedListFragment.$r8$lambda$rIAnjvHuyAGfNBpmw0ALMi8IROw(Unknown Source:0)
    at com.owncloud.android.ui.fragment.ExtendedListFragment$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)
    at android.os.Handler.handleCallback(Handler.java:1070)
    at android.os.Handler.dispatchMessage(Handler.java:125)
    at android.os.Looper.dispatchMessage(Looper.java:333)
    at android.os.Looper.loopOnce(Looper.java:263)
    at android.os.Looper.loop(Looper.java:367)
    at android.app.ActivityThread.main(ActivityThread.java:9282)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

### How to reproduce?

1. Perform a fresh installation of the application.
2. Query a search (e.g., "a") and submit using the Done action on the keyboard.
3. Repeat the process multiple times in quick succession and press back from toolbar

