### PR TITLE
fix(file-utils): get available space on device

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -1135,15 +1135,16 @@ public class FileOperationsHelper {
     /**
      * @return -1 if no space could computed, otherwise available space in bytes
      */
-    public static Long getAvailableSpaceOnDevice() {
-        StatFs stat;
+    public static long getAvailableSpaceOnDevice() {
         try {
-            stat = new StatFs(MainApp.getStoragePath());
-        } catch (NullPointerException | IllegalArgumentException e) {
+            StatFs statFs = new StatFs(Environment.getDataDirectory().getPath());
+            long availableBlocks = statFs.getAvailableBlocksLong();
+            long blockSize = statFs.getBlockSizeLong();
+            return availableBlocks * blockSize;
+        } catch (Exception e) {
+            Log_OC.e(TAG, "getAvailableSpaceOnDevice: " + e);
             return -1L;
         }
-
-        return stat.getBlockSizeLong() * stat.getAvailableBlocksLong();
     }
 
     public static boolean isEndToEndEncryptionSetup(Context context, User user) {

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -787,14 +787,13 @@ public final class FileStorageUtils {
      *
      * @param file @link{OCFile}
      * @return boolean: true if there is enough space left
-     * @throws RuntimeException
      */
     public static boolean checkIfEnoughSpace(OCFile file) {
         // Get the remaining space on device
         long availableSpaceOnDevice = FileOperationsHelper.getAvailableSpaceOnDevice();
 
         if (availableSpaceOnDevice == -1) {
-            throw new RuntimeException("Error while computing available space");
+            return false;
         }
 
         return checkIfEnoughSpace(availableSpaceOnDevice, file);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->


### Changes

- Uses `Environment` instead of `MainApp.getStoragePath()`
- Return false instead of crash

### Demo

#### Emulator

2026-06-08 10:28:03.305  2466-2466  FileDisplayActivity     com.nextcloud.client                 D  OLD_WAY: 2203226112
2026-06-08 10:28:03.305  2466-2466  FileDisplayActivity     com.nextcloud.client                 D  NEW_WAY: 2203226112

#### Xiaomi 13T Pro HyperOS 3 No sd card

2026-06-08 10:43:24.304 24768-24768 FileDisplayActivity     com.nextcloud.client                 D  OLD_WAY: 301689778176
2026-06-08 10:43:24.304 24768-24768 FileDisplayActivity     com.nextcloud.client                 D  NEW_WAY: 301689778176


@tobiasKaminsky Why do we need `MainApp.getStoragePath()`? Can't we just use `Environment` since it's returns the user's data directory.

See results above still giving same result.