### PR TITLE
fix(auto-upload): check qualification before insert

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/FileSystemRepository.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/FileSystemRepository.kt
@@ -14,7 +14,6 @@ import android.provider.MediaStore
 import com.nextcloud.client.database.dao.FileSystemDao
 import com.nextcloud.client.database.entity.FilesystemEntity
 import com.nextcloud.utils.extensions.shouldSkipFile
-import com.nextcloud.utils.extensions.toFile
 import com.owncloud.android.datamodel.SyncedFolder
 import com.owncloud.android.datamodel.UploadsStorageManager
 import com.owncloud.android.lib.common.utils.Log_OC
@@ -60,27 +59,19 @@ class FileSystemRepository(
         val entities = dao.getAutoUploadFilesEntities(syncedFolderId, BATCH_SIZE, lastId)
         val filtered = mutableListOf<Pair<String, Int>>()
 
-        entities.forEach { entity ->
-            entity.localPath?.let { path ->
-                val file = File(path)
-                if (!file.exists()) {
-                    Log_OC.w(TAG, "Ignoring file for upload (doesn't exist): $path")
-                    deleteAutoUploadAndUploadEntity(syncedFolder, path, entity)
-                } else if (!SyncedFolderUtils.isQualifiedFolder(file.parent)) {
-                    Log_OC.w(TAG, "Ignoring file for upload (unqualified folder): $path")
-                    deleteAutoUploadAndUploadEntity(syncedFolder, path, entity)
-                } else if (!SyncedFolderUtils.isFileNameQualifiedForAutoUpload(file.name)) {
-                    Log_OC.w(TAG, "Ignoring file for upload (unqualified file): $path")
-                    deleteAutoUploadAndUploadEntity(syncedFolder, path, entity)
-                } else {
-                    Log_OC.d(TAG, "Adding path to upload: $path")
+        for (entity in entities) {
+            val file = SyncedFolderUtils.validateForAutoUpload(entity.localPath)
+            if (file == null) {
+                deleteAutoUploadAndUploadEntity(syncedFolder, entity.localPath ?: "", entity)
+                continue
+            }
 
-                    if (entity.id != null) {
-                        filtered.add(path to entity.id)
-                    } else {
-                        Log_OC.w(TAG, "cant adding path to upload, id is null")
-                    }
-                }
+            Log_OC.d(TAG, "Adding path to upload: ${entity.localPath}")
+
+            if (entity.id != null) {
+                filtered.add(entity.localPath!! to entity.id)
+            } else {
+                Log_OC.w(TAG, "cant adding path to upload, id is null")
             }
         }
 
@@ -176,7 +167,7 @@ class FileSystemRepository(
         checkFileType: Boolean = false
     ) {
         try {
-            val file = localPath?.toFile()
+            val file = SyncedFolderUtils.validateForAutoUpload(localPath)
             if (file == null) {
                 Log_OC.w(TAG, "file null, cannot insert or replace: $localPath")
                 return
@@ -187,7 +178,7 @@ class FileSystemRepository(
                 return
             }
 
-            val entity = dao.getFileByPathAndFolder(localPath, syncedFolder.id.toString())
+            val entity = dao.getFileByPathAndFolder(localPath!!, syncedFolder.id.toString())
 
             val fileModified = (lastModified ?: file.lastModified())
             val hasNotChanged = entity?.fileModified == fileModified

--- a/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
+++ b/app/src/main/java/com/owncloud/android/utils/SyncedFolderUtils.kt
@@ -7,15 +7,19 @@
  */
 package com.owncloud.android.utils
 
+import com.nextcloud.utils.extensions.toFile
 import com.owncloud.android.datamodel.MediaFolder
 import com.owncloud.android.datamodel.MediaFolderType
 import com.owncloud.android.datamodel.SyncedFolder
+import com.owncloud.android.lib.common.utils.Log_OC
 import java.io.File
 
 /**
  * Utility class with methods for processing synced folders.
  */
 object SyncedFolderUtils {
+    private const val TAG = "SyncedFolderUtils"
+
     private val DISQUALIFIED_MEDIA_DETECTION_SOURCE = listOf(
         "cover.jpg",
         "cover.jpeg",
@@ -173,5 +177,26 @@ object SyncedFolderUtils {
             }
         }
         return false
+    }
+
+    @Suppress("ReturnCount")
+    fun validateForAutoUpload(path: String?): File? {
+        val file = path?.toFile()
+        if (file == null) {
+            Log_OC.w(TAG, "Ignoring file for upload (doesn't exist): $path")
+            return null
+        }
+
+        if (!isQualifiedFolder(file.parent)) {
+            Log_OC.w(TAG, "Ignoring file for upload (unqualified folder): $path")
+            return null
+        }
+
+        if (!isFileNameQualifiedForAutoUpload(file.name)) {
+            Log_OC.w(TAG, "Ignoring file for upload (unqualified file): $path")
+            return null
+        }
+
+        return file
     }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

###  Issue

```
D  inserting new file system entity: FilesystemEntity(id=null, localPath=/storage/emulated/0/Pictures/.thumbnails/863.jpg, fileIsFolder=0, fileFoundRecently=1773994034406, fileSentForUpload=0, syncedFolderId=1, crc32=2785216207, fileModified=1773043948000)
2026-03-20 09:07:14.406  3329-3458  SyncedFolderExtensions  com.nextcloud.client                 

D  Checking file: 750.jpg, lastModified=1773043948000, lastScan=1773992741550
2026-03-20 09:07:14.407  3329-3458  FilesystemRepository    com.nextcloud.client                 

D  inserting new file system entity: FilesystemEntity(id=null, localPath=/storage/emulated/0/Pictures/.thumbnails/750.jpg, fileIsFolder=0, fileFoundRecently=1773994034407, fileSentForUpload=0, syncedFolderId=1, crc32=3726356940, fileModified=1773043948000)
2026-03-20 09:07:14.408  3329-3458  SyncedFolderExtensions  com.nextcloud.client                 

D  Checking file: 753.jpg, lastModified=1773043948000, lastScan=1773992741550
2026-03-20 09:07:14.409  3329-3458  FilesystemRepository    com.nextcloud.client                 

D  inserting new file system entity: FilesystemEntity(id=null, localPath=/storage/emulated/0/Pictures/.thumbnails/753.jpg, fileIsFolder=0, fileFoundRecently=1773994034409, fileSentForUpload=0, syncedFolderId=1, crc32=1993494185, fileModified=1773043948000)
```
