### PR TITLE
fix(oc-file-list-fragment): npe on destroy action mode

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -874,16 +874,23 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
             // show FAB on multi selection mode exit
             if (!mHideFab && !searchFragment) {
-                setFabVisible(mFile.canCreateFileAndFolder());
+                final var file = mFile;
+                if (file != null) {
+                    setFabVisible(file.canCreateFileAndFolder());
+                }
             }
 
-            Activity activity = getActivity();
+            final var activity = getActivity();
             if (activity != null) {
                 viewThemeUtils.platform.resetStatusBar(activity);
             }
 
-            getCommonAdapter().setMultiSelect(false);
-            getCommonAdapter().clearCheckedItems();
+            final var adapter = getCommonAdapter();
+            if (adapter != null) {
+                adapter.setMultiSelect(false);
+                adapter.clearCheckedItems();
+            }
+
             isMultipleFileSelectedForCopyOrMove = false;
         }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

```
Exception java.lang.NullPointerException:
  at com.owncloud.android.ui.fragment.OCFileListFragment$MultiChoiceModeListener.onDestroyActionMode (OCFileListFragment.java:1002)
  at com.android.internal.policy.DecorView$ActionModeCallback2Wrapper.onDestroyActionMode (DecorView.java:2703)
  at androidx.appcompat.view.SupportActionModeWrapper$CallbackWrapper.onDestroyActionMode (SupportActionModeWrapper.java:176)
  at androidx.appcompat.app.AppCompatDelegateImpl$ActionModeCallbackWrapperV9.onDestroyActionMode (AppCompatDelegateImpl.java:3011)
  at androidx.appcompat.view.StandaloneActionMode.finish (StandaloneActionMode.java:109)
  at androidx.appcompat.widget.ActionBarContextView$1.onClick (ActionBarContextView.java:174)
  at android.view.View.performClick (View.java:8275)
  at android.view.View.performClickInternal (View.java:8252)
  at android.view.View.-$$Nest$mperformClickInternal (Unknown Source)
  at android.view.View$PerformClick.run (View.java:33111)
  at android.os.Handler.handleCallback (Handler.java:995)
  at android.os.Handler.dispatchMessage (Handler.java:103)
  at android.os.Looper.loopOnce (Looper.java:265)
  at android.os.Looper.loop (Looper.java:358)
  at android.app.ActivityThread.main (ActivityThread.java:9952)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:616)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1091)
```