### PR TITLE
fix(auto-upload): pending media items

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/FileSystemRepository.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/FileSystemRepository.kt
@@ -9,6 +9,7 @@ package com.nextcloud.client.jobs.autoUpload
 
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
 import com.nextcloud.client.database.dao.FileSystemDao
 import com.nextcloud.client.database.entity.FilesystemEntity
@@ -115,7 +116,11 @@ class FileSystemRepository(
             syncedPath += File.separator
         }
 
-        val selection = "${MediaStore.MediaColumns.DATA} LIKE ?"
+        val selection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            "${MediaStore.MediaColumns.DATA} LIKE ? AND ${MediaStore.MediaColumns.IS_PENDING} = 0"
+        } else {
+            "${MediaStore.MediaColumns.DATA} LIKE ?"
+        }
         val selectionArgs = arrayOf("$syncedPath%")
 
         Log_OC.d(TAG, "Querying MediaStore for files in: $syncedPath, uri: $uri")


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->


### Fixes

Pending media items should not be inserted until its finished.

`2026-03-16 10:25:27.971  9854-9900  FilesystemRepository    com.nextcloud.client                 D  inserting new file system entity: FilesystemEntity(id=null, localPath=/storage/emulated/0/Movies/.pending-1774257922-VID_20260316_102522.mp4, fileIsFolder=0, fileFoundRecently=1773653127971, fileSentForUpload=0, syncedFolderId=2, crc32=1291491402, fileModified=1773653122000)`

### How to reproduce?

1. Choose a local storage that has videos for auto-upload
2. Record video
3. Insert logic will be triggered