### PR TITLE
build(User/Account): update deprecation notes and add to overrides

### DIFF
--- a/app/src/main/java/com/nextcloud/client/account/AnonymousUser.kt
+++ b/app/src/main/java/com/nextcloud/client/account/AnonymousUser.kt
@@ -49,10 +49,16 @@ internal data class AnonymousUser(private val accountType: String) :
     override val server = Server(URI.create(""), MainApp.MINIMUM_SUPPORTED_SERVER_VERSION)
     override val isAnonymous = true
 
-    @Deprecated("Temporary workaround: Legacy Android Account access. Refactor code to use User object directly instead of platform Account.")
+    @Deprecated(
+        "Temporary workaround: Legacy Android Account access. Refactor code to use User object " +
+            "directly instead of platform Account."
+    )
     override fun toPlatformAccount(): Account = Account(accountName, accountType)
 
-    @Deprecated("Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object directly instead of OwnCloudAccount.")
+    @Deprecated(
+        "Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object " +
+            "directly instead of OwnCloudAccount."
+    )
     override fun toOwnCloudAccount(): OwnCloudAccount = OwnCloudAccount(Uri.EMPTY, OwnCloudBasicCredentials("", ""))
 
     override fun nameEquals(user: User?): Boolean = user?.accountName.equals(accountName, true)

--- a/app/src/main/java/com/nextcloud/client/account/MockUser.kt
+++ b/app/src/main/java/com/nextcloud/client/account/MockUser.kt
@@ -44,10 +44,16 @@ data class MockUser(override val accountName: String, val accountType: String) :
     override val server = Server(URI.create(""), MainApp.MINIMUM_SUPPORTED_SERVER_VERSION)
     override val isAnonymous = false
 
-    @Deprecated("Temporary workaround: Legacy Android Account access. Refactor code to use User object directly instead of platform Account.")
+    @Deprecated(
+        "Temporary workaround: Legacy Android Account access. Refactor code to use User object " +
+            "directly instead of platform Account."
+    )
     override fun toPlatformAccount(): Account = Account(accountName, accountType)
 
-    @Deprecated("Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object directly instead of OwnCloudAccount.")
+    @Deprecated(
+        "Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object " +
+            "directly instead of OwnCloudAccount."
+    )
     override fun toOwnCloudAccount(): OwnCloudAccount = OwnCloudAccount(Uri.EMPTY, OwnCloudBasicCredentials("", ""))
 
     override fun nameEquals(user: User?): Boolean = user?.accountName.equals(accountName, true)

--- a/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt
+++ b/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt
@@ -41,10 +41,16 @@ internal data class RegisteredUser(
         return account.name
     }
 
-    @Deprecated("Temporary workaround: Legacy Android Account access. Refactor code to use User object directly instead of platform Account.")
+    @Deprecated(
+        "Temporary workaround: Legacy Android Account access. Refactor code to use User object " +
+            "directly instead of platform Account."
+    )
     override fun toPlatformAccount(): Account = account
 
-    @Deprecated("Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object directly instead of OwnCloudAccount.")
+    @Deprecated(
+        "Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object " +
+            "directly instead of OwnCloudAccount."
+    )
     override fun toOwnCloudAccount(): OwnCloudAccount = ownCloudAccount
 
     override fun nameEquals(user: User?): Boolean = nameEquals(user?.accountName)

--- a/app/src/main/java/com/nextcloud/client/account/User.kt
+++ b/app/src/main/java/com/nextcloud/client/account/User.kt
@@ -27,7 +27,10 @@ interface User :
      *
      * @return Account instance that is associated with this User object.
      */
-    @Deprecated("Temporary workaround: Legacy Android Account access. Refactor code to use User object directly instead of platform Account.")
+    @Deprecated(
+        "Temporary workaround: Legacy Android Account access. Refactor code to use User object " +
+            "directly instead of platform Account."
+    )
     override fun toPlatformAccount(): Account
 
     /**
@@ -39,7 +42,10 @@ interface User :
      *
      * @return OwnCloudAccount instance that is associated with this User object.
      */
-    @Deprecated("Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object directly instead of OwnCloudAccount.")
+    @Deprecated(
+        "Temporary workaround: Legacy OwnCloudAccount access. Refactor code to use User object " +
+            "directly instead of OwnCloudAccount."
+    )
     fun toOwnCloudAccount(): OwnCloudAccount
 
     /**


### PR DESCRIPTION
Addresses lint warnings like these:
```
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/AnonymousUser.kt:52:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/AnonymousUser.kt:54:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/MockUser.kt:47:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/MockUser.kt:49:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt:33:16 'fun <T : Parcelable!> readParcelable(p0: ClassLoader?): T?' is deprecated. Deprecated in Java.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt:34:16 'fun <T : Parcelable!> readParcelable(p0: ClassLoader?): T?' is deprecated. Deprecated in Java.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt:35:16 'fun <T : Parcelable!> readParcelable(p0: ClassLoader?): T?' is deprecated. Deprecated in Java.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt:44:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/account/RegisteredUser.kt:46:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
```

Also makes the deprecation notice a bit more informative.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [x] Tests written, or not not needed
