### PR TITLE
fix(file-listing): action bar title after preview

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1368,6 +1368,7 @@ class FileDisplayActivity :
         } else if (!ocFileListFragment.isSearchFragment && startFile == null) {
             ocFileListFragment.listDirectory(MainApp.isOnlyOnDevice())
             ocFileListFragment.registerFabListener()
+            updateActionBarTitleAndHomeButton(currentDir)
         } else {
             ocFileListFragment.listDirectory(startFile, false)
             updateActionBarTitleAndHomeButton(startFile)


### PR DESCRIPTION


<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [x] Tests written, or not not needed

### Issue

Last opened PDF file name appears in action bar.

### How to reproduce?

1. Upload large pdf file along with multiple images
2. Open large pdf file press back
3. Open image file press back
4. Action bar title still showing the pdf file's name