### PR TITLE
Fix a typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,9 +224,9 @@ Source code of app:
 - small, isolated tests, with no need of Android SDK
 - code coverage can be directly shown via right click on test and select "Run Test with Coverage"
 
-```
-./gradlew jacocoTestGplayDebugUnitTest
 ```bash
+./gradlew jacocoTestGplayDebugUnitTest
+```
 
 #### Instrumented tests
 - tests to see larger code working in correct way


### PR DESCRIPTION
Hello Nextcloud Android team o/

I've started studying the codebase and I've noticed a small typo in the markdown of CONTRIBUTING.md that, causing part of the file to be rendered incorrectly.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before

https://github.com/nextcloud/android/blob/448b459165b78f376a7bfb4db9a8562daa310938/CONTRIBUTING.md#testing

<img width="1034" height="424" alt="grafik" src="https://github.com/user-attachments/assets/431b5f34-6c64-4616-9d3f-7bcd097e17ff" />


🏡 After

https://github.com/sitegui/nextcloud-android/blob/978b49eb281efca974355c4d197cc868e6c977b1/CONTRIBUTING.md#testing

<img width="1034" height="424" alt="grafik" src="https://github.com/user-attachments/assets/ed2c3551-dccd-4f98-9749-cdc26c876a26" />


### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
