### PR TITLE
fix: upload completion listener

### DIFF
--- a/app/src/main/java/com/nextcloud/model/WorkerState.kt
+++ b/app/src/main/java/com/nextcloud/model/WorkerState.kt
@@ -18,7 +18,7 @@ sealed class WorkerState {
     data class FileDownloadCompleted(var currentFile: OCFile?) : WorkerState()
 
     data class FileUploadStarted(var user: User?) : WorkerState()
-    data class FileUploadCompleted(var currentFile: OCFile?) : WorkerState()
+    object FileUploadCompleted : WorkerState()
 
     data object OfflineOperationsCompleted : WorkerState()
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1917,9 +1917,8 @@ class FileDisplayActivity :
                 }
 
                 is FileUploadCompleted -> {
-                    state.currentFile?.let {
-                        ocFileListFragment?.adapter?.insertFile(it)
-                    }
+                    Log_OC.d(TAG, "one or more files are uploaded")
+                    listOfFilesFragment?.listDirectory(currentDir, MainApp.isOnlyOnDevice(), false)
                 }
 
                 is OfflineOperationsCompleted -> {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -1044,24 +1044,4 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         ocFileListDelegate.cleanup();
         helper.cleanup();
     }
-
-    public void insertFile(@NonNull OCFile file) {
-        mFiles.add(file);
-        mFilesAll.add(file);
-
-        // Re-sort to maintain order
-        if (sortOrder != null) {
-            boolean foldersBeforeFiles = preferences.isSortFoldersBeforeFiles();
-            boolean favoritesFirst = preferences.isSortFavoritesFirst();
-            mFiles = sortOrder.sortCloudFiles(mFiles, foldersBeforeFiles, favoritesFirst);
-        }
-
-        // Find actual position and notify
-        int position = mFiles.indexOf(file);
-        if (shouldShowHeader()) {
-            position++;
-        }
-
-        notifyItemInserted(position);
-    }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Once upload completed, adapter needs to be refreshed via correct data.

### Fixes

Sets worker state in finally blocks
Ensure all database operations are completed before signaling completion
Notify adapter only once when `FileUploadWorker` finished

### Demo


https://github.com/user-attachments/assets/ff191eee-69e3-4167-866c-1742e2c4884c

