### PR TITLE
refactor(test): use DAO injection for ArbitraryDataProviderImpl in TestActivity

### DIFF
--- a/app/src/debug/java/com/nextcloud/test/TestActivity.kt
+++ b/app/src/debug/java/com/nextcloud/test/TestActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.nextcloud.client.database.NextcloudDatabase
 import com.nextcloud.client.jobs.download.FileDownloadWorker
 import com.nextcloud.client.jobs.upload.FileUploadHelper
 import com.nextcloud.client.network.Connectivity
@@ -131,7 +132,9 @@ class TestActivity :
                 userAccountManager,
                 connectivityServiceMock,
                 EditorUtils(
-                    ArbitraryDataProviderImpl(baseContext)
+                    ArbitraryDataProviderImpl(
+                        NextcloudDatabase.getInstance(baseContext).arbitraryDataDao()
+                    )
                 )
             )
         }


### PR DESCRIPTION
One less layer in the deprecation stack; better alignment with #11050.

Deprecation stack: ~~Context constructor~~ → `NextcloudDatabase.getInstance(context)` (deprecated but intended for legacy use) → `arbitraryDataDao()`

In response to this **check (lint)** warning:
```
w: file:///home/runner/work/android/android/app/src/debug/java/com/nextcloud/test/TestActivity.kt:134:21 'constructor(context: Context!): ArbitraryDataProviderImpl' is deprecated. Deprecated in Java.
```

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [x] Tests written, or not not needed
