### PR TITLE
refactor: simplify LinkShareViewHolder.setSubline()

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/LinkShareViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/LinkShareViewHolder.kt
@@ -98,26 +98,33 @@ internal class LinkShareViewHolder(itemView: View) : RecyclerView.ViewHolder(ite
         }
     }
 
-    private fun setSubline(binding: FileDetailsShareLinkShareItemBinding?, context: Context?, publicShare: OCShare) {
+    /**
+     * Displays download limit information when available, hides subline otherwise.
+     * Clears text on hide to prevent RecyclerView item reuse issues.
+     */
+    private fun setSubline(
+        binding: FileDetailsShareLinkShareItemBinding?,
+        context: Context?,
+        publicShare: OCShare
+    ) {
         if (binding == null || context == null) {
             return
         }
 
-        val downloadLimit = publicShare.fileDownloadLimit
-        if (downloadLimit != null) {
-            val remaining = publicShare.remainingDownloadLimit() ?: return
-            val text = context.resources.getQuantityString(
+        val remaining = publicShare.remainingDownloadLimit()
+
+        if (remaining != null) {
+            val binding.subline.text = context.resources.getQuantityString(
                 R.plurals.share_download_limit_description,
                 remaining,
                 remaining
             )
-
-            binding.subline.text = text
             binding.subline.visibility = View.VISIBLE
-            return
+        } else {
+            // No download limit set at all
+            binding.subline.text = ""
+            binding.subline.visibility = View.GONE
         }
-
-        binding.subline.visibility = View.GONE
     }
 
     private fun setPermissionName(

--- a/app/src/main/java/com/owncloud/android/ui/adapter/LinkShareViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/LinkShareViewHolder.kt
@@ -111,19 +111,19 @@ internal class LinkShareViewHolder(itemView: View) : RecyclerView.ViewHolder(ite
             return
         }
 
-        val remaining = publicShare.remainingDownloadLimit()
+        val remaining = publicShare.remainingDownloadLimit()?.coerceAtLeast(0)
 
-        if (remaining != null) {
+        if (remaining == null) {
+            // No download limit set at all
+            binding.subline.text = ""
+            binding.subline.visibility = View.GONE
+        } else {
             val binding.subline.text = context.resources.getQuantityString(
                 R.plurals.share_download_limit_description,
                 remaining,
                 remaining
             )
             binding.subline.visibility = View.VISIBLE
-        } else {
-            // No download limit set at all
-            binding.subline.text = ""
-            binding.subline.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -43,6 +43,7 @@ import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.theme.CapabilityUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import java.text.NumberFormat
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailsSharingProcessFragment.kt
@@ -42,6 +42,7 @@ import com.owncloud.android.utils.ClipboardUtil
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.theme.CapabilityUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
+import java.text.NumberFormat
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -491,22 +492,24 @@ class FileDetailsSharingProcessFragment :
         }
     }
 
+    /**
+     * Pre-fills download limit controls with current remaining count for existing share.
+     * Clamps negative values to 0. Returns early if no limit is set.
+     */
     private fun updateFileDownloadLimitView() {
         if (!canSetDownloadLimit()) {
             return
         }
 
-        // user can set download limit thus no need to rely on current limit to show download limit
-        showFileDownloadLimitInput(true)
+        showFileDownloadLimitInput(true) // only other option
         binding.shareProcessSetDownloadLimitSwitch.visibility = View.VISIBLE
         binding.shareProcessSetDownloadLimitInput.visibility = View.VISIBLE
 
-        val currentLimit = share?.remainingDownloadLimit() ?: return
-        if (currentLimit > 0) {
-            binding.shareProcessSetDownloadLimitSwitch.isChecked = true
-            binding.shareProcessSetDownloadLimitInput.setText(
-                "%d".format(Locale.getDefault(), currentLimit)
-            )
+        val currentLimit = share?.remainingDownloadLimit()?.coerceAtLeast(0) ?: return
+
+        binding.shareProcessSetDownloadLimitSwitch.isChecked = true
+        binding.shareProcessSetDownloadLimitInput.setText(
+            NumberFormat.getInstance(Locale.getDefault()).format(currentLimit)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1452,6 +1452,7 @@
     <string name="set_download_limit_failed">Unable to set download limit. Please check capabilities.</string>
     <string name="download_limit">Download limit</string>
     <plurals name="share_download_limit_description">
+        <item quantity="zero">No downloads remaining</item>
         <item quantity="one">%1$d download remaining</item>
         <item quantity="other">%1$d downloads remaining</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1456,6 +1456,9 @@
         <item quantity="one">%1$d download remaining</item>
         <item quantity="other">%1$d downloads remaining</item>
     </plurals>
+    <string name="share_download_limit_required">Download limit is required</string>
+    <string name="share_download_limit_invalid">Please enter a valid number</string>
+    <string name="share_download_limit_must_be_positive">Download limit must be greater than 0</string>
     <string name="sign_tos_failed">Please manually check terms of service!</string>
     <string name="terms_of_service_title">Terms of service</string>
     <string name="terms_of_services_agree">I agree to the above ToS</string>


### PR DESCRIPTION
Changes:
- fix: Replace toInt() with NumberFormat.parse() to handle locale-specific grouping separators (e.g., "1,000" or "1.000"). Add validation for empty and negative inputs with inline error messages.
- refactor: use NumberFormat consistently
- refactor: remove redundant null check (already handled by remainingDownloadLimit())
- refactor: miscellaneous code tidying
- docs: miscellaneous additions/clarifications/tidying

Also addresses CI/CD detekt output:
```
/home/runner/actions-runner/_work/android/android/app/src/main/java/com/owncloud/android/ui/adapter/LinkShareViewHolder.kt - 10min debt
	ReturnCount - [Function setSubline has 3 return statements which exceeds the limit of 2.] at /home/runner/actions-runner/_work/android/android/app/src/main/java/com/owncloud/android/ui/adapter/LinkShareViewHolder.kt:101:17
```

No functional changes - simplifies logic while maintaining identical behavior.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
