### PR TITLE
fix(e2ee-upload): counter usage

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -526,7 +526,8 @@ public class UploadFileOperation extends SyncOperation {
                 return result;
             }
 
-            long counter = e2eeCounterFetchOperation.resolveE2EECounter(parentFile, getStorageManager(), mContext);
+            long lastCounter = e2eeCounterFetchOperation.fetch(mContext, parentFile, getStorageManager(), user, client);
+            long counter = lastCounter + 1;
 
             try {
                 token = getFolderUnlockTokenOrLockFolder(client, parentFile, counter);

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -57,6 +57,7 @@ import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.operations.e2e.E2EClientData;
 import com.owncloud.android.operations.e2e.E2EData;
+import com.owncloud.android.operations.e2e.E2EECounterFetchOperation;
 import com.owncloud.android.operations.e2e.E2EFiles;
 import com.owncloud.android.operations.upload.UploadFileException;
 import com.owncloud.android.operations.upload.UploadFileOperationExtensionsKt;
@@ -516,6 +517,7 @@ public class UploadFileOperation extends SyncOperation {
         FileChannel channel = null;
         ArbitraryDataProvider arbitraryDataProvider = new ArbitraryDataProviderImpl(getContext());
         String publicKey = arbitraryDataProvider.getValue(user.getAccountName(), EncryptionUtils.PUBLIC_KEY);
+        E2EECounterFetchOperation e2eeCounterFetchOperation = new E2EECounterFetchOperation();
 
         try {
             result = checkConditions(e2eFiles.getOriginalFile());
@@ -524,7 +526,7 @@ public class UploadFileOperation extends SyncOperation {
                 return result;
             }
 
-            long counter = getE2ECounter(parentFile);
+            long counter = e2eeCounterFetchOperation.resolveE2EECounter(parentFile, getStorageManager(), mContext);
 
             try {
                 token = getFolderUnlockTokenOrLockFolder(client, parentFile, counter);
@@ -619,16 +621,6 @@ public class UploadFileOperation extends SyncOperation {
     private boolean isEndToEndVersionAtLeastV2() {
         final var capability = CapabilityUtils.getCapability(mContext);
         return E2EVersionHelper.INSTANCE.isV2Plus(capability);
-    }
-
-    private long getE2ECounter(OCFile parentFile) {
-        long counter = -1;
-
-        if (isEndToEndVersionAtLeastV2()) {
-            counter = parentFile.getE2eCounter() + 1;
-        }
-
-        return counter;
     }
 
     private String getFolderUnlockTokenOrLockFolder(OwnCloudClient client, OCFile parentFile, long counter) throws UploadException {

--- a/app/src/main/java/com/owncloud/android/operations/e2e/E2EECounterFetchOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/e2e/E2EECounterFetchOperation.kt
@@ -9,6 +9,7 @@ package com.owncloud.android.operations.e2e
 
 import android.content.Context
 import com.nextcloud.client.account.UserAccountManager
+import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.network.ClientFactory
 import com.nextcloud.utils.e2ee.E2EVersionHelper.isV2Plus
 import com.owncloud.android.datamodel.FileDataStorageManager
@@ -19,70 +20,78 @@ import com.owncloud.android.operations.RefreshFolderOperation
 import com.owncloud.android.utils.theme.CapabilityUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class E2EECounterFetchOperation {
+class E2EECounterFetchOperation: Injectable {
     @Inject
     lateinit var accountManager: UserAccountManager
 
     @Inject
     lateinit var clientFactory: ClientFactory
 
-    private var job: Job? = null
-    private val scope = CoroutineScope(Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     companion object {
         private const val TAG = "E2EECounterFetchOperation"
     }
 
-    fun execute(
+    fun fetchAsync(
         file: OCFile,
         storageManager: FileDataStorageManager,
         context: Context,
         onComplete: (Long) -> Unit
     ) {
-        job = scope.launch(Dispatchers.IO) {
-            var counter = getE2ECounter(context, file)
-
-            runCatching {
-                val client = clientFactory.create(accountManager.user)
-                val metadata = RefreshFolderOperation
-                    .getDecryptedFolderMetadata(true, file, client, accountManager.user, context)
-                if (metadata is DecryptedFolderMetadataFile) {
-                    counter = metadata.metadata.counter
-                    file.setE2eCounter(metadata.metadata.counter)
-                    storageManager.saveFile(file)
-                }
-            }.onFailure { e ->
-                Log_OC.e(TAG, "Error refreshing E2E counter: ${e.message}")
-            }
-
+        scope.launch {
+            val counter = resolveE2EECounter(file, storageManager, context)
             withContext(Dispatchers.Main) {
                 onComplete(counter)
             }
         }
     }
 
-    private fun isEndToEndVersionAtLeastV2(context: Context): Boolean {
+    fun resolveE2EECounter(
+        file: OCFile,
+        storageManager: FileDataStorageManager,
+        context: Context
+    ): Long {
+        return try {
+            val client = clientFactory.create(accountManager.user)
+            val metadata = RefreshFolderOperation
+                .getDecryptedFolderMetadata(true, file, client, accountManager.user, context)
+            if (metadata is DecryptedFolderMetadataFile) {
+                file.setE2eCounter(metadata.metadata.counter)
+                storageManager.saveFile(file)
+                Log_OC.i(TAG, "latest counter fetched")
+                metadata.metadata.counter
+            } else {
+                Log_OC.w(TAG, "local counter is used")
+                getFallbackCounter(context, file)
+            }
+        } catch (e: Exception) {
+            Log_OC.e(TAG, "error refreshing E2E counter: ${e.message}")
+            getFallbackCounter(context, file)
+        }
+    }
+
+    fun stop() {
+        scope.cancel()
+    }
+
+    // region private methods
+    private fun supportsE2EEv2(context: Context): Boolean {
         val capability = CapabilityUtils.getCapability(context)
         return isV2Plus(capability)
     }
 
-    private fun getE2ECounter(context: Context, file: OCFile): Long {
-        var counter: Long = -1
-
-        if (isEndToEndVersionAtLeastV2(context)) {
-            counter = file.e2eCounter + 1
+    private fun getFallbackCounter(context: Context, file: OCFile): Long {
+        if (!supportsE2EEv2(context)) {
+            return -1
         }
-
-        return counter
+        return file.e2eCounter + 1
     }
-
-    fun stop() {
-        job?.cancel()
-        job = null
-    }
+    // endregion
 }

--- a/app/src/main/java/com/owncloud/android/operations/e2e/E2EECounterFetchOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/e2e/E2EECounterFetchOperation.kt
@@ -1,0 +1,88 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.operations.e2e
+
+import android.content.Context
+import com.nextcloud.client.account.UserAccountManager
+import com.nextcloud.client.network.ClientFactory
+import com.nextcloud.utils.e2ee.E2EVersionHelper.isV2Plus
+import com.owncloud.android.datamodel.FileDataStorageManager
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.datamodel.e2e.v2.decrypted.DecryptedFolderMetadataFile
+import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.operations.RefreshFolderOperation
+import com.owncloud.android.utils.theme.CapabilityUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class E2EECounterFetchOperation {
+    @Inject
+    lateinit var accountManager: UserAccountManager
+
+    @Inject
+    lateinit var clientFactory: ClientFactory
+
+    private var job: Job? = null
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    companion object {
+        private const val TAG = "E2EECounterFetchOperation"
+    }
+
+    fun execute(
+        file: OCFile,
+        storageManager: FileDataStorageManager,
+        context: Context,
+        onComplete: (Long) -> Unit
+    ) {
+        job = scope.launch(Dispatchers.IO) {
+            var counter = getE2ECounter(context, file)
+
+            runCatching {
+                val client = clientFactory.create(accountManager.user)
+                val metadata = RefreshFolderOperation
+                    .getDecryptedFolderMetadata(true, file, client, accountManager.user, context)
+                if (metadata is DecryptedFolderMetadataFile) {
+                    counter = metadata.metadata.counter
+                    file.setE2eCounter(metadata.metadata.counter)
+                    storageManager.saveFile(file)
+                }
+            }.onFailure { e ->
+                Log_OC.e(TAG, "Error refreshing E2E counter: ${e.message}")
+            }
+
+            withContext(Dispatchers.Main) {
+                onComplete(counter)
+            }
+        }
+    }
+
+    private fun isEndToEndVersionAtLeastV2(context: Context): Boolean {
+        val capability = CapabilityUtils.getCapability(context)
+        return isV2Plus(capability)
+    }
+
+    private fun getE2ECounter(context: Context, file: OCFile): Long {
+        var counter: Long = -1
+
+        if (isEndToEndVersionAtLeastV2(context)) {
+            counter = file.e2eCounter + 1
+        }
+
+        return counter
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+}

--- a/app/src/main/java/com/owncloud/android/operations/e2e/E2EECounterFetchOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/e2e/E2EECounterFetchOperation.kt
@@ -8,13 +8,13 @@
 package com.owncloud.android.operations.e2e
 
 import android.content.Context
-import com.nextcloud.client.account.UserAccountManager
-import com.nextcloud.client.di.Injectable
+import com.nextcloud.client.account.User
 import com.nextcloud.client.network.ClientFactory
 import com.nextcloud.utils.e2ee.E2EVersionHelper.isV2Plus
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.e2e.v2.decrypted.DecryptedFolderMetadataFile
+import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.operations.RefreshFolderOperation
 import com.owncloud.android.utils.theme.CapabilityUtils
@@ -24,15 +24,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-class E2EECounterFetchOperation: Injectable {
-    @Inject
-    lateinit var accountManager: UserAccountManager
-
-    @Inject
-    lateinit var clientFactory: ClientFactory
-
+class E2EECounterFetchOperation {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     companion object {
@@ -40,41 +33,45 @@ class E2EECounterFetchOperation: Injectable {
     }
 
     fun fetchAsync(
+        context: Context,
         file: OCFile,
         storageManager: FileDataStorageManager,
-        context: Context,
+        user: User,
+        clientFactory: ClientFactory,
         onComplete: (Long) -> Unit
     ) {
         scope.launch {
-            val counter = resolveE2EECounter(file, storageManager, context)
+            val client = clientFactory.create(user)
+            val counter = fetch(context, file, storageManager, user, client)
             withContext(Dispatchers.Main) {
                 onComplete(counter)
             }
         }
     }
 
-    fun resolveE2EECounter(
+    fun fetch(
+        context: Context,
         file: OCFile,
         storageManager: FileDataStorageManager,
-        context: Context
-    ): Long {
-        return try {
-            val client = clientFactory.create(accountManager.user)
-            val metadata = RefreshFolderOperation
-                .getDecryptedFolderMetadata(true, file, client, accountManager.user, context)
-            if (metadata is DecryptedFolderMetadataFile) {
-                file.setE2eCounter(metadata.metadata.counter)
-                storageManager.saveFile(file)
-                Log_OC.i(TAG, "latest counter fetched")
-                metadata.metadata.counter
-            } else {
-                Log_OC.w(TAG, "local counter is used")
-                getFallbackCounter(context, file)
-            }
-        } catch (e: Exception) {
-            Log_OC.e(TAG, "error refreshing E2E counter: ${e.message}")
-            getFallbackCounter(context, file)
+        user: User,
+        client: OwnCloudClient
+    ): Long = try {
+        val metadata = RefreshFolderOperation
+            .getDecryptedFolderMetadata(true, file, client, user, context)
+        if (metadata is DecryptedFolderMetadataFile) {
+            val result = metadata.metadata.counter
+            file.setE2eCounter(result)
+            storageManager.saveFile(file)
+            Log_OC.i(TAG, "latest counter fetched, counter is: $result")
+            result
+        } else {
+            val result = getFallbackCounter(context, file)
+            Log_OC.w(TAG, "local counter is used, counter is: $result")
+            result
         }
+    } catch (e: Exception) {
+        Log_OC.e(TAG, "error refreshing E2E counter: ${e.message}")
+        getFallbackCounter(context, file)
     }
 
     fun stop() {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -358,7 +358,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                         return Unit.INSTANCE;
                     }
 
-                    if (file.getE2eCounter() == -1) {
+                    if (counter == -1) {
                         // V1 cannot share
                         binding.searchContainer.setVisibility(View.GONE);
                         binding.createLink.setVisibility(View.GONE);

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -50,16 +50,14 @@ import com.owncloud.android.databinding.FileDetailsSharingFragmentBinding;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.datamodel.SharesType;
-import com.owncloud.android.datamodel.e2e.v2.decrypted.DecryptedFolderMetadataFile;
 import com.owncloud.android.lib.common.OwnCloudAccount;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.lib.resources.status.NextcloudVersion;
 import com.owncloud.android.lib.resources.status.OCCapability;
-import com.owncloud.android.operations.RefreshFolderOperation;
+import com.owncloud.android.operations.e2e.E2EECounterFetchOperation;
 import com.owncloud.android.providers.UsersAndGroupsSearchConfig;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
@@ -116,6 +114,8 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     
     private ShareeListAdapter externalShareeListAdapter;
 
+    private E2EECounterFetchOperation e2eeCounterFetchOperation;
+
     @Inject UserAccountManager accountManager;
     @Inject ClientFactory clientFactory;
     @Inject ViewThemeUtils viewThemeUtils;
@@ -155,6 +155,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
         }
 
         fileActivity = (FileActivity) getActivity();
+        e2eeCounterFetchOperation = new E2EECounterFetchOperation();
 
         if (fileActivity == null) {
             throw new IllegalArgumentException("FileActivity may not be null");
@@ -272,6 +273,7 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        e2eeCounterFetchOperation.stop();
         binding = null;
     }
 
@@ -349,27 +351,28 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                binding.internalShareHeadline.setText(getResources().getString(R.string.internal_share_headline_end_to_end_encrypted));
                binding.internalShareDescription.setVisibility(View.VISIBLE);
                binding.externalSharesHeadline.setText(getResources().getString(R.string.create_end_to_end_encrypted_share_title));
+                final Context context = requireContext();
+                e2eeCounterFetchOperation.fetchAsync(file, fileDataStorageManager, context, counter -> {
+                    if (binding == null) {
+                        return Unit.INSTANCE;
+                    }
 
-               fetchE2EECounter(() -> {
-                   if (binding == null) {
-                        return;
-                   }
+                    if (file.getE2eCounter() == -1) {
+                        // V1 cannot share
+                        binding.searchContainer.setVisibility(View.GONE);
+                        binding.createLink.setVisibility(View.GONE);
+                    } else {
+                        binding.createLink.setText(R.string.add_new_secure_file_drop);
+                        binding.searchView.setQueryHint(getResources().getString(R.string.secure_share_search));
 
-                   if (file.getE2eCounter() == -1) {
-                       // V1 cannot share
-                       binding.searchContainer.setVisibility(View.GONE);
-                       binding.createLink.setVisibility(View.GONE);
-                   } else {
-                       binding.createLink.setText(R.string.add_new_secure_file_drop);
-                       binding.searchView.setQueryHint(getResources().getString(R.string.secure_share_search));
-
-                       if (file.isSharedViaLink()) {
-                           binding.searchView.setQueryHint(getResources().getString(R.string.share_not_allowed_when_file_drop));
-                           binding.searchView.setInputType(InputType.TYPE_NULL);
-                           toggleSearchViewEnable(binding.searchView, false);
-                       }
-                   }
-               });
+                        if (file.isSharedViaLink()) {
+                            binding.searchView.setQueryHint(getResources().getString(R.string.share_not_allowed_when_file_drop));
+                            binding.searchView.setInputType(InputType.TYPE_NULL);
+                            toggleSearchViewEnable(binding.searchView, false);
+                        }
+                    }
+                    return Unit.INSTANCE;
+                });
             } else {
                 binding.createLink.setText(R.string.create_link);
                 binding.searchView.setQueryHint(getResources().getString(R.string.share_search_internal));
@@ -396,28 +399,6 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                                                        startActivity(Intent.createChooser(IntentUtil.createSendIntent(requireContext(), file), 
                                                                                           requireContext().getString(R.string.activity_chooser_send_file_title)))
                                                   );
-    }
-
-    private void fetchE2EECounter(Runnable onComplete) {
-        final Context context = requireContext();
-
-        new Thread(() -> {
-            try {
-                OwnCloudClient client = clientFactory.create(user);
-                Object metadata = RefreshFolderOperation.getDecryptedFolderMetadata(true, file, client, user, context);
-                if (metadata instanceof DecryptedFolderMetadataFile decryptedMetadata) {
-                    file.setE2eCounter(decryptedMetadata.getMetadata().getCounter());
-                    fileDataStorageManager.saveFile(file);
-                }
-            } catch (Exception e) {
-                Log_OC.e(TAG, "Error refreshing E2E counter: " + e.getMessage());
-            }
-
-            final var activity = getActivity();
-            if (activity != null) {
-                activity.runOnUiThread(onComplete);
-            }
-        }).start();
     }
 
     private void checkShareViaUser() {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailSharingFragment.java
@@ -352,7 +352,8 @@ public class FileDetailSharingFragment extends Fragment implements ShareeListAda
                binding.internalShareDescription.setVisibility(View.VISIBLE);
                binding.externalSharesHeadline.setText(getResources().getString(R.string.create_end_to_end_encrypted_share_title));
                 final Context context = requireContext();
-                e2eeCounterFetchOperation.fetchAsync(file, fileDataStorageManager, context, counter -> {
+
+                e2eeCounterFetchOperation.fetchAsync(context, file, fileDataStorageManager, user, clientFactory, counter -> {
                     if (binding == null) {
                         return Unit.INSTANCE;
                     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

After first successful upload in encrypted folder, next upload attempt fails due to wrong counter usage

### How to reproduce?

1. Upload file to the encrypted file
2. Upload another file after that (do not refresh folder)