### PR TITLE
fix(upload-list): conflict check npe

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt
@@ -8,6 +8,7 @@
 package com.nextcloud.client.jobs.utils
 
 import android.app.Notification
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -31,6 +32,11 @@ import kotlinx.coroutines.withContext
 
 object UploadErrorNotificationManager {
     private const val TAG = "UploadErrorNotificationManager"
+
+    fun dismissConflictResolveNotification(context: Context, id: Long) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.cancel(id.toInt())
+    }
 
     /**
      * Processes the result of an upload operation and manages error notifications.

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -360,8 +360,12 @@ public class FileDataStorageManager {
         offlineOperationsRepository.updateNextOperations(entity);
     }
 
-    private @Nullable
-    OCFile getFileByPath(String type, String path) {
+    @Nullable
+    private OCFile getFileByPath(String type, String path) {
+        if (path == null) {
+            return null;
+        }
+
         final boolean shouldUseEncryptedPath = ProviderTableMeta.FILE_PATH.equals(type);
         FileEntity fileEntity = shouldUseEncryptedPath ?
             fileDao.getFileByEncryptedRemotePath(path, user.getAccountName()) :

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -10,7 +10,6 @@
 package com.owncloud.android.ui.activity
 
 import android.annotation.SuppressLint
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -24,6 +23,7 @@ import com.nextcloud.client.jobs.operation.FileOperationHelper
 import com.nextcloud.client.jobs.upload.FileUploadHelper
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.jobs.upload.UploadNotificationManager
+import com.nextcloud.client.jobs.utils.UploadErrorNotificationManager
 import com.nextcloud.model.HTTPStatusCodes
 import com.nextcloud.utils.extensions.getDecryptedPath
 import com.nextcloud.utils.extensions.getParcelableArgument
@@ -141,7 +141,10 @@ class ConflictsResolveActivity :
                 }
 
                 withContext(Dispatchers.Main) {
-                    dismissConflictResolveNotification()
+                    UploadErrorNotificationManager.dismissConflictResolveNotification(
+                        this@ConflictsResolveActivity,
+                        conflictUploadId
+                    )
                     finish()
                 }
             }
@@ -330,10 +333,6 @@ class ConflictsResolveActivity :
 
         file?.isUpdateThumbnailNeeded = true
         fileDataStorageManager.saveFile(file)
-    }
-
-    private fun dismissConflictResolveNotification() {
-        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).cancel(conflictUploadId.toInt())
     }
 
     private fun showErrorAndFinish(code: Int? = null) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.kt
@@ -26,6 +26,7 @@ import com.nextcloud.client.core.Clock
 import com.nextcloud.client.device.PowerManagementService
 import com.nextcloud.client.jobs.upload.FileUploadEventBroadcaster
 import com.nextcloud.client.jobs.upload.FileUploadHelper
+import com.nextcloud.client.jobs.utils.UploadErrorNotificationManager
 import com.nextcloud.client.utils.Throttler
 import com.nextcloud.utils.extensions.webDavParentPath
 import com.owncloud.android.R
@@ -343,6 +344,10 @@ class UploadListActivity :
 
             if (result.isSuccess) {
                 withContext(Dispatchers.Main) {
+                    UploadErrorNotificationManager.dismissConflictResolveNotification(
+                        this@UploadListActivity,
+                        upload.uploadId
+                    )
                     uploadListAdapter.loadUploadItemsFromDb()
                 }
             }

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.kt
@@ -320,21 +320,21 @@ class UploadListActivity :
             val client = clientRepository.getOwncloudClient()
 
             // Check parent folder exists
-            val parentPath = storageManager
-                .getFileByPath(upload.remotePath)
-                .parentRemotePath
-                ?: upload.remotePath.webDavParentPath()
+            val file = storageManager.getFileByPath(upload.remotePath)
+            val parentPath = (file?.parentRemotePath ?: upload.remotePath?.webDavParentPath())
 
-            val checkOp = ExistenceCheckRemoteOperation(parentPath, false)
-            val checkResult = checkOp.execute(client)
+            parentPath?.let {
+                val checkOp = ExistenceCheckRemoteOperation(it, false)
+                val checkResult = checkOp.execute(client)
 
-            if (!checkResult.isSuccess &&
-                checkResult.code == RemoteOperationResult.ResultCode.FILE_NOT_FOUND
-            ) {
-                withContext(Dispatchers.Main) {
-                    showConflictSnackbar(R.string.uploader_file_not_found_message)
+                if (!checkResult.isSuccess &&
+                    checkResult.code == RemoteOperationResult.ResultCode.FILE_NOT_FOUND
+                ) {
+                    withContext(Dispatchers.Main) {
+                        showConflictSnackbar(R.string.uploader_file_not_found_message)
+                    }
+                    return@launch
                 }
-                return@launch
             }
 
             val result = uploadFileOperationFactory


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

On some devices's db might not `getParentRemotePath` exists, thus app should check that.

```java
Exception in thread "DefaultDispatcher-worker-2" java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.owncloud.android.datamodel.OCFile.getParentRemotePath()' on a null object reference
    at com.owncloud.android.ui.activity.UploadListActivity$retryUpload$1.invokeSuspend(UploadListActivity.kt:325)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
    at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)

```

### Changes

- NPE check
- Dismiss conflict resolve notification automatically after resolving from Upload list screen