### PR TITLE
fix(assistant): resolve LocalContext resource query in LaunchedEffect

### DIFF
--- a/app/src/main/java/com/nextcloud/client/assistant/translate/TranslationScreen.kt
+++ b/app/src/main/java/com/nextcloud/client/assistant/translate/TranslationScreen.kt
@@ -64,10 +64,9 @@ import com.owncloud.android.utils.ClipboardUtil
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TranslationScreen(viewModel: TranslationViewModel, assistantViewModel: AssistantViewModel) {
-    val context = LocalContext.current
     val state by viewModel.screenState.collectAsState()
     val messageId by viewModel.snackbarMessageId.collectAsState()
-    val snackbarMessage = messageId?.let { context.getString(it) }
+    val message = messageId?.let { stringResource(it) }
     val snackbarHostState = remember { SnackbarHostState() }
 
     BackHandler {
@@ -75,8 +74,8 @@ fun TranslationScreen(viewModel: TranslationViewModel, assistantViewModel: Assis
         assistantViewModel.updateScreenState(AssistantScreenState.TaskContent)
     }
 
-    LaunchedEffect(snackbarMessage) {
-        snackbarMessage?.let {
+    LaunchedEffect(message) {
+        message?.let {
             snackbarHostState.showSnackbar(it)
             viewModel.updateSnackbarMessage(null)
         }


### PR DESCRIPTION
**Fixes lint error: `"Querying resource values using LocalContext.current"`**

Extract string resource retrieval outside `LaunchedEffect` to ensure proper recomposition on configuration changes. This resolves the `LocalContextGetResourceValueCall` lint error and prevents stale snackbar messages when configuration changes occur (e.g., language switches, dark mode toggles).

The snackbar message string is now computed in the composable body where `LocalContext.current` changes trigger recomposition, ensuring the `LaunchedEffect` always receives up-to-date string values.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
