### PR TITLE
fix(gallery): prevent multiple onRefresh calls during multi-image delete to avoid flicker

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/DeleteBatchTracker.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/DeleteBatchTracker.kt
@@ -1,0 +1,32 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.ui.dialog
+
+class DeleteBatchTracker(private val onAllDeletesFinished: () -> Unit) {
+    private var expectedDeletes: Int = -1
+    private var completedDeletes: Int = 0
+
+    fun startBatchDelete(fileCount: Int) {
+        expectedDeletes = fileCount
+        completedDeletes = 0
+    }
+
+    fun onSingleDeleteFinished() {
+        if (expectedDeletes < 0) return // batch not active
+
+        completedDeletes++
+
+        if (completedDeletes == expectedDeletes) {
+            // Reset so it can handle the next batch
+            expectedDeletes = -1
+            completedDeletes = 0
+
+            onAllDeletesFinished()
+        }
+    }
+}

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RemoveFilesDialogFragment.kt
@@ -100,6 +100,8 @@ class RemoveFilesDialogFragment :
             if (result) {
                 fileActivity.showLoadingDialog(fileActivity.getString(R.string.wait_a_moment))
 
+                fda?.deleteBatchTracker?.startBatchDelete(files.size)
+
                 if (files.isNotEmpty()) {
                     // Display the snackbar message only when a single file is deleted.
                     val inBackground = (files.size != 1)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

If user selects multiple image from media tab and deletes, multiple times `onRefresh` logic gets called and causing flicker.