### PR TITLE
fix(file-extension): to file, npe

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/extensions/BitmapDecodeTests.kt
+++ b/app/src/androidTest/java/com/nextcloud/extensions/BitmapDecodeTests.kt
@@ -70,6 +70,12 @@ class BitmapDecodeTests {
     }
 
     @Test
+    fun testToFileWhenPathIsNullShouldReturnNull() {
+        val result = null.toFile()
+        assertNull(result)
+    }
+
+    @Test
     fun testToFileWhenFileDoesNotExistShouldReturnNull() {
         val nonExistentPath = tempDir.resolve("does_not_exist.jpg")
         val result = nonExistentPath.absolutePathString().toFile()

--- a/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/FileExtensions.kt
@@ -37,7 +37,7 @@ fun Path.toLocalPath(): String = toAbsolutePath().toString()
  * @return [File] instance if the file exists, or `null` if the path is null, empty, or non-existent.
  */
 @Suppress("ReturnCount")
-fun String.toFile(): File? {
+fun String?.toFile(): File? {
     if (isNullOrEmpty()) {
         Log_OC.w(TAG, "given path is null or empty: $this")
         return null


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

`
E  Unexpected error for admin@10.0.2.2:55000 java.lang.NullPointerException: Parameter specified as non-null is null: method com.nextcloud.utils.extensions.FileExtensionsKt.toFile, parameter <this> at com.nextcloud.utils.extensions.FileExtensionsKt.toFile(Unknown Source:2) at com.owncloud.android.datamodel.FileDataStorageManager.removeLocalCopyIfNeeded(FileDataStorageManager.java:925) at com.owncloud.android.datamodel.FileDataStorageManager.removeFile(FileDataStorageManager.java:912) at com.owncloud.android.operations.RemoveFileOperation.run(RemoveFileOperation.kt:89) at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:193) at com.owncloud.android.services.OperationsService$ServiceHandler.nextOperation(OperationsService.java:443) at com.owncloud.android.services.OperationsService$ServiceHandler.handleMessage(OperationsService.java:406) at android.os.Handler.dispatchMessage(Handler.java:110) at android.os.Looper.loopOnce(Looper.java:248) at android.os.Looper.loop(Looper.java:338) at android.os.HandlerThread.run(HandlerThread.java:85)`