### PR TITLE
Show folder name in SharedListFragment actionbar

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -2234,6 +2234,9 @@ public class OCFileListFragment extends ExtendedListFragment implements
     }
 
     public boolean shouldNavigateBackToAllFiles() {
-        return ((this instanceof GalleryFragment) || isSearchEventFavorite() || DrawerActivity.menuItemId == R.id.nav_favorites);
+        return this instanceof GalleryFragment ||
+            isSearchEventFavorite() ||
+            isSearchEventShared() ||
+            DrawerActivity.menuItemId == R.id.nav_favorites;
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
@@ -61,7 +61,6 @@ class SharedListFragment :
         Handler().post {
             if (activity is FileDisplayActivity) {
                 val fileDisplayActivity = activity as FileDisplayActivity
-                fileDisplayActivity.updateActionBarTitleAndHomeButtonByString(getString(R.string.drawer_item_shared))
                 fileDisplayActivity.setMainFabVisible(false)
             }
         }


### PR DESCRIPTION
When opening a file contained within a shared folder from the *Shared* tab, the action bar title didn't show the folder name. *Shared* was displayed instead.

### Steps to reproduce the issue
1. Open Nextcloud Android client
2. Create a folder and move/copy an image file into said folder
3. Share the folder (e.g. via a public link share)
4. Open the *Shared* tab from the drawer menu
5. Navigate into the folder and open the image
6. Upon exiting the image preview the action bar should show the name of the current directory (and not *Shared*)

When pressing the back button in the *Shared* tab, the app used to exit. This has been changed so that it returns to the *All files* view instead to be consisted with other views.

---
- [ ] Tests written, or not not needed
