### PR TITLE
fix(live-photo): oome

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/helper/OCFileListAdapterHelper.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/helper/OCFileListAdapterHelper.kt
@@ -118,28 +118,27 @@ class OCFileListAdapterHelper {
 
     @Suppress("NestedBlockDepth")
     private fun mergeOCFilesForLivePhoto(files: List<OCFile>): List<OCFile> {
+        val localIdMap: Map<String, OCFile> = files
+            .filter { it.localId != 0L && it.localId != -1L }
+            .associateBy { it.localId.toString() }
+
         val filesToRemove = mutableSetOf<OCFile>()
 
-        for (i in files.indices) {
-            val file = files[i]
+        for (file in files) {
+            val linkedId = file.linkedFileIdForLivePhoto ?: continue
 
-            for (j in i + 1 until files.size) {
-                val nextFile = files[j]
-                val fileLocalId = file.localId.toString()
-                val nextFileLinkedLocalId = nextFile.linkedFileIdForLivePhoto
+            // no match, skip
+            val linkedFile = localIdMap[linkedId] ?: continue
 
-                if (fileLocalId == nextFileLinkedLocalId) {
-                    when {
-                        MimeTypeUtil.isVideo(file.mimeType) -> {
-                            nextFile.livePhotoVideo = file
-                            filesToRemove.add(file)
-                        }
+            when {
+                MimeTypeUtil.isVideo(linkedFile.mimeType) -> {
+                    file.livePhotoVideo = linkedFile
+                    filesToRemove.add(linkedFile)
+                }
 
-                        MimeTypeUtil.isVideo(nextFile.mimeType) -> {
-                            file.livePhotoVideo = nextFile
-                            filesToRemove.add(nextFile)
-                        }
-                    }
+                MimeTypeUtil.isVideo(file.mimeType) -> {
+                    linkedFile.livePhotoVideo = file
+                    filesToRemove.add(file)
                 }
             }
         }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception java.lang.OutOfMemoryError:
  at java.lang.StringFactory.newStringFromUtf8Bytes
  at java.lang.StringFactory.newStringFromBytes (StringFactory.java:94)
  at java.lang.StringFactory.newStringFromBytes (StringFactory.java:68)
  at java.lang.StringFactory.newStringFromBytes (StringFactory.java:44)
  at java.lang.Long.toString (Long.java:482)
  at java.lang.String.valueOf (String.java:4650)
  at com.owncloud.android.ui.adapter.helper.OCFileListAdapterHelper.mergeOCFilesForLivePhoto (OCFileListAdapterHelper.kt:128)
  at com.owncloud.android.ui.adapter.helper.OCFileListAdapterHelper.prepareFileList (OCFileListAdapterHelper.kt:99)
  at com.owncloud.android.ui.adapter.helper.OCFileListAdapterHelper$prepareFileList$2.invokeSuspend (Unknown Source:20)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.UndispatchedCoroutine.afterResume (CoroutineContext.kt:266)
  at kotlinx.coroutines.AbstractCoroutine.resumeWith (AbstractCoroutine.kt:100)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:47)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:101)
  at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run (LimitedDispatcher.kt:113)
  at kotlinx.coroutines.scheduling.TaskImpl.run (Tasks.kt:89)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:589)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:823)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:720)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:707)
```

### Changes

On2 to On