### PR TITLE
Test that move or copy files starts in the file's parent folder

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/fragment/OCFileListFragmentStaticServerIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/fragment/OCFileListFragmentStaticServerIT.kt
@@ -437,9 +437,7 @@ class OCFileListFragmentStaticServerIT : AbstractIT() {
                 activity.supportFragmentManager.executePendingTransactions()
 
                 fragment.listDirectory(testFolder, false)
-                activity.supportFragmentManager.executePendingTransactions()
                 fragment.onFileActionChosen(R.id.action_move_or_copy, setOf(testFile))
-                activity.supportFragmentManager.executePendingTransactions()
             }
             // Check that the FolderPickerActivity was opened
             intended(hasComponent(FolderPickerActivity::class.java.canonicalName))


### PR DESCRIPTION
Original PR: #16188
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

This tests the changes of https://github.com/nextcloud/android/pull/15925, where the old behavior of moving up to the root folder was changed to stay in the parent folder of the file(s) to move/copy.
The new behavior is in sync with iOS and the Web UI, hence this test ensures it doesn't break