### PR TITLE
fix(client-integration): icon crash

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/fileactions/ClientIntegration.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/ClientIntegration.kt
@@ -9,14 +9,10 @@ package com.nextcloud.ui.fileactions
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Canvas
-import android.graphics.drawable.PictureDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.graphics.createBitmap
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import com.google.gson.Gson
@@ -81,31 +77,25 @@ class ClientIntegration(
                 }
                 text.text = endpoint.name
 
+                val px = DisplayUtils.convertDpToPixel(
+                    context.resources.getDimension(R.dimen.iconized_single_line_item_icon_size),
+                    context
+                )
+
                 if (endpoint.icon != null) {
                     sheet.lifecycleScope.launch(Dispatchers.IO) {
                         val client = OwnCloudClientManagerFactory.getDefaultSingleton()
                             .getNextcloudClientFor(user.toOwnCloudAccount(), context)
 
-                        val drawable =
-                            GlideHelper.getDrawable(context, client, client.baseUri.toString() + endpoint.icon)
-                                ?.mutate()
-
-                        val px = DisplayUtils.convertDpToPixel(
-                            context.resources.getDimension(R.dimen.iconized_single_line_item_icon_size),
-                            context
-                        )
-                        val returnedBitmap =
-                            createBitmap(drawable?.intrinsicWidth ?: px, drawable?.intrinsicHeight ?: px)
-
-                        val canvas = Canvas(returnedBitmap)
-                        canvas.drawPicture((drawable as PictureDrawable).picture)
-
-                        val d = returnedBitmap.toDrawable(context.resources)
-
-                        val tintedDrawable = viewThemeUtils.platform.tintDrawable(
+                        val drawable = GlideHelper.fetchDrawable(
                             context,
-                            d
-                        )
+                            client,
+                            client.baseUri.toString() + endpoint.icon,
+                            width = px,
+                            height = px
+                        )?.mutate()
+
+                        val tintedDrawable = drawable?.let { viewThemeUtils.platform.tintDrawable(context, it) }
 
                         withContext(Dispatchers.Main) {
                             icon.setImageDrawable(tintedDrawable)

--- a/app/src/main/java/com/nextcloud/ui/fileactions/ClientIntegration.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/ClientIntegration.kt
@@ -9,11 +9,15 @@ package com.nextcloud.ui.fileactions
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Canvas
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.toDrawable
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import com.google.gson.Gson
@@ -78,46 +82,58 @@ class ClientIntegration(
                 }
                 text.text = endpoint.name
 
-                val px = DisplayUtils.convertDpToPixel(
-                    context.resources.getDimension(R.dimen.iconized_single_line_item_icon_size),
-                    context
-                )
+                sheet.lifecycleScope.launch(Dispatchers.IO) {
+                    val client = OwnCloudClientManagerFactory.getDefaultSingleton()
+                        .getNextcloudClientFor(user.toOwnCloudAccount(), context)
 
-                if (endpoint.icon != null) {
-                    sheet.lifecycleScope.launch(Dispatchers.IO) {
-                        val client = OwnCloudClientManagerFactory.getDefaultSingleton()
-                            .getNextcloudClientFor(user.toOwnCloudAccount(), context)
-
-                        val drawable = GlideHelper
-                            .getDrawable(context, client, client.baseUri.toString() + endpoint.icon)?.mutate()
-
-                        withContext(Dispatchers.Main) {
-                            val tintedDrawable = drawable?.let { viewThemeUtils.platform.tintDrawable(context, it) }
-                            if (tintedDrawable != null) {
-                                icon.setImageDrawable(tintedDrawable)
-                            } else {
-                                getDefaultTintedIconDrawable(viewThemeUtils)?.let {
-                                    icon.setImageDrawable(it)
-                                }
-                            }
-                        }
+                    val rawDrawable = if (endpoint.icon != null) {
+                        GlideHelper.getDrawable(context, client, client.baseUri.toString() + endpoint.icon)?.mutate()
+                    } else {
+                        null
                     }
-                } else {
-                    getDefaultTintedIconDrawable(viewThemeUtils)?.let {
-                        icon.setImageDrawable(it)
+
+                    val tintableDrawable = prepareDrawableForTinting(rawDrawable) ?: getDefaultIconDrawable()
+
+                    withContext(Dispatchers.Main) {
+                        tintableDrawable?.let {
+                            val tinted = viewThemeUtils.platform.tintDrawable(context, it)
+                            icon.setImageDrawable(tinted)
+                        }
                     }
                 }
             }
+
         return itemBinding.root
     }
 
-    private fun getDefaultTintedIconDrawable(viewThemeUtils: ViewThemeUtils): Drawable? {
-        val drawable = AppCompatResources.getDrawable(context, R.drawable.ic_activity) ?: return null
-        return viewThemeUtils.platform.tintDrawable(
-            context,
-            drawable
-        )
+    private fun prepareDrawableForTinting(drawable: Drawable?): Drawable? {
+        if (drawable == null) {
+            return null
+        }
+
+        if (drawable is PictureDrawable) {
+            val defaultSize = DisplayUtils.convertDpToPixel(
+                context.resources.getDimension(R.dimen.iconized_single_line_item_icon_size),
+                context
+            ).toInt().coerceAtLeast(1)
+
+            val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else defaultSize
+            val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else defaultSize
+
+            val safeWidth = width.coerceAtLeast(1)
+            val safeHeight = height.coerceAtLeast(1)
+
+            val bitmap = createBitmap(safeWidth, safeHeight)
+            val canvas = Canvas(bitmap)
+            canvas.drawPicture(drawable.picture)
+
+            return bitmap.toDrawable(context.resources)
+        }
+
+        return drawable
     }
+
+    private fun getDefaultIconDrawable(): Drawable? = AppCompatResources.getDrawable(context, R.drawable.ic_activity)
 
     private fun requestClientIntegration(endpoint: Endpoint, fileId: String, filePath: String) {
         sheet.lifecycleScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/nextcloud/ui/fileactions/ClientIntegration.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/ClientIntegration.kt
@@ -9,6 +9,7 @@ package com.nextcloud.ui.fileactions
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -87,30 +88,35 @@ class ClientIntegration(
                         val client = OwnCloudClientManagerFactory.getDefaultSingleton()
                             .getNextcloudClientFor(user.toOwnCloudAccount(), context)
 
-                        val drawable = GlideHelper.fetchDrawable(
-                            context,
-                            client,
-                            client.baseUri.toString() + endpoint.icon,
-                            width = px,
-                            height = px
-                        )?.mutate()
-
-                        val tintedDrawable = drawable?.let { viewThemeUtils.platform.tintDrawable(context, it) }
+                        val drawable = GlideHelper
+                            .getDrawable(context, client, client.baseUri.toString() + endpoint.icon)?.mutate()
 
                         withContext(Dispatchers.Main) {
-                            icon.setImageDrawable(tintedDrawable)
+                            val tintedDrawable = drawable?.let { viewThemeUtils.platform.tintDrawable(context, it) }
+                            if (tintedDrawable != null) {
+                                icon.setImageDrawable(tintedDrawable)
+                            } else {
+                                getDefaultTintedIconDrawable(viewThemeUtils)?.let {
+                                    icon.setImageDrawable(it)
+                                }
+                            }
                         }
                     }
                 } else {
-                    val tintedDrawable = viewThemeUtils.platform.tintDrawable(
-                        context,
-                        AppCompatResources.getDrawable(context, R.drawable.ic_activity)!!
-                    )
-
-                    icon.setImageDrawable(tintedDrawable)
+                    getDefaultTintedIconDrawable(viewThemeUtils)?.let {
+                        icon.setImageDrawable(it)
+                    }
                 }
             }
         return itemBinding.root
+    }
+
+    private fun getDefaultTintedIconDrawable(viewThemeUtils: ViewThemeUtils): Drawable? {
+        val drawable = AppCompatResources.getDrawable(context, R.drawable.ic_activity) ?: return null
+        return viewThemeUtils.platform.tintDrawable(
+            context,
+            drawable
+        )
     }
 
     private fun requestClientIntegration(endpoint: Endpoint, fileId: String, filePath: String) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

```
Exception java.util.concurrent.ExecutionException: com.bumptech.glide.load.engine.GlideException: Failed to load resource
There was 1 root cause:
com.bumptech.glide.load.HttpException(Failed to connect or obtain data, status code: -1)
 call GlideException#logRootCauses(String) for more detail
  at com.bumptech.glide.request.RequestFutureTarget.doGet (RequestFutureTarget.java:217)
  at com.bumptech.glide.request.RequestFutureTarget.get (RequestFutureTarget.java:130)
  at com.nextcloud.utils.GlideHelper.getDrawable (GlideHelper.kt:179)
  at com.nextcloud.ui.fileactions.ClientIntegration$inflateClientIntegrationActionView$itemBinding$1$2.invokeSuspend (ClientIntegration.kt:90)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:101)
  at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run (LimitedDispatcher.kt:113)
  at kotlinx.coroutines.scheduling.TaskImpl.run (Tasks.kt:89)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:589)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:823)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:720)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:707)
```