### PR TITLE
fix(settings-activity): dialogs

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/AppPassCodeDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/AppPassCodeDialog.kt
@@ -145,6 +145,11 @@ class AppPassCodeDialog :
         )
     }
 
+    override fun onDismiss(dialog: android.content.DialogInterface) {
+        super.onDismiss(dialog)
+        activity?.finish()
+    }
+
     companion object {
         private const val ARG_DISMISSABLE = "dismissable"
 

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ThemeSelectionDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ThemeSelectionDialog.kt
@@ -98,4 +98,9 @@ class ThemeSelectionDialog :
             bundleOf(ExtendedSettingsActivityDialog.ThemeSelection.key to mode.name)
         )
     }
+
+    override fun onDismiss(dialog: android.content.DialogInterface) {
+        super.onDismiss(dialog)
+        activity?.finish()
+    }
 }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

User can't open passcode after press cancel or dismiss dialog first.