### PR TITLE
fix: use existing parent id for gallery search task

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.java
@@ -51,7 +51,7 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
     }
 
     @Override
-    protected GallerySearchTask.Result doInBackground(Void... voids) {
+    protected Result doInBackground(Void... voids) {
         if (photoFragmentWeakReference.get() == null) {
             return new Result(false, false, -1);
         }
@@ -98,7 +98,7 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
     }
 
     @Override
-    protected void onPostExecute(GallerySearchTask.Result result) {
+    protected void onPostExecute(Result result) {
         if (photoFragmentWeakReference.get() != null) {
             GalleryFragment photoFragment = photoFragmentWeakReference.get();
             photoFragment.searchCompleted(result.emptySearch, result.lastTimestamp);
@@ -147,9 +147,11 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
                 continue;
             }
 
+
             final OCFile existingFile = storageManager.getFileByDecryptedRemotePath(remoteFile.getRemotePath());
 
             // add missing values from local storage to prevent override with null values
+
             if (existingFile != null) {
                 final var imageDimension = existingFile.getImageDimension();
                 if (imageDimension != null) {
@@ -160,7 +162,14 @@ public class GallerySearchTask extends AsyncTask<Void, Void, GallerySearchTask.R
                 remoteFile.setUploadTimestamp(existingFile.getUploadTimestamp());
             }
 
+            // initialize oc file from remote file
             OCFile ocFile = FileStorageUtils.fillOCFile(remoteFile);
+
+            // since remote does not contains parent id information use existing file to prevent overriding parent id with 0
+            if (existingFile != null) {
+                ocFile.setParentId(existingFile.getParentId());
+                ocFile.setCreationTimestamp(existingFile.getCreationTimestamp());
+            }
 
             if (BuildConfig.DEBUG) {
                 SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Helps: https://github.com/nextcloud/android/issues/16139. Please read the issue first.

### How to reproduce?

1. Have a large number of images in nested directories
2. Perform a fresh installation of the app
3. Open the Media tab
4. Navigate back to All Files
5. Observe the database using App Inspection: files that previously had a valid parent ID are set to `0` after visiting the Media tab

### Fixes

Overwriting parent id value