### PR TITLE
fix: auto upload worker crash

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -501,7 +501,6 @@ internal class BackgroundJobManagerImpl(
                 TimeUnit.SECONDS
             )
             .setInputData(arguments)
-            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         workManager.enqueueUniquePeriodicWork(


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

 ```
E  FATAL EXCEPTION: main
                                                                                                    Process: com.nextcloud.client, PID: 9860
                                                                                                    java.lang.RuntimeException: Unable to create application com.owncloud.android.MainApp: java.lang.IllegalArgumentException: PeriodicWorkRequests cannot be expedited
                                                                                                    	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7510)
                                                                                                    	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2416)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:107)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                    	at android.os.Looper.loop(Looper.java:317)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8705)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
                                                                                                    Caused by: java.lang.IllegalArgumentException: PeriodicWorkRequests cannot be expedited
                                                                                                    	at androidx.work.PeriodicWorkRequest$Builder.buildInternal$work_runtime_release(PeriodicWorkRequest.kt:335)
                                                                                                    	at androidx.work.PeriodicWorkRequest$Builder.buildInternal$work_runtime_release(PeriodicWorkRequest.kt:56)
                                                                                                    	at androidx.work.WorkRequest$Builder.build(WorkRequest.kt:293)
                                                                                                    	at com.nextcloud.client.jobs.BackgroundJobManagerImpl.schedulePeriodicFilesSyncJob(BackgroundJobManagerImpl.kt:505)
                                                                                                    	at com.owncloud.android.utils.FilesSyncHelper.scheduleFilesSyncForAllFoldersIfNeeded(FilesSyncHelper.java:235)
                                                                                                    	at com.owncloud.android.MainApp.initSyncOperations(MainApp.java:627)
                                                                                                    	at com.owncloud.android.MainApp.onCreate(MainApp.java:341)
                                                                                                    	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1386)
                                                                                                    	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7504)
                                                                                                    	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0) 
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2416) 
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:107) 
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:232) 
                                                                                                    	at android.os.Looper.loop(Looper.java:317) 
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8705) 
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method) 
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580) 
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886) 
---
```
