### PR TITLE
make media folder detection worker silent

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/MediaFoldersDetectionWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/MediaFoldersDetectionWork.kt
@@ -221,7 +221,6 @@ class MediaFoldersDetectionWork(
             .setAutoCancel(true)
             .setSound(null)
             .setVibrate(null)
-            .setOnlyAlertOnce(true)
             .setSilent(true)
             .setContentIntent(pendingIntent)
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Whenver I create a folder media detection worker sends notification with sound and this can be annoying.
