### PR TITLE
chore: suppress notify data set changed lint

### DIFF
--- a/app/src/main/java/com/nextcloud/client/etm/EtmMenuAdapter.kt
+++ b/app/src/main/java/com/nextcloud/client/etm/EtmMenuAdapter.kt
@@ -6,6 +6,7 @@
  */
 package com.nextcloud.client.etm
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +21,7 @@ class EtmMenuAdapter(context: Context, val onItemClicked: (Int) -> Unit) :
 
     private val layoutInflater = LayoutInflater.from(context)
     var pages: List<EtmMenuEntry> = listOf()
+        @SuppressLint("NotifyDataSetChanged")
         set(value) {
             field = value
             notifyDataSetChanged()

--- a/app/src/main/java/com/nextcloud/client/etm/pages/EtmFileTransferFragment.kt
+++ b/app/src/main/java/com/nextcloud/client/etm/pages/EtmFileTransferFragment.kt
@@ -6,6 +6,7 @@
  */
 package com.nextcloud.client.etm.pages
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -63,6 +64,7 @@ class EtmFileTransferFragment : EtmBaseFragment() {
 
         private var transfers = listOf<Transfer>()
 
+        @SuppressLint("NotifyDataSetChanged")
         fun setStatus(status: TransferManager.Status) {
             transfers = listOf(status.pending, status.running, status.completed).flatten().reversed()
             notifyDataSetChanged()

--- a/app/src/main/java/com/nextcloud/ui/SetStatusMessageBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/SetStatusMessageBottomSheet.kt
@@ -335,6 +335,7 @@ class SetStatusMessageBottomSheet(val user: User, val currentStatus: Status?) :
         }
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     @VisibleForTesting
     fun setPredefinedStatus(predefinedStatus: ArrayList<PredefinedStatus>) {
         adapter.list = predefinedStatus

--- a/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -12,6 +12,7 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.annotation.SuppressLint;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.os.Bundle;
@@ -392,6 +393,7 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
             this.viewThemeUtils = viewThemeUtils;
         }
 
+        @SuppressLint("NotifyDataSetChanged")
         public void setData(List<UserInfoDetailsItem> displayList) {
             mDisplayList = displayList == null ? new LinkedList<>() : displayList;
             notifyDataSetChanged();

--- a/app/src/main/java/com/owncloud/android/ui/adapter/ActivityAndVersionListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/ActivityAndVersionListAdapter.java
@@ -8,6 +8,7 @@
  */
 package com.owncloud.android.ui.adapter;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.format.DateFormat;
 import android.view.LayoutInflater;
@@ -54,6 +55,7 @@ public class ActivityAndVersionListAdapter extends ActivityListAdapter {
         this.versionListInterface = versionListInterface;
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void setActivityAndVersionItems(List<Object> items, NextcloudClient newClient, boolean clear) {
         if (client == null) {
             client = newClient;

--- a/app/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/ActivityListAdapter.java
@@ -10,6 +10,7 @@
  */
 package com.owncloud.android.ui.adapter;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -98,6 +99,7 @@ public class ActivityListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         this.viewThemeUtils = viewThemeUtils;
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void setActivityItems(List<Object> activityItems, NextcloudClient client, boolean clear) {
         this.client = client;
         String sTime = "";

--- a/app/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/NotificationListAdapter.java
@@ -10,6 +10,7 @@
  */
 package com.owncloud.android.ui.adapter;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Typeface;
@@ -75,6 +76,7 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
             notificationsActivity.getResources().getColor(R.color.text_color));
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void setNotificationItems(List<Notification> notificationItems) {
         notificationsList.clear();
         notificationsList.addAll(notificationItems);
@@ -340,6 +342,7 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
         }
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void removeAllNotifications() {
         notificationsList.clear();
         notifyDataSetChanged();

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -202,6 +202,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         isRTL = DisplayUtils.isRTL();
 
         activity.registerComponentCallbacks(new ComponentCallbacks() {
+            @SuppressLint("NotifyDataSetChanged")
             @Override
             public void onConfigurationChanged(@NonNull Configuration newConfig) {
                 notifyDataSetChanged(); // force update of orientation-dependent layout (e.g. share button visibility)

--- a/app/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
@@ -90,6 +90,7 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         this.viewThemeUtils = viewThemeUtils;
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void setTrashbinFiles(List<TrashbinFile> trashbinFiles, boolean clear) {
         if (clear) {
             files.clear();
@@ -206,6 +207,7 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         }
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void removeAllFiles() {
         files.clear();
         notifyDataSetChanged();
@@ -345,6 +347,7 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         asyncTasks.clear();
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void setSortOrder(FileSortOrder sortOrder) {
         preferences.setSortOrder(FileSortOrder.Type.trashBinView, sortOrder);
         files = sortOrder.sortTrashbinFiles(files);

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UserListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UserListAdapter.java
@@ -12,6 +12,7 @@
  */
 package com.owncloud.android.ui.adapter;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
@@ -162,6 +163,7 @@ public class UserListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
      *
      * @param items The item list to be added
      */
+    @SuppressLint("NotifyDataSetChanged")
     public void addAll(List<UserListItem> items){
         if(values == null){
             values = new ArrayList<>();


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

For each `notifyDataSetChanged` logic needs to be checked and replaced with `notifyItemChanged`. Until then, we can reset `notifyDataSetChanged` lint count.

<img width="889" height="1088" alt="Screenshot 2025-11-05 at 09 10 17" src="https://github.com/user-attachments/assets/edcbab12-eab3-4fe4-b2d1-c310d3b5d249" />

