### PR TITLE
fix(unified-search): hide current directory section when path does not exists

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2975,17 +2975,11 @@ class FileDisplayActivity :
     }
 
     fun performUnifiedSearch(query: String, listOfHiddenFiles: ArrayList<String>?) {
-        val path = currentDir?.decryptedRemotePath
-            ?: run {
-                Log_OC.w(TAG, "currentDir is null, using ROOT_PATH")
-                OCFile.ROOT_PATH
-            }
-
         val unifiedSearchFragment =
-            UnifiedSearchFragment.Companion.newInstance(
+            UnifiedSearchFragment.newInstance(
                 query,
                 listOfHiddenFiles,
-                path
+                currentDir?.decryptedRemotePath
             )
         setLeftFragment(unifiedSearchFragment, false)
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -95,7 +95,7 @@ class UnifiedSearchFragment :
         fun newInstance(
             query: String?,
             listOfHiddenFiles: ArrayList<String>?,
-            currentDirPath: String
+            currentDirPath: String?
         ): UnifiedSearchFragment = UnifiedSearchFragment().apply {
             arguments = Bundle().apply {
                 putString(ARG_QUERY, query)
@@ -141,8 +141,9 @@ class UnifiedSearchFragment :
         super.onCreate(savedInstanceState)
         vm = ViewModelProvider(this, vmFactory)[UnifiedSearchViewModel::class.java]
         initialQuery = savedInstanceState?.getString(ARG_QUERY) ?: arguments?.getString(ARG_QUERY)
-        val currentDirPath = savedInstanceState?.getString(CURRENT_DIR_PATH) ?: arguments?.getString(CURRENT_DIR_PATH)
-        currentDir = storageManager.getFileByDecryptedRemotePath(currentDirPath)
+        savedInstanceState?.getString(CURRENT_DIR_PATH) ?: arguments?.getString(CURRENT_DIR_PATH)?.let {
+            currentDir = storageManager.getFileByDecryptedRemotePath(it)
+        }
         listOfHiddenFiles =
             savedInstanceState?.getStringArrayList(ARG_HIDDEN_FILES) ?: arguments?.getStringArrayList(ARG_HIDDEN_FILES)
                 ?: ArrayList()


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Changes

If given path is null, do not show "In this Folder" section.
