### PR TITLE
fix(auto-upload): show notification only when conditions are met

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/folderDownload/FolderDownloadWorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/folderDownload/FolderDownloadWorkerNotificationManager.kt
@@ -13,9 +13,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.work.ForegroundInfo
 import com.nextcloud.client.jobs.notification.WorkerNotificationManager
-import com.nextcloud.utils.ForegroundServiceHelper
 import com.owncloud.android.R
-import com.owncloud.android.datamodel.ForegroundServiceType
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.ui.notifications.NotificationUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
@@ -108,13 +106,6 @@ class FolderDownloadWorkerNotificationManager(private val context: Context, view
 
         return getForegroundInfo(notification)
     }
-
-    fun getForegroundInfo(notification: Notification): ForegroundInfo =
-        ForegroundServiceHelper.createWorkerForegroundInfo(
-            NOTIFICATION_ID,
-            notification,
-            ForegroundServiceType.DataSync
-        )
 
     fun dismiss() {
         notificationManager.cancel(NOTIFICATION_ID)

--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -14,7 +14,10 @@ import android.graphics.BitmapFactory
 import android.os.Handler
 import android.os.Looper
 import androidx.core.app.NotificationCompat
+import androidx.work.ForegroundInfo
+import com.nextcloud.utils.ForegroundServiceHelper
 import com.owncloud.android.R
+import com.owncloud.android.datamodel.ForegroundServiceType
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
 open class WorkerNotificationManager(
@@ -75,4 +78,11 @@ open class WorkerNotificationManager(
     fun getId(): Int = id
 
     fun getNotification(): Notification = notificationBuilder.build()
+
+    fun getForegroundInfo(notification: Notification): ForegroundInfo =
+        ForegroundServiceHelper.createWorkerForegroundInfo(
+            id,
+            notification,
+            ForegroundServiceType.DataSync
+        )
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


### Issue

`trySetForeground()` called before ensuring conditions, this causing to see multiple notifications. Conditions need to be checked first.