### PR TITLE
fix(gallery): image job cancellation

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/gallery/GalleryImageGenerationJob.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/gallery/GalleryImageGenerationJob.kt
@@ -108,8 +108,7 @@ class GalleryImageGenerationJob(private val user: User, private val storageManag
             }
 
             setThumbnail(bitmap, file, imageView, newImage, listener)
-        } catch (e: Exception) {
-            Log_OC.e(TAG, "gallery image generation job: ", e)
+        } catch (_: Exception) {
             withContext(Dispatchers.Main) {
                 listener.onError()
             }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -420,10 +420,15 @@ class OCFileListDelegate(
         showShareAvatar = bool
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun cleanup() {
         ioScope.cancel()
 
-        GalleryImageGenerationJob.cancelAllActiveJobs()
+        try {
+            GalleryImageGenerationJob.cancelAllActiveJobs()
+        } catch (e: Exception) {
+            Log_OC.e(TAG, "exception: ", e)
+        }
 
         // cancel async tasks from ThumbnailsCacheManager
         cancelAllPendingTasks()


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

The crash happened because toList() calculates the size of the map and then iterates through it but this method is not lifecycle aware thus  if a "weak" entry was cleared after the size was calculated but before the iteration finished, the internal calculation will become wrong.

```
Exception java.lang.IllegalArgumentException: Illegal Capacity: -1
  at java.util.ArrayList.<init> (ArrayList.java:167)
  at java.util.WeakHashMap$EntrySet.deepCopy (WeakHashMap.java:1002)
  at java.util.WeakHashMap$EntrySet.toArray (WeakHashMap.java:1009)
  at java.util.ArrayList.<init> (ArrayList.java:188)
  at kotlin.collections.CollectionsKt___CollectionsKt.toMutableList (_Collections.kt:1366)
  at kotlin.collections.CollectionsKt___CollectionsKt.toList (_Collections.kt:1347)
  at com.nextcloud.client.jobs.gallery.GalleryImageGenerationJob$Companion.cancelAllActiveJobs (GalleryImageGenerationJob.kt:44)
  at com.owncloud.android.ui.adapter.OCFileListDelegate.cleanup (OCFileListDelegate.kt:415)
  at com.owncloud.android.ui.adapter.GalleryAdapter.cleanup (GalleryAdapter.kt:398)
  at com.owncloud.android.ui.fragment.GalleryFragment.onDestroyView (GalleryFragment.java:124)
  at androidx.fragment.app.Fragment.performDestroyView (Fragment.java:3362)
  at androidx.fragment.app.FragmentStateManager.destroyFragmentView (FragmentStateManager.java:797)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:352)
  at androidx.fragment.app.SpecialEffectsController$FragmentStateManagerOperation.complete$fragment_release (SpecialEffectsController.kt:846)
  at androidx.fragment.app.SpecialEffectsController.commitEffects$fragment_release (SpecialEffectsController.kt:446)
  at androidx.fragment.app.SpecialEffectsController.executePendingOperations (SpecialEffectsController.kt:288)
  at androidx.fragment.app.FragmentManager.executeOpsTogether (FragmentManager.java:2227)
  at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute (FragmentManager.java:2109)
  at androidx.fragment.app.FragmentManager.execPendingActions (FragmentManager.java:2052)
  at androidx.fragment.app.FragmentManager.executePendingTransactions (FragmentManager.java:779)
  at com.owncloud.android.ui.activity.FileDisplayActivity.handleSpecialIntents (FileDisplayActivity.kt:583)
  at com.owncloud.android.ui.activity.FileDisplayActivity.onNewIntent (FileDisplayActivity.kt:557)
  at android.app.Activity.onNewIntent (Activity.java:2504)
  at android.app.Activity.performNewIntent (Activity.java:9267)
  at android.app.Instrumentation.callActivityOnNewIntent (Instrumentation.java:1659)
  at android.app.Instrumentation.internalCallActivityOnNewIntent (Instrumentation.java:1680)
  at android.app.Instrumentation.callActivityOnNewIntent (Instrumentation.java:1668)
  at android.app.ActivityThread.deliverNewIntents (ActivityThread.java:4977)
  at android.app.ActivityThread.handleNewIntent (ActivityThread.java:4987)
  at android.app.servertransaction.NewIntentItem.execute (NewIntentItem.java:69)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:63)
  at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem (TransactionExecutor.java:133)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:103)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:80)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:3043)
  at android.os.Handler.dispatchMessage (Handler.java:120)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:339)
  at android.app.ActivityThread.main (ActivityThread.java:9785)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:618)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1022)
```