### PR TITLE
fix(auto-upload): expedited work

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -501,7 +501,6 @@ internal class BackgroundJobManagerImpl(
             jobName = JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID
         )
             .setInputData(arguments)
-            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .setConstraints(constraints)
             .setBackoffCriteria(
                 BackoffPolicy.LINEAR,


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->


### Cause of error
Exception in thread "main" java.lang.IllegalArgumentException: Expedited jobs only support network and storage constraints
    at androidx.work.WorkRequest$Builder.build(WorkRequest.kt:302)
    at com.nextcloud.client.jobs.BackgroundJobManagerImpl.startAutoUpload(BackgroundJobManagerImpl.kt:511)
    at com.owncloud.android.utils.FilesSyncHelper.startAutoUploadForEnabledSyncedFolders(FilesSyncHelper.kt:52)
    at com.owncloud.android.MainApp.lambda$new$0(MainApp.java:392)
    at com.owncloud.android.MainApp.$r8$lambda$oCtB6k620EEvDHJD80ppjAsFQwE(Unknown Source:0)
    at com.owncloud.android.MainApp$$ExternalSyntheticLambda0.onStateChanged(D8$$SyntheticClass:0)
    at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.jvm.kt:316)
    at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.jvm.kt:253)
    at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.jvm.kt:291)
    at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.jvm.kt:136)
    at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.jvm.kt:119)
    at androidx.lifecycle.ProcessLifecycleOwner.activityStarted$lifecycle_process(ProcessLifecycleOwner.kt:92)
    at androidx.lifecycle.ProcessLifecycleOwner$attach$1$onActivityPreCreated$1.onActivityPostStarted(ProcessLifecycleOwner.kt:156)
    at android.app.Activity.dispatchActivityPostStarted(Activity.java:1669)
    at android.app.Activity.performStart(Activity.java:9601)
    at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4744)
    at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:214)
    at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:194)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:166)
    at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:101)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:3150)
    at android.os.Handler.dispatchMessage(Handler.java:110)
    at android.os.Looper.loopOnce(Looper.java:273)
    at android.os.Looper.loop(Looper.java:363)
    at android.app.ActivityThread.main(ActivityThread.java:10060)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)



