### PR TITLE
fix(manage-space-activity): app in foreground

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/metadata/MetadataWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/metadata/MetadataWorker.kt
@@ -35,6 +35,11 @@ class MetadataWorker(private val context: Context, params: WorkerParameters, pri
             return Result.failure()
         }
 
+        if (user.isAnonymous) {
+            Log_OC.w(TAG, "user is anonymous cannot start metadata worker")
+            return Result.failure()
+        }
+
         val storageManager = FileDataStorageManager(user, context.contentResolver)
         val currentDir = storageManager.getFileByDecryptedRemotePath(filePath)
         if (currentDir == null) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
+import androidx.work.WorkManager
 import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.android.common.ui.util.extensions.applyEdgeToEdgeWithSystemBarPadding
 import com.nextcloud.client.account.UserAccountManager
@@ -61,6 +62,9 @@ class ManageSpaceActivity :
     @Suppress("MagicNumber")
     private suspend fun clearData() {
         withContext(Dispatchers.IO) {
+            // cancel all works
+            WorkManager.getInstance(this@ManageSpaceActivity).cancelAllWork()
+
             val lockPref = preferences.lockPreference
             val passCodeEnable = SettingsActivity.LOCK_PASSCODE == lockPref
             var passCodeDigits = arrayOfNulls<String>(4)
@@ -87,6 +91,7 @@ class ManageSpaceActivity :
             val result = clearApplicationData()
             withContext(Dispatchers.Main) {
                 if (result) {
+                    finishAffinity()
                     finishAndRemoveTask()
                     exitProcess(0)
                 } else {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -840,6 +840,10 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             return;
         }
 
+        if (userId == null) {
+            return;
+        }
+
         helper.prepareFileList(directory,
                                adapterDataProvider,
                                onlyOnDevice,


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

App is crashing when user trying to open the app after deleting data.

### How to reproduce?

1. Open the app and log in.
2. Send the app to the background.
3. Go to the app’s settings.
4. Begin the process to delete the app’s data and confirm.
5. Attempt to reopen the app afterward.