### PR TITLE
Respect avatar border for TextDrawable

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/AvatarGroupLayout.kt
+++ b/app/src/main/java/com/owncloud/android/ui/AvatarGroupLayout.kt
@@ -111,7 +111,8 @@ class AvatarGroupLayout @JvmOverloads constructor(
                             avatarRadius,
                             resources,
                             avatar,
-                            context
+                            context,
+                            avatarBorderSize
                         )
                     }
                 }

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -460,6 +460,7 @@ public final class DisplayUtils {
      * @param avatarRadius the avatar radius
      * @param resources    reference for density information
      * @param callContext  which context is called to set the generated avatar
+     * @param context      general context
      */
     public static void setAvatar(@NonNull User user,
                                  @NonNull String userId,
@@ -469,6 +470,30 @@ public final class DisplayUtils {
                                  Resources resources,
                                  Object callContext,
                                  Context context) {
+        setAvatar(user, userId, displayName, listener, avatarRadius, resources, callContext, context, 0);
+    }
+
+    /**
+     * fetches and sets the avatar of the given account in the passed callContext
+     *
+     * @param user           the account to be used to connect to server
+     * @param userId         the userId which avatar should be set
+     * @param displayName    displayName used to generate avatar with first char, only used as fallback
+     * @param avatarRadius   the avatar radius
+     * @param resources      reference for density information
+     * @param callContext    which context is called to set the generated avatar
+     * @param context        general context
+     * @param avatarBorder  value in case the avatar has a border, like in the case of the AvatarGroupLayout
+     */
+    public static void setAvatar(@NonNull User user,
+                                 @NonNull String userId,
+                                 String displayName,
+                                 AvatarGenerationListener listener,
+                                 float avatarRadius,
+                                 Resources resources,
+                                 Object callContext,
+                                 Context context,
+                                 int avatarBorder) {
         if (callContext instanceof View v) {
             v.setContentDescription(String.valueOf(user.toPlatformAccount().hashCode()));
         }
@@ -495,7 +520,8 @@ public final class DisplayUtils {
             // if no one exists, show colored icon with initial char
             if (avatar == null) {
                 try {
-                    avatar = TextDrawable.createAvatarByUserId(displayName, avatarRadius);
+                    avatar = TextDrawable.createAvatarByUserId(displayName,
+                                                               (avatarRadius - avatarBorder));
                 } catch (Exception e) {
                     Log_OC.e(TAG, "Error calculating RGB value for active account icon.", e);
                     avatar = ResourcesCompat.getDrawable(resources,


### PR DESCRIPTION
...since they can't resize automatically, so the border must be calculated into the radius.

Follow-up to #16227

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1080" height="178" alt="before" src="https://github.com/user-attachments/assets/7c31ed2a-4835-4486-8c81-1f92902699fa" />|<img width="1080" height="169" alt="after" src="https://github.com/user-attachments/assets/6a4a09aa-5ec5-4190-a1ac-0039b0109550" />

- [x] Tests written, or not not needed

For testing have a file shared with you by a user that got deactivated, so you don't get an avatar from the server. The fallback is a TextDrawable but that doesn't resize, so in case of the avatar group the border needs to be calculated into the radius, else the avatar is (slightly) to big.