### PR TITLE
Fix typo in conflict_folder_headline - values-de/string.xml

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -195,7 +195,7 @@
     <string name="confirmation_remove_folders_alert">Möchten Sie die ausgewählten Elemente und deren inhalt wirklich löschen?</string>
     <string name="confirmation_remove_local">Nur lokal</string>
     <string name="conflict_dialog_error">Konfliktlösungsdialog konnte nicht erstellt werden</string>
-    <string name="conflict_folder_headline">Ordnerkonfilikt</string>
+    <string name="conflict_folder_headline">Ordnerkonflikt</string>
     <string name="conflict_local_file">Lokale Datei</string>
     <string name="conflict_message_description">Falls beide Versionen gewählt werden, wird bei der lokalen Datei eine Zahl am Ende des Dateinamens hinzugefügt.</string>
     <string name="conflict_message_description_for_folder">Falls beide Versionen gewählt werden, wird beim lokalen Ordner eine Zahl am Ende des Dateinamens hinzugefügt.</string>


### PR DESCRIPTION
- [x] Tests written, or not not needed

The German string.xml hat a typo (Ordnerkonfilikt, should be Odnerkonflikt)
-> Corrected

No string Names or values beside the one letter typo was changed.
