### PR TITLE
fix(tabs-list-mode): layout switch

### DIFF
--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -655,20 +655,26 @@ public final class AppPreferencesImpl implements AppPreferences {
     }
 
     /**
-     * Get preference value for a folder. If folder is not set itself, it finds an ancestor that is set.
+     * Retrieves a preference value for a specific folder.
+     * <p>
+     * If the folder itself does not have the preference set, the method searches up its ancestor hierarchy
+     * until a value is found. If no value is found in any ancestor, the provided {@code defaultValue} is returned.
+     * <p>
+     * Anonymous users or {@code null} folders will always return the {@code defaultValue}.
      *
-     * @param context        Context object.
-     * @param preferenceName Name of the preference to lookup.
-     * @param folder         Folder.
-     * @param defaultValue   Fallback value in case no ancestor is set.
-     * @return Preference value
+     * @param context        The Android context.
+     * @param user           The user for whom the preference is queried.
+     * @param preferenceName The name/key of the preference to look up.
+     * @param folder         The folder to check.
+     * @param defaultValue   The value to return if no preference is set in the folder hierarchy.
+     * @return The preference value for the folder, or {@code defaultValue} if none is set.
      */
     private static String getFolderPreference(final Context context,
                                               final User user,
                                               final String preferenceName,
                                               final OCFile folder,
                                               final String defaultValue) {
-        if (user.isAnonymous()) {
+        if (user.isAnonymous() || folder == null) {
             return defaultValue;
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -557,6 +557,8 @@ public abstract class DrawerActivity extends ToolbarActivity
             }
 
             closeDrawer();
+            setupHomeSearchToolbarWithSortAndListButtons();
+            updateActionBarTitleAndHomeButton(null);
         } else if (itemId == R.id.nav_favorites) {
             openFavoritesTab();
         } else if (itemId == R.id.nav_gallery) {
@@ -630,6 +632,8 @@ public abstract class DrawerActivity extends ToolbarActivity
                     fda.browseToRoot();
                 }
                 EventBus.getDefault().post(new ChangeMenuEvent());
+                setupHomeSearchToolbarWithSortAndListButtons();
+                updateActionBarTitleAndHomeButton(null);
             } else if (menuItemId == R.id.nav_favorites) {
                 openFavoritesTab();
             } else if (menuItemId == R.id.nav_assistant && !(this instanceof ComposeActivity)) {
@@ -706,8 +710,7 @@ public abstract class DrawerActivity extends ToolbarActivity
         }
     }
 
-    protected void openSharedTab() {
-        resetFileDepth();
+    private void openSharedTab() {
         resetOnlyPersonalAndOnDevice();
         SearchEvent searchEvent = new SearchEvent("", SearchRemoteOperation.SearchType.SHARED_FILTER);
         launchActivityForSearch(searchEvent, R.id.nav_shared);

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2767,7 +2767,6 @@ class FileDisplayActivity :
 
         listOfFilesFragment?.setCurrentSearchType(event)
         updateActionBarTitleAndHomeButton(null)
-        // listOfFilesFragment?.setActionBarTitle()
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -765,9 +765,13 @@ open class ExtendedListFragment :
         }
     }
 
-    protected fun setGridSwitchButton() {
+    protected fun setLayoutSwitchButton() {
+        setLayoutSwitchButton(isGridEnabled)
+    }
+
+    protected fun setLayoutSwitchButton(isGrid: Boolean) {
         mSwitchGridViewButton?.let {
-            if (isGridEnabled) {
+            if (isGrid) {
                 it.setContentDescription(getString(R.string.action_switch_list_view))
                 it.icon = ContextCompat.getDrawable(requireContext(), R.drawable.ic_view_list)
             } else {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -134,7 +134,7 @@ public class LocalFileListFragment extends ExtendedListFragment implements
             }
         }
 
-        setGridSwitchButton();
+        setLayoutSwitchButton();
 
         if (mSwitchGridViewButton != null) {
             mSwitchGridViewButton.setOnClickListener(v -> {
@@ -143,7 +143,7 @@ public class LocalFileListFragment extends ExtendedListFragment implements
                 } else {
                     switchToGridView();
                 }
-                setGridSwitchButton();
+                setLayoutSwitchButton();
             });
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -435,7 +435,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 } else {
                     setGridAsPreferred();
                 }
-                setGridSwitchButton();
+                setLayoutSwitchButton();
             });
         }
 
@@ -1573,17 +1573,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
     }
 
     private void updateLayout() {
-        // decide grid vs list view
-        if (isGridViewPreferred(mFile)) {
-            switchToGridView();
-        } else {
-            switchToListView();
-        }
-
+        setLayoutViewMode();
         updateSortButton();
-        if (mSwitchGridViewButton != null) {
-            setGridSwitchButton();
-        }
+        setLayoutSwitchButton();
 
         setFabVisible(!mHideFab);
         slideHideBottomBehaviourForBottomNavigationView(!mHideFab);
@@ -1619,14 +1611,34 @@ public class OCFileListFragment extends ExtendedListFragment implements
     }
 
     /**
-     * Determines if user set folder to grid or list view. If folder is not set itself, it finds a parent that is set
-     * (at least root is set).
+     * Determines whether a folder should be displayed in grid or list view.
+     * <p>
+     * The preference is checked for the given folder. If the folder itself does not have a preference set,
+     * it will fall back to its parent folder recursively until a preference is found (root folder is always set).
+     * Additionally, if a search event is active and is of type {@code SHARED_FILTER}, grid view is disabled.
      *
-     * @param folder Folder to check or null for root folder
-     * @return 'true' is folder should be shown in grid mode, 'false' if list mode is preferred.
+     * @param folder The folder to check, or {@code null} to refer to the root folder.
+     * @return {@code true} if the folder should be displayed in grid mode, {@code false} if list mode is preferred.
      */
-    public boolean isGridViewPreferred(@Nullable OCFile folder) {
-        return FOLDER_LAYOUT_GRID.equals(preferences.getFolderLayout(folder));
+    private boolean isGridViewPreferred(@Nullable OCFile folder) {
+        if (searchEvent != null) {
+            return (searchEvent.toSearchType() != SHARED_FILTER) &&
+                FOLDER_LAYOUT_GRID.equals(preferences.getFolderLayout(folder));
+        } else {
+            return FOLDER_LAYOUT_GRID.equals(preferences.getFolderLayout(folder));
+        }
+    }
+
+    private void setLayoutViewMode() {
+        boolean isGrid = isGridViewPreferred(mFile);
+
+        if (isGrid) {
+            switchToGridView();
+        } else {
+            switchToListView();
+        }
+
+        setLayoutSwitchButton(isGrid);
     }
 
     public void setListAsPreferred() {
@@ -1857,11 +1869,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
         new Handler(Looper.getMainLooper()).post(() -> {
             updateSortButton();
-            if (isGridViewPreferred(mFile) && !isGridEnabled()) {
-                switchToGridView();
-            } else if (!isGridViewPreferred(mFile) && isGridEnabled()) {
-                switchToListView();
-            }
+            setLayoutViewMode();
         });
 
         final User currentUser = accountManager.getUser();


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Changing the layout mode in the **Favorites** tab currently affects the **Shared** tab as well.
The Shared tab does **not** support grid view and should always display files in list view.

**Actual behavior:**
Files in the Shared tab are displayed in grid view when the layout is toggled in the Favorites tab, even though no toggle button is available in the Shared tab.

**Expected behavior:**
Layout changes in the Favorites tab should **not** impact the Shared tab, which should always remain in list view.

---

### Changes

* Use the default layout value when the folder is `null` to determine the correct file list mode.
* Include the **Shared filter** when determining the appropriate layout mode to ensure Shared files always use list view.

---

### Out of scope

- The app has multiple roots (e.g., All Files, Favorites, Shared). Currently, the layout preference for Favorites and All Files roots is not stored separately. Therefore, remembering the last picked layout for these roots is **out of scope** for this PR.

- Introducing layout switch mode for shared tab.


