### PR TITLE
Fix resource leaks and improve file upload collision handling

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
@@ -502,7 +502,7 @@ class AutoUploadWorker(
                     val dateTime = formatter.parse(exifDate, pos)
                     if (dateTime != null) {
                         lastModificationTime = dateTime.time
-                        Log_OC.w(TAG, "calculateLastModificationTime calculatedTime is: $lastModificationTime")
+                        Log_OC.i(TAG, "calculateLastModificationTime calculatedTime is: $lastModificationTime")
                     } else {
                         Log_OC.w(TAG, "calculateLastModificationTime dateTime is empty")
                     }

--- a/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt
@@ -172,7 +172,7 @@ object UploadErrorNotificationManager {
             result.code == ResultCode.USER_CANCELLED ||
             operation.isMissingPermissionThrown
         ) {
-            Log_OC.w(TAG, "operation is successful, cancelled or lack of storage permission")
+            Log_OC.i(TAG, "operation is successful, cancelled or lack of storage permission")
             return false
         }
 

--- a/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -193,16 +193,21 @@ public class UploadsStorageManager extends Observable {
             null
                                 );
 
-        if (c != null) {
-            if (c.getCount() != SINGLE_RESULT) {
-                Log_OC.e(TAG, c.getCount() + " items for id=" + id
-                    + " available in UploadDb. Expected 1. Failed to update upload db.");
+        try {
+            if (c != null) {
+                if (c.getCount() != SINGLE_RESULT) {
+                    Log_OC.e(TAG, c.getCount() + " items for id=" + id
+                        + " available in UploadDb. Expected 1. Failed to update upload db.");
+                } else {
+                    updateUploadInternal(c, status, result, remotePath, localPath);
+                }
             } else {
-                updateUploadInternal(c, status, result, remotePath, localPath);
+                Log_OC.e(TAG, "Cursor is null");
             }
-            c.close();
-        } else {
-            Log_OC.e(TAG, "Cursor is null");
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
 
     }
@@ -302,9 +307,15 @@ public class UploadsStorageManager extends Observable {
             new String[]{Long.toString(id)},
             "_id ASC");
 
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                result = createOCUploadFromCursor(cursor);
+        try {
+            if (cursor != null) {
+                if (cursor.moveToFirst()) {
+                    result = createOCUploadFromCursor(cursor);
+                }
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
             }
         }
         Log_OC.d(TAG, "Retrieve job " + result + " for id " + id);
@@ -414,8 +425,8 @@ public class UploadsStorageManager extends Observable {
             pageSelectionArgs,
             sortOrder);
 
-        if (c != null) {
-            if (c.moveToFirst()) {
+        try {
+            if (c != null && c.moveToFirst()) {
                 do {
                     OCUpload upload = createOCUploadFromCursor(c);
                     if (upload == null) {
@@ -425,7 +436,10 @@ public class UploadsStorageManager extends Observable {
                     }
                 } while (c.moveToNext() && !c.isAfterLast());
             }
-            c.close();
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
         return uploads;
     }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -624,30 +624,35 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
 
         Cursor cursor = fileActivity.getContentResolver().query(contactUri, projection, null, null, null);
 
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                // The contact has only one email address, use it.
-                int columnIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Email.ADDRESS);
-                if (columnIndex != -1) {
-                    // Use the email address as needed.
-                    // email variable contains the selected contact's email address.
-                    String email = cursor.getString(columnIndex);
-                    binding.searchView.post(() -> {
-                        binding.searchView.setQuery(email, false);
-                        binding.searchView.requestFocus();
-                    });
+        try {
+            if (cursor != null) {
+                if (cursor.moveToFirst()) {
+                    // The contact has only one email address, use it.
+                    int columnIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Email.ADDRESS);
+                    if (columnIndex != -1) {
+                        // Use the email address as needed.
+                        // email variable contains the selected contact's email address.
+                        String email = cursor.getString(columnIndex);
+                        binding.searchView.post(() -> {
+                            binding.searchView.setQuery(email, false);
+                            binding.searchView.requestFocus();
+                        });
+                    } else {
+                        DisplayUtils.showSnackMessage(binding.getRoot(), R.string.email_pick_failed);
+                        Log_OC.e(FileDetailSharingFragment.class.getSimpleName(), "Failed to pick email address.");
+                    }
                 } else {
                     DisplayUtils.showSnackMessage(binding.getRoot(), R.string.email_pick_failed);
-                    Log_OC.e(FileDetailSharingFragment.class.getSimpleName(), "Failed to pick email address.");
+                    Log_OC.e(FileDetailSharingFragment.class.getSimpleName(), "Failed to pick email address as no Email found.");
                 }
             } else {
                 DisplayUtils.showSnackMessage(binding.getRoot(), R.string.email_pick_failed);
-                Log_OC.e(FileDetailSharingFragment.class.getSimpleName(), "Failed to pick email address as no Email found.");
+                Log_OC.e(FileDetailSharingFragment.class.getSimpleName(), "Failed to pick email address as Cursor is null.");
             }
-            cursor.close();
-        } else {
-            DisplayUtils.showSnackMessage(binding.getRoot(), R.string.email_pick_failed);
-            Log_OC.e(FileDetailSharingFragment.class.getSimpleName(), "Failed to pick email address as Cursor is null.");
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
         }
     }
 


### PR DESCRIPTION
Fix resource leaks and improve file upload collision handling

- Fix Cursor resource leaks in UploadsStorageManager and FileDetailSharingFragment
  by adding proper try-finally blocks to ensure cursors are always closed

- Improve file upload collision handling in UploadFileOperation
  - Add content comparison for non-encrypted files when SKIP policy is used
  - Report SYNC_CONFLICT when file with same name has different content
  - Preserve old behavior for encrypted files and edge cases

- Change log level from warning to info for informational messages
  in AutoUploadWorker and UploadErrorNotificationManager