### PR TITLE
fix(conflict-resolve-activity): threading

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "ReturnCount")
 class ConflictsResolveActivity :
     FileActivity(),
     OnConflictDecisionMadeListener {
@@ -120,27 +120,31 @@ class ConflictsResolveActivity :
                 return@OnConflictDecisionMadeListener
             }
 
-            val offlineOperation = offlineOperationPath?.let {
-                fileDataStorageManager.offlineOperationDao.getByPath(it)
-            }
+            lifecycleScope.launch(Dispatchers.IO) {
+                val offlineOperation = offlineOperationPath?.let {
+                    fileDataStorageManager.offlineOperationDao.getByPath(it)
+                }
 
-            when (decision) {
-                Decision.KEEP_LOCAL -> handleFile(file, upload, optionalUser.get(), NameCollisionPolicy.OVERWRITE)
-                Decision.KEEP_BOTH -> handleFile(file, upload, optionalUser.get(), NameCollisionPolicy.RENAME)
-                Decision.KEEP_SERVER -> keepServer(file, upload, optionalUser.get())
-                Decision.KEEP_OFFLINE_FOLDER -> keepOfflineFolder(file, offlineOperation)
-                Decision.KEEP_SERVER_FOLDER -> keepServerFile(offlineOperation)
-                Decision.KEEP_BOTH_FOLDER -> keepBothFolder(offlineOperation, file)
-                else -> Unit
-            }
+                when (decision) {
+                    Decision.KEEP_LOCAL -> handleFile(file, upload, optionalUser.get(), NameCollisionPolicy.OVERWRITE)
+                    Decision.KEEP_BOTH -> handleFile(file, upload, optionalUser.get(), NameCollisionPolicy.RENAME)
+                    Decision.KEEP_SERVER -> keepServer(file, upload, optionalUser.get())
+                    Decision.KEEP_OFFLINE_FOLDER -> keepOfflineFolder(file, offlineOperation)
+                    Decision.KEEP_SERVER_FOLDER -> keepServerFile(offlineOperation)
+                    Decision.KEEP_BOTH_FOLDER -> keepBothFolder(offlineOperation, file)
+                    else -> Unit
+                }
 
-            upload?.remotePath?.let { path ->
-                val oldFile = storageManager.getFileByDecryptedRemotePath(path)
-                updateThumbnailIfNeeded(decision, file, oldFile)
-            }
+                upload?.remotePath?.let { path ->
+                    val oldFile = storageManager.getFileByDecryptedRemotePath(path)
+                    updateThumbnailIfNeeded(decision, file, oldFile)
+                }
 
-            dismissConflictResolveNotification()
-            finish()
+                withContext(Dispatchers.Main) {
+                    dismissConflictResolveNotification()
+                    finish()
+                }
+            }
         }
     }
 
@@ -149,7 +153,7 @@ class ConflictsResolveActivity :
         uploadHelper.uploadUpdatedFile(user, arrayOf(file), localBehaviour, policy)
     }
 
-    private fun keepServer(file: OCFile?, upload: OCUpload?, user: User) {
+    private suspend fun keepServer(file: OCFile?, upload: OCUpload?, user: User) {
         if (!shouldDeleteLocal()) {
             file?.let {
                 downloadHelper.downloadFile(
@@ -163,41 +167,48 @@ class ConflictsResolveActivity :
         upload?.let {
             uploadHelper.removeFileUpload(it.remotePath, it.accountName)
             val id = it.uploadId.toInt()
-            UploadNotificationManager(applicationContext, viewThemeUtils, id).dismissNotification(id)
+
+            withContext(Dispatchers.Main) {
+                UploadNotificationManager(applicationContext, viewThemeUtils, id).dismissNotification(id)
+            }
         }
     }
 
-    private fun keepBothFolder(offlineOperation: OfflineOperationEntity?, serverFile: OCFile?) {
+    private suspend fun keepBothFolder(offlineOperation: OfflineOperationEntity?, serverFile: OCFile?) {
         offlineOperation ?: return
         fileDataStorageManager.keepOfflineOperationAndServerFile(offlineOperation, serverFile)
         backgroundJobManager.startOfflineOperations()
-        offlineOperationNotificationManager.dismissNotification(offlineOperation.id)
+        withContext(Dispatchers.Main) {
+            offlineOperationNotificationManager.dismissNotification(offlineOperation.id)
+        }
     }
 
-    private fun keepServerFile(offlineOperation: OfflineOperationEntity?) {
+    private suspend fun keepServerFile(offlineOperation: OfflineOperationEntity?) {
         offlineOperation ?: return
         fileDataStorageManager.offlineOperationDao.delete(offlineOperation)
-        offlineOperation.id?.let { offlineOperationNotificationManager.dismissNotification(it) }
+        offlineOperation.id?.let {
+            withContext(Dispatchers.Main) {
+                offlineOperationNotificationManager.dismissNotification(it)
+            }
+        }
     }
 
-    private fun keepOfflineFolder(serverFile: OCFile?, offlineOperation: OfflineOperationEntity?) {
+    private suspend fun keepOfflineFolder(serverFile: OCFile?, offlineOperation: OfflineOperationEntity?) {
         serverFile ?: return
         offlineOperation ?: return
 
-        lifecycleScope.launch(Dispatchers.IO) {
-            val client = clientRepository.getOwncloudClient() ?: return@launch
-            val isSuccess = fileOperationHelper.removeFile(
-                serverFile,
-                onlyLocalCopy = false,
-                inBackground = false,
-                client = client
-            )
+        val client = clientRepository.getOwncloudClient() ?: return
+        val isSuccess = fileOperationHelper.removeFile(
+            serverFile,
+            onlyLocalCopy = false,
+            inBackground = false,
+            client = client
+        )
 
-            if (isSuccess) {
-                backgroundJobManager.startOfflineOperations()
-                withContext(Dispatchers.Main) {
-                    offlineOperationNotificationManager.dismissNotification(offlineOperation.id)
-                }
+        if (isSuccess) {
+            backgroundJobManager.startOfflineOperations()
+            withContext(Dispatchers.Main) {
+                offlineOperationNotificationManager.dismissNotification(offlineOperation.id)
             }
         }
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue
```

"main" tid=1 Timed Waiting
  at jdk.internal.misc.Unsafe.park (Native method)
  at java.util.concurrent.locks.LockSupport.parkNanos (LockSupport.java:269)
  at android.database.sqlite.SQLiteConnectionPool.waitForConnection (SQLiteConnectionPool.java:1044)
  at android.database.sqlite.SQLiteConnectionPool.acquireConnection (SQLiteConnectionPool.java:619)
  at android.database.sqlite.SQLiteSession.acquireConnection (SQLiteSession.java:916)
  at android.database.sqlite.SQLiteSession.beginTransactionUnchecked (SQLiteSession.java:312)
  at android.database.sqlite.SQLiteSession.beginTransaction (SQLiteSession.java:300)
  at android.database.sqlite.SQLiteDatabase.beginTransaction (SQLiteDatabase.java:970)
  at android.database.sqlite.SQLiteDatabase.beginTransaction (SQLiteDatabase.java:880)
  at androidx.sqlite.db.framework.FrameworkSQLiteDatabase.beginTransaction (FrameworkSQLiteDatabase.android.kt:52)
  at com.owncloud.android.providers.FileContentProvider.query (FileContentProvider.java:454)
  at android.content.ContentProvider.query (ContentProvider.java:1677)
  at android.content.ContentProvider.query (ContentProvider.java:1773)
  at android.content.ContentProvider$Transport.query (ContentProvider.java:297)
  at android.content.ContentResolver.query (ContentResolver.java:1229)
  at android.content.ContentResolver.query (ContentResolver.java:1161)
  at android.content.ContentResolver.query (ContentResolver.java:1117)
  at com.owncloud.android.datamodel.FileDataStorageManager.getCapabilityCursorForAccount (FileDataStorageManager.java:2428)
  at com.owncloud.android.datamodel.FileDataStorageManager.getCapability (FileDataStorageManager.java:2455)
  at com.owncloud.android.datamodel.FileDataStorageManager.getCapability (FileDataStorageManager.java:2449)
  at com.nextcloud.client.jobs.upload.FileUploadHelper.getUploadByPaths (FileUploadHelper.kt:291)
  at com.nextcloud.client.jobs.upload.FileUploadHelper.uploadUpdatedFile (FileUploadHelper.kt:528)
  at com.owncloud.android.ui.activity.ConflictsResolveActivity.keepLocal (ConflictsResolveActivity.kt:197)
  at com.owncloud.android.ui.activity.ConflictsResolveActivity.setupOnConflictDecisionMadeListener$lambda$0 (ConflictsResolveActivity.kt:118)
  at com.owncloud.android.ui.activity.ConflictsResolveActivity$$ExternalSyntheticLambda2.conflictDecisionMade (D8$$SyntheticClass)
  at com.owncloud.android.ui.activity.ConflictsResolveActivity.conflictDecisionMade (ConflictsResolveActivity.kt:256)
  at com.nmc.android.ui.conflict.ConflictsResolveConsentDialog.onCreateDialog$lambda$0 (ConflictsResolveConsentDialog.kt:110)
  at com.nmc.android.ui.conflict.ConflictsResolveConsentDialog$$ExternalSyntheticLambda0.onClick (D8$$SyntheticClass)
  at android.view.View.performClick (View.java:8047)
  at android.widget.TextView.performClick (TextView.java:17792)
  at com.google.android.material.button.MaterialButton.performClick (MaterialButton.java:1345)
  at android.view.View.performClickInternal (View.java:8024)
  at android.view.View.-$$Nest$mperformClickInternal (unavailable)
  at android.view.View$PerformClick.run (View.java:31890)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8919)
  at java.lang.reflect.Method.invoke (Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)

```