### PR TITLE
fix(e2ee): sub folder creation

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/e2ee/E2ECounterHelper.kt
+++ b/app/src/main/java/com/nextcloud/utils/e2ee/E2ECounterHelper.kt
@@ -1,0 +1,31 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.e2ee
+
+import android.content.Context
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.datamodel.e2e.v2.decrypted.DecryptedFolderMetadataFile
+
+object E2ECounterHelper {
+
+    private const val NO_METADATA_COUNTER = -1L
+    private const val INCREMENTER = 1L
+
+    @Suppress("ReturnCount")
+    fun getCounter(context: Context, parentFile: OCFile, metadata: Any?): Long {
+        if (!E2EVersionHelper.isV2Plus(context)) {
+            return NO_METADATA_COUNTER
+        }
+
+        if (metadata is DecryptedFolderMetadataFile) {
+            return metadata.metadata.counter + INCREMENTER
+        }
+
+        return parentFile.e2eCounter + INCREMENTER
+    }
+}

--- a/app/src/main/java/com/nextcloud/utils/e2ee/E2EVersionHelper.kt
+++ b/app/src/main/java/com/nextcloud/utils/e2ee/E2EVersionHelper.kt
@@ -7,14 +7,24 @@
 
 package com.nextcloud.utils.e2ee
 
+import android.content.Context
 import com.google.gson.reflect.TypeToken
 import com.owncloud.android.datamodel.e2e.v1.encrypted.EncryptedFolderMetadataFileV1
 import com.owncloud.android.datamodel.e2e.v2.encrypted.EncryptedFolderMetadataFile
 import com.owncloud.android.lib.resources.status.E2EVersion
 import com.owncloud.android.lib.resources.status.OCCapability
 import com.owncloud.android.utils.EncryptionUtils
+import com.owncloud.android.utils.theme.CapabilityUtils
 
 object E2EVersionHelper {
+
+    /**
+     * Returns true if the given E2EE version is v2 or newer.
+     */
+    fun isV2Plus(context: Context): Boolean {
+        val capability = CapabilityUtils.getCapability(context)
+        return isV2Plus(capability)
+    }
 
     /**
      * Returns true if the given E2EE version is v2 or newer.
@@ -24,7 +34,7 @@ object E2EVersionHelper {
     /**
      * Returns true if the given E2EE version is v2 or newer.
      */
-    fun isV2Plus(version: E2EVersion): Boolean = version == E2EVersion.V2_0 || version == E2EVersion.V2_1
+    fun isV2Plus(version: E2EVersion): Boolean = (version == E2EVersion.V2_0 || version == E2EVersion.V2_1)
 
     /**
      * Returns true if the given E2EE version is v1.x.

--- a/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -15,11 +15,14 @@ import android.content.Context;
 import android.util.Pair;
 
 import com.nextcloud.client.account.User;
+import com.nextcloud.utils.e2ee.E2ECounterHelper;
 import com.nextcloud.utils.e2ee.E2EVersionHelper;
+import com.nextcloud.utils.extensions.OCFileExtensionsKt;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
 import com.owncloud.android.datamodel.ArbitraryDataProviderImpl;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.OCFileDepth;
 import com.owncloud.android.datamodel.e2e.v1.decrypted.Data;
 import com.owncloud.android.datamodel.e2e.v1.decrypted.DecryptedFolderMetadataFileV1;
 import com.owncloud.android.datamodel.e2e.v1.encrypted.EncryptedFolderMetadataFileV1;
@@ -34,7 +37,6 @@ import com.owncloud.android.lib.resources.e2ee.ToggleEncryptionRemoteOperation;
 import com.owncloud.android.lib.resources.files.CreateFolderRemoteOperation;
 import com.owncloud.android.lib.resources.files.ReadFolderRemoteOperation;
 import com.owncloud.android.lib.resources.files.model.RemoteFile;
-import com.owncloud.android.lib.resources.status.E2EVersion;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.utils.EncryptionUtils;
 import com.owncloud.android.utils.EncryptionUtilsV2;
@@ -277,10 +279,16 @@ public class CreateFolderOperation extends SyncOperation implements OnRemoteOper
         String encryptedRemotePath = null;
 
         String filename = new File(remotePath).getName();
+        final var folderDepth = OCFileExtensionsKt.getDepth(parent);
+        long counter = EncryptionUtils.E2E_V2_INITIAL_COUNTER;
+        if (folderDepth != OCFileDepth.Root) {
+            final var metadataObject = EncryptionUtils.downloadFolderMetadata(parent, client, context, user);
+            counter = E2ECounterHelper.INSTANCE.getCounter(context, parent, metadataObject);
+        }
 
         try {
             // lock folder
-            token = EncryptionUtils.lockFolder(parent, client, EncryptionUtils.E2E_V2_INITIAL_COUNTER);
+            token = EncryptionUtils.lockFolder(parent, client, counter);
 
             // get metadata
             EncryptionUtilsV2 encryptionUtilsV2 = new EncryptionUtilsV2();

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -24,6 +24,7 @@ import com.nextcloud.client.jobs.upload.FileUploadWorker;
 import com.nextcloud.client.network.Connectivity;
 import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.utils.autoRename.AutoRename;
+import com.nextcloud.utils.e2ee.E2ECounterHelper;
 import com.nextcloud.utils.e2ee.E2EVersionHelper;
 import com.nextcloud.utils.extensions.RemoteOperationResultExtensionsKt;
 import com.owncloud.android.datamodel.ArbitraryDataProvider;
@@ -53,7 +54,6 @@ import com.owncloud.android.lib.resources.files.ExistenceCheckRemoteOperation;
 import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation;
 import com.owncloud.android.lib.resources.files.UploadFileRemoteOperation;
 import com.owncloud.android.lib.resources.files.model.RemoteFile;
-import com.owncloud.android.lib.resources.status.E2EVersion;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.operations.e2e.E2EClientData;
@@ -511,7 +511,7 @@ public class UploadFileOperation extends SyncOperation {
         E2EFiles e2eFiles = new E2EFiles(parentFile, null, new File(mOriginalStoragePath), null, null);
         FileLock fileLock = null;
         long size;
-        boolean metadataExists = false;
+        boolean isV1MetadataExists = false;
         String token = null;
         Object object = null;
         FileChannel channel = null;
@@ -528,10 +528,10 @@ public class UploadFileOperation extends SyncOperation {
             EncryptionUtilsV2 encryptionUtilsV2 = new EncryptionUtilsV2();
             object = EncryptionUtils.downloadFolderMetadata(parentFile, client, mContext, user);
             if (object instanceof DecryptedFolderMetadataFileV1 decrypted && decrypted.getMetadata() != null) {
-                metadataExists = true;
+                isV1MetadataExists = true;
             }
 
-            boolean isEndToEndVersionAtLeastV2 = isEndToEndVersionAtLeastV2();
+            boolean isEndToEndVersionAtLeastV2 = E2EVersionHelper.INSTANCE.isV2Plus(mContext);
 
             if (isEndToEndVersionAtLeastV2) {
                 if (object == null) {
@@ -541,7 +541,7 @@ public class UploadFileOperation extends SyncOperation {
                 object = getDecryptedFolderMetadataV1(publicKey, object);
             }
 
-            long counter = getE2ECounter(parentFile, object, isEndToEndVersionAtLeastV2);
+            long counter = E2ECounterHelper.INSTANCE.getCounter(mContext, parentFile, object);
             Log_OC.d(TAG, "counter: " + counter);
 
             try {
@@ -596,7 +596,7 @@ public class UploadFileOperation extends SyncOperation {
             result = performE2EUpload(clientData);
 
             if (result.isSuccess()) {
-                updateMetadataForE2E(object, e2eData, clientData, e2eFiles, arbitraryDataProvider, encryptionUtilsV2, metadataExists);
+                updateMetadataForE2E(object, e2eData, clientData, e2eFiles, arbitraryDataProvider, encryptionUtilsV2, isV1MetadataExists);
             }
         } catch (FileNotFoundException e) {
             Log_OC.e(TAG, mFile.getStoragePath() + " does not exist anymore");
@@ -617,23 +617,6 @@ public class UploadFileOperation extends SyncOperation {
         completeE2EUpload(result, e2eFiles, client);
 
         return result;
-    }
-
-    private boolean isEndToEndVersionAtLeastV2() {
-        final var capability = CapabilityUtils.getCapability(mContext);
-        return E2EVersionHelper.INSTANCE.isV2Plus(capability);
-    }
-
-    private long getE2ECounter(OCFile parentFile, Object metadata, boolean isEndToEndVersionAtLeastV2) {
-        if (!isEndToEndVersionAtLeastV2) {
-            return -1;
-        }
-
-        if (metadata instanceof DecryptedFolderMetadataFile decrypted) {
-            return decrypted.getMetadata().getCounter() + 1;
-        }
-
-        return parentFile.getE2eCounter() + 1;
     }
 
     private String getFolderUnlockTokenOrLockFolder(OwnCloudClient client, OCFile parentFile, long counter) throws UploadException {
@@ -823,7 +806,7 @@ public class UploadFileOperation extends SyncOperation {
         return new E2EData(key, iv, encryptedFile, encryptedFileName);
     }
 
-    private void updateMetadataForE2E(Object object, E2EData e2eData, E2EClientData clientData, E2EFiles e2eFiles, ArbitraryDataProvider arbitraryDataProvider, EncryptionUtilsV2 encryptionUtilsV2, boolean metadataExists)
+    private void updateMetadataForE2E(Object object, E2EData e2eData, E2EClientData clientData, E2EFiles e2eFiles, ArbitraryDataProvider arbitraryDataProvider, EncryptionUtilsV2 encryptionUtilsV2, boolean isV1MetadataExists)
 
         throws InvalidAlgorithmParameterException, UploadException, NoSuchPaddingException, IllegalBlockSizeException, CertificateException,
         NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
@@ -839,7 +822,7 @@ public class UploadFileOperation extends SyncOperation {
                                 clientData,
                                 e2eFiles.getParentFile(),
                                 arbitraryDataProvider,
-                                metadataExists);
+                                isV1MetadataExists);
         } else if (object instanceof DecryptedFolderMetadataFile metadata) {
             updateMetadataForV2(metadata,
                                 encryptionUtilsV2,
@@ -850,7 +833,7 @@ public class UploadFileOperation extends SyncOperation {
     }
 
     private void updateMetadataForV1(DecryptedFolderMetadataFileV1 metadata, E2EData e2eData, E2EClientData clientData,
-                                     OCFile parentFile, ArbitraryDataProvider arbitraryDataProvider, boolean metadataExists)
+                                     OCFile parentFile, ArbitraryDataProvider arbitraryDataProvider, boolean isV1MetadataExists)
 
         throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException,
         CertificateException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException, UploadException {
@@ -889,7 +872,7 @@ public class UploadFileOperation extends SyncOperation {
                                        serializedFolderMetadata,
                                        clientData.getToken(),
                                        clientData.getClient(),
-                                       metadataExists,
+                                       isV1MetadataExists,
                                        e2eeVersion,
                                        "",
                                        arbitraryDataProvider,

--- a/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/EncryptionUtils.java
@@ -1308,13 +1308,13 @@ public final class EncryptionUtils {
                                       String serializedFolderMetadata,
                                       String token,
                                       OwnCloudClient client,
-                                      boolean metadataExists,
+                                      boolean isV1MetadataExists,
                                       E2EVersion version,
                                       String signature,
                                       ArbitraryDataProvider arbitraryDataProvider,
                                       User user) throws UploadException {
         RemoteOperationResult<String> uploadMetadataOperationResult;
-        if (metadataExists) {
+        if (isV1MetadataExists) {
             // update metadata
             if (E2EVersionHelper.INSTANCE.isV2Plus(version)) {
                 uploadMetadataOperationResult = new UpdateMetadataV2RemoteOperation(


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

Cannot create encrypted sub folder of sub folder

```
RemoteOperationResult:
 processed: UNHANDLED_HTTP_CODE
 HTTP Status: 412 Precondition Failed

2026-07-01 12:25:30.215
E/OperationsService: Unexpected error for <user>@<server>

java.lang.RuntimeException: Could not clean up after failing folder creation!
   at [com.owncloud.android](http://com.owncloud.android/).operations.CreateFolderOperation.encryptedCreateV2([CreateFolderOperation.java:385](http://createfolderoperation.java:385/))
   at [com.owncloud.android.operations.CreateFolderOperation.run](http://com.owncloud.android.operations.createfolderoperation.run/)([CreateFolderOperation.java:112](http://createfolderoperation.java:112/))
   at [com.owncloud.android](http://com.owncloud.android/).lib.common.operations.RemoteOperation.execute([RemoteOperation.java:193](http://remoteoperation.java:193/))
   at [com.owncloud.android.services](http://com.owncloud.android.services/).OperationsService$ServiceHandler.nextOperation([OperationsService.java:444](http://operationsservice.java:444/))
   at [com.owncloud.android.services](http://com.owncloud.android.services/).OperationsService$ServiceHandler.handleMessage([OperationsService.java:407](http://operationsservice.java:407/))
   at android.os.Handler.dispatchMessage([Handler.java:110](http://handler.java:110/))
   at android.os.Looper.loopOnce([Looper.java:248](http://looper.java:248/))
   at android.os.Looper.loop([Looper.java:338](http://looper.java:338/))
   at [android.os.HandlerThread.run](http://android.os.handlerthread.run/)([HandlerThread.java:85](http://handlerthread.java:85/))

Caused by: [com.owncloud.android](http://com.owncloud.android/).operations.UploadException: Could not lock folder
   at [com.owncloud.android](http://com.owncloud.android/).utils.EncryptionUtils.lockFolder([EncryptionUtils.java:1179](http://encryptionutils.java:1179/))
   at [com.owncloud.android](http://com.owncloud.android/).operations.CreateFolderOperation.encryptedCreateV2([CreateFolderOperation.java:283](http://createfolderoperation.java:283/))
   ... 8 more
```