### PR TITLE
fix(oc-file-list): browseToRoot use root dir instead current file

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1925,7 +1925,8 @@ class FileDisplayActivity :
         listOfFilesFragment?.let {
             val root = storageManager.getFileByPath(OCFile.ROOT_PATH)
             it.resetSearchAttributes()
-            file = it.currentFile
+            file = root
+            it.listDirectory(root, MainApp.isOnlyOnDevice())
             startSyncFolderOperation(root, false)
         }
 


### PR DESCRIPTION
Before
- browse to subfolder
- click "all files" 
--> UI changed, but still within subfolder

Now:
-> shows (and reloads) root folder