### PR TITLE
fix(oc-file-list): local file deletion

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/RemoveFileOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/RemoveFileOperation.kt
@@ -34,7 +34,7 @@ import com.owncloud.android.utils.MimeTypeUtil
 @Suppress("LongParameterList")
 class RemoveFileOperation(
     val file: OCFile,
-    private val onlyLocalCopy: Boolean,
+    val onlyLocalCopy: Boolean,
     private val user: User,
     val isInBackground: Boolean,
     private val context: Context,

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2201,7 +2201,7 @@ class FileDisplayActivity :
             resetScrollingAndUpdateActionBar()
         }
 
-        if (leftFragment is OCFileListFragment) {
+        if (leftFragment is OCFileListFragment && !operation.onlyLocalCopy) {
             leftFragment.adapter?.removeFile(removedFile)
 
             if (leftFragment.adapter?.isEmpty == true) {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

- Local file deletion visually removes the element from adapter

### Steps to reproduce

1. Tap delete
2. Choose local

### Expected flow

Local file deletion should not remove the element from the adapter since remote file still exists.