### PR TITLE
fix: handle negative lock timeout (ETA_INFINITE sentinel) from files_lock

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsViewModel.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsViewModel.kt
@@ -9,6 +9,7 @@ package com.nextcloud.ui.fileactions
 
 import android.os.Bundle
 import androidx.annotation.IdRes
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -125,7 +126,8 @@ class FileActionsViewModel @Inject constructor(
         }
     }
 
-    private fun getLockedUntil(file: OCFile): Long? = if (file.lockTimestamp == 0L || file.lockTimeout == 0L) {
+    @VisibleForTesting
+    internal fun getLockedUntil(file: OCFile): Long? = if (file.lockTimestamp == 0L || file.lockTimeout <= 0L) {
         null
     } else {
         (file.lockTimestamp + file.lockTimeout) * TimeConstants.MILLIS_PER_SECOND

--- a/app/src/test/java/com/nextcloud/ui/fileactions/FileActionsViewModelTest.kt
+++ b/app/src/test/java/com/nextcloud/ui/fileactions/FileActionsViewModelTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
+ */
+package com.nextcloud.ui.fileactions
+
+import com.nextcloud.client.account.CurrentAccountProvider
+import com.nextcloud.client.logger.Logger
+import com.nextcloud.utils.TimeConstants
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.files.FileMenuFilter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class FileActionsViewModelTest {
+
+    private lateinit var viewModel: FileActionsViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = FileActionsViewModel(
+            mock<CurrentAccountProvider>(),
+            mock<FileMenuFilter.Factory>(),
+            mock<Logger>()
+        )
+    }
+
+    @Test
+    fun `getLockedUntil returns null when lockTimestamp is zero`() {
+        val file = OCFile("/test.docx").apply {
+            lockTimestamp = 0L
+            lockTimeout = 300L
+        }
+        assertNull(viewModel.getLockedUntil(file))
+    }
+
+    @Test
+    fun `getLockedUntil returns null when lockTimeout is zero`() {
+        val file = OCFile("/test.docx").apply {
+            lockTimestamp = 1_700_000_000L
+            lockTimeout = 0L
+        }
+        assertNull(viewModel.getLockedUntil(file))
+    }
+
+    @Test
+    fun `getLockedUntil returns null when lockTimeout is negative (ETA_INFINITE sentinel)`() {
+        val file = OCFile("/test.docx").apply {
+            lockTimestamp = 1_700_000_000L
+            lockTimeout = -60L
+        }
+        assertNull(viewModel.getLockedUntil(file))
+    }
+
+    @Test
+    fun `getLockedUntil returns correct millis when both values are positive`() {
+        val timestamp = 1_700_000_000L
+        val timeout = 300L
+        val file = OCFile("/test.docx").apply {
+            lockTimestamp = timestamp
+            lockTimeout = timeout
+        }
+        val expected = (timestamp + timeout) * TimeConstants.MILLIS_PER_SECOND
+        assertEquals(expected, viewModel.getLockedUntil(file))
+    }
+}


### PR DESCRIPTION
## Summary

- When `files_lock` is configured with infinite timeout (the default, `-1` minutes), it sends `nc:lock-timeout=-60` via WebDAV PROPFIND
- `getLockedUntil()` was computing `(lockTimestamp + lockTimeout) * MILLIS_PER_SECOND` without guarding against negative timeout values, resulting in a date in the past
- This caused the UI to show **"Expires: 1 minute ago"** on actively locked files

The guard was changed from `file.lockTimeout == 0L` to `file.lockTimeout <= 0L` so any non-positive timeout (including the `-60` sentinel) correctly returns `null` (no expiry shown).

The root cause fix is server-side in `files_lock` ([see related PR](https://github.com/nextcloud/files_lock)). This is a defensive client-side guard for servers that haven't been updated yet.

## Test plan

- [ ] `FileActionsViewModelTest` — 4 unit tests covering `lockTimeout == 0`, `lockTimeout < 0` (`-60` sentinel), `lockTimestamp == 0`, and positive values
- [ ] Open a file locked with infinite timeout on an unpatched server and verify no expiry label is shown

🤖 Generated with [Claude Code](https://claude.ai/claude-code)