### PR TITLE
fix(e2ee): file and folder actions

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
@@ -20,7 +20,7 @@ import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
-import androidx.core.view.isEmpty
+import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.setFragmentResult
@@ -126,17 +126,17 @@ class FileActionsBottomSheet :
                 if (state.lockInfo != null) {
                     displayLockInfo(state.lockInfo)
                 }
-                displayActions(state.actions)
+                displayActions(state.titleFile, state.actions)
                 displayTitle(state.titleFile)
             }
 
             is FileActionsViewModel.UiState.LoadedForMultipleFiles -> {
                 setMultipleFilesThumbnail()
-                displayActions(state.actions)
+                displayActions(state.firstFile, state.actions)
                 displayTitle(state.fileCount)
             }
 
-            FileActionsViewModel.UiState.Loading -> {}
+            FileActionsViewModel.UiState.Loading -> Unit
 
             FileActionsViewModel.UiState.Error -> {
                 activity?.let {
@@ -210,26 +210,32 @@ class FileActionsBottomSheet :
         }
     }
 
-    private fun displayActions(actions: List<FileAction>) {
-        if (binding.fileActionsList.isEmpty()) {
-            actions.forEach { action ->
-                val view = inflateActionView(action)
-                binding.fileActionsList.addView(view)
-            }
+    private fun displayActions(file: OCFile?, actions: List<FileAction>) {
+        if (binding.fileActionsList.isNotEmpty()) {
+            return
+        }
 
-            // add client integration
-            if (endpoints != null) {
-                for (val e in endpoints) {
-                    val ui = clientIntegration.inflateClientIntegrationActionView(
-                        e,
-                        layoutInflater,
-                        binding,
-                        viewModel,
-                        viewThemeUtils
-                    )
-                    binding.fileActionsList.addView(ui)
-                }
-            }
+        actions.forEach { action ->
+            val view = inflateActionView(action)
+            binding.fileActionsList.addView(view)
+        }
+
+        val parentDir = file?.parentId?.let { storageManager.getFileById(it) }
+
+        if (endpoints.isNullOrEmpty() || parentDir?.isEncrypted == true) {
+            return
+        }
+
+        // add client integration
+        endpoints?.forEach {
+            val view = clientIntegration.inflateClientIntegrationActionView(
+                it,
+                layoutInflater,
+                binding,
+                viewModel,
+                viewThemeUtils
+            )
+            binding.fileActionsList.addView(view)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsViewModel.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsViewModel.kt
@@ -41,7 +41,8 @@ class FileActionsViewModel @Inject constructor(
             val lockInfo: LockInfo? = null
         ) : UiState
 
-        data class LoadedForMultipleFiles(val actions: List<FileAction>, val fileCount: Int) : UiState
+        data class LoadedForMultipleFiles(val firstFile: OCFile, val actions: List<FileAction>, val fileCount: Int) :
+            UiState
     }
 
     private val _uiState: MutableLiveData<UiState> = MutableLiveData(UiState.Loading)
@@ -110,7 +111,10 @@ class FileActionsViewModel @Inject constructor(
                 UiState.LoadedForSingleFile(availableActions, file, getLockInfo(file))
             }
 
-            else -> UiState.LoadedForMultipleFiles(availableActions, files.size)
+            else -> {
+                val file = files.first()
+                UiState.LoadedForMultipleFiles(file, availableActions, files.size)
+            }
         }
         _uiState.postValue(state)
     }

--- a/app/src/main/java/com/nextcloud/utils/extensions/OCCapabilityExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/OCCapabilityExtensions.kt
@@ -66,3 +66,9 @@ fun jsonToList(json: String?): List<String> {
         emptyList()
     }
 }
+
+fun OCCapability.isTemplateAvailable(): Boolean = (
+    richDocuments.isTrue &&
+        richDocumentsDirectEditing.isTrue &&
+        richDocumentsTemplatesAvailable.isTrue
+    )

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListBottomSheetDialog.kt
@@ -24,6 +24,7 @@ import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.documentscan.AppScanOptionalFeature
 import com.nextcloud.utils.BuildHelper.isFlavourGPlay
 import com.nextcloud.utils.EditorUtils
+import com.nextcloud.utils.extensions.isTemplateAvailable
 import com.nextcloud.utils.extensions.setVisibleIf
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
@@ -126,20 +127,21 @@ class OCFileListBottomSheetDialog(
         }
     }
 
-    @Suppress("ComplexCondition")
     private fun checkTemplateVisibility() {
         val optionalCapability = fileActivity.capabilities
-        if (optionalCapability.isPresent) {
-            val capability = optionalCapability.get()
-            if (capability.richDocuments.isTrue &&
-                capability.richDocumentsDirectEditing.isTrue &&
-                capability.richDocumentsTemplatesAvailable.isTrue &&
-                !file.isEncrypted
-            ) {
-                binding.menuNewDocument.visibility = View.VISIBLE
-                binding.menuNewSpreadsheet.visibility = View.VISIBLE
-                binding.menuNewPresentation.visibility = View.VISIBLE
-            }
+        if (file.isEncrypted || optionalCapability.isEmpty) {
+            return
+        }
+
+        val capability = optionalCapability.get()
+        if (!capability.isTemplateAvailable()) {
+            return
+        }
+
+        binding.run {
+            menuNewDocument.visibility = View.VISIBLE
+            menuNewSpreadsheet.visibility = View.VISIBLE
+            menuNewPresentation.visibility = View.VISIBLE
         }
     }
 
@@ -148,66 +150,68 @@ class OCFileListBottomSheetDialog(
         val json = ArbitraryDataProviderImpl(context)
             .getValue(user, ArbitraryDataProvider.DIRECT_EDITING)
 
-        if (json.isNotEmpty() && !file.isEncrypted) {
-            val directEditing = Gson().fromJson(json, DirectEditing::class.java)
-            if (directEditing.creators.isEmpty()) {
-                return
-            }
+        if (json.isEmpty() || file.isEncrypted) {
+            return
+        }
 
-            binding.creatorsContainer.visibility = View.VISIBLE
-            binding.creators.removeAllViews()
+        val directEditing = Gson().fromJson(json, DirectEditing::class.java)
+        if (directEditing.creators.isEmpty()) {
+            return
+        }
 
-            val itemHeight = context.resources.getDimensionPixelSize(R.dimen.bottom_sheet_item_height)
-            val standardPadding = context.resources.getDimensionPixelSize(R.dimen.standard_padding)
-            val iconSize = context.resources.getDimensionPixelSize(R.dimen.iconized_single_line_item_icon_size)
+        binding.creatorsContainer.visibility = View.VISIBLE
+        binding.creators.removeAllViews()
 
-            for (creator in directEditing.creators.values) {
-                val creatorButton = MaterialButton(
-                    ContextThemeWrapper(
-                        context,
-                        R.style.ThemeOverlay_App_Button_BottomSheetItem
-                    ),
-                    null,
-                    com.google.android.material.R.attr.materialButtonStyle
-                ).apply {
-                    id = View.generateViewId()
-                    layoutParams = LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        itemHeight
-                    )
+        val itemHeight = context.resources.getDimensionPixelSize(R.dimen.bottom_sheet_item_height)
+        val standardPadding = context.resources.getDimensionPixelSize(R.dimen.standard_padding)
+        val iconSize = context.resources.getDimensionPixelSize(R.dimen.iconized_single_line_item_icon_size)
 
-                    gravity = Gravity.START or Gravity.CENTER_VERTICAL
-                    setPaddingRelative(standardPadding, 0, standardPadding, 0)
+        for (creator in directEditing.creators.values) {
+            val creatorButton = MaterialButton(
+                ContextThemeWrapper(
+                    context,
+                    R.style.ThemeOverlay_App_Button_BottomSheetItem
+                ),
+                null,
+                com.google.android.material.R.attr.materialButtonStyle
+            ).apply {
+                id = View.generateViewId()
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    itemHeight
+                )
 
-                    val buttonText = String.format(
-                        fileActivity.getString(R.string.editor_placeholder),
-                        fileActivity.getString(R.string.create_new),
-                        creator.name
-                    )
-                    text = buttonText
-                    setTextColor(ContextCompat.getColor(context, R.color.text_color))
-                    textSize = 16f
-                    isAllCaps = false
+                gravity = Gravity.START or Gravity.CENTER_VERTICAL
+                setPaddingRelative(standardPadding, 0, standardPadding, 0)
 
-                    icon = MimeTypeUtil.getFileTypeIcon(
-                        creator.mimetype,
-                        creator.extension,
-                        context,
-                        viewThemeUtils
-                    )
-                    this.iconSize = iconSize
-                    this.iconPadding = standardPadding
-                    iconGravity = MaterialButton.ICON_GRAVITY_START
-                    iconTint = null
+                val buttonText = String.format(
+                    fileActivity.getString(R.string.editor_placeholder),
+                    fileActivity.getString(R.string.create_new),
+                    creator.name
+                )
+                text = buttonText
+                setTextColor(ContextCompat.getColor(context, R.color.text_color))
+                textSize = 16f
+                isAllCaps = false
 
-                    setOnClickListener {
-                        actions.showTemplate(creator, buttonText)
-                        dismiss()
-                    }
+                icon = MimeTypeUtil.getFileTypeIcon(
+                    creator.mimetype,
+                    creator.extension,
+                    context,
+                    viewThemeUtils
+                )
+                this.iconSize = iconSize
+                this.iconPadding = standardPadding
+                iconGravity = MaterialButton.ICON_GRAVITY_START
+                iconTint = null
+
+                setOnClickListener {
+                    actions.showTemplate(creator, buttonText)
+                    dismiss()
                 }
-
-                binding.creators.addView(creatorButton)
             }
+
+            binding.creators.addView(creatorButton)
         }
     }
 

--- a/app/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
+++ b/app/src/main/res/layout/file_list_actions_bottom_sheet_fragment.xml
@@ -161,11 +161,13 @@
                 android:text="@string/create_new_document"
                 android:textColor="@color/text_color"
                 android:textSize="@dimen/bottom_sheet_text_size"
+                android:visibility="gone"
                 app:icon="@drawable/file_doc"
                 app:iconGravity="start"
                 app:iconPadding="@dimen/standard_padding"
                 app:iconSize="@dimen/iconized_single_line_item_icon_size"
-                app:iconTint="@null" />
+                app:iconTint="@null"
+                tools:visibility="visible" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/menu_new_spreadsheet"
@@ -179,11 +181,13 @@
                 android:text="@string/create_new_spreadsheet"
                 android:textColor="@color/text_color"
                 android:textSize="@dimen/bottom_sheet_text_size"
+                android:visibility="gone"
                 app:icon="@drawable/file_xls"
                 app:iconGravity="start"
                 app:iconPadding="@dimen/standard_padding"
                 app:iconSize="@dimen/iconized_single_line_item_icon_size"
-                app:iconTint="@null" />
+                app:iconTint="@null"
+                tools:visibility="visible" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/menu_new_presentation"
@@ -197,11 +201,13 @@
                 android:text="@string/create_new_presentation"
                 android:textColor="@color/text_color"
                 android:textSize="@dimen/bottom_sheet_text_size"
+                android:visibility="gone"
                 app:icon="@drawable/file_ppt"
                 app:iconGravity="start"
                 app:iconPadding="@dimen/standard_padding"
                 app:iconSize="@dimen/iconized_single_line_item_icon_size"
-                app:iconTint="@null" />
+                app:iconTint="@null"
+                tools:visibility="visible" />
 
             <LinearLayout
                 android:id="@+id/creators_container"
@@ -222,8 +228,8 @@
                 android:id="@+id/menu_create_rich_workspace_divider"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/bottom_sheet_menu_item_divider_standard_margin"
                 android:layout_marginVertical="@dimen/standard_half_margin"
+                android:layout_marginStart="@dimen/bottom_sheet_menu_item_divider_standard_margin"
                 app:dividerColor="@color/list_divider_background" />
 
             <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

Encrypted file and folder actions cannot be same as normal file and folder.

### Changes

- Filter actions according to the expected behaviour.
- Apply fail fast.

### Screenshot

<table>
  <tr>
    <th>Folder actions</th>
    <th>File actions</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0a3fea1c-5cf8-4007-9fd6-4c25479d3381" width="500" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/870acf93-fb2f-43e5-bf39-a3c11a62f923" width="500" alt="after"></td>
  </tr>
</table>

### Screenshot of Web

Web will adjust later as well. Client integration / office things should not be available on E2E.

<table>
  <tr>
    <th>Folder actions</th>
    <th>File actions</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/61dadcdc-7338-40f7-b19e-32999f2eb6be" width="500" alt="before"></td>
    <td><img src="https://github.com/user-attachments/assets/6fed8fc7-27e1-4c25-b215-6622bac547a4" width="500" alt="after"></td>
  </tr>
</table>