### PR TITLE
chore(core): suppress unchecked cast warning in LocalConnection

### DIFF
--- a/app/src/main/java/com/nextcloud/client/core/LocalConnection.kt
+++ b/app/src/main/java/com/nextcloud/client/core/LocalConnection.kt
@@ -78,6 +78,7 @@ abstract class LocalConnection<S : Service>(protected val context: Context) : Se
         if (binder !is LocalBinder<*>) {
             throw IllegalStateException("Binder is not extending ${LocalBinder::class.java.name}")
         }
+        @Suppress("UNCHECKED_CAST") // Safe: type S guaranteed by service binding contract
         serviceBinder = binder as LocalBinder<S>
         onBound(binder)
     }


### PR DESCRIPTION
Fixes:
```
w: file:///home/runner/work/android/android/app/src/main/java/com/nextcloud/client/core/LocalConnection.kt:81:32 Unchecked cast of 'LocalBinder<*>' to 'LocalBinder<S (of class LocalConnection<S : Service>)>'.
```
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [x] Tests written, or not not needed
