### PR TITLE
check(set-avatar): user id

### DIFF
--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -434,6 +434,11 @@ public final class DisplayUtils {
         String userId = accountManager.getUserData(user.toPlatformAccount(),
                 com.owncloud.android.lib.common.accounts.AccountUtils.Constants.KEY_USER_ID);
 
+        if (userId == null) {
+            Log_OC.e(TAG, "user id is null, cannot set avatar");
+            return;
+        }
+
         setAvatar(user, userId, listener, avatarRadius, resources, callContext, context);
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.isEmpty()' on a null object reference
  at com.owncloud.android.utils.DisplayUtils.setAvatar (DisplayUtils.java:480)
  at com.owncloud.android.utils.DisplayUtils.setAvatar (DisplayUtils.java:451)
  at com.owncloud.android.utils.DisplayUtils.setAvatar (DisplayUtils.java:437)
  at com.nextcloud.ui.ChooseAccountDialogFragment.onViewCreated (ChooseAccountDialogFragment.kt:94)
  at androidx.fragment.app.Fragment.performViewCreated (Fragment.java:3152)
  at androidx.fragment.app.FragmentStateManager.createView (FragmentStateManager.java:608)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:286)
  at androidx.fragment.app.FragmentStore.moveToExpectedState (FragmentStore.java:114)
  at androidx.fragment.app.FragmentManager.moveToState (FragmentManager.java:1685)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (FragmentManager.java:3319)
  at androidx.fragment.app.FragmentManager.dispatchActivityCreated (FragmentManager.java:3237)
  at androidx.fragment.app.FragmentController.dispatchActivityCreated (FragmentController.java:263)
  at androidx.fragment.app.FragmentActivity.onStart (FragmentActivity.java:350)
  at androidx.appcompat.app.AppCompatActivity.onStart (AppCompatActivity.java:238)
  at com.owncloud.android.ui.activity.DrawerActivity.onStart (DrawerActivity.java:1293)
  at com.owncloud.android.ui.activity.FileActivity.onStart (FileActivity.java:280)
  at com.owncloud.android.ui.activity.FileDisplayActivity.onStart (FileDisplayActivity.kt:2758)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1701)
  at android.app.Activity.performStart (Activity.java:9107)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:4184)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:270)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:250)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:222)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:107)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:81)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2702)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:246)
  at android.os.Looper.loop (Looper.java:334)
  at android.app.ActivityThread.main (ActivityThread.java:8895)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:681)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:902)
```