### PR TITLE
fix user account switch, use account name instead of hash

### DIFF
--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManager.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManager.java
@@ -95,7 +95,7 @@ public interface UserAccountManager extends CurrentAccountProvider {
 
     boolean setCurrentOwnCloudAccount(String accountName);
 
-    boolean setCurrentOwnCloudAccount(int hashCode);
+    boolean setCurrentOwnCloudAccount(User user);
 
     /**
      * Access the version of the OC server corresponding to an account SAVED IN THE ACCOUNTMANAGER

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -346,11 +346,11 @@ public class UserAccountManagerImpl implements UserAccountManager {
     }
 
     @Override
-    public boolean setCurrentOwnCloudAccount(int hashCode) {
+    public boolean setCurrentOwnCloudAccount(User chosenUser) {
         boolean result = false;
-        if (hashCode != 0) {
+        if (chosenUser != null) {
             for (final User user : getAllUsers()) {
-                if (hashCode == user.hashCode()) {
+                if (chosenUser.nameEquals(user)) {
                     SharedPreferences.Editor appPrefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
                     appPrefs.putString(PREF_SELECT_OC_ACCOUNT, user.getAccountName());
                     appPrefs.apply();

--- a/app/src/main/java/com/nextcloud/ui/ChooseAccountDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/ui/ChooseAccountDialogFragment.kt
@@ -231,7 +231,7 @@ class ChooseAccountDialogFragment :
     }
 
     override fun onAccountClicked(user: User?) {
-        (activity as DrawerActivity).accountClicked(user.hashCode())
+        (activity as DrawerActivity).accountClicked(user)
     }
 
     override fun onOptionItemClicked(user: User?, view: View?) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -734,11 +734,11 @@ public abstract class DrawerActivity extends ToolbarActivity
      * sets the new/current account and restarts. In case the given account equals the actual/current account the call
      * will be ignored.
      *
-     * @param hashCode HashCode of account to be set
+     * @param User user to be set
      */
-    public void accountClicked(int hashCode) {
+    public void accountClicked(User user) {
         final User currentUser = accountManager.getUser();
-        if (currentUser.hashCode() != hashCode && accountManager.setCurrentOwnCloudAccount(hashCode)) {
+        if (!currentUser.nameEquals(user) && accountManager.setCurrentOwnCloudAccount(user)) {
             fetchExternalLinks(true);
             restart();
         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -153,8 +153,8 @@ import com.owncloud.android.utils.ErrorMessageAdapter
 import com.owncloud.android.utils.FileSortOrder
 import com.owncloud.android.utils.MimeTypeUtil
 import com.owncloud.android.utils.PermissionUtil
-import com.owncloud.android.utils.PermissionUtil.requestStoragePermissionIfNeeded
 import com.owncloud.android.utils.PermissionUtil.requestNotificationPermission
+import com.owncloud.android.utils.PermissionUtil.requestStoragePermissionIfNeeded
 import com.owncloud.android.utils.PushUtils
 import com.owncloud.android.utils.StringUtils
 import com.owncloud.android.utils.theme.CapabilityUtils
@@ -2875,7 +2875,7 @@ class FileDisplayActivity :
                 } else if (!TextUtils.isEmpty(filePath)) {
                     openFileByPath(optionalUser.get(), filePath)
                 } else {
-                    accountClicked(optionalUser.get().hashCode())
+                    accountClicked(optionalUser.get())
                 }
             } else {
                 DisplayUtils.showSnackMessage(this, getString(R.string.associated_account_not_found))

--- a/app/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.kt
@@ -435,7 +435,7 @@ class ManageAccountsActivity :
                 val itemId = item.itemId
                 when (itemId) {
                     R.id.action_open_account -> {
-                        accountClicked(user.hashCode())
+                        accountClicked(user)
                     }
                     R.id.action_delete_account -> {
                         openAccountRemovalDialog(user, supportFragmentManager)

--- a/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -161,7 +161,7 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
         if (itemId == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
         } else if (itemId == R.id.action_open_account) {
-            accountClicked(user.hashCode());
+            accountClicked(user);
         } else if (itemId == R.id.action_delete_account) {
             openAccountRemovalDialog(user, getSupportFragmentManager());
         } else {


### PR DESCRIPTION
It seems that after app restart the hash is different and thus account switching for the very first time does not work.

To test:
- install & config master
- adb shell pm clear com.nextcloud.client
- open app and try to switch account
--> fails
- test above with this PR -> works

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
