### PR TITLE
fix(thumbnail): generation for zip file

### DIFF
--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -578,6 +578,9 @@ public final class ThumbnailsCacheManager {
             String imageKey = PREFIX_THUMBNAIL + file.getRemoteId();
 
             boolean updateEnforced = (file instanceof OCFile && ((OCFile) file).isUpdateThumbnailNeeded());
+            if (MimeTypeUtil.isZip(file)) {
+                return null;
+            }
 
             // Try to load thumbnail from disk cache
             if (!updateEnforced) {

--- a/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -330,6 +330,27 @@ public final class MimeTypeUtil {
         return isPDF(file.getMimeType()) || isPDF(getMimeTypeFromPath(file.getRemotePath()));
     }
 
+    public static boolean isZip(String mimeType) {
+        if (mimeType == null) {
+            return false;
+        }
+        String lower = mimeType.toLowerCase(Locale.ROOT);
+        return lower.equals("application/zip")
+            || lower.equals("application/x-7z-compressed")
+            || lower.equals("application/x-bzip2")
+            || lower.equals("application/x-compressed")
+            || lower.equals("application/x-deb")
+            || lower.equals("application/gzip")
+            || lower.equals("application/x-gzip")
+            || lower.equals("application/x-rar-compressed")
+            || lower.equals("application/x-tar")
+            || lower.equals("application/vnd.android.package-archive");
+    }
+
+    public static boolean isZip(ServerFileInterface file) {
+        return isZip(file.getMimeType());
+    }
+
     /**
      * Extracts the mime type for the given file.
      *


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

Thumbnail should not be downloaded for zip file.

```
2026-06-11 10:38:23.146  1971-3020  ThumbnailsCacheManager  com.nextcloud.client  E
Exception downloading thumbnail for file: 2GB_file.zip

java.net.SocketTimeoutException: Read timed out
    at java.net.SocketInputStream.socketRead0(Native Method)
    at java.net.SocketInputStream.socketRead(SocketInputStream.java:118)
    at java.net.SocketInputStream.read(SocketInputStream.java:173)
    at java.net.SocketInputStream.read(SocketInputStream.java:143)
    at org.conscrypt.ConscryptEngineSocket$SSLInputStream.readFromSocket(ConscryptEngineSocket.java:920)
    at org.conscrypt.ConscryptEngineSocket$SSLInputStream.processDataFromSocket(ConscryptEngineSocket.java:884)
    at org.conscrypt.ConscryptEngineSocket$SSLInputStream.readUntilDataAvailable(ConscryptEngineSocket.java:799)
    at org.conscrypt.ConscryptEngineSocket$SSLInputStream.read(ConscryptEngineSocket.java:772)
    at java.io.BufferedInputStream.fill(BufferedInputStream.java:239)
    at java.io.BufferedInputStream.read(BufferedInputStream.java:258)
    at org.apache.commons.httpclient.HttpParser.readRawLine(HttpParser.java:78)
    at org.apache.commons.httpclient.HttpParser.readLine(HttpParser.java:106)
    at org.apache.commons.httpclient.HttpConnection.readLine(HttpConnection.java:1116)
    at org.apache.commons.httpclient.MultiThreadedHttpConnectionManager$HttpConnectionAdapter.readLine(
        MultiThreadedHttpConnectionManager.java:1413
    )
    at org.apache.commons.httpclient.HttpMethodBase.readStatusLine(HttpMethodBase.java:1973)
    at org.apache.commons.httpclient.HttpMethodBase.readResponse(HttpMethodBase.java:1735)
    at org.apache.commons.httpclient.HttpMethodBase.execute(HttpMethodBase.java:1098)
    at org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry(HttpMethodDirector.java:398)
    at org.apache.commons.httpclient.HttpMethodDirector.executeMethod(HttpMethodDirector.java:171)
    at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:397)
    at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:323)
    at com.owncloud.android.lib.common.OwnCloudClient.executeMethod(OwnCloudClient.java:192)
    at com.owncloud.android.lib.common.OwnCloudClient.executeMethod(OwnCloudClient.java:155)
    at com.owncloud.android.datamodel.ThumbnailsCacheManager$ThumbnailGenerationTask
        .doThumbnailFromOCFileInBackground(ThumbnailsCacheManager.java:662)
    at com.owncloud.android.datamodel.ThumbnailsCacheManager$ThumbnailGenerationTask
        .doInBackground(ThumbnailsCacheManager.java:507)
    at com.owncloud.android.datamodel.ThumbnailsCacheManager$ThumbnailGenerationTask
        .doInBackground(ThumbnailsCacheManager.java:428)
    at android.os.AsyncTask$3.call(AsyncTask.java:394)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
    at java.lang.Thread.run(Thread.java:1119)

2026-06-11 10:38:23.146  1971-3020  ThumbnailsCacheManager  com.nextcloud.client  W
Failed to obtain thumbnail for file: 2GB_file.zip
```