### PR TITLE
fix: only refresh related gallery row

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
@@ -150,11 +150,6 @@ class GalleryAdapter(
         }
     }
 
-    override fun onBindFooterViewHolder(holder: SectionedViewHolder?, section: Int) {
-        TODO("Not yet implemented")
-    }
-
-    @SuppressLint("NotifyDataSetChanged")
     fun showAllGalleryItems(
         remotePath: String,
         mediaState: GalleryFragmentBottomSheetDialog.MediaState,
@@ -257,24 +252,6 @@ class GalleryAdapter(
         return getAbsolutePosition(item, row)
     }
 
-    override fun swapDirectory(
-        user: User,
-        directory: OCFile,
-        storageManager: FileDataStorageManager,
-        onlyOnDevice: Boolean,
-        mLimitToMimeType: String
-    ) {
-        TODO("Not yet implemented")
-    }
-
-    override fun setHighlightedItem(file: OCFile) {
-        TODO("Not yet implemented")
-    }
-
-    override fun setSortOrder(mFile: OCFile, sortOrder: FileSortOrder) {
-        TODO("Not yet implemented")
-    }
-
     override fun addCheckedFile(file: OCFile) {
         ocFileListDelegate.addCheckedFile(file)
     }
@@ -293,10 +270,8 @@ class GalleryAdapter(
 
     override fun getFilesCount(): Int = files.fold(0) { acc, item -> acc + item.rows.size }
 
-    @SuppressLint("NotifyDataSetChanged")
     override fun setMultiSelect(boolean: Boolean) {
         ocFileListDelegate.isMultiSelect = boolean
-        notifyDataSetChanged()
     }
 
     private fun getAllFiles(): List<OCFile> = files.flatMap { galleryItem ->
@@ -323,21 +298,30 @@ class GalleryAdapter(
         columns = newColumn
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     fun markAsFavorite(remotePath: String, favorite: Boolean) {
         val allFiles = getAllFiles()
-        for (file in allFiles) {
-            if (file.remotePath == remotePath) {
-                file.isFavorite = favorite
-                break
+        allFiles.firstOrNull { it.remotePath == remotePath }?.also { file ->
+            file.isFavorite = favorite
+            Handler(Looper.getMainLooper()).post {
+                files = allFiles.toGalleryItems()
+                notifyItemChanged(file)
             }
         }
-
-        Handler(Looper.getMainLooper()).post {
-            files = allFiles.toGalleryItems()
-            notifyDataSetChanged()
-        }
     }
+
+    override fun onBindFooterViewHolder(holder: SectionedViewHolder?, section: Int) = Unit
+
+    override fun swapDirectory(
+        user: User,
+        directory: OCFile,
+        storageManager: FileDataStorageManager,
+        onlyOnDevice: Boolean,
+        mLimitToMimeType: String
+    ) = Unit
+
+    override fun setHighlightedItem(file: OCFile) = Unit
+
+    override fun setSortOrder(mFile: OCFile, sortOrder: FileSortOrder) = Unit
 
     private fun List<OCFile>.toGalleryItems(): List<GalleryItems> = this
         .groupBy { firstOfMonth(it.modificationTimestamp) }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Changes

No need to refresh whole adapter for marking file as favorite or during multi-select

### Before

https://github.com/user-attachments/assets/72c6fe59-d511-45bb-a86b-ca07afc9285a

### After

https://github.com/user-attachments/assets/17d81ff9-7eb7-4944-9ea3-45cc84c873a8

