### PR TITLE
fix(unified-search): screen state

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragmentScreenState.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragmentScreenState.kt
@@ -1,0 +1,38 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.ui.fragment
+
+import com.owncloud.android.R
+
+sealed class UnifiedSearchFragmentScreenState {
+
+    /**
+     * Content is being displayed (search results or current directory items)
+     */
+    object ShowingContent : UnifiedSearchFragmentScreenState()
+
+    /**
+     * Empty state with customizable message
+     */
+    data class Empty(val titleId: Int, val descriptionId: Int, val iconId: Int) : UnifiedSearchFragmentScreenState() {
+
+        companion object {
+            fun startSearch() = Empty(
+                titleId = R.string.file_list_empty_unified_search_start_search,
+                descriptionId = R.string.file_list_empty_unified_search_start_search_description,
+                iconId = R.drawable.ic_search_grey
+            )
+
+            fun noResults() = Empty(
+                titleId = R.string.file_list_empty_headline_server_search,
+                descriptionId = R.string.file_list_empty_unified_search_no_results,
+                iconId = R.drawable.ic_search_grey
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/IUnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/IUnifiedSearchViewModel.kt
@@ -8,10 +8,13 @@ package com.owncloud.android.ui.unifiedsearch
 
 import android.net.Uri
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.lib.common.SearchResultEntry
+import com.owncloud.android.ui.fragment.UnifiedSearchFragmentScreenState
 
 interface IUnifiedSearchViewModel {
+    val screenState: MutableLiveData<UnifiedSearchFragmentScreenState>
     val browserUri: LiveData<Uri>
     val error: LiveData<String>
     val file: LiveData<OCFile>
@@ -25,4 +28,5 @@ interface IUnifiedSearchViewModel {
     fun setQuery(query: String)
     fun openFile(remotePath: String)
     fun getRemoteFile(remotePath: String)
+    fun updateScreenState(state: UnifiedSearchFragmentScreenState)
 }

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -25,6 +25,7 @@ import com.owncloud.android.lib.common.SearchResult
 import com.owncloud.android.lib.common.SearchResultEntry
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.asynctasks.GetRemoteFileTask
+import com.owncloud.android.ui.fragment.UnifiedSearchFragmentScreenState
 import javax.inject.Inject
 
 @Suppress("LongParameterList")
@@ -53,6 +54,8 @@ class UnifiedSearchViewModel(application: Application) :
     private lateinit var repository: IUnifiedSearchRepository
     private var results: MutableMap<ProviderID, UnifiedSearchMetadata> = mutableMapOf()
 
+    override val screenState: MutableLiveData<UnifiedSearchFragmentScreenState> =
+        MutableLiveData(UnifiedSearchFragmentScreenState.ShowingContent)
     override val isLoading = MutableLiveData(false)
     override val searchResults = MutableLiveData<List<UnifiedSearchSection>>(mutableListOf())
     override val error = MutableLiveData("")
@@ -243,5 +246,9 @@ class UnifiedSearchViewModel(application: Application) :
     @VisibleForTesting
     fun setConnectivityService(connectivityService: ConnectivityService) {
         this.connectivityService = connectivityService
+    }
+
+    override fun updateScreenState(state: UnifiedSearchFragmentScreenState) {
+        screenState.value = state
     }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Unified search shows start search state along with result state.

<img width="415" alt="Screenshot_20260130_143802" src="https://github.com/user-attachments/assets/9e9ca0a2-7478-43b8-99f0-2c023bd5ffc5" />

### How to reproduce?

1. Try to search something doesn't exists
2. Search again something exists
