### PR TITLE
#591 Groups in user info

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -53,6 +53,8 @@ import com.owncloud.android.utils.theme.ViewThemeUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -267,7 +269,7 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
 
         if (TextUtils.isEmpty(userInfo.getPhone()) && TextUtils.isEmpty(userInfo.getEmail())
             && TextUtils.isEmpty(userInfo.getAddress()) && TextUtils.isEmpty(userInfo.getTwitter())
-            && TextUtils.isEmpty(userInfo.getWebsite())) {
+            && TextUtils.isEmpty(userInfo.getWebsite()) && (userInfo.getGroups() == null || userInfo.getGroups().isEmpty())) {
             binding.userinfoList.setVisibility(View.GONE);
             binding.loadingContent.setVisibility(View.GONE);
             binding.emptyList.emptyListView.setVisibility(View.VISIBLE);
@@ -297,6 +299,13 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
                     R.string.user_info_website);
         addToListIfNeeded(result, R.drawable.ic_twitter, DisplayUtils.beautifyTwitterHandle(userInfo.getTwitter()),
                     R.string.user_info_twitter);
+
+        if (userInfo.getGroups() != null) {
+            final ArrayList<String> sortedGroups = new ArrayList<>(userInfo.getGroups());
+            Collections.sort(sortedGroups);
+            addToListIfNeeded(result, R.drawable.ic_group, String.join(", ", sortedGroups),
+                              R.string.user_info_groups);
+        }
 
         return result;
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -12,12 +12,10 @@
  */
 package com.owncloud.android.ui.activity;
 
-import android.annotation.SuppressLint;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -29,6 +27,7 @@ import android.widget.ImageView;
 import com.bumptech.glide.request.target.CustomTarget;
 import com.bumptech.glide.request.target.Target;
 import com.bumptech.glide.request.transition.Transition;
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.di.Injectable;
 import com.nextcloud.client.preferences.AppPreferences;
@@ -48,15 +47,12 @@ import com.owncloud.android.ui.dialog.AccountRemovalDialog;
 import com.owncloud.android.ui.events.TokenPushEvent;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.PushUtils;
-import com.owncloud.android.utils.theme.ViewThemeUtils;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 import javax.inject.Inject;
 
@@ -68,7 +64,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Lifecycle;
-import androidx.recyclerview.widget.RecyclerView;
 import kotlin.Unit;
 
 /**
@@ -127,8 +122,6 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
             viewThemeUtils.files.themeActionBar(this, actionBar);
         }
 
-        binding.userinfoList.setAdapter(new UserInfoAdapter(null, viewThemeUtils));
-
         if (userInfo != null) {
             populateUserInfoUi(userInfo);
         } else {
@@ -174,7 +167,7 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
     }
 
     private void setMultiListLoadingMessage() {
-        binding.userinfoList.setVisibility(View.GONE);
+        binding.userinfoListContainer.setVisibility(View.GONE);
         binding.emptyList.emptyListView.setVisibility(View.GONE);
     }
 
@@ -185,7 +178,7 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
 
         binding.emptyList.emptyListIcon.setVisibility(View.VISIBLE);
         binding.emptyList.emptyListViewText.setVisibility(View.VISIBLE);
-        binding.userinfoList.setVisibility(View.GONE);
+        binding.userinfoListContainer.setVisibility(View.GONE);
         binding.loadingContent.setVisibility(View.GONE);
     }
 
@@ -267,10 +260,12 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
             binding.userinfoFullName.setText(userInfo.getDisplayName());
         }
 
-        if (TextUtils.isEmpty(userInfo.getPhone()) && TextUtils.isEmpty(userInfo.getEmail())
+        final boolean userInfoEmpty = TextUtils.isEmpty(userInfo.getPhone()) && TextUtils.isEmpty(userInfo.getEmail())
             && TextUtils.isEmpty(userInfo.getAddress()) && TextUtils.isEmpty(userInfo.getTwitter())
-            && TextUtils.isEmpty(userInfo.getWebsite()) && (userInfo.getGroups() == null || userInfo.getGroups().isEmpty())) {
-            binding.userinfoList.setVisibility(View.GONE);
+            && TextUtils.isEmpty(userInfo.getWebsite());
+        final boolean groupInfoEmpty = userInfo.getGroups() == null || userInfo.getGroups().isEmpty();
+        if (userInfoEmpty && groupInfoEmpty) {
+            binding.userinfoListContainer.setVisibility(View.GONE);
             binding.loadingContent.setVisibility(View.GONE);
             binding.emptyList.emptyListView.setVisibility(View.VISIBLE);
 
@@ -280,41 +275,72 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
             binding.loadingContent.setVisibility(View.VISIBLE);
             binding.emptyList.emptyListView.setVisibility(View.GONE);
 
-            if (binding.userinfoList.getAdapter() instanceof UserInfoAdapter) {
-                binding.userinfoList.setAdapter(new UserInfoAdapter(createUserInfoDetails(userInfo), viewThemeUtils));
+            if (!userInfoEmpty) {
+                viewThemeUtils.platform.colorTextView(binding.userinfoListTitle, ColorRole.PRIMARY);
+                showUserInfoDetails(binding.userinfoList, userInfo);
+                binding.userinfoList.setVisibility(View.VISIBLE);
+                binding.userinfoListTitle.setVisibility(View.VISIBLE);
+            } else {
+                binding.userinfoList.setVisibility(View.GONE);
+                binding.userinfoListTitle.setVisibility(View.GONE);
+            }
+
+            if (!groupInfoEmpty) {
+                viewThemeUtils.platform.colorTextView(binding.groupinfoListTitle, ColorRole.PRIMARY);
+                showGroupsInfoDetails(binding.groupinfoList, userInfo);
+                binding.groupinfoList.setVisibility(View.VISIBLE);
+                binding.groupinfoListTitle.setVisibility(View.VISIBLE);
+            } else {
+                binding.groupinfoList.setVisibility(View.GONE);
+                binding.groupinfoListTitle.setVisibility(View.GONE);
             }
 
             binding.loadingContent.setVisibility(View.GONE);
-            binding.userinfoList.setVisibility(View.VISIBLE);
+            binding.userinfoListContainer.setVisibility(View.VISIBLE);
         }
     }
 
-    private List<UserInfoDetailsItem> createUserInfoDetails(UserInfo userInfo) {
-        List<UserInfoDetailsItem> result = new LinkedList<>();
+    private void showUserInfoDetails(ViewGroup container, UserInfo userInfo) {
+        container.removeAllViews();
+        addToListIfNeeded(container, R.drawable.ic_phone, userInfo.getPhone(), R.string.user_info_phone);
+        addToListIfNeeded(container, R.drawable.ic_email, userInfo.getEmail(), R.string.user_info_email);
+        addToListIfNeeded(container, R.drawable.ic_map_marker, userInfo.getAddress(), R.string.user_info_address);
+        addToListIfNeeded(container, R.drawable.ic_web, DisplayUtils.beautifyURL(userInfo.getWebsite()),
+                R.string.user_info_website);
+        addToListIfNeeded(container, R.drawable.ic_twitter, DisplayUtils.beautifyTwitterHandle(userInfo.getTwitter()),
+                R.string.user_info_twitter);
+    }
 
-        addToListIfNeeded(result, R.drawable.ic_phone, userInfo.getPhone(), R.string.user_info_phone);
-        addToListIfNeeded(result, R.drawable.ic_email, userInfo.getEmail(), R.string.user_info_email);
-        addToListIfNeeded(result, R.drawable.ic_map_marker, userInfo.getAddress(), R.string.user_info_address);
-        addToListIfNeeded(result, R.drawable.ic_web, DisplayUtils.beautifyURL(userInfo.getWebsite()),
-                    R.string.user_info_website);
-        addToListIfNeeded(result, R.drawable.ic_twitter, DisplayUtils.beautifyTwitterHandle(userInfo.getTwitter()),
-                    R.string.user_info_twitter);
-
+    private void showGroupsInfoDetails(ViewGroup container, UserInfo userInfo) {
+        container.removeAllViews();
         if (userInfo.getGroups() != null) {
             final ArrayList<String> sortedGroups = new ArrayList<>(userInfo.getGroups());
             Collections.sort(sortedGroups);
-            addToListIfNeeded(result, R.drawable.ic_group, String.join(", ", sortedGroups),
-                              R.string.user_info_groups);
+            addToListIfNeeded(container, R.drawable.ic_group, String.join(", ", sortedGroups),
+                          R.string.user_info_groups);
         }
-
-        return result;
     }
 
-    private void addToListIfNeeded(List<UserInfoDetailsItem> info, @DrawableRes int icon, String text,
+    private void addToListIfNeeded(ViewGroup container, @DrawableRes int icon, String text,
                                    @StringRes int contentDescriptionInt) {
-        if (!TextUtils.isEmpty(text)) {
-            info.add(new UserInfoDetailsItem(icon, text, getResources().getString(contentDescriptionInt)));
-        }
+        if (TextUtils.isEmpty(text))
+            return;
+
+        final UserInfoDetailsTableItemBinding binding = UserInfoDetailsTableItemBinding.inflate(
+            getLayoutInflater(),
+            container,
+            false
+        );
+        binding.icon.setImageResource(icon);
+        binding.text.setText(text);
+        binding.icon.setContentDescription(getString(contentDescriptionInt));
+        viewThemeUtils.platform.colorImageView(binding.icon, ColorRole.PRIMARY);
+
+        // Separator
+        if (container.getChildCount() > 0)
+            binding.getRoot().setBackgroundResource(R.drawable.rounded_corners_group_item_background);
+
+        container.addView(binding.getRoot());
     }
 
     public static void openAccountRemovalDialog(User user, FragmentManager fragmentManager) {
@@ -369,68 +395,5 @@ public class UserInfoActivity extends DrawerActivity implements Injectable {
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     public void onMessageEvent(TokenPushEvent event) {
         PushUtils.pushRegistrationToServer(getUserAccountManager(), preferences.getPushToken());
-    }
-
-
-    protected static class UserInfoDetailsItem {
-        @DrawableRes public int icon;
-        public String text;
-        public String iconContentDescription;
-
-        public UserInfoDetailsItem(@DrawableRes int icon, String text, String iconContentDescription) {
-            this.icon = icon;
-            this.text = text;
-            this.iconContentDescription = iconContentDescription;
-        }
-    }
-
-    protected static class UserInfoAdapter extends RecyclerView.Adapter<UserInfoAdapter.ViewHolder> {
-        protected List<UserInfoDetailsItem> mDisplayList;
-        protected ViewThemeUtils viewThemeUtils;
-
-        public static class ViewHolder extends RecyclerView.ViewHolder {
-            protected UserInfoDetailsTableItemBinding binding;
-
-            public ViewHolder(UserInfoDetailsTableItemBinding binding) {
-                super(binding.getRoot());
-                this.binding = binding;
-            }
-        }
-
-        public UserInfoAdapter(List<UserInfoDetailsItem> displayList, ViewThemeUtils viewThemeUtils) {
-            mDisplayList = displayList == null ? new LinkedList<>() : displayList;
-            this.viewThemeUtils = viewThemeUtils;
-        }
-
-        @SuppressLint("NotifyDataSetChanged")
-        public void setData(List<UserInfoDetailsItem> displayList) {
-            mDisplayList = displayList == null ? new LinkedList<>() : displayList;
-            notifyDataSetChanged();
-        }
-
-        @NonNull
-        @Override
-        public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-            return new ViewHolder(
-                UserInfoDetailsTableItemBinding.inflate(
-                    LayoutInflater.from(parent.getContext()),
-                    parent,
-                    false)
-            );
-        }
-
-        @Override
-        public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-            UserInfoDetailsItem item = mDisplayList.get(position);
-            holder.binding.icon.setImageResource(item.icon);
-            holder.binding.text.setText(item.text);
-            holder.binding.icon.setContentDescription(item.iconContentDescription);
-            viewThemeUtils.platform.colorImageView(holder.binding.icon);
-        }
-
-        @Override
-        public int getItemCount() {
-            return mDisplayList.size();
-        }
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UserInfoActivity.java
@@ -8,6 +8,7 @@
  * SPDX-FileCopyrightText: 2017 Mario Danic <mario@lovelyhq.com>
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH
  * SPDX-FileCopyrightText: 2025 TSI-mc <surinder.kumar@t-systems.com>
+ * SPDX-FileCopyrightText: 2026 Daniele Verducci <daniele.verducci@ichibi.eu>
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.owncloud.android.ui.activity;

--- a/app/src/main/res/drawable/rounded_corners_group_background.xml
+++ b/app/src/main/res/drawable/rounded_corners_group_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Nextcloud - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2026 Daniele Verducci <daniele.verducci@ichibi.eu>
+  ~ SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/bg_default"/>
+    <stroke android:width="1dp" android:color="@color/grey_200" />
+    <corners android:radius="4dp"/>
+    <padding android:left="0dp" android:top="0dp" android:right="0dp" android:bottom="0dp" />
+</shape>

--- a/app/src/main/res/drawable/rounded_corners_group_item_background.xml
+++ b/app/src/main/res/drawable/rounded_corners_group_item_background.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Nextcloud - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2026 Daniele Verducci <daniele.verducci@ichibi.eu>
+  ~ SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:top="0dp" android:left="-2dp" android:right="-2dp" android:bottom="-2dp">
+        <shape android:shape="rectangle">
+            <stroke android:width="1dp" android:color="@color/grey_200"/>
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/user_info_details_table_item.xml
+++ b/app/src/main/res/layout/user_info_details_table_item.xml
@@ -10,7 +10,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/iconized_single_line_item_layout_height"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/standard_padding"
+    android:paddingBottom="@dimen/standard_padding"
     android:orientation="horizontal">
 
     <ImageView

--- a/app/src/main/res/layout/user_info_layout.xml
+++ b/app/src/main/res/layout/user_info_layout.xml
@@ -4,6 +4,7 @@
   ~
   ~ SPDX-FileCopyrightText: 2017 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2017 Nextcloud
+  ~ SPDX-FileCopyrightText: 2026 Daniele Verducci <daniele.verducci@ichibi.eu>
   ~ SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/user_info_layout.xml
+++ b/app/src/main/res/layout/user_info_layout.xml
@@ -84,16 +84,57 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/userinfo_list"
+    <ScrollView
+        android:id="@+id/userinfo_list_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
         android:visibility="gone"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        tools:itemCount="3"
-        tools:listitem="@layout/user_info_details_table_item"
-        tools:visibility="gone" />
+        tools:visibility="gone" >
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/standard_margin"
+            android:clipToPadding="false"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/userinfo_list_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_margin"
+                android:layout_marginBottom="@dimen/standard_margin"
+                android:textAppearance="@style/NextcloudTextAppearanceSectionTitle"
+                android:text="@string/user_info_profile"/>
+
+            <LinearLayout
+                android:id="@+id/userinfo_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/rounded_corners_group_background"
+                android:elevation="@dimen/cardview_default_elevation"/>
+
+            <TextView
+                android:id="@+id/groupinfo_list_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_margin"
+                android:layout_marginBottom="@dimen/standard_margin"
+                android:textAppearance="@style/NextcloudTextAppearanceSectionTitle"
+                android:text="@string/user_info_groups"/>
+
+            <LinearLayout
+                android:id="@+id/groupinfo_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/rounded_corners_group_background"
+                android:elevation="@dimen/cardview_default_elevation"/>
+
+        </LinearLayout>
+
+    </ScrollView>
 
     <include
         android:id="@+id/emptyList"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -837,6 +837,7 @@
     <string name="user_info_address">Address</string>
     <string name="user_info_website">Website</string>
     <string name="user_info_twitter">Twitter</string>
+    <string name="user_info_groups">Groups</string>
 
     <string name="user_information_retrieval_error">Error retrieving user information</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -837,6 +837,7 @@
     <string name="user_info_address">Address</string>
     <string name="user_info_website">Website</string>
     <string name="user_info_twitter">Twitter</string>
+    <string name="user_info_profile">Profile</string>
     <string name="user_info_groups">Groups</string>
 
     <string name="user_information_retrieval_error">Error retrieving user information</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -338,6 +338,12 @@
 
     <style name="NextcloudTextAppearanceMedium" parent="@style/TextAppearance.AppCompat.Medium"></style>
 
+    <style name="NextcloudTextAppearanceSectionTitle" parent="@style/TextAppearance.AppCompat.Small">
+        <item name="android:textColor">@color/primary</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/activity_list_item_title_header_text_size</item>
+    </style>
+
     <style name="Widget.App.Login.TextInputLayout" parent="Widget.Material3.TextInputLayout.OutlinedBox">
         <item name="materialThemeOverlay">@style/ThemeOverlay.App.Login.TextInputLayout</item>
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.SmallComponent</item>


### PR DESCRIPTION
### 🖼️ Screenshots

Implementation of https://github.com/nextcloud/android/issues/591

Notes: the previous implementation used RecyclerView for the list items. That's a sleek implementation and it's very efficient for long lists due to the efficiency in instantiating only the views needed to cover the screen and recycling them when the user scrolls. But in this case, the list barely consists of 6 elements (as I see, all the groups are concatenated in a single item), and in the vast majority of devices they will be all instantiated and drawn anyway, so it doesn't make a real difference.

Obtaining the required result (see "variant 1" in https://github.com/nextcloud/android/issues/591#issuecomment-334705913) with the two "groups" of items while keeping the current structure is possible (playing with cell backgrounds and different row views for the headers), but in my opinion unnecessarily complex, and less maintainable.

I decided to remove the RecyclerView and opt for a simpler implementation, that should be more readable.
Let me know if there is something that could have been done differently and I'll fix it.

🏚️ Before | 🏡 After
---|---
<img width="540" height="1200" alt="before" src="https://github.com/user-attachments/assets/ce800349-9f53-4899-95fd-1c82cbc5d891" />|<img width="540" height="1200" alt="after" src="https://github.com/user-attachments/assets/b632c3a4-81a8-4f0b-be19-9f10c72e1520" />

### 🏁 Checklist
 
- [x] Tests written, or not not needed
