### PR TITLE
fix: group folder adapter crash

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/GroupFolderListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GroupFolderListAdapter.kt
@@ -1,6 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
+ * SPDX-FileCopyrightText: 2025 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-FileCopyrightText: 2023 Tobias Kaminsky <tobias@kaminsky.me>
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
@@ -27,7 +28,7 @@ class GroupFolderListAdapter(
     private val groupFolderListInterface: GroupfolderListInterface,
     private val isDarkMode: Boolean
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    lateinit var list: List<Groupfolder>
+    private var list: List<Groupfolder> = listOf()
 
     fun setData(result: Map<String, Groupfolder>) {
         list = result.values.sortedBy { it.mountPoint }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Navigate to group folder tab crash

 ```
E  FATAL EXCEPTION: main
                                                                                                    Process: com.nextcloud.client, PID: 4625
                                                                                                    kotlin.UninitializedPropertyAccessException: lateinit property list has not been initialized
                                                                                                    	at com.owncloud.android.ui.adapter.GroupFolderListAdapter.getList(GroupFolderListAdapter.kt:30)
                                                                                                    	at com.owncloud.android.ui.adapter.GroupFolderListAdapter.getItemCount(GroupFolderListAdapter.kt:46)
                                                                                                    	at com.owncloud.android.ui.EmptyRecyclerView.configureEmptyView(EmptyRecyclerView.kt:53)
                                                                                                    	at com.owncloud.android.ui.EmptyRecyclerView.setAdapter(EmptyRecyclerView.kt:33)
                                                                                                    	at com.owncloud.android.ui.fragment.ExtendedListFragment.setRecyclerViewAdapter(ExtendedListFragment.kt:137)
                                                                                                    	at com.owncloud.android.ui.fragment.GroupfolderListFragment.setAdapter(GroupfolderListFragment.kt:59)
                                                                                                    	at com.owncloud.android.ui.fragment.OCFileListFragment.onActivityCreated(OCFileListFragment.java:390)
                                                                                                    	at com.owncloud.android.ui.fragment.GroupfolderListFragment.onActivityCreated(GroupfolderListFragment.kt:48)
                                                                                                    	at androidx.fragment.app.Fragment.performActivityCreated(Fragment.java:3161)
                                                                                                    	at androidx.fragment.app.FragmentStateManager.activityCreated(FragmentStateManager.java:639)
                                                                                                    	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:289)
                                                                                                    	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2214)
                                                                                                    	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2109)
                                                                                                    	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2052)
                                                                                                    	at androidx.fragment.app.FragmentManager.executePendingTransactions(FragmentManager.java:779)
                                                                                                    	at com.owncloud.android.ui.activity.FileDisplayActivity.handleSpecialIntents(FileDisplayActivity.kt:575)
                                                                                                    	at com.owncloud.android.ui.activity.FileDisplayActivity.onNewIntent(FileDisplayActivity.kt:547)
                                                                                                    	at android.app.Activity.onNewIntent(Activity.java:2418)
                                                                                                    	at android.app.Activity.performNewIntent(Activity.java:9029)
                                                                                                    	at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1646)
                                                                                                    	at android.app.Instrumentation.internalCallActivityOnNewIntent(Instrumentation.java:1667)
                                                                                                    	at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1655)
                                                                                                    	at android.app.ActivityThread.deliverNewIntents(ActivityThread.java:4280)
                                                                                                    	at android.app.ActivityThread.handleNewIntent(ActivityThread.java:4290)
                                                                                                    	at android.app.servertransaction.NewIntentItem.execute(NewIntentItem.java:58)
                                                                                                    	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:60)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:174)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:109)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:81)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2636)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:107)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                    	at android.os.Looper.loop(Looper.java:317)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8705)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```