### PR TITLE
fix(file-detail): show snackbar crash

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -186,7 +186,10 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
             return Unit.INSTANCE;
         }, () -> {
             showShareContainer();
-            DisplayUtils.showSnackMessage(getView(), R.string.error_fetching_sharees);
+            final var view = getView();
+            if (view != null) {
+                DisplayUtils.showSnackMessage(view, R.string.error_fetching_sharees);
+            }
             return Unit.INSTANCE;
         });
     }
@@ -411,7 +414,10 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
         OwnCloudAccount account = accountManager.getCurrentOwnCloudAccount();
 
         if (account == null) {
-            DisplayUtils.showSnackMessage(getView(), getString(R.string.could_not_retrieve_url));
+            final var view = getView();
+            if (view != null) {
+                DisplayUtils.showSnackMessage(view, getString(R.string.could_not_retrieve_url));
+            }
             return;
         }
 
@@ -575,7 +581,10 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
         }
 
         if (internalShareeListAdapter == null) {
-            DisplayUtils.showSnackMessage(getView(), getString(R.string.could_not_retrieve_shares));
+            final var view = getView();
+            if (view != null) {
+                DisplayUtils.showSnackMessage(view, getString(R.string.could_not_retrieve_shares));
+            }
             return;
         }
 
@@ -728,7 +737,10 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                 fileDataStorageManager.updateFileEntity(entity);
             }
         } else {
-            DisplayUtils.showSnackMessage(getView(), getString(R.string.failed_update_ui));
+            final var view = getView();
+            if (view != null) {
+                DisplayUtils.showSnackMessage(view, getString(R.string.failed_update_ui));
+            }
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.res.Resources android.view.View.getResources()' on a null object reference
  at com.google.android.material.snackbar.Snackbar.make (Snackbar.java:191)
  at com.owncloud.android.utils.DisplayUtils.showSnackMessage (DisplayUtils.java:634)
  at com.owncloud.android.ui.fragment.FileDetailSharingFragment.lambda$fetchSharees$1 (FileDetailSharingFragment.java:189)
  at com.owncloud.android.ui.fragment.FileDetailSharingFragment.$r8$lambda$YWJAJ2t4LoLqlEaRn1FST1E5QaY (Unknown Source)
  at com.owncloud.android.ui.fragment.FileDetailSharingFragment$$ExternalSyntheticLambda9.invoke (D8$$SyntheticClass)
  at com.owncloud.android.ui.fragment.share.RemoteShareRepository$fetchSharees$1$1.invokeSuspend (RemoteShareRepository.kt:54)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:101)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8757)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
```