### PR TITLE
fix(file-display-activity): on rename finish operation

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2375,7 +2375,11 @@ class FileDisplayActivity :
         }
 
         val file = storageManager.getFileById(renamedFile.parentId)
-        if (file != null && file == getCurrentDir()) {
+        val isCurrentDirParentDirOfGivenFile = (file != null && file == currentDir)
+
+        // if current dir is root user may be in shared root or favorite root thus
+        // checking parent of current dir will always fail
+        if (currentDir?.isRootDirectory == true || isCurrentDirParentDirOfGivenFile) {
             fileListFragment?.adapter?.updateFile(renamedFile)
         }
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2377,10 +2377,13 @@ class FileDisplayActivity :
         val file = storageManager.getFileById(renamedFile.parentId)
         val isCurrentDirParentDirOfGivenFile = (file != null && file == currentDir)
 
-        // if current dir is root user may be in shared root or favorite root thus
-        // checking parent of current dir will always fail
+        // checking current dir against renamed file's parent will always fail when user is in Shared/Favorites root.
+        // thus check is current dir is root or not as well
         if (currentDir?.isRootDirectory == true || isCurrentDirParentDirOfGivenFile) {
             val fragment = fileListFragment
+
+            // OCFileSearchTask may still run during rename, so use a single refresh path to avoid
+            // flicker/inconsistent filenames.
             if (fragment?.isSearchFragment == true) {
                 fragment.cancelAndRetriggerSearch()
             } else {

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -2380,7 +2380,12 @@ class FileDisplayActivity :
         // if current dir is root user may be in shared root or favorite root thus
         // checking parent of current dir will always fail
         if (currentDir?.isRootDirectory == true || isCurrentDirParentDirOfGivenFile) {
-            fileListFragment?.adapter?.updateFile(renamedFile)
+            val fragment = fileListFragment
+            if (fragment?.isSearchFragment == true) {
+                fragment.cancelAndRetriggerSearch()
+            } else {
+                fragment?.adapter?.updateFile(renamedFile)
+            }
         }
 
         refreshGalleryFragmentIfNeeded()

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -2122,6 +2122,16 @@ public class OCFileListFragment extends ExtendedListFragment implements
         return searchFragment;
     }
 
+    public void cancelAndRetriggerSearch() {
+        if (searchTask != null) {
+            searchTask.cancel();
+            searchTask = null;
+        }
+        if (searchEvent != null) {
+            handleSearchEvent(searchEvent);
+        }
+    }
+
     /**
      * De-/select all elements in the current list view.
      *


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Fixes following issues

1. Parent directory of file should not be checked if user in root shared or root favorite
2. `OCFileSearchTask` may run during renaming process thus only one central place should be used to refresh adapter to prevent flicker and displaying wrong filename