### PR TITLE
fix(upload-notification): dismiss error notification

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/notification/WorkerNotificationManager.kt
@@ -57,6 +57,10 @@ open class WorkerNotificationManager(
         notificationManager.notify(id, notification)
     }
 
+    fun dismissNotification(id: Int) {
+        notificationManager.cancel(id)
+    }
+
     @Suppress("MagicNumber")
     fun setProgress(percent: Int, progressText: String?, indeterminate: Boolean) {
         notificationBuilder.run {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/UploadNotificationManager.kt
@@ -116,21 +116,10 @@ class UploadNotificationManager(private val context: Context, viewThemeUtils: Vi
             return
         }
 
-        dismissOldErrorNotification(operation.file.remotePath, operation.file.storagePath)
-
-        operation.oldFile?.let {
-            dismissOldErrorNotification(it.remotePath, it.storagePath)
-        }
+        dismissNotification(operation.ocUploadId.toInt())
     }
 
     fun dismissErrorNotification() = notificationManager.cancel(FileUploadWorker.NOTIFICATION_ERROR_ID)
-
-    fun dismissOldErrorNotification(remotePath: String, localPath: String) {
-        notificationManager.cancel(
-            NotificationUtils.createUploadNotificationTag(remotePath, localPath),
-            FileUploadWorker.NOTIFICATION_ERROR_ID
-        )
-    }
 
     fun notifyPaused(intent: PendingIntent) {
         notificationBuilder.run {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -230,12 +230,13 @@ class ConflictsResolveActivity :
 
         upload?.let {
             FileUploadHelper.instance().removeFileUpload(it.remotePath, it.accountName)
-
-            UploadNotificationManager(
+            val id = it.uploadId.toInt()
+            val nm = UploadNotificationManager(
                 applicationContext,
                 viewThemeUtils,
-                upload.uploadId.toInt()
-            ).dismissOldErrorNotification(it.remotePath, it.localPath)
+                id
+            )
+            nm.dismissNotification(id)
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.kt
+++ b/app/src/main/java/com/owncloud/android/ui/notifications/NotificationUtils.kt
@@ -22,7 +22,4 @@ object NotificationUtils {
     const val NOTIFICATION_CHANNEL_BACKGROUND_OPERATIONS: String = "NOTIFICATION_CHANNEL_BACKGROUND_OPERATIONS"
     const val NOTIFICATION_CHANNEL_OFFLINE_OPERATIONS: String = "NOTIFICATION_CHANNEL_OFFLINE_OPERATIONS"
     const val NOTIFICATION_CHANNEL_CONTENT_OBSERVER: String = "NOTIFICATION_CHANNEL_CONTENT_OBSERVER"
-
-    @JvmStatic
-    fun createUploadNotificationTag(remotePath: String?, localPath: String): String = remotePath + localPath
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue: https://github.com/nextcloud/android/issues/16302

Uploads are managed by notification ID (see: [code](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt#L68)), and notification tags are no longer used. For upload-specific error notifications, the `OCUpload ID` is used as the notification identifier. As a result, tag-based notifications derived from remote and local paths are no longer valid, and the related tag creation and handling have been removed.

### How to reproduce?

1. Create a file conflict
2. Select the keep server option
