### PR TITLE
fix(unified search): Show no results page when no results are available

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
@@ -220,7 +220,7 @@ class UnifiedSearchListAdapter(
         notifyDataSetChanged()
     }
 
-    fun isCurrentDirItemsEmpty(): Boolean = currentDirItems.isEmpty()
+    fun hasLocalResults(): Boolean = currentDirItems.isNotEmpty()
 
     init {
         // initialise thumbnails cache on background thread

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -318,21 +318,18 @@ class UnifiedSearchFragment :
             binding.swipeContainingList.isRefreshing = loading
         }
 
-        PairMediatorLiveData(vm.searchResults, vm.isLoading).observe(viewLifecycleOwner) { pair ->
-            if (pair.second == false) {
-                var count = 0
+        PairMediatorLiveData(vm.searchResults, vm.isLoading).observe(viewLifecycleOwner) { (searchResults, isLoading) ->
+            if (isLoading == true || searchResults.isNullOrEmpty()) {
+                return@observe
+            }
 
-                pair.first?.forEach {
-                    count += it.entries.size
-                }
+            val hasSearchResult = searchResults.any { searchResult -> searchResult.entries.isNotEmpty() }
 
-                if (count == 0 &&
-                    pair.first?.isNotEmpty() == true &&
-                    context != null &&
-                    !adapter.isCurrentDirItemsEmpty()
-                ) {
-                    showNoResult()
-                }
+            if (context != null &&
+                !hasSearchResult &&
+                !adapter.hasLocalResults()
+            ) {
+                showNoResult()
             }
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -37,11 +37,7 @@ class UnifiedSearchViewModel(application: Application) :
     }
 
     private data class UnifiedSearchMetadata(var results: MutableList<SearchResult> = mutableListOf()) {
-        fun nextCursor(): Int? = try {
-            results.lastOrNull()?.cursor?.toInt()
-        } catch (e: NumberFormatException) {
-            null
-        }
+        fun nextCursor(): Int? = results.lastOrNull()?.cursor?.toIntOrNull()
         fun name(): String? = results.lastOrNull()?.name
     }
 


### PR DESCRIPTION
Previously a flaw in one condition meant that a blank page was displayed instead of the usual *No results* page. This pull request aims to fix this issue and improve code readability.

### Steps to reproduce the issue
1. Open Nextcloud client
2. Open search bar (*Search in ...*)
3. Enter search term that will not return any results
4. *No results* should be displayed

---
- [ ] Tests written, or not not needed
