### PR TITLE
local videos cannot be used for preview

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -37,7 +37,6 @@ import android.widget.ImageView;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.utils.BitmapExtensionsKt;
-import com.nextcloud.utils.extensions.ThumbnailsCacheManagerExtensionsKt;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.OwnCloudAccount;
@@ -1416,7 +1415,7 @@ public final class ThumbnailsCacheManager {
             int pxW = p.x;
             int pxH = p.y;
 
-            if (file.isDown()) {
+            if (file.isDown() && MimeTypeUtil.isImage(file)) {
                 Bitmap bitmap = BitmapUtils.decodeSampledBitmapFromFile(file.getStoragePath(), pxW, pxH);
 
                 if (bitmap != null) {


### PR DESCRIPTION
How to test
- upload a video
- go directly to "media"
- thus no preview is generated within file listing
- wait for upload
- see that now video thumbnail is fetched from server
- Before: it tried to generate locally a video preview, which failed and thus only placeholder was shown

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
