### PR TITLE
fix: e2ee folder shortcut open

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -701,7 +701,14 @@ class FileDisplayActivity :
         Handler(Looper.getMainLooper()).post {
             (supportFragmentManager.findFragmentByTag(TAG_LIST_OF_FILES) as? OCFileListFragment)?.let { fragment ->
                 leftFragment = fragment
-                setupHomeSearchToolbarWithSortAndListButtons()
+                if (file.isFolder) {
+                    // TODO MAKE home is back button
+                    // unify this logic
+                    setupToolbar()
+                    updateActionBarTitleAndHomeButtonByString(file.fileName)
+                } else {
+                    setupHomeSearchToolbarWithSortAndListButtons()
+                }
                 fragment.onItemClicked(file)
             }
         }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -701,14 +701,8 @@ class FileDisplayActivity :
         Handler(Looper.getMainLooper()).post {
             (supportFragmentManager.findFragmentByTag(TAG_LIST_OF_FILES) as? OCFileListFragment)?.let { fragment ->
                 leftFragment = fragment
-                if (file.isFolder) {
-                    // TODO MAKE home is back button
-                    // unify this logic
-                    setupToolbar()
-                    updateActionBarTitleAndHomeButtonByString(file.fileName)
-                } else {
-                    setupHomeSearchToolbarWithSortAndListButtons()
-                }
+                fragment.setFileDepth(file)
+                updateActionBarTitleAndHomeButton(file)
                 fragment.onItemClicked(file)
             }
         }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1257,7 +1257,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         }
     }
 
-    private void setFileDepth(OCFile file) {
+    public void setFileDepth(OCFile file) {
         fileDepth = OCFileExtensionsKt.getDepth(file);
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1291,6 +1291,10 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 boolean result = bundle.getBoolean(SetupEncryptionDialogFragment.SUCCESS, false);
                 if (!result) {
                     Log_OC.d(TAG, "setup encryption dialog is dismissed");
+                    boolean cancelled = bundle.getBoolean(SetupEncryptionDialogFragment.RESULT_KEY_CANCELLED, false);
+                    if (cancelled) {
+                        browseToRoot();
+                    }
                     return;
                 }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

Opening encrypted folder from shortcut causing to show wrong action bar and empty screen state.

### Scenario I


https://github.com/user-attachments/assets/fad55e7b-6fe8-4122-af85-10a6fd2a42ec

### Scenario II


https://github.com/user-attachments/assets/b70170a1-c5c0-4220-9205-3979a5acd763

