### PR TITLE
Fix video thumbnail generation for media

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/extensions/OwnCloudClientExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OwnCloudClientExtensions.kt
@@ -21,9 +21,9 @@ fun OwnCloudClient.toNextcloudClient(context: Context): NextcloudClient = OwnClo
     isFollowRedirects
 )
 
-fun OwnCloudClient.getPreviewEndpoint(localFileId: Long, x: Int, y: Int): String = baseUri
+fun OwnCloudClient.getPreviewEndpoint(remoteId: String, x: Int, y: Int): String = baseUri
     .toString() +
     "/index.php/core/preview?fileId=" +
-    localFileId +
+    remoteId +
     "&x=" + (x / 2) + "&y=" + (y / 2) +
     "&a=1&mode=cover&forceIcon=0"

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -1270,7 +1270,7 @@ public final class ThumbnailsCacheManager {
         int pxW = p.x;
         int pxH = p.y;
 
-        if (file.isDown()) {
+        if (file.isDown() && MimeTypeUtil.isImage(file)) {
             Bitmap bitmap = BitmapUtils.decodeSampledBitmapFromFile(file.getStoragePath(), pxW, pxH);
             if (bitmap != null) {
                 if (OCFileExtensionsKt.isPNG(file)) {
@@ -1283,7 +1283,7 @@ public final class ThumbnailsCacheManager {
             GetMethod getMethod = null;
 
             try {
-                String uri = OwnCloudClientExtensionsKt.getPreviewEndpoint(mClient, file.getLocalId(), pxW, pxH);
+                String uri = OwnCloudClientExtensionsKt.getPreviewEndpoint(mClient, file.getRemoteId(), pxW, pxH);
                 Log_OC.d(TAG, "generating resized image: " + file.getFileName() + " URI: " + uri);
 
                 getMethod = new GetMethod(uri);


### PR DESCRIPTION
Thumbnail
- only generate locally if image
- use remoteId instead of localId

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
