### PR TITLE
fix(filename text watcher): existing file names provider npe

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameTextWatcher.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameTextWatcher.kt
@@ -17,15 +17,12 @@ import com.nextcloud.utils.fileNameValidator.FileNameValidator.isFileHidden
 import com.owncloud.android.R
 import com.owncloud.android.lib.resources.status.OCCapability
 
-/**
- * A TextWatcher which wraps around [FileNameValidator]
- */
 @Suppress("LongParameterList")
 class FileNameTextWatcher(
     private val previousFileName: String?,
     private val context: Context,
     private val capabilitiesProvider: () -> OCCapability,
-    private val existingFileNamesProvider: () -> Set<String>?,
+    private val existingFileNamesProvider: () -> Set<String>,
     private val onValidationError: Consumer<String>,
     private val onValidationWarning: Consumer<String>,
     private val onValidationSuccess: Runnable

--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
@@ -38,16 +38,14 @@ object FileNameValidator {
         filename: String,
         capability: OCCapability,
         context: Context,
-        existingFileNames: Set<String>? = null
+        existingFileNames: Set<String> = setOf()
     ): String? {
         if (filename.isBlank()) {
             return context.getString(R.string.filename_empty)
         }
 
-        existingFileNames?.let {
-            if (isFileNameAlreadyExist(filename, existingFileNames)) {
-                return context.getString(R.string.file_already_exists)
-            }
+        if (isFileNameAlreadyExist(filename, existingFileNames)) {
+            return context.getString(R.string.file_already_exists)
         }
 
         if (!capability.checkWCFRestrictions()) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -99,6 +99,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Stack;
@@ -904,7 +905,9 @@ public class ReceiveExternalFilesActivity extends FileActivity
             fileName,
             this,
             () -> capability,
-            () -> receiveExternalFilesAdapter.getFileNames(),
+            () -> receiveExternalFilesAdapter != null
+                ? receiveExternalFilesAdapter.getFileNames()
+                : Collections.emptySet(),
             validationError -> {
                 binding.userInputContainer.setError(validationError);
                 binding.uploaderChooseFolder.setEnabled(false);

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.kt
@@ -251,7 +251,7 @@ class ChooseRichDocumentsTemplateDialogFragment :
             name,
             fileDataStorageManager.getCapability(currentAccount.user),
             requireContext(),
-            fileNames
+            fileNames ?: setOf()
         )
 
         if (selectedTemplate == null) {
@@ -301,7 +301,7 @@ class ChooseRichDocumentsTemplateDialogFragment :
             name,
             fileDataStorageManager.getCapability(currentAccount.user),
             requireContext(),
-            fileNames
+            fileNames ?: setOf()
         )
         val isExtension = (
             selectedTemplate == null ||

--- a/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.kt
@@ -100,7 +100,7 @@ class RenameFileDialogFragment :
                 previousFileName = mTargetFile?.fileName,
                 context = binding.userInputContainer.context,
                 capabilitiesProvider = { oCCapability },
-                existingFileNamesProvider = { fileNames },
+                existingFileNamesProvider = { fileNames ?: setOf() },
                 onValidationError = { validationError: String ->
                     binding.userInputContainer.error = validationError
                     positiveButton?.isEnabled = false
@@ -162,7 +162,7 @@ class RenameFileDialogFragment :
                 newFileName = binding.userInput.text.toString()
             }
 
-            val errorMessage = checkFileName(newFileName, oCCapability, requireContext(), null)
+            val errorMessage = checkFileName(newFileName, oCCapability, requireContext())
             if (errorMessage != null) {
                 DisplayUtils.showSnackMessage(requireActivity(), errorMessage)
                 return


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception java.lang.NullPointerException:
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.lambda$getFileNameTextWatcher$6 (ReceiveExternalFilesActivity.java:907)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.$r8$lambda$7aQSDlHWZ2ECuUzMqE_fcn8_TAk (Unknown Source)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity$$ExternalSyntheticLambda11.invoke (D8$$SyntheticClass)
  at com.nextcloud.utils.fileNameValidator.FileNameTextWatcher.afterTextChanged (FileNameTextWatcher.kt:43)
  at android.widget.TextView.sendAfterTextChanged (TextView.java:13603)
  at android.widget.TextView.setText (TextView.java:7949)
  at android.widget.TextView.setText (TextView.java:7719)
  at android.widget.EditText.setText (EditText.java:184)
  at android.widget.TextView.setText (TextView.java:7657)
  at android.widget.TextView.onRestoreInstanceState (TextView.java:7524)
  at android.view.View.dispatchRestoreInstanceState (View.java:24610)
  at android.view.ViewGroup.dispatchRestoreInstanceState (ViewGroup.java:4279)
  at android.view.ViewGroup.dispatchRestoreInstanceState (ViewGroup.java:4279)
  at com.google.android.material.textfield.TextInputLayout.dispatchRestoreInstanceState (TextInputLayout.java:3208)
  at android.view.ViewGroup.dispatchRestoreInstanceState (ViewGroup.java:4279)
  at android.view.ViewGroup.dispatchRestoreInstanceState (ViewGroup.java:4279)
  at android.view.ViewGroup.dispatchRestoreInstanceState (ViewGroup.java:4279)
  at android.view.ViewGroup.dispatchRestoreInstanceState (ViewGroup.java:4279)
  at android.view.View.restoreHierarchyState (View.java:24588)
  at com.android.internal.policy.PhoneWindow.restoreHierarchyState (PhoneWindow.java:2435)
  at android.app.Activity.onRestoreInstanceState (Activity.java:2056)
  at com.owncloud.android.ui.activity.DrawerActivity.onRestoreInstanceState (DrawerActivity.java:1163)
  at android.app.Activity.performRestoreInstanceState (Activity.java:2009)
  at android.app.Instrumentation.callActivityOnRestoreInstanceState (Instrumentation.java:1571)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:4770)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:214)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:194)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:166)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:101)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:80)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:3150)
  at android.os.Handler.dispatchMessage (Handler.java:110)
  at android.os.Looper.loopOnce (Looper.java:273)
  at android.os.Looper.loop (Looper.java:363)
  at android.app.ActivityThread.main (ActivityThread.java:10060)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:975)
```

### Changes

Makes `existingFileNamesProvider` non-nullable.