### PR TITLE
fix(gallery-image-generation-job): concurrent modification exception

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/gallery/GalleryImageGenerationJob.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/gallery/GalleryImageGenerationJob.kt
@@ -41,7 +41,8 @@ class GalleryImageGenerationJob(private val user: User, private val storageManag
         private val activeJobs = WeakHashMap<ImageView, Job>()
 
         fun cancelAllActiveJobs() {
-            for ((_, job) in activeJobs) {
+            val entries = activeJobs.entries.toList()
+            for ((_, job) in entries) {
                 job.cancel()
             }
             activeJobs.clear()


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed


```
Exception java.util.ConcurrentModificationException:
  at java.util.WeakHashMap$HashIterator.nextEntry (WeakHashMap.java:815)
  at java.util.WeakHashMap$EntryIterator.next (WeakHashMap.java:854)
  at java.util.WeakHashMap$EntryIterator.next (WeakHashMap.java:852)
  at com.nextcloud.client.jobs.gallery.GalleryImageGenerationJob$Companion.cancelAllActiveJobs (GalleryImageGenerationJob.kt:44)
  at com.owncloud.android.ui.adapter.OCFileListDelegate.cleanup (OCFileListDelegate.kt:415)
  at com.owncloud.android.ui.adapter.GalleryAdapter.cleanup (GalleryAdapter.kt:377)
  at com.owncloud.android.ui.fragment.GalleryFragment.onDestroyView (GalleryFragment.java:123)
  at androidx.fragment.app.Fragment.performDestroyView (Fragment.java:3362)
  at androidx.fragment.app.FragmentStateManager.destroyFragmentView (FragmentStateManager.java:797)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:352)
  at androidx.fragment.app.SpecialEffectsController$FragmentStateManagerOperation.complete$fragment_release (SpecialEffectsController.kt:846)
  at androidx.fragment.app.SpecialEffectsController.commitEffects$fragment_release (SpecialEffectsController.kt:446)
  at androidx.fragment.app.SpecialEffectsController.executePendingOperations (SpecialEffectsController.kt:288)
  at androidx.fragment.app.FragmentManager.executeOpsTogether (FragmentManager.java:2227)
  at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute (FragmentManager.java:2109)
  at androidx.fragment.app.FragmentManager.execPendingActions (FragmentManager.java:2052)
  at androidx.fragment.app.FragmentManager$5.run (FragmentManager.java:703)
  at android.os.Handler.handleCallback (Handler.java:959)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.app.ActivityThread.main (ActivityThread.java:9593)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:593)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:936)
```