### PR TITLE
fix(uri-util): illegal argument

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -865,7 +865,12 @@ public class ReceiveExternalFilesActivity extends FileActivity
         if (mStreamsToUpload == null || mStreamsToUpload.size() != 1) {
             return;
         }
-        final String fileName = getDisplayNameForUri((Uri) mStreamsToUpload.get(0), getActivity());
+
+        if (!(mStreamsToUpload.get(0) instanceof Uri source)) {
+            return;
+        }
+
+        final String fileName = getDisplayNameForUri(source, getActivity());
         if (fileName == null) {
             return;
         }

--- a/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
@@ -76,14 +76,12 @@ class UriUploader @JvmOverloads constructor(
                 code = UriUploaderResultCode.ERROR_SENSITIVE_PATH
             } else {
                 val uris = mUrisToUpload
-                    .filterNotNull()
-                    .map { it as Uri }
-                    .map { Pair(it, getRemotePathForUri(it)) }
+                    .mapNotNull { (it as? Uri)?.let { sourceUri -> Pair(sourceUri, getRemotePathForUri(sourceUri)) } }
 
                 val fileUris = uris.filter { it.first.scheme == ContentResolver.SCHEME_FILE }
                 if (fileUris.isNotEmpty()) {
-                    val localPaths = Array<String>(fileUris.size) { "" }
-                    val remotePaths = Array<String>(fileUris.size) { "" }
+                    val localPaths = Array(fileUris.size) { "" }
+                    val remotePaths = Array(fileUris.size) { "" }
 
                     for (i in 0..<fileUris.size) {
                         val uri = fileUris[i]


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception java.lang.IllegalArgumentException:
  at com.owncloud.android.utils.UriUtils.getDisplayNameForUri (UriUtils.kt:27)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.setupFileNameInputField (ReceiveExternalFilesActivity.java:868)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.populateDirectoryList (ReceiveExternalFilesActivity.java:803)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.browseToFolderIfItExists (ReceiveExternalFilesActivity.java:274)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.onStart (ReceiveExternalFilesActivity.java:266)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1699)
  at android.app.Activity.performStart (Activity.java:9562)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:4744)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:214)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:194)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:166)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:101)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:80)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:3150)
  at android.os.Handler.dispatchMessage (Handler.java:110)
  at android.os.Looper.loopOnce (Looper.java:273)
  at android.os.Looper.loop (Looper.java:363)
  at android.app.ActivityThread.main (ActivityThread.java:10060)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:975)
```

