### PR TITLE
build(app): remove redundant room schema location from annotationProc…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,10 +107,6 @@ android {
         buildConfigField("boolean", "CI", ciBuild.toString())
         buildConfigField("boolean", "RUNTIME_PERF_ANALYSIS", perfAnalysis.toString())
 
-        javaCompileOptions.annotationProcessorOptions {
-            arguments += mapOf("room.schemaLocation" to "$projectDir/schemas")
-        }
-
         // arguments to be passed to functional tests
         testInstrumentationRunner = if (shotTest) "com.karumi.shot.ShotTestRunner"
         else "com.nextcloud.client.TestRunner"


### PR DESCRIPTION
…essorOptions

Removes the 'room.schemaLocation' argument from the general annotationProcessorOptions block in app/build.gradle.kts. Fixes this warning in the build chain:
```
warning: The following options were not recognized by any processor: '[room.schemaLocation, kapt.kotlin.generated]'
```

Since KSP is already used for the Room compiler, the schema location is already correctly provided via 'ksp.arg'. Leaving it in the general javaCompileOptions caused Kapt to pass the argument to other processors (like prism4j), resulting in "unrecognized options" warnings during compilation.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [x] Tests written, or not not needed
