### PR TITLE
fix: conflict resolve activity

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -194,11 +194,6 @@ class ConflictsResolveActivity :
             return
         }
 
-        if (existingFile == null || existingFile?.fileId == -1L) {
-            Log_OC.e(TAG, "existing file is null, cannot be delete.")
-            return
-        }
-
         lifecycleScope.launch {
             val result = withContext(Dispatchers.IO) {
                 fileDataStorageManager.removeFile(existingFile, true, false)
@@ -330,6 +325,7 @@ class ConflictsResolveActivity :
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun resolveExistingFileFromDbOrServer(): OCFile? {
         val candidate = file ?: return null
 
@@ -363,7 +359,6 @@ class ConflictsResolveActivity :
         }
 
         val remoteFile = result.data[0] as? RemoteFile ?: return null
-
         dbFile = fileDataStorageManager.getFileByDecryptedRemotePath(remoteFile.remotePath)
 
         if (dbFile != null && dbFile.fileId != -1L) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Fixes

Fixes existingFile initialization previously, `EXTRA_EXISTING_FILE` was never set, causing `existingFile` to always have a file ID of -1L. With this PR, `existingFile` is properly initialized, ensuring correct file references throughout the flow.

Removes `newFile` to simplify logic, the `newFile` variable was misleading, it actually referred to a file from `FileActivity`. File refers to the newly selected file from local storage.

Fixes `keepLocal` behavior. `keepLocal` must just do, removes the existing remote file and uploads the newly selected local file. Thus, thumbnail and preview of the new file will appear correctly.