### PR TITLE
fix(manifest): Move camera2 feature declaration to scan-enabled flavors

### DIFF
--- a/app/src/gplay/AndroidManifest.xml
+++ b/app/src/gplay/AndroidManifest.xml
@@ -15,6 +15,12 @@
 
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
+    <!-- Used for document scanning, but lib declares it as required, which it's not -->
+    <uses-feature
+        android:name="android.hardware.camera2"
+        android:required="false"
+        tools:node="replace" />
+
     <application
         android:name=".MainApp"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/huawei/AndroidManifest.xml
+++ b/app/src/huawei/AndroidManifest.xml
@@ -9,6 +9,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Used for document scanning, but lib declares it as required, which it's not -->
+    <uses-feature
+        android:name="android.hardware.camera2"
+        android:required="false"
+        tools:node="replace" />
+
     <application
         android:name=".MainApp"
         android:fullBackupContent="@xml/backup_config"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,13 +11,9 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
-    <uses-permission android:name="android.permission.WRITE_CALENDAR" /> <!-- Used for document scanning, but lib declares it as required, which it's not -->
-    <uses-feature
-        android:name="android.hardware.camera2"
-        android:required="false"
-        tools:node="replace" />
-    <!--
- WRITE_EXTERNAL_STORAGE may be enabled or disabled by the user after installation in
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <!-- 
+        WRITE_EXTERNAL_STORAGE may be enabled or disabled by the user after installation in
         API >= 23; the app needs to handle this
     -->
     <uses-permission

--- a/app/src/qa/AndroidManifest.xml
+++ b/app/src/qa/AndroidManifest.xml
@@ -8,6 +8,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Used for document scanning, but lib declares it as required, which it's not -->
+    <uses-feature
+        android:name="android.hardware.camera2"
+        android:required="false"
+        tools:node="replace" />
+
     <application
         android:allowBackup="false"
         tools:replace="android:allowBackup" />


### PR DESCRIPTION
Moving to flavor-specific manifests to avoid warning about `tools:node="replace"` for builds that don't have scanning/camera2

Eliminates this check (lint) warning:

```
> Task :app:processGenericDebugMainManifest
/home/runner/work/android/android/app/src/debug/AndroidManifest.xml Warning:
	uses-feature#android.hardware.camera2 was tagged at AndroidManifest.xml:0 to replace another declaration but no other declaration present
```
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
