### PR TITLE
fix: battery optimization check

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/BatteryOptimizationHelper.kt
+++ b/app/src/main/java/com/nextcloud/utils/BatteryOptimizationHelper.kt
@@ -1,0 +1,46 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.core.net.toUri
+import com.owncloud.android.lib.common.utils.Log_OC
+
+object BatteryOptimizationHelper {
+
+    private const val TAG = "BatteryOptimizationHelper"
+
+    fun isBatteryOptimizationEnabled(context: Context): Boolean {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return !pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    @SuppressLint("BatteryLife")
+    fun openBatteryOptimizationSettings(context: Context) {
+        try {
+            val intent = Intent(
+                Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                "package:${context.packageName}".toUri()
+            )
+
+            if (intent.resolveActivity(context.packageManager) != null) {
+                context.startActivity(intent)
+            } else {
+                // Fallback to generic battery optimization settings
+                context.startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+            }
+        } catch (e: Exception) {
+            Log_OC.d(TAG, "open battery optimization settings: ", e)
+        }
+    }
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


Checks `isBatteryOptimizationEnabled` only via `POWER_SERVICE`
If unable to start `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` fallback to `ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS`.
Checks activity resumed or not before creating dialog
Uses package name from given context