### PR TITLE
fix(e2ee): handle E2EE v2.1

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/e2ee/E2EVersionHelper.kt
+++ b/app/src/main/java/com/nextcloud/utils/e2ee/E2EVersionHelper.kt
@@ -16,22 +16,45 @@ import com.owncloud.android.utils.EncryptionUtils
 
 object E2EVersionHelper {
 
-    fun isV2orAbove(capability: OCCapability): Boolean = isV2orAbove(capability.endToEndEncryptionApiVersion)
+    /**
+     * Returns true if the given E2EE version is v2 or newer.
+     */
+    fun isV2Plus(capability: OCCapability): Boolean = isV2Plus(capability.endToEndEncryptionApiVersion)
 
-    fun isV2orAbove(version: E2EVersion): Boolean = version == E2EVersion.V2_0 || version == E2EVersion.V2_1
+    /**
+     * Returns true if the given E2EE version is v2 or newer.
+     */
+    fun isV2Plus(version: E2EVersion): Boolean = version == E2EVersion.V2_0 || version == E2EVersion.V2_1
 
+    /**
+     * Returns true if the given E2EE version is v1.x.
+     */
     fun isV1(capability: OCCapability): Boolean = isV1(capability.endToEndEncryptionApiVersion)
 
+    /**
+     * Returns true if the given E2EE version is v1.x.
+     */
     fun isV1(version: E2EVersion): Boolean =
         version == E2EVersion.V1_0 || version == E2EVersion.V1_1 || version == E2EVersion.V1_2
 
-    fun getLatestE2EVersion(isV2: Boolean): E2EVersion = if (isV2) {
+    /**
+     * Returns the latest supported E2EE version.
+     *
+     * @param isV2 indicates whether the E2EE v2 series should be used
+     */
+    fun latestVersion(isV2: Boolean): E2EVersion = if (isV2) {
         E2EVersion.V2_1
     } else {
         E2EVersion.V1_2
     }
 
-    fun determineE2EFromVersionString(version: String?): E2EVersion = when (version?.trim()) {
+    /**
+     * Maps a raw version string to an [E2EVersion].
+     *
+     * @param version version string
+     * @return resolved [E2EVersion] or [E2EVersion.UNKNOWN] if unsupported
+     */
+    fun fromVersionString(version: String?): E2EVersion = when (version?.trim()) {
         "1.0" -> E2EVersion.V1_0
         "1.1" -> E2EVersion.V1_1
         "1.2" -> E2EVersion.V1_2
@@ -40,13 +63,19 @@ object E2EVersionHelper {
         else -> E2EVersion.UNKNOWN
     }
 
-    fun determineE2EVersion(metadata: String): E2EVersion = runCatching {
+    /**
+     * Determines the E2EE version by inspecting encrypted folder metadata.
+     *
+     * Supports both V1 and V2 metadata formats and falls back safely
+     * to [E2EVersion.UNKNOWN] if parsing fails.
+     */
+    fun fromMetadata(metadata: String): E2EVersion = runCatching {
         val v1 = EncryptionUtils.deserializeJSON<EncryptedFolderMetadataFileV1>(
             metadata,
             object : TypeToken<EncryptedFolderMetadataFileV1>() {}
         )
 
-        determineE2EFromVersionString(v1?.metadata?.version.toString()).also {
+        fromVersionString(v1?.metadata?.version.toString()).also {
             if (it == E2EVersion.UNKNOWN) {
                 throw IllegalStateException("Unknown V1 version")
             }
@@ -57,6 +86,6 @@ object E2EVersionHelper {
             object : TypeToken<EncryptedFolderMetadataFile>() {}
         )
 
-        determineE2EFromVersionString(v2.version)
+        fromVersionString(v2.version)
     }.getOrDefault(E2EVersion.UNKNOWN)
 }

--- a/app/src/main/java/com/owncloud/android/datamodel/e2e/v2/decrypted/DecryptedFolderMetadataFile.kt
+++ b/app/src/main/java/com/owncloud/android/datamodel/e2e/v2/decrypted/DecryptedFolderMetadataFile.kt
@@ -17,5 +17,5 @@ data class DecryptedFolderMetadataFile(
     var users: MutableList<DecryptedUser> = mutableListOf(),
     @Transient
     val filedrop: MutableMap<String, DecryptedFile> = HashMap(),
-    val version: String = E2EVersionHelper.getLatestE2EVersion(true).value
+    val version: String = E2EVersionHelper.latestVersion(true).value
 )

--- a/app/src/main/java/com/owncloud/android/datamodel/e2e/v2/encrypted/EncryptedFolderMetadataFile.kt
+++ b/app/src/main/java/com/owncloud/android/datamodel/e2e/v2/encrypted/EncryptedFolderMetadataFile.kt
@@ -16,5 +16,5 @@ data class EncryptedFolderMetadataFile(
     val metadata: EncryptedMetadata,
     val users: List<EncryptedUser>,
     @Transient val filedrop: MutableMap<String, EncryptedFiledrop>?,
-    val version: String = E2EVersionHelper.getLatestE2EVersion(true).value
+    val version: String = E2EVersionHelper.latestVersion(true).value
 )

--- a/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -34,7 +34,6 @@ import com.owncloud.android.lib.resources.e2ee.ToggleEncryptionRemoteOperation;
 import com.owncloud.android.lib.resources.files.CreateFolderRemoteOperation;
 import com.owncloud.android.lib.resources.files.ReadFolderRemoteOperation;
 import com.owncloud.android.lib.resources.files.model.RemoteFile;
-import com.owncloud.android.lib.resources.status.E2EVersion;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.utils.EncryptionUtils;
 import com.owncloud.android.utils.EncryptionUtilsV2;
@@ -99,7 +98,7 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
         if (encryptedAncestor) {
             final var capability = getStorageManager().getCapability(user);
 
-            if (E2EVersionHelper.INSTANCE.isV2orAbove(capability)) {
+            if (E2EVersionHelper.INSTANCE.isV2Plus(capability)) {
                 return encryptedCreateV2(parent, client);
             } else if (E2EVersionHelper.INSTANCE.isV1(capability)) {
                 return encryptedCreateV1(parent, client);
@@ -175,7 +174,7 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
                                                token,
                                                client,
                                                metadataExists,
-                                               E2EVersionHelper.INSTANCE.getLatestE2EVersion(false),
+                                               E2EVersionHelper.INSTANCE.latestVersion(false),
                                                "",
                                                arbitraryDataProvider,
                                                user);

--- a/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -541,7 +541,7 @@ public class RefreshFolderOperation extends RemoteOperation {
 
         final var capability = CapabilityUtils.getCapability(mContext);
 
-        if (E2EVersionHelper.INSTANCE.isV2orAbove(capability)) {
+        if (E2EVersionHelper.INSTANCE.isV2Plus(capability)) {
             if (encryptedAncestor && object == null) {
                 throw new IllegalStateException("metadata is null!");
             }
@@ -551,10 +551,10 @@ public class RefreshFolderOperation extends RemoteOperation {
         Map<String, OCFile> localFilesMap;
         E2EVersion e2EVersion;
         if (object instanceof DecryptedFolderMetadataFileV1 metadataFileV1) {
-            e2EVersion = E2EVersionHelper.INSTANCE.getLatestE2EVersion(false);
+            e2EVersion = E2EVersionHelper.INSTANCE.latestVersion(false);
             localFilesMap = prefillLocalFilesMap(metadataFileV1, fileDataStorageManager.getFolderContent(mLocalFolder, false));
         } else {
-            e2EVersion = E2EVersionHelper.INSTANCE.getLatestE2EVersion(true);
+            e2EVersion = E2EVersionHelper.INSTANCE.latestVersion(true);
             localFilesMap = prefillLocalFilesMap(object, fileDataStorageManager.getFolderContent(mLocalFolder, false));
 
             // update counter
@@ -601,7 +601,7 @@ public class RefreshFolderOperation extends RemoteOperation {
             FileStorageUtils.searchForLocalFileInDefaultPath(updatedFile, user.getAccountName());
 
             // update file name for encrypted files
-            if (e2EVersion == E2EVersionHelper.INSTANCE.getLatestE2EVersion(false)) {
+            if (e2EVersion == E2EVersionHelper.INSTANCE.latestVersion(false)) {
                 updateFileNameForEncryptedFileV1(fileDataStorageManager,
                                                  (DecryptedFolderMetadataFileV1) object,
                                                  updatedFile);
@@ -624,7 +624,7 @@ public class RefreshFolderOperation extends RemoteOperation {
 
         // save updated contents in local database
         // update file name for encrypted files
-        if (e2EVersion == E2EVersionHelper.INSTANCE.getLatestE2EVersion(false)) {
+        if (e2EVersion == E2EVersionHelper.INSTANCE.latestVersion(false)) {
             updateFileNameForEncryptedFileV1(fileDataStorageManager,
                                              (DecryptedFolderMetadataFileV1) object,
                                              mLocalFolder);

--- a/app/src/main/java/com/owncloud/android/operations/RemoveRemoteEncryptedFileOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/RemoveRemoteEncryptedFileOperation.kt
@@ -56,7 +56,7 @@ class RemoveRemoteEncryptedFileOperation internal constructor(
         var delete: DeleteMethod? = null
         var token: String? = null
         val capability = CapabilityUtils.getCapability(context)
-        val isE2EVersionAtLeast2 = (E2EVersionHelper.isV2orAbove(capability))
+        val isE2EVersionAtLeast2 = (E2EVersionHelper.isV2Plus(capability))
 
         try {
             token = EncryptionUtils.lockFolder(parentFolder, client)
@@ -149,7 +149,7 @@ class RemoveRemoteEncryptedFileOperation internal constructor(
             token,
             client,
             metadataExists,
-            E2EVersionHelper.getLatestE2EVersion(false),
+            E2EVersionHelper.latestVersion(false),
             "",
             arbitraryDataProvider,
             user

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -586,7 +586,7 @@ public class UploadFileOperation extends SyncOperation {
 
     private boolean isEndToEndVersionAtLeastV2() {
         final var capability = CapabilityUtils.getCapability(mContext);
-        return E2EVersionHelper.INSTANCE.isV2orAbove(capability);
+        return E2EVersionHelper.INSTANCE.isV2Plus(capability);
     }
 
     private long getE2ECounter(OCFile parentFile) {
@@ -851,7 +851,7 @@ public class UploadFileOperation extends SyncOperation {
                                        clientData.getToken(),
                                        clientData.getClient(),
                                        metadataExists,
-                                       E2EVersionHelper.INSTANCE.getLatestE2EVersion(false),
+                                       E2EVersionHelper.INSTANCE.latestVersion(false),
                                        "",
                                        arbitraryDataProvider,
                                        user);

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1972,7 +1972,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 String token = EncryptionUtils.lockFolder(folder, client);
 
                 OCCapability ocCapability = mContainerActivity.getStorageManager().getCapability(user.getAccountName());
-                if (E2EVersionHelper.INSTANCE.isV2orAbove(ocCapability)) {
+                if (E2EVersionHelper.INSTANCE.isV2Plus(ocCapability)) {
                     // Update metadata
                     Pair<Boolean, DecryptedFolderMetadataFile> metadataPair = EncryptionUtils.retrieveMetadata(folder,
                                                                                                                client,

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -414,9 +414,9 @@ public final class EncryptionUtils {
         }
 
         String serializedEncryptedMetadata = getMetadataOperationResult.getResultData().getMetadata();
-        E2EVersion version = E2EVersionHelper.INSTANCE.determineE2EVersion(serializedEncryptedMetadata);
+        E2EVersion version = E2EVersionHelper.INSTANCE.fromMetadata(serializedEncryptedMetadata);
 
-        if (E2EVersionHelper.INSTANCE.isV2orAbove(version)) {
+        if (E2EVersionHelper.INSTANCE.isV2Plus(version)) {
             EncryptionUtilsV2 encryptionUtilsV2 = new EncryptionUtilsV2();
             return encryptionUtilsV2.parseAnyMetadata(getMetadataOperationResult.getResultData(),
                                                       user,
@@ -439,7 +439,7 @@ public final class EncryptionUtils {
                                                                          folder.getLocalId());
 
                 OCCapability capability = CapabilityUtils.getCapability(context);
-                if (E2EVersionHelper.INSTANCE.isV2orAbove(capability)) {
+                if (E2EVersionHelper.INSTANCE.isV2Plus(capability)) {
                     new EncryptionUtilsV2().migrateV1ToV2andUpload(
                         v1,
                         client.getUserId(),
@@ -1220,7 +1220,7 @@ public final class EncryptionUtils {
             metadata = new DecryptedFolderMetadataFileV1();
             metadata.setMetadata(new DecryptedMetadata());
 
-            final var latestV1E2EEVersion = E2EVersionHelper.INSTANCE.getLatestE2EVersion(false);
+            final var latestV1E2EEVersion = E2EVersionHelper.INSTANCE.latestVersion(false);
 
             metadata.getMetadata().setVersion(Double.parseDouble(latestV1E2EEVersion.getValue()));
             metadata.getMetadata().setMetadataKeys(new HashMap<>());
@@ -1281,7 +1281,7 @@ public final class EncryptionUtils {
 
         } else if (getMetadataOperationResult.getHttpCode() == HttpStatus.SC_NOT_FOUND ||
             getMetadataOperationResult.getHttpCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
-            final var latestE2EEV2Version = E2EVersionHelper.INSTANCE.getLatestE2EVersion(true);
+            final var latestE2EEV2Version = E2EVersionHelper.INSTANCE.latestVersion(true);
 
             // new metadata
             metadata = new DecryptedFolderMetadataFile(new com.owncloud.android.datamodel.e2e.v2.decrypted.DecryptedMetadata(),
@@ -1317,7 +1317,7 @@ public final class EncryptionUtils {
         RemoteOperationResult<String> uploadMetadataOperationResult;
         if (metadataExists) {
             // update metadata
-            if (E2EVersionHelper.INSTANCE.isV2orAbove(version)) {
+            if (E2EVersionHelper.INSTANCE.isV2Plus(version)) {
                 uploadMetadataOperationResult = new UpdateMetadataV2RemoteOperation(
                     parentFile.getRemoteId(),
                     serializedFolderMetadata,
@@ -1333,7 +1333,7 @@ public final class EncryptionUtils {
             }
         } else {
             // store metadata
-            if (E2EVersionHelper.INSTANCE.isV2orAbove(version)) {
+            if (E2EVersionHelper.INSTANCE.isV2Plus(version)) {
                 uploadMetadataOperationResult = new StoreMetadataV2RemoteOperation(
                     parentFile.getRemoteId(),
                     serializedFolderMetadata,

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtilsV2.kt
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtilsV2.kt
@@ -607,9 +607,9 @@ class EncryptionUtilsV2 {
             object : TypeToken<EncryptedFolderMetadataFile>() {}
         )
 
-        val e2eeVersion = E2EVersionHelper.determineE2EFromVersionString(v2.version)
+        val e2eeVersion = E2EVersionHelper.fromVersionString(v2.version)
 
-        val decryptedFolderMetadata = if (E2EVersionHelper.isV2orAbove(e2eeVersion)) {
+        val decryptedFolderMetadata = if (E2EVersionHelper.isV2Plus(e2eeVersion)) {
             val userId = AccountManager.get(context).getUserData(
                 user.toPlatformAccount(),
                 AccountUtils.Constants.KEY_USER_ID

--- a/app/src/test/java/com/owncloud/android/utils/E2EVersionHelperTest.kt
+++ b/app/src/test/java/com/owncloud/android/utils/E2EVersionHelperTest.kt
@@ -36,16 +36,16 @@ class E2EVersionHelperTest {
 
     @Test
     fun `isV2orAbove returns true for V2 versions`() {
-        assertTrue(E2EVersionHelper.isV2orAbove(E2EVersion.V2_0))
-        assertTrue(E2EVersionHelper.isV2orAbove(E2EVersion.V2_1))
+        assertTrue(E2EVersionHelper.isV2Plus(E2EVersion.V2_0))
+        assertTrue(E2EVersionHelper.isV2Plus(E2EVersion.V2_1))
     }
 
     @Test
     fun `isV2orAbove returns false for non V2 versions`() {
-        assertFalse(E2EVersionHelper.isV2orAbove(E2EVersion.V1_0))
-        assertFalse(E2EVersionHelper.isV2orAbove(E2EVersion.V1_1))
-        assertFalse(E2EVersionHelper.isV2orAbove(E2EVersion.V1_2))
-        assertFalse(E2EVersionHelper.isV2orAbove(E2EVersion.UNKNOWN))
+        assertFalse(E2EVersionHelper.isV2Plus(E2EVersion.V1_0))
+        assertFalse(E2EVersionHelper.isV2Plus(E2EVersion.V1_1))
+        assertFalse(E2EVersionHelper.isV2Plus(E2EVersion.V1_2))
+        assertFalse(E2EVersionHelper.isV2Plus(E2EVersion.UNKNOWN))
     }
 
     @Test
@@ -64,78 +64,78 @@ class E2EVersionHelperTest {
 
     @Test
     fun `getLatestE2EVersion returns latest V2 when isV2 is true`() {
-        assertEquals(E2EVersion.V2_1, E2EVersionHelper.getLatestE2EVersion(true))
+        assertEquals(E2EVersion.V2_1, E2EVersionHelper.latestVersion(true))
     }
 
     @Test
     fun `getLatestE2EVersion returns latest V1 when isV2 is false`() {
-        assertEquals(E2EVersion.V1_2, E2EVersionHelper.getLatestE2EVersion(false))
+        assertEquals(E2EVersion.V1_2, E2EVersionHelper.latestVersion(false))
     }
 
     @Test
     fun `determineE2EVersion returns V1_0`() {
         mockV1("1.0")
-        assertEquals(E2EVersion.V1_0, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_0, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion via double returns V1_0`() {
         mockV1Double(1.0)
-        assertEquals(E2EVersion.V1_0, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_0, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion via second double returns V1_0`() {
         mockV1Double(1.00)
-        assertEquals(E2EVersion.V1_0, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_0, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion via third double returns V1_1`() {
         mockV1Double(1.10)
-        assertEquals(E2EVersion.V1_1, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_1, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion via fourth double returns V1_2`() {
         mockV1Double(1.2)
-        assertEquals(E2EVersion.V1_2, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_2, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion returns V1_1`() {
         mockV1("1.1")
-        assertEquals(E2EVersion.V1_1, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_1, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion returns V1_2`() {
         mockV1("1.2")
-        assertEquals(E2EVersion.V1_2, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V1_2, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion returns V2_0 for 2_0 or 2`() {
         mockV1Throw()
         mockV2("2.0")
-        assertEquals(E2EVersion.V2_0, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V2_0, E2EVersionHelper.fromMetadata("meta"))
 
         mockV2("2")
-        assertEquals(E2EVersion.V2_0, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V2_0, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion returns V2_1`() {
         mockV1Throw()
         mockV2("2.1")
-        assertEquals(E2EVersion.V2_1, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.V2_1, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EVersion returns UNKNOWN for unknown V2 version`() {
         mockV1Throw()
         mockV2("3.0")
-        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
@@ -154,24 +154,24 @@ class E2EVersionHelperTest {
             )
         } throws RuntimeException()
 
-        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.determineE2EVersion("meta"))
+        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.fromMetadata("meta"))
     }
 
     @Test
     fun `determineE2EFromVersionString maps versions correctly`() {
-        assertEquals(E2EVersion.V1_0, E2EVersionHelper.determineE2EFromVersionString("1.0"))
-        assertEquals(E2EVersion.V1_1, E2EVersionHelper.determineE2EFromVersionString("1.1"))
-        assertEquals(E2EVersion.V1_2, E2EVersionHelper.determineE2EFromVersionString("1.2"))
-        assertEquals(E2EVersion.V2_0, E2EVersionHelper.determineE2EFromVersionString("2"))
-        assertEquals(E2EVersion.V2_0, E2EVersionHelper.determineE2EFromVersionString("2.0"))
-        assertEquals(E2EVersion.V2_1, E2EVersionHelper.determineE2EFromVersionString("2.1"))
+        assertEquals(E2EVersion.V1_0, E2EVersionHelper.fromVersionString("1.0"))
+        assertEquals(E2EVersion.V1_1, E2EVersionHelper.fromVersionString("1.1"))
+        assertEquals(E2EVersion.V1_2, E2EVersionHelper.fromVersionString("1.2"))
+        assertEquals(E2EVersion.V2_0, E2EVersionHelper.fromVersionString("2"))
+        assertEquals(E2EVersion.V2_0, E2EVersionHelper.fromVersionString("2.0"))
+        assertEquals(E2EVersion.V2_1, E2EVersionHelper.fromVersionString("2.1"))
     }
 
     @Test
     fun `determineE2EFromVersionString returns UNKNOWN for invalid input`() {
-        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.determineE2EFromVersionString(null))
-        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.determineE2EFromVersionString(""))
-        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.determineE2EFromVersionString("3.0"))
+        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.fromVersionString(null))
+        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.fromVersionString(""))
+        assertEquals(E2EVersion.UNKNOWN, E2EVersionHelper.fromVersionString("3.0"))
     }
 
     private fun mockV1(version: String) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

The introduction of `E2EE v2.1` exposed multiple code paths that relied on exact version matching `(== 2.0)`, causing logic meant for v2.x to be skipped. As a result, the app crashes when interacting with encrypted folders created using E2EE 2.1.

### How to reproduce

1. Install End-to-End Encrypted app [v2.0.0-rc.6.](https://github.com/nextcloud/end_to_end_encryption/releases/tag/v2.0.0-rc.6)
2. Create an encrypted folder
3. Refresh the newly created folder
4. App crashes; the folder remains locked and uploads are blocked

### Changes

- Treats E2EE v2.1 as compatible with v2.0 logic (v2 or above)
- Replaces exact version checks with consolidated helpers to avoid missing logic for future versions
- Deduplicates repeated E2EE version checks and centralizes them in a single helper
- Adds extension helpers (e.g. resolving E2EE version from capabilities) to reduce code duplication
- Adds unit tests for the new version helper to prevent regressions