### PR TITLE
fix lint

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,6 @@
     <string name="assistant_task_status_failed">failed</string>
 
     <!-- Translation Screen -->
-    <string name="assistant_screen_select_task">Please select task</string>
     <string name="translation_screen_label_from">Translate from: </string>
     <string name="translation_screen_label_to">Translate to: </string>
     <string name="translation_screen_translating">Translating…</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,9 @@ android.nonTransitiveRClass=true
 
 
 # JVM arguments to optimize heap usage, enable heap dump on out-of-memory errors, and set the file encoding
-org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
 org.gradle.dependency.verification.console=verbose
-kotlin.daemon.jvmargs=-Xmx3g -XX:+UseParallelGC
+kotlin.daemon.jvmargs=-Xmx4g -XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->



Removes unused resource: `assistant_screen_select_task`

Fixes:

```
The Daemon will expire after the build after running out of JVM Metaspace.
The project memory settings are likely not configured or are configured to an insufficient value.
The daemon will restart for the next build, which may increase subsequent build times.
These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
The currently configured max heap space is '2 GiB' and the configured max metaspace is '512 MiB'.
For more information on how to set these values, please refer to https://docs.gradle.org/9.3.1/userguide/build_environment.html#sec:configuring_jvm_memory in the Gradle documentation.
To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'.
Daemon will be stopped at the end of the build after running out of JVM Metaspace
```
