### PR TITLE
fix(offline-sync): remote path npe

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt
@@ -72,8 +72,14 @@ class OfflineSyncWork(
         if (files != null) {
             for (file in files) {
                 val ocFile = storageManager.getFileByLocalPath(file.path)
+                val remotePath = ocFile?.remotePath
+                if (remotePath == null) {
+                    Log_OC.w(TAG, "remote path is null can't sync")
+                    continue
+                }
+
                 val synchronizeFileOperation = SynchronizeFileOperation(
-                    ocFile?.remotePath,
+                    remotePath,
                     user,
                     true,
                     context,

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -186,18 +186,8 @@ public class SynchronizeFileOperation extends SyncOperation {
         mTransferWasRequested = false;
 
         if (mLocalFile == null) {
-            if (mRemotePath == null) {
-                Log_OC.e(TAG, "Cannot synchronize file: remotePath is null");
-                return new RemoteOperationResult<>(ResultCode.FILE_NOT_FOUND);
-            }
-
             // Get local file from the DB
             mLocalFile = getStorageManager().getFileByPath(mRemotePath);
-        }
-
-        if (mLocalFile == null) {
-            Log_OC.e(TAG, "Cannot synchronize file: local file not found in database for path: " + mRemotePath);
-            return new RemoteOperationResult(ResultCode.FILE_NOT_FOUND);
         }
 
         if (!mLocalFile.isDown()) {

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -186,8 +186,18 @@ public class SynchronizeFileOperation extends SyncOperation {
         mTransferWasRequested = false;
 
         if (mLocalFile == null) {
+            if (mRemotePath == null) {
+                Log_OC.e(TAG, "Cannot synchronize file: remotePath is null");
+                return new RemoteOperationResult<>(ResultCode.FILE_NOT_FOUND);
+            }
+
             // Get local file from the DB
             mLocalFile = getStorageManager().getFileByPath(mRemotePath);
+        }
+
+        if (mLocalFile == null) {
+            Log_OC.e(TAG, "Cannot synchronize file: local file not found in database for path: " + mRemotePath);
+            return new RemoteOperationResult(ResultCode.FILE_NOT_FOUND);
         }
 
         if (!mLocalFile.isDown()) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue



```
E  Work [ id=38e277fa-a127-4183-8f21-5a084f2fa44f, tags={ com.nextcloud.client.jobs.OfflineSyncWork,*,name:periodic_offline_sync,timestamp:1776261120706,class:OfflineSyncWork } ] failed because it threw an exception/error
                                                                                                    java.lang.NullPointerException: Parameter specified as non-null is null: method com.nextcloud.client.database.dao.FileDao_Impl.getFileByEncryptedRemotePath, parameter path
                                                                                                    	at com.nextcloud.client.database.dao.FileDao_Impl.getFileByEncryptedRemotePath(Unknown Source:2)
                                                                                                    	at com.owncloud.android.datamodel.FileDataStorageManager.getFileByPath(FileDataStorageManager.java:367)
                                                                                                    	at com.owncloud.android.datamodel.FileDataStorageManager.getFileByEncryptedRemotePath(FileDataStorageManager.java:145)
                                                                                                    	at com.owncloud.android.datamodel.FileDataStorageManager.getFileByPath(FileDataStorageManager.java:141)
                                                                                                    	at com.owncloud.android.operations.SynchronizeFileOperation.run(SynchronizeFileOperation.java:190)
                                                                                                    	at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:132)
                                                                                                    	at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:141)
                                                                                                    	at com.owncloud.android.operations.common.SyncOperation.execute(SyncOperation.java:51)
                                                                                                    	at com.nextcloud.client.jobs.OfflineSyncWork.recursive(OfflineSyncWork.kt:84)
                                                                                                    	at com.nextcloud.client.jobs.OfflineSyncWork.doWork(OfflineSyncWork.kt:53)
                                                                                                    	at androidx.work.Worker.startWork$lambda$0(Worker.kt:64)
                                                                                                    	at androidx.work.Worker$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
                                                                                                    	at androidx.work.WorkerKt.future$lambda$2$lambda$1(Worker.kt:100)
                                                                                                    	at androidx.work.WorkerKt$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
                                                                                                    	at java.lang.Thread.run(Thread.java:1119)
```

### Fix

Do not fail whole worker