### PR TITLE
fix(conflict-resolve): auto upload

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/utils/UploadErrorNotificationManager.kt
@@ -210,7 +210,7 @@ object UploadErrorNotificationManager {
             context,
             operation.ocUploadId.toInt(),
             intent,
-            PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ConflictsResolveActivity.kt
@@ -84,6 +84,22 @@ class ConflictsResolveActivity :
         offlineOperationNotificationManager = OfflineOperationsNotificationManager(this, viewThemeUtils)
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+
+        setIntent(intent)
+
+        // re-read extras from new intent
+        restoreState(null)
+
+        // force fresh remote file fetch in onStart
+        existingFile = null
+
+        val upload = uploadsStorageManager.getUploadById(conflictUploadId)
+        newFile = file
+        setupDecisionListener(upload)
+    }
+
     private fun restoreState(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {
             conflictUploadId = savedInstanceState.getLong(EXTRA_CONFLICT_UPLOAD_ID)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

During auto upload conflict resolution not working properly for local file selection

### Changes

- Pending intent flag changed to `FLAG_UPDATE_CURRENT` or `FLAG_IMMUTABLE` since same operation can be used.
- `onNewIntent` `ConflictsResolveActivity` since activity data needs to be reset for each new conflict.