### PR TITLE
fix(file-details): refresh from fda

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -850,6 +850,7 @@ class FileDisplayActivity :
                 leftFragment.listenForTransferProgress()
                 leftFragment.updateFileDetails(true, false)
             }
+
             FileDownloadEventBroadcaster.ACTION_DOWNLOAD_COMPLETED -> {
                 val waitedPreview = mWaitingToPreview?.remotePath == downloadedRemotePath
                 val previewStarted = waitedPreview && tryStartWaitingPreview(success)
@@ -872,18 +873,22 @@ class FileDisplayActivity :
                 startMediaPreview(file, 0, true, true, true, true)
                 true
             }
+
             MimeTypeUtil.isVCard(file.mimeType) -> {
                 startContactListFragment(file)
                 true
             }
+
             PreviewTextFileFragment.canBePreviewed(file) -> {
                 startTextPreview(file, true)
                 true
             }
+
             MimeTypeUtil.isPDF(file) -> {
                 startPdfPreview(file)
                 true
             }
+
             else -> {
                 fileOperationsHelper.openFile(file)
                 false

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -837,50 +837,56 @@ class FileDisplayActivity :
         downloadedRemotePath: String,
         success: Boolean
     ) {
-        val leftFragment = this.leftFragment
-        if (leftFragment is FileDetailFragment) {
-            val waitedPreview = mWaitingToPreview != null && mWaitingToPreview?.remotePath == downloadedRemotePath
-            val fileInFragment = leftFragment.file
-            if (fileInFragment != null && downloadedRemotePath != fileInFragment.remotePath) {
-                // the user browsed to other file ; forget the automatic preview
-                mWaitingToPreview = null
-            } else if (downloadEvent == FileDownloadEventBroadcaster.ACTION_DOWNLOAD_ENQUEUED) {
-                // grant that the details fragment updates the progress bar
+        val leftFragment = this.leftFragment as? FileDetailFragment ?: return
+        val fileInFragment = leftFragment.file
+
+        if (fileInFragment != null && downloadedRemotePath != fileInFragment.remotePath) {
+            mWaitingToPreview = null
+            return
+        }
+
+        when (downloadEvent) {
+            FileDownloadEventBroadcaster.ACTION_DOWNLOAD_ENQUEUED -> {
                 leftFragment.listenForTransferProgress()
                 leftFragment.updateFileDetails(true, false)
-            } else if (downloadEvent == FileDownloadEventBroadcaster.ACTION_DOWNLOAD_COMPLETED) {
-                //  update the details panel
-                var detailsFragmentChanged = false
-                if (waitedPreview) {
-                    if (success) {
-                        // update the file from database, for the local storage path
-                        mWaitingToPreview = mWaitingToPreview?.fileId?.let { storageManager.getFileById(it) }
-
-                        if (PreviewMediaActivity.Companion.canBePreviewed(mWaitingToPreview)) {
-                            mWaitingToPreview?.let {
-                                startMediaPreview(it, 0, true, true, true, true)
-                                detailsFragmentChanged = true
-                            }
-                        } else if (MimeTypeUtil.isVCard(mWaitingToPreview?.mimeType)) {
-                            startContactListFragment(mWaitingToPreview)
-                            detailsFragmentChanged = true
-                        } else if (PreviewTextFileFragment.canBePreviewed(mWaitingToPreview)) {
-                            startTextPreview(mWaitingToPreview, true)
-                            detailsFragmentChanged = true
-                        } else if (MimeTypeUtil.isPDF(mWaitingToPreview)) {
-                            mWaitingToPreview?.let {
-                                startPdfPreview(it)
-                                detailsFragmentChanged = true
-                            }
-                        } else {
-                            fileOperationsHelper.openFile(mWaitingToPreview)
-                        }
-                    }
-                    mWaitingToPreview = null
-                }
-                if (!detailsFragmentChanged) {
+            }
+            FileDownloadEventBroadcaster.ACTION_DOWNLOAD_COMPLETED -> {
+                val waitedPreview = mWaitingToPreview?.remotePath == downloadedRemotePath
+                val previewStarted = waitedPreview && tryStartWaitingPreview(success)
+                mWaitingToPreview = null
+                if (!previewStarted) {
                     leftFragment.updateFileDetails(false, success)
                 }
+            }
+        }
+    }
+
+    private fun tryStartWaitingPreview(success: Boolean): Boolean {
+        if (!success) return false
+
+        mWaitingToPreview = mWaitingToPreview?.fileId?.let { storageManager.getFileById(it) }
+        val file = mWaitingToPreview ?: return false
+
+        return when {
+            PreviewMediaActivity.canBePreviewed(file) -> {
+                startMediaPreview(file, 0, true, true, true, true)
+                true
+            }
+            MimeTypeUtil.isVCard(file.mimeType) -> {
+                startContactListFragment(file)
+                true
+            }
+            PreviewTextFileFragment.canBePreviewed(file) -> {
+                startTextPreview(file, true)
+                true
+            }
+            MimeTypeUtil.isPDF(file) -> {
+                startPdfPreview(file)
+                true
+            }
+            else -> {
+                fileOperationsHelper.openFile(file)
+                false
             }
         }
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->


```
Exception java.lang.NullPointerException:
  at com.owncloud.android.utils.MimeTypeUtil.isPDF (MimeTypeUtil.java:330)
  at com.owncloud.android.ui.activity.FileDisplayActivity.refreshDetailsFragmentIfVisible (FileDisplayActivity.kt:866)
  at com.owncloud.android.ui.activity.FileDisplayActivity$FileDownloadCompletedReceiver.updateUIForFileDownload (FileDisplayActivity.kt:1856)
  at com.owncloud.android.ui.activity.FileDisplayActivity$FileDownloadCompletedReceiver.onReceive (FileDisplayActivity.kt:1826)
  at androidx.localbroadcastmanager.content.LocalBroadcastManager.executePendingBroadcasts (LocalBroadcastManager.java:313)
  at androidx.localbroadcastmanager.content.LocalBroadcastManager$1.handleMessage (LocalBroadcastManager.java:121)
  at android.os.Handler.dispatchMessage (Handler.java:110)
  at android.os.Looper.loopOnce (Looper.java:273)
  at android.os.Looper.loop (Looper.java:363)
  at android.app.ActivityThread.main (ActivityThread.java:10060)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:975)
```