### PR TITLE
fix(foreground-service): did not start in time exception

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
@@ -78,6 +78,8 @@ class AutoUploadWorker(
     @Suppress("ReturnCount")
     override suspend fun doWork(): Result {
         return try {
+            trySetForeground()
+
             val syncFolderId = inputData.getLong(SYNCED_FOLDER_ID, -1)
             syncedFolder = syncedFolderProvider.getSyncedFolderByID(syncFolderId)
                 ?.takeIf { it.isEnabled } ?: return Result.failure()
@@ -274,7 +276,6 @@ class AutoUploadWorker(
         val client = OwnCloudClientManagerFactory.getDefaultSingleton()
             .getClientFor(ocAccount, context)
 
-        trySetForeground()
         updateNotification()
 
         var lastId = 0

--- a/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/FileDownloadWorker.kt
@@ -117,7 +117,7 @@ class FileDownloadWorker(
 
         return try {
             setUser()
-            val remotePath = inputData.keyValueMap[FILE_REMOTE_PATH] as String? ?: return Result.failure()
+            val remotePath = inputData.keyValueMap[FILE_REMOTE_PATH] as? String? ?: return Result.failure()
             val ocFile = fileDataStorageManager?.getFileByEncryptedRemotePath(remotePath) ?: return Result.failure()
             val requestDownloads = getRequestDownloads(ocFile)
             addAccountUpdateListener()

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -122,11 +122,11 @@ class FileUploadWorker(
     private val fileUploadBroadcastManager = FileUploadBroadcastManager(localBroadcastManager)
 
     override suspend fun doWork(): Result = try {
+        trySetForeground()
+
         Log_OC.d(TAG, "FileUploadWorker started")
         val workerName = BackgroundJobManagerImpl.formatClassTag(this::class)
         backgroundJobManager.logStartOfWorker(workerName)
-
-        trySetForeground()
 
         val result = uploadFiles()
         backgroundJobManager.logEndOfWorker(workerName, result)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

```
Exception android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException:
  at android.app.ActivityThread.generateForegroundServiceDidNotStartInTimeException (ActivityThread.java:2512)
  at android.app.ActivityThread.throwRemoteServiceException (ActivityThread.java:2486)
  at android.app.ActivityThread.-$$Nest$mthrowRemoteServiceException (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2777)
  at android.os.Handler.dispatchMessage (Handler.java:114)
  at android.os.Looper.loopOnce (Looper.java:206)
  at android.os.Looper.loop (Looper.java:296)
  at android.app.ActivityThread.main (ActivityThread.java:9205)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:591)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1027)
```