### PR TITLE
fix(file-activity): loading dialog illegal-state-exception

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -41,6 +41,7 @@ import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.receiver.NetworkChangeListener;
 import com.nextcloud.receiver.NetworkChangeReceiver;
 import com.nextcloud.utils.EditorUtils;
+import com.nextcloud.utils.extensions.ActivityExtensionsKt;
 import com.nextcloud.utils.extensions.BundleExtensionsKt;
 import com.nextcloud.utils.extensions.FileExtensionsKt;
 import com.nextcloud.utils.extensions.IntentExtensionsKt;
@@ -562,13 +563,23 @@ public abstract class FileActivity extends DrawerActivity
      */
     public void showLoadingDialog(String message) {
         runOnUiThread(() -> {
+            if (!ActivityExtensionsKt.isActive(this)) {
+                Log_OC.w(TAG, "cannot show loading dialog, activity is finishing");
+                return;
+            }
+
             FragmentManager fragmentManager = getSupportFragmentManager();
             fragmentManager.executePendingTransactions();
             Fragment existingDialog = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);
 
             if (existingDialog instanceof LoadingDialog loadingDialog) {
                 Log_OC.d(TAG, "dismiss previous loading dialog");
-                loadingDialog.dismiss();
+
+                if (!fragmentManager.isStateSaved()) {
+                    loadingDialog.dismiss();
+                } else {
+                    loadingDialog.dismissAllowingStateLoss();
+                }
             }
 
             // Show new dialog
@@ -585,6 +596,11 @@ public abstract class FileActivity extends DrawerActivity
      */
     public void dismissLoadingDialog() {
         runOnUiThread(() -> {
+            if (!ActivityExtensionsKt.isActive(this)) {
+                Log_OC.w(TAG, "cannot dismiss loading dialog, activity is finishing");
+                return;
+            }
+
             FragmentManager fragmentManager = getSupportFragmentManager();
             fragmentManager.executePendingTransactions();
             Fragment fragment = fragmentManager.findFragmentByTag(DIALOG_WAIT_TAG);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

```
Exception java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
  at androidx.fragment.app.FragmentManager.checkStateLoss (FragmentManager.java:1862)
  at androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1902)
  at androidx.fragment.app.BackStackRecord.commitInternal (BackStackRecord.java:342)
  at androidx.fragment.app.BackStackRecord.commit (BackStackRecord.java:306)
  at androidx.fragment.app.DialogFragment.dismissInternal (DialogFragment.java:616)
  at androidx.fragment.app.DialogFragment.dismiss (DialogFragment.java:550)
  at com.owncloud.android.ui.activity.FileActivity.lambda$showLoadingDialog$0 (FileActivity.java:570)
  at com.owncloud.android.ui.activity.FileActivity.$r8$lambda$nnl4G_wZDgkvD6wdFZ2uoTUqJso (Unknown Source)
  at com.owncloud.android.ui.activity.FileActivity$$ExternalSyntheticLambda3.run (D8$$SyntheticClass)
  at android.app.Activity.runOnUiThread (Activity.java:7558)
  at com.owncloud.android.ui.activity.FileActivity.showLoadingDialog (FileActivity.java:564)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.lambda$syncFile$1 (FileOperationsHelper.java:222)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.$r8$lambda$Zjp8lEWqA9AaSFevrtcfzcD4bWI (Unknown Source)
  at com.owncloud.android.ui.helpers.FileOperationsHelper$$ExternalSyntheticLambda3.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8503)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:561)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:954)
```