### PR TITLE
gradle properties use defaults

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,14 +24,6 @@ org.gradle.configuration-cache=true
 # automatically aded via AGP migration
 # see https://developer.android.com/build/releases/agp-9-0-0-release-notes
 # should be changed with https://github.com/nextcloud/android/issues/15993
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

Only these two are needed because the latest stable version of `KAPT` does not support `builtInKotlin`. I was able to build the project locally. Could you please check?

```
android.builtInKotlin=false
android.newDsl=false
```