### PR TITLE
Investigating the Drone timeout issue

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/providers/DocumentsStorageProviderIT.kt
@@ -32,6 +32,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.random.Random
 
@@ -195,6 +196,7 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
 
     @Suppress("MagicNumber")
     @Test(timeout = 5 * 60 * 1000)
+    @Ignore("Problem with endless sleep")
     fun testServerChangedFileContent() {
         // create random file
         val file1 = rootDir.createFile("text/plain", RandomStringGenerator.make())!!
@@ -234,6 +236,7 @@ class DocumentsStorageProviderIT : AbstractOnServerIT() {
     }
 
     @Test
+    @Ignore("Problem with endless sleep")
     fun testServerSuccessive() {
         // create random file
         val file1 = rootDir.createFile("text/plain", RandomStringGenerator.make())!!

--- a/app/src/androidTest/java/com/owncloud/android/ui/preview/PreviewImageActivityIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/preview/PreviewImageActivityIT.kt
@@ -39,6 +39,7 @@ import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 
+@Ignore("Investigating Drone CI timeout")
 class PreviewImageActivityIT : AbstractOnServerIT() {
     companion object {
         private const val REMOTE_FOLDER: String = "/PreviewImageActivityIT/"


### PR DESCRIPTION
## Notes
- No timestamp printing needed. The Drone log UI shows the elapsed seconds on the right, when opening full screen.
- Looking at the prior MR's drone run of test-stable: https://drone.nextcloud.com/nextcloud/android/28763/1/3
   -  assembleGplayDebugAndroidTest: 7.5 minutes
   - waiting for Emulator: 5 seconds
   - installGplayDebugAndroidTest: 26 second
   - waiting for server & deleting old Github comments: 10 seconds
   - createGplayDebugCoverageReport (configuring the tasks): 2 minutes
   - createGplayDebugCoverageReport (actually running the tests): ? - timeout
     - After task configuration, the actual test runs in the logs are only spanning 24 minutes.
   - the last log line `android(AVD) - 16 Tests 417/569 completed. (0 skipped) (0 failed)` appears at second 2058 (**34 minutes total time**). This is shorter than the stated overall time of 60 minutes.
   - So either there is something crashing so hard that the job dangles until timeout. Or the job is stopped too early.
   - The parallel `server` job's last log line is also at around 34 minutes
- Looking at this MR's drone run https://drone.nextcloud.com/nextcloud/android/28833/1/3
  - the last log line `android(AVD) - 16 Tests 439/595 completed. (0 skipped) (7 failed)` appears at second 2973 seconds (49 minutes total time).

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [ ] Tests written, or not not needed
