### PR TITLE
refactor(ReceiveExternalFilesActivity): modernize and harden intent parsing for file uploads

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Resources.NotFoundException;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -110,6 +111,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog.Builder;
 import androidx.appcompat.widget.SearchView;
+import androidx.core.content.IntentCompat;
 import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
@@ -119,7 +121,12 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import static com.owncloud.android.utils.DisplayUtils.openSortingOrderDialogFragment;
 
 /**
- * This can be used to upload things to an Nextcloud instance.
+ * Activity for handling files or text shared to the Nextcloud app from external apps.
+ *
+ * Allows users to select a destination folder, handles account selection,
+ * and manages the upload process for received files or shared text into their Nextcloud account.
+ * Supports single/multiple file uploads, plain text, and provides rich UI feedback for all actions.
+ *
  */
 public class ReceiveExternalFilesActivity extends FileActivity
     implements View.OnClickListener, CopyAndUploadContentUrisTask.OnCopyTmpFilesTaskListener,
@@ -141,7 +148,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     private AccountManager mAccountManager;
     private Stack<String> mParents = new Stack<>();
-    private List<Parcelable> mStreamsToUpload;
+    private ArrayList<Uri> mStreamsToUpload;
     private String mUploadPath;
     private OCFile mFile;
 
@@ -892,20 +899,52 @@ public class ReceiveExternalFilesActivity extends FileActivity
         return full_path.toString();
     }
 
+    /**
+     * Prepares the list of files or text to upload by parsing the incoming Intent.
+     * Supports single file (ACTION_SEND + EXTRA_STREAM), multiple files (ACTION_SEND_MULTIPLE + EXTRA_STREAM),
+     * and plain text (ACTION_SEND + EXTRA_TEXT).
+     */
     private void prepareStreamsToUpload() {
         Intent intent = getIntent();
+        String action = intent.getAction();
+        mStreamsToUpload = new ArrayList<>();
 
-        if (intent.hasExtra(Intent.EXTRA_STREAM) && Intent.ACTION_SEND.equals(intent.getAction())) {
-            mStreamsToUpload = new ArrayList<>();
-            mStreamsToUpload.add(IntentExtensionsKt.getParcelableArgument(intent, Intent.EXTRA_STREAM, Parcelable.class));
-        } else if (intent.hasExtra(Intent.EXTRA_STREAM) && Intent.ACTION_SEND_MULTIPLE.equals(intent.getAction())) {
-            mStreamsToUpload = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
-        } else if (intent.hasExtra(Intent.EXTRA_TEXT) && Intent.ACTION_SEND.equals(intent.getAction())) {
-            mStreamsToUpload = null;
-            saveTextsFromIntent(intent);
-        } else {
-            showErrorDialog(R.string.uploader_error_message_no_file_to_upload, R.string.uploader_error_title_file_cannot_be_uploaded);
+        // Multiple files
+        if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+            ArrayList<Uri> uriList = IntentCompat.getParcelableArrayListExtra(intent, Intent.EXTRA_STREAM, Uri.class);
+            Log.d(TAG, "ACTION_SEND_MULTIPLE received with uriList: " + uriList);
+            if (uriList != null && !uriList.isEmpty()) {
+                // Defensive: Remove any nulls just in case
+                for (Uri uri : uriList) {
+                    if (uri != null) {
+                        mStreamsToUpload.add(uri);
+                    }
+                }
+                if (!mStreamsToUpload.isEmpty()) {
+                    return;
+                }
+            }
         }
+
+        // Single file
+        if (Intent.ACTION_SEND.equals(action)) {
+            Uri stream = IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri.class);
+            if (stream != null) {
+                mStreamsToUpload.add(stream);
+                return;
+            }
+
+            // Plain text sharing (ACTION_SEND, no stream, but has text)
+            if (intent.hasExtra(Intent.EXTRA_TEXT)) { 
+                mStreamsToUpload = null;
+                saveTextsFromIntent(intent);
+                return;
+            }
+        }
+
+        // Fallback: No recognized share type found or error scenario
+        showErrorDialog(R.string.uploader_error_message_no_file_to_upload,
+                       R.string.uploader_error_title_file_cannot_be_uploaded);
     }
 
     private void saveTextsFromIntent(Intent intent) {
@@ -925,8 +964,13 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private boolean somethingToUpload() {
-        return (mStreamsToUpload != null && !mStreamsToUpload.isEmpty() && mStreamsToUpload.get(0) != null ||
-            mUploadFromTmpFile);
+        if (mUploadFromTmpFile) {
+            return true;
+        }
+
+        // Valid stream
+        return mStreamsToUpload != null
+                && !mStreamsToUpload.isEmpty();
     }
 
     public void uploadFile(String tmpName, String filename) {

--- a/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
@@ -44,7 +44,7 @@ import com.owncloud.android.utils.UriUtils.getDisplayNameForUri
 ) // legacy code
 class UriUploader(
     private val mActivity: FileActivity,
-    private val mUrisToUpload: List<Parcelable?>,
+    private val mUrisToUpload: ArrayList<Uri>,
     private val mUploadPath: String,
     private val user: User,
     private val mBehaviour: Int,
@@ -64,17 +64,12 @@ class UriUploader(
     fun uploadUris(): UriUploaderResultCode {
         var code = UriUploaderResultCode.OK
         try {
-            val anySensitiveUri = mUrisToUpload
-                .filterNotNull()
-                .any { isSensitiveUri((it as Uri)) }
+            val anySensitiveUri = mUrisToUpload.any { isSensitiveUri(it) }
             if (anySensitiveUri) {
                 Log_OC.e(TAG, "Sensitive URI detected, aborting upload.")
                 code = UriUploaderResultCode.ERROR_SENSITIVE_PATH
             } else {
-                val uris = mUrisToUpload
-                    .filterNotNull()
-                    .map { it as Uri }
-                    .map { Pair(it, getRemotePathForUri(it)) }
+                val uris = mUrisToUpload.map { Pair(it, getRemotePathForUri(it)) }
 
                 val fileUris = uris.filter { it.first.scheme == ContentResolver.SCHEME_FILE }
                 if (fileUris.isNotEmpty()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,11 @@
     <string name="uploader_error_message_read_permission_not_granted">%1$s is not allowed to read a received file</string>
     <string name="uploader_error_message_source_file_not_found">File selected for upload not found. Please check whether the file exists.</string>
     <string name="uploader_error_message_source_file_not_copied">Could not copy file to a temporary folder. Try to resend it.</string>
+    <plurals name="uploader_error_partial_success">
+        <item quantity="one">%1$d of %2$d files was accepted and will be uploaded.</item>
+        <item quantity="other">%1$d of %2$d files were accepted and will be uploaded.</item>
+    </plurals>
+    <string name="uploader_error_message_file_cannot_be_accessed">Some files couldn't be accessed. Please check permissions or try again.</string>
     <string name="uploader_upload_files_behaviour">Upload option:</string>
     <string name="file_upload_worker_same_file_already_exists">%s already exists, no conflict detected</string>
     <string name="uploader_upload_files_behaviour_move_to_nextcloud_folder">Move file to %1$s folder</string>


### PR DESCRIPTION
- Refactor prepareStreamsToUpload() to use IntentCompat for safer extra access
- Add defensive state reset of mStreamsToUpload
- Use null-safety and explicit logging for incoming URIs
- Clarify handling of multiple, single, and text uploads
- Improve code clarity with early returns and error handling

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
