### PR TITLE
fix(unified search): filename overflow issue

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchCurrentDirItemViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchCurrentDirItemViewHolder.kt
@@ -8,11 +8,11 @@
 package com.owncloud.android.ui.adapter
 
 import android.content.Context
+import android.view.View
 import com.afollestad.sectionedrecyclerview.SectionedViewHolder
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.account.User
 import com.nextcloud.client.preferences.AppPreferences
-import com.nextcloud.utils.extensions.setVisibleIf
 import com.owncloud.android.databinding.UnifiedSearchCurrentDirectoryItemBinding
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
@@ -38,10 +38,17 @@ class UnifiedSearchCurrentDirItemViewHolder(
     fun bind(file: OCFile) {
         val filenameWithExtension = storageManager.getFilenameConsideringOfflineOperation(file)
         val isFolder = file.isFolder
-        val (filename, extension) = FileStorageUtils.getFilenameAndExtension(filenameWithExtension, isFolder, isRTL)
-        binding.extension.setVisibleIf(!isFolder)
-        binding.extension.text = extension
-        binding.filename.text = filename
+        val containsBidiControlCharacters = FileStorageUtils.containsBidiControlCharacters(filenameWithExtension)
+
+        if (!containsBidiControlCharacters || isFolder) {
+            binding.extension.visibility = View.GONE
+            binding.filename.text = filenameWithExtension
+        } else {
+            val (filename, extension) = FileStorageUtils.getFilenameAndExtension(filenameWithExtension, false, isRTL)
+            binding.extension.text = extension
+            binding.filename.text = filename
+        }
+
         viewThemeUtils.platform.colorImageView(binding.thumbnail, ColorRole.PRIMARY)
         DisplayUtils.setThumbnail(
             file,

--- a/app/src/main/res/layout/unified_search_current_directory_item.xml
+++ b/app/src/main/res/layout/unified_search_current_directory_item.xml
@@ -35,32 +35,36 @@
         android:visibility="gone"
         app:corners="8" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/filename"
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/standard_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/more"
         app:layout_constraintStart_toEndOf="@+id/thumbnail"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:ellipsize="middle"
-        android:singleLine="true"
-        android:textColor="@color/text_color"
-        android:textSize="@dimen/two_line_primary_text_size"
-        tools:text="@string/placeholder_filename"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        app:layout_constraintTop_toTopOf="parent">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/extension"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/filename"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:ellipsize="middle"
-        android:singleLine="true"
-        android:textColor="@color/text_color"
-        android:textSize="@dimen/two_line_primary_text_size"
-        tools:text="@string/placeholder_extension"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/filename"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="middle"
+            android:singleLine="true"
+            android:textColor="@color/text_color"
+            android:textSize="@dimen/two_line_primary_text_size"
+            tools:text="@string/placeholder_filename" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/extension"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="middle"
+            android:singleLine="true"
+            android:textColor="@color/text_color"
+            android:textSize="@dimen/two_line_primary_text_size"
+            tools:text="@string/placeholder_extension" />
+
+    </LinearLayout>
 
     <ImageButton
         android:id="@+id/more"


### PR DESCRIPTION
This change addresses an issue where long filenames would overflow in the unified search results.

### Steps to reproduce
1. Open Nextcloud client
2. Create (or copy) a file with a long filename **in (/into) the current directory**
    - e.g. `The quick brown fox jumps over the lazy dog.md`
3. Open unified search and search for that file
4. Observe any text overflows

### Screenshots
Current Version on `master` | This Pull Request
--- | ---
<img width="500" height="889" alt="master" src="https://github.com/user-attachments/assets/3f209fd8-fac5-4b3b-8cd7-72619dbceae8" /> | <img width="500" height="889" alt="pr" src="https://github.com/user-attachments/assets/49dff6d2-195d-4088-99d3-d69f8d06d0a0" />

---
- [ ] Tests written, or not not needed
