### PR TITLE
fix(ui): prevent snackbar crash in bottom sheet and simplify

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,6 +259,9 @@
     <string name="upload_chooser_title">Upload from…</string>
     <string name="uploader_info_dirname">Folder name</string>
 
+    <string name="set_online_status_bottom_sheet_error_message">Failed to set status!</string>
+
+
     <string name="upload_notification_manager_start_text">%1$d / %2$d - %3$s</string>
 
     <string name="folder_download_worker_ticker_id">Syncing…</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

```
Exception java.lang.IllegalArgumentException: No suitable parent found from the given view. Please provide a valid view.
  at com.google.android.material.snackbar.Snackbar.makeInternal (Snackbar.java:232)
  at com.google.android.material.snackbar.Snackbar.make (Snackbar.java:170)
  at com.owncloud.android.utils.DisplayUtils.showSnackMessage (DisplayUtils.java:607)
  at com.nextcloud.ui.SetOnlineStatusBottomSheet.showErrorSnackbar (SetOnlineStatusBottomSheet.kt:101)
  at com.nextcloud.ui.SetOnlineStatusBottomSheet.setStatus$lambda$0 (SetOnlineStatusBottomSheet.kt:91)
  at com.nextcloud.ui.SetOnlineStatusBottomSheet.$r8$lambda$HvsEGhxHmnRpl-GuIHrqyPiZuaE (Unknown Source)
  at com.nextcloud.ui.SetOnlineStatusBottomSheet$$ExternalSyntheticLambda0.invoke (D8$$SyntheticClass)
  at com.nextcloud.client.core.Task.run$lambda$1 (Task.kt:42)
  at com.nextcloud.client.core.Task.$r8$lambda$u8Jjo5s6oNnFcuWJ1zRAVw6oOdU (Unknown Source)
  at com.nextcloud.client.core.Task$$ExternalSyntheticLambda1.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:210)
  at android.os.Looper.loop (Looper.java:299)
  at android.app.ActivityThread.main (ActivityThread.java:8337)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:556)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1037)
```

### Changes

Fixes crash
Adds missing translation
Deduplicate repeated codes 