### PR TITLE
fix: keep FAB hidden in sharing options

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -857,12 +857,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
         binding.tabLayout.setVisibility(isFragmentReplaced ? View.GONE : View.VISIBLE);
         binding.pager.setVisibility(isFragmentReplaced ? View.GONE : View.VISIBLE);
         binding.sharingFrameContainer.setVisibility(isFragmentReplaced ? View.VISIBLE : View.GONE);
-        FloatingActionButton mFabMain = requireActivity().findViewById(R.id.fab_main);
-        if (isFragmentReplaced) {
-            mFabMain.hide();
-        } else {
-            mFabMain.show();
-        }
     }
 
     /**


### PR DESCRIPTION
This change addresses an issue where the FAB would become visible in the file details section.

### Steps to reproduce the issue
1. Open Nextcloud client
2. Navigate to file details and open *Sharing* tab
3. Set up public link share via *Create link* with default options
4. Open *Settings* of the link share
5. Close settings by either selecting *Cancel* or *Share and copy link*

#### Expected behaviour
FAB continues to be hidden when retuning to file details/sharing tab.

#### Actual behaviour
FAB becomes visible.

---
- [ ] Tests written, or not not needed
