### PR TITLE
fix(file-list): file indicator folder downloaded check

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -349,10 +349,16 @@ class OCFileListDelegate(
             fileUploadHelper.isUploading(file.remotePath, user.accountName)
     }
 
+    private fun OCFile.canCheckFolderDown(): Boolean = mimeType != null &&
+        isFolder &&
+        !isEncrypted &&
+        fileLength != 0L &&
+        !etag.isNullOrBlank()
+
     @Suppress("ComplexCondition")
     private fun showLocalFileIndicator(file: OCFile, holder: ListViewHolder) {
         var isFolderDown = false
-        if (file.isFolder && !file.isEncrypted && file.fileLength != 0L && file.etag.isNotBlank()) {
+        if (file.canCheckFolderDown()) {
             isFolderDown = storageManager.fileDao.areAllFilesHaveMediaPath(file.fileId, user.accountName)
         }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
java.lang.NullPointerException: getEtag(...) must not be null
at com.owncloud.android.ui.adapter.OCFileListDelegate.showLocalFileIndicator(OCFileListDelegate.kt:355)
at com.owncloud.android.ui.adapter.OCFileListDelegate.bindGridMetadataViews(OCFileListDelegate.kt:335)
at com.owncloud.android.ui.adapter.OCFileListDelegate.bindViewHolder(OCFileListDelegate.kt:232)
```