### PR TITLE
Shared with me: transfer owner info from partial file

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/SharedListFragment.kt
@@ -87,6 +87,8 @@ class SharedListFragment :
             FileStorageUtils.searchForLocalFileInDefaultPath(file, user.accountName)
             val savedFile = mContainerActivity.storageManager.saveFileWithParent(file, context)
             savedFile.apply {
+                ownerId = partialFile.ownerId
+                ownerDisplayName = partialFile.ownerDisplayName
                 isSharedViaLink = partialFile.isSharedViaLink
                 isSharedWithSharee = partialFile.isSharedWithSharee
                 sharees = partialFile.sharees


### PR DESCRIPTION
Pre-requisite: User already have a shared file with 'resharing permission'

Step to reproduce:
1. Launch the app and login
2. From All Files open Shared screen for the same folder where "resharing permission" is given.
3. Now go to Shared tab and open the Shared screen for the same folder.
4. The UI shows without the user name from whom share is received.
5. Now go to All files and open the Shared screen from same folder. Now from All Files also the User name doesn't shows up.
6. Doing manual refresh doesn't do anything.

Actual result:
Shared - received file on All files shows - 'Resharing is not allowed' with disabled further sharing functionality along with shared(file/folder) user name.
Shared - received file on Shared tab shows - Shows disabled views but without user name.

Expected result:
Shared file - same share permission with UI should get display on shared tab also compared with All files dashboard.