### PR TITLE
fix(local-file-list-adapter): navigation

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -371,8 +371,6 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     public void swapDirectory(final File directory) {
         localFileListFragmentInterface.setLoading(true);
         currentOffset = 0;
-        mFiles.clear();
-        mFilesAll.clear();
 
         singleThreadExecutor.execute(() -> {
             // Load first page of folders
@@ -398,8 +396,10 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     @SuppressLint("NotifyDataSetChanged")
     private void updateUIForFirstPage(List<File> firstPage) {
         new Handler(Looper.getMainLooper()).post(() -> {
-            mFiles = new ArrayList<>(firstPage);
-            mFilesAll = new ArrayList<>(firstPage);
+            mFiles.clear();
+            mFilesAll.clear();
+            mFiles.addAll(firstPage);
+            mFilesAll.addAll(firstPage);
             notifyDataSetChanged();
             localFileListFragmentInterface.setLoading(false);
         });
@@ -432,15 +432,16 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     private void notifyItemRange(List<File> updatedList) {
         new Handler(Looper.getMainLooper()).post(() -> {
-            int from = mFiles.size();
-            int to = updatedList.size();
+            int headerOffset = shouldShowHeader() ? 1 : 0;
+            int startPositionInAdapter = mFiles.size() + headerOffset;
+            int itemCount = updatedList.size();
 
             mFiles.addAll(updatedList);
             mFilesAll.addAll(updatedList);
 
             Log_OC.d(TAG, "notifyItemRange, item size: " + mFilesAll.size());
 
-            notifyItemRangeInserted(from, to);
+            notifyItemRangeInserted(startPositionInAdapter, itemCount);
         });
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The app crashes when the user presses back from the local directory

### How to reproduce?

1. Tap the "+" button and go to Upload files.
2. On the upload screen, navigate to an internal folder or subfolder and scroll through the files.
3. Tap the back button in the top-left corner without selecting any files.
4. Repeat the steps above if the crash doesn’t occur the first time.