### PR TITLE
perf: gallery adapter caching

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
@@ -190,10 +190,6 @@ class GalleryAdapter(
         }
     }
 
-    override fun onBindFooterViewHolder(holder: SectionedViewHolder?, section: Int) {
-        TODO("Not yet implemented")
-    }
-
     @SuppressLint("NotifyDataSetChanged")
     fun showAllGalleryItems(
         remotePath: String,
@@ -292,24 +288,6 @@ class GalleryAdapter(
         return getAbsolutePosition(section, row)
     }
 
-    override fun swapDirectory(
-        user: User,
-        directory: OCFile,
-        storageManager: FileDataStorageManager,
-        onlyOnDevice: Boolean,
-        mLimitToMimeType: String
-    ) {
-        TODO("Not yet implemented")
-    }
-
-    override fun setHighlightedItem(file: OCFile) {
-        TODO("Not yet implemented")
-    }
-
-    override fun setSortOrder(mFile: OCFile, sortOrder: FileSortOrder) {
-        TODO("Not yet implemented")
-    }
-
     override fun addCheckedFile(file: OCFile) {
         ocFileListDelegate.addCheckedFile(file)
     }
@@ -328,10 +306,8 @@ class GalleryAdapter(
 
     override fun getFilesCount(): Int = cachedFilesCount
 
-    @SuppressLint("NotifyDataSetChanged")
     override fun setMultiSelect(boolean: Boolean) {
         ocFileListDelegate.isMultiSelect = boolean
-        notifyDataSetChanged()
     }
 
     private fun getAllFiles(): List<OCFile> = cachedAllFiles ?: files.flatMap { galleryItem ->
@@ -356,19 +332,14 @@ class GalleryAdapter(
         columns = newColumn
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     fun markAsFavorite(remotePath: String, favorite: Boolean) {
         val allFiles = getAllFiles()
-        for (file in allFiles) {
-            if (file.remotePath == remotePath) {
-                file.isFavorite = favorite
-                break
+        allFiles.firstOrNull { it.remotePath == remotePath }?.also { file ->
+            file.isFavorite = favorite
+            Handler(Looper.getMainLooper()).post {
+                files = allFiles.toGalleryItems()
+                notifyItemChanged(file)
             }
-        }
-
-        Handler(Looper.getMainLooper()).post {
-            files = allFiles.toGalleryItems()
-            notifyDataSetChanged()
         }
     }
 
@@ -381,4 +352,18 @@ class GalleryAdapter(
             }
             .sortedByDescending { it.date }
     }
+
+    override fun onBindFooterViewHolder(holder: SectionedViewHolder?, section: Int) = Unit
+
+    override fun swapDirectory(
+        user: User,
+        directory: OCFile,
+        storageManager: FileDataStorageManager,
+        onlyOnDevice: Boolean,
+        mLimitToMimeType: String
+    ) = Unit
+
+    override fun setHighlightedItem(file: OCFile) = Unit
+
+    override fun setSortOrder(mFile: OCFile, sortOrder: FileSortOrder) = Unit
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Changes

Introduces caching, reducing repeated expensive calculations such as for example every time `getAllFiles()` or `getFilesCount()` is called, it computes the list or counts on the fly by traversing all `GalleryItems`.

Handles of empty lists.

Better sorting and mapping logic.


