### PR TITLE
Forbid to change extension with template

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.kt
@@ -310,7 +310,9 @@ class ChooseRichDocumentsTemplateDialogFragment :
                     ignoreCase = true
                 )
             )
-        val isEnable = isExtension && errorMessage == null
+        val isChangedExtension = name.substringAfterLast(DOT) != selectedTemplate?.extension
+
+        val isEnable = isExtension && !isChangedExtension && errorMessage == null
 
         positiveButton?.let {
             it.isEnabled = isEnable
@@ -320,7 +322,11 @@ class ChooseRichDocumentsTemplateDialogFragment :
         binding.filenameContainer.run {
             isErrorEnabled = !isEnable
             error = if (!isEnable) {
-                errorMessage ?: getText(R.string.filename_empty)
+                when {
+                    errorMessage != null -> errorMessage
+                    isChangedExtension -> getString(R.string.extension_cannot_be_changed)
+                    else -> getText(R.string.filename_empty)
+                }
             } else {
                 null
             }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseTemplateDialogFragment.kt
@@ -275,16 +275,18 @@ class ChooseTemplateDialogFragment :
 
         val isNameValid = (errorMessage == null) && !name.equals(DOT + selectedTemplate?.extension, ignoreCase = true)
         val isHiddenFileName = FileNameValidator.isFileHidden(name)
+        val isChangedExtension = name.substringAfterLast(DOT) != selectedTemplate?.extension
 
-        binding.filenameContainer.isErrorEnabled = !isNameValid || isHiddenFileName
+        binding.filenameContainer.isErrorEnabled = !isNameValid || isHiddenFileName || isChangedExtension
         binding.filenameContainer.error = when {
             !isNameValid -> errorMessage ?: getString(R.string.enter_filename)
             isHiddenFileName -> getText(R.string.hidden_file_name_warning)
+            isChangedExtension -> getString(R.string.extension_cannot_be_changed)
             else -> null
         }
 
         positiveButton?.apply {
-            isEnabled = isNameValid && !isHiddenFileName
+            isEnabled = isNameValid && !isHiddenFileName && !isChangedExtension
             isClickable = isEnabled
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1504,4 +1504,5 @@
     <string name="sync_conflict_notification_title">File upload conflicts</string>
     <string name="sync_conflict_notification_description">Upload conflicts detected. Open uploads to resolve.</string>
     <string name="sync_conflict_notification_action_title">Resolve conflicts</string>
+    <string name="extension_cannot_be_changed">Extension cannot be changed</string>
 </resources>


### PR DESCRIPTION
This will create otherwise a non-expected file, e.g template with ".md" is selected, but ".txt" is file name.

To test:
- select template or no
- see default extension
- change extension
--> dialog cannot be confirmed