### PR TITLE
fix(file-list): refresh directory

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
@@ -18,7 +18,6 @@ import com.nextcloud.client.account.UserAccountManager
 import com.nextcloud.client.database.entity.toOCUpload
 import com.nextcloud.client.database.entity.toUploadEntity
 import com.nextcloud.client.device.PowerManagementService
-import com.nextcloud.client.jobs.BackgroundJobManager
 import com.nextcloud.client.jobs.upload.FileUploadBroadcastManager
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.jobs.utils.UploadErrorNotificationManager
@@ -430,7 +429,6 @@ class AutoUploadWorker(
         fileUploadBroadcastManager.sendFinished(
             operation,
             result,
-            operation.oldFile?.storagePath,
             context
         )
     }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadBroadcastManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadBroadcastManager.kt
@@ -84,12 +84,7 @@ class FileUploadBroadcastManager(private val broadcastManager: LocalBroadcastMan
      *  - [com.owncloud.android.ui.preview.PreviewImageActivity.UploadFinishReceiver]
      *
      */
-    fun sendFinished(
-        upload: UploadFileOperation,
-        uploadResult: RemoteOperationResult<*>,
-        unlinkedFromRemotePath: String?,
-        context: Context
-    ) {
+    fun sendFinished(upload: UploadFileOperation, uploadResult: RemoteOperationResult<*>, context: Context) {
         Log_OC.d(TAG, "upload finished broadcast sent")
         val intent = Intent(UPLOAD_FINISHED).apply {
             // real remote path, after possible automatic renaming
@@ -102,9 +97,6 @@ class FileUploadBroadcastManager(private val broadcastManager: LocalBroadcastMan
             putExtra(FileUploadWorker.EXTRA_OLD_FILE_PATH, upload.originalStoragePath)
             putExtra(FileUploadWorker.ACCOUNT_NAME, upload.user.accountName)
             putExtra(FileUploadWorker.EXTRA_UPLOAD_RESULT, uploadResult.isSuccess)
-            if (unlinkedFromRemotePath != null) {
-                putExtra(FileUploadWorker.EXTRA_LINKED_TO_PATH, unlinkedFromRemotePath)
-            }
             setPackage(context.packageName)
         }
         broadcastManager.sendBroadcast(intent)

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadWorker.kt
@@ -81,7 +81,6 @@ class FileUploadWorker(
         const val EXTRA_REMOTE_PATH = "REMOTE_PATH"
         const val EXTRA_OLD_REMOTE_PATH = "OLD_REMOTE_PATH"
         const val EXTRA_OLD_FILE_PATH = "OLD_FILE_PATH"
-        const val EXTRA_LINKED_TO_PATH = "LINKED_TO"
         const val ACCOUNT_NAME = "ACCOUNT_NAME"
         const val EXTRA_ACCOUNT_NAME = "ACCOUNT_NAME"
         const val ACTION_CANCEL_BROADCAST = "CANCEL"
@@ -288,7 +287,6 @@ class FileUploadWorker(
             fileUploadBroadcastManager.sendFinished(
                 operation,
                 result,
-                operation.oldFile?.storagePath,
                 context
             )
         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1698,10 +1698,7 @@ class FileDisplayActivity :
                 currentDir != null && uploadedRemotePath != null && uploadedRemotePath.startsWith(currentDir.remotePath)
 
             if (sameAccount && isDescendant) {
-                val linkedToRemotePath = intent.getStringExtra(FileUploadWorker.EXTRA_LINKED_TO_PATH)
-                if (linkedToRemotePath == null || isAscendant(linkedToRemotePath)) {
-                    updateListOfFilesFragment()
-                }
+                updateListOfFilesFragment()
             }
 
             val uploadWasFine = intent.getBooleanExtra(FileUploadWorker.EXTRA_UPLOAD_RESULT, false)
@@ -1748,12 +1745,6 @@ class FileDisplayActivity :
                     }
                 }
             }
-        }
-
-        // TODO refactor this receiver, and maybe DownloadFinishReceiver; this method is duplicated :S
-        fun isAscendant(linkedToRemotePath: String): Boolean {
-            val currentDir = getCurrentDir()
-            return currentDir != null && currentDir.remotePath.startsWith(linkedToRemotePath)
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

`val linkedToRemotePath = intent.getStringExtra(FileUploadWorker.EXTRA_LINKED_TO_PATH)` this check was causing the file list not updated