### PR TITLE
fix(receive-external-activity): npe adapter

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -804,9 +804,14 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private void setupReceiveExternalFilesAdapter(List<OCFile> files) {
+        final var optionalUser = getUser();
+        if (optionalUser.isEmpty()) {
+            return;
+        }
+
         receiveExternalFilesAdapter = new ReceiveExternalFilesAdapter(files,
                                                                       this,
-                                                                      getUser().get(),
+                                                                      optionalUser.get(),
                                                                       getStorageManager(),
                                                                       viewThemeUtils,
                                                                       syncedFolderProvider,
@@ -1079,13 +1084,17 @@ public class ReceiveExternalFilesActivity extends FileActivity
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
-                receiveExternalFilesAdapter.filter(query);
+                if (receiveExternalFilesAdapter != null) {
+                    receiveExternalFilesAdapter.filter(query);
+                }
                 return false;
             }
 
             @Override
             public boolean onQueryTextChange(String newText) {
-                receiveExternalFilesAdapter.filter(newText);
+                if (receiveExternalFilesAdapter != null) {
+                    receiveExternalFilesAdapter.filter(newText);
+                }
                 return false;
             }
         });


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

```
Exception java.lang.NullPointerException:
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity$2.onQueryTextChange (ReceiveExternalFilesActivity.java:1091)
  at androidx.appcompat.widget.SearchView.onTextChanged (SearchView.java:1198)
  at androidx.appcompat.widget.SearchView$10.onTextChanged (SearchView.java:1736)
  at android.widget.TextView.sendOnTextChanged (TextView.java:13573)
  at android.widget.TextView.handleTextChanged (TextView.java:13702)
  at android.widget.TextView$ChangeWatcher.onTextChanged (TextView.java:17605)
  at android.text.SpannableStringBuilder.sendTextChanged (SpannableStringBuilder.java:1269)
  at android.text.SpannableStringBuilder.replace (SpannableStringBuilder.java:578)
  at androidx.emoji2.text.SpannableBuilder.replace (SpannableBuilder.java:308)
  at android.text.SpannableStringBuilder.replace (SpannableStringBuilder.java:509)
  at androidx.emoji2.text.SpannableBuilder.replace (SpannableBuilder.java:298)
  at androidx.emoji2.text.SpannableBuilder.replace (SpannableBuilder.java:48)
  at android.view.inputmethod.BaseInputConnection.replaceTextInternal (BaseInputConnection.java:1027)
  at android.view.inputmethod.BaseInputConnection.replaceText (BaseInputConnection.java:962)
  at android.view.inputmethod.BaseInputConnection.setComposingText (BaseInputConnection.java:743)
  at android.view.inputmethod.InputConnectionWrapper.setComposingText (InputConnectionWrapper.java:161)
  at android.view.inputmethod.RemoteInputConnectionImpl.lambda$setComposingText$26 (RemoteInputConnectionImpl.java:831)
  at android.view.inputmethod.RemoteInputConnectionImpl.$r8$lambda$soHIVgnaTkxIKf20X9il0IHyeeA (Unknown Source)
  at android.view.inputmethod.RemoteInputConnectionImpl$$ExternalSyntheticLambda28.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:995)
  at android.os.Handler.dispatchMessage (Handler.java:103)
  at android.os.Looper.loopOnce (Looper.java:273)
  at android.os.Looper.loop (Looper.java:363)
  at android.app.ActivityThread.main (ActivityThread.java:10060)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:975)
```