### PR TITLE
check nullability of assistant

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -325,7 +325,13 @@ public abstract class DrawerActivity extends ToolbarActivity
 
     @SuppressFBWarnings("RV")
     private void checkAssistantBottomNavigationMenu() {
-        boolean isAssistantAvailable = getCapabilities().getAssistant().isTrue();
+        final var capability = getCapabilities();
+        boolean isAssistantAvailable;
+        if (capability == null) {
+            isAssistantAvailable = false;
+        } else {
+            isAssistantAvailable = capability.getAssistant().isTrue();
+        }
 
         bottomNavigationView
             .getMenu()


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

```
Exception java.lang.RuntimeException: Unable to start activity ComponentInfo{com.nextcloud.client/com.owncloud.android.ui.activity.FileDisplayActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'com.owncloud.android.lib.resources.status.CapabilityBooleanType com.owncloud.android.lib.resources.status.OCCapability.getAssistant()' on a null object reference
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:4049)
  at android.app.ActivityThread.handleLaunchActivity (ActivityThread.java:4236)
  at android.app.servertransaction.LaunchActivityItem.execute (LaunchActivityItem.java:112)
  at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem (TransactionExecutor.java:174)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:109)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:81)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2637)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:232)
  at android.os.Looper.loop (Looper.java:317)
  at android.app.ActivityThread.main (ActivityThread.java:8751)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:580)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:892)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'com.owncloud.android.lib.resources.status.CapabilityBooleanType com.owncloud.android.lib.resources.status.OCCapability.getAssistant()' on a null object reference
  at com.owncloud.android.ui.activity.DrawerActivity.checkAssistantBottomNavigationMenu (DrawerActivity.java:328)
  at com.owncloud.android.ui.activity.DrawerActivity.setupDrawer (DrawerActivity.java:274)
  at com.owncloud.android.ui.activity.FileDisplayActivity.onCreate (FileDisplayActivity.kt:281)
  at android.app.Activity.performCreate (Activity.java:9002)
  at android.app.Activity.performCreate (Activity.java:8980)
  at android.app.Instrumentation.callActivityOnCreate (Instrumentation.java:1527)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:4031)
```