### PR TITLE
fix(document-storage-provider): permission denial

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.kt
@@ -120,6 +120,11 @@ class DownloadFileOperation(
             if (cancellationRequested.get()) return RemoteOperationResult(OperationCancelledException())
         }
 
+        if (file.isFolder) {
+            Log_OC.e(TAG, "Cannot download a folder as a file: ${file.remotePath}")
+            return RemoteOperationResult(RemoteOperationResult.ResultCode.CANNOT_CREATE_FILE)
+        }
+
         if (!FileStorageUtils.isValidExtFilename(file.fileName)) {
             mainThreadHandler.post { context.get()?.showToast(R.string.download_download_invalid_local_file_name) }
             return RemoteOperationResult(RemoteOperationResult.ResultCode.INVALID_CHARACTER_IN_NAME)
@@ -213,11 +218,21 @@ class DownloadFileOperation(
         )
     }
 
+    private fun ensureParentDirectory(target: File) {
+        val parent = target.parentFile ?: return
+
+        if (parent.exists() && !parent.isDirectory && !parent.delete()) {
+            Log_OC.e(TAG, "Unable to delete file blocking parent folder ${parent.absolutePath}")
+        }
+
+        if (!parent.exists() && !parent.mkdirs()) {
+            Log_OC.e(TAG, "Unable to create parent folder ${parent.absolutePath}")
+        }
+    }
+
     private fun handleFileMove(tmpFile: File, currentResult: RemoteOperationResult<Unit>): RemoteOperationResult<Unit> {
         val newFile = File(savePath)
-        newFile.parentFile?.takeIf { !it.exists() }?.also {
-            if (!it.mkdirs()) Log_OC.e(TAG, "Unable to create parent folder ${it.absolutePath}")
-        }
+        ensureParentDirectory(newFile)
 
         val tempFilePath = tmpFile.toPath()
         val newFilePath = newFile.toPath()

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -678,45 +678,59 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         // FIXME we need to update the mimeType somewhere else as well
 
-        // perform the upload, no need for chunked operation as we have a empty file
-        OwnCloudClient client = targetFolder.getClient();
-        final var result = new UploadFileRemoteOperation(emptyFile.getAbsolutePath(),
-                                                                     newFilePath,
-                                                                     mimeType,
-                                                                     "",
-                                                                     System.currentTimeMillis() / 1000,
-                                                                     FileUtil.getCreationTimestamp(emptyFile),
-                                                                     false)
-            .execute(client);
+        try {
+            // perform the upload, no need for chunked operation as we have a empty file
+            OwnCloudClient client = targetFolder.getClient();
+            final var result = new UploadFileRemoteOperation(emptyFile.getAbsolutePath(),
+                                                                         newFilePath,
+                                                                         mimeType,
+                                                                         "",
+                                                                         System.currentTimeMillis() / 1000,
+                                                                         FileUtil.getCreationTimestamp(emptyFile),
+                                                                         false)
+                .execute(client);
 
-        if (!result.isSuccess()) {
-            Log_OC.e(TAG, result.toString());
-            throw new FileNotFoundException("Failed to upload document with path " + newFilePath);
+            if (!result.isSuccess()) {
+                Log_OC.e(TAG, result.toString());
+                notifyRemoteOperationError(result);
+                throw new FileNotFoundException("Failed to upload document with path " + newFilePath);
+            }
+
+            Context context = getNonNullContext();
+
+            final var updateParent = new RefreshFolderOperation(targetFolder.getFile(),
+                                                                            System.currentTimeMillis(),
+                                                                            false,
+                                                                            false,
+                                                                            true,
+                                                                            targetFolder.getStorageManager(),
+                                                                            user,
+                                                                            context)
+                .execute(client);
+
+            if (!updateParent.isSuccess()) {
+                Log_OC.e(TAG, updateParent.toString());
+                notifyRemoteOperationError(updateParent);
+                throw new FileNotFoundException("Failed to create document with documentId "
+                                                    + targetFolder.getDocumentId());
+            }
+
+            Document newFile = new Document(targetFolder.getStorageManager(), newFilePath);
+
+            context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+
+            return newFile.getDocumentId();
+        } finally {
+            if (emptyFile.exists() && !emptyFile.delete()) {
+                Log_OC.w(TAG, "Temp file could not be deleted: " + emptyFile.getAbsolutePath());
+            }
         }
+    }
 
-        Context context = getNonNullContext();
-
-        final var updateParent = new RefreshFolderOperation(targetFolder.getFile(),
-                                                                        System.currentTimeMillis(),
-                                                                        false,
-                                                                        false,
-                                                                        true,
-                                                                        targetFolder.getStorageManager(),
-                                                                        user,
-                                                                        context)
-            .execute(client);
-
-        if (!updateParent.isSuccess()) {
-            Log_OC.e(TAG, updateParent.toString());
-            throw new FileNotFoundException("Failed to create document with documentId "
-                                                + targetFolder.getDocumentId());
+    private void notifyRemoteOperationError(RemoteOperationResult result) {
+        if (result.getCode() == RemoteOperationResult.ResultCode.MAINTENANCE_MODE) {
+            showToast(R.string.maintenance_mode);
         }
-
-        Document newFile = new Document(targetFolder.getStorageManager(), newFilePath);
-
-        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
-
-        return newFile.getDocumentId();
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -362,20 +362,20 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public String renameDocument(String documentId, String displayName) throws FileNotFoundException {
         Log_OC.d(TAG, "renameDocument(), id=" + documentId);
 
-        String errorMessage = checkFileName(displayName);
-        if (errorMessage != null) {
-            showToast(errorMessage);
-            return null;
-        }
-
-        Document document = toDocument(documentId);
-        if (!document.getFile().canRename()) {
-            showToast(R.string.document_storage_provider_cannot_rename);
-            return null;
-        }
-
         final long token = Binder.clearCallingIdentity();
         try {
+            String errorMessage = checkFileName(displayName);
+            if (errorMessage != null) {
+                showToast(errorMessage);
+                return null;
+            }
+
+            Document document = toDocument(documentId);
+            if (!document.getFile().canRename()) {
+                showToast(R.string.document_storage_provider_cannot_rename);
+                return null;
+            }
+
             final var result = new RenameFileOperation(document.getRemotePath(),
                                                                    displayName,
                                                                    document.getStorageManager())
@@ -400,20 +400,20 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public String copyDocument(String sourceDocumentId, String targetParentDocumentId) throws FileNotFoundException {
         Log_OC.d(TAG, "copyDocument(), id=" + sourceDocumentId);
 
-        Document targetFolder = toDocument(targetParentDocumentId);
-
-        String filename = targetFolder.getFile().getFileName();
-        isFolderPathValid = checkFolderPath(filename);
-        if (!isFolderPathValid) {
-            showToast(R.string.file_name_validator_error_contains_reserved_names_or_invalid_characters);
-            return null;
-        }
-
-        Document document = toDocument(sourceDocumentId);
-        FileDataStorageManager storageManager = document.getStorageManager();
-
         final long token = Binder.clearCallingIdentity();
         try {
+            Document targetFolder = toDocument(targetParentDocumentId);
+
+            String filename = targetFolder.getFile().getFileName();
+            isFolderPathValid = checkFolderPath(filename);
+            if (!isFolderPathValid) {
+                showToast(R.string.file_name_validator_error_contains_reserved_names_or_invalid_characters);
+                return null;
+            }
+
+            Document document = toDocument(sourceDocumentId);
+            FileDataStorageManager storageManager = document.getStorageManager();
+
             final var result = new CopyFileOperation(document.getRemotePath(),
                                                                  targetFolder.getRemotePath(),
                                                                  document.getStorageManager())
@@ -464,23 +464,23 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         throws FileNotFoundException {
         Log_OC.d(TAG, "moveDocument(), id=" + sourceDocumentId);
 
-        Document targetFolder = toDocument(targetParentDocumentId);
-
-        String filename = targetFolder.getFile().getFileName();
-        isFolderPathValid = checkFolderPath(filename);
-        if (!isFolderPathValid) {
-            showToast(R.string.file_name_validator_error_contains_reserved_names_or_invalid_characters);
-            return null;
-        }
-
-        Document document = toDocument(sourceDocumentId);
-        if (!document.getFile().canMove()) {
-            showToast(R.string.document_storage_provider_cannot_move);
-            return null;
-        }
-
         final long token = Binder.clearCallingIdentity();
         try {
+            Document targetFolder = toDocument(targetParentDocumentId);
+
+            String filename = targetFolder.getFile().getFileName();
+            isFolderPathValid = checkFolderPath(filename);
+            if (!isFolderPathValid) {
+                showToast(R.string.file_name_validator_error_contains_reserved_names_or_invalid_characters);
+                return null;
+            }
+
+            Document document = toDocument(sourceDocumentId);
+            if (!document.getFile().canMove()) {
+                showToast(R.string.document_storage_provider_cannot_move);
+                return null;
+            }
+
             final var result = new MoveFileOperation(document.getRemotePath(),
                                                                  targetFolder.getRemotePath(),
                                                                  document.getStorageManager())
@@ -538,20 +538,20 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public String createDocument(String documentId, String mimeType, String displayName) throws FileNotFoundException {
         Log_OC.d(TAG, "createDocument(), id=" + documentId);
 
-        String errorMessage = checkFileName(displayName);
-        if (errorMessage != null) {
-            showToast(errorMessage);
-            return null;
-        }
-
-        Document folderDocument = toDocument(documentId);
-        if (!folderDocument.getFile().canCreateFileAndFolder()) {
-            showToast(R.string.document_storage_provider_cannot_create_file_and_folder);
-            return null;
-        }
-
         final long token = Binder.clearCallingIdentity();
         try {
+            String errorMessage = checkFileName(displayName);
+            if (errorMessage != null) {
+                showToast(errorMessage);
+                return null;
+            }
+
+            Document folderDocument = toDocument(documentId);
+            if (!folderDocument.getFile().canCreateFileAndFolder()) {
+                showToast(R.string.document_storage_provider_cannot_create_file_and_folder);
+                return null;
+            }
+
             if (DocumentsContract.Document.MIME_TYPE_DIR.equalsIgnoreCase(mimeType)) {
                 return createFolder(folderDocument, displayName);
             } else {

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -18,6 +18,7 @@ import android.database.Cursor;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Binder;
 import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.os.Handler;
@@ -373,21 +374,26 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return null;
         }
 
-        final var result = new RenameFileOperation(document.getRemotePath(),
-                                                               displayName,
-                                                               document.getStorageManager())
-            .execute(document.getClient());
+        final long token = Binder.clearCallingIdentity();
+        try {
+            final var result = new RenameFileOperation(document.getRemotePath(),
+                                                                   displayName,
+                                                                   document.getStorageManager())
+                .execute(document.getClient());
 
-        if (!result.isSuccess()) {
-            Log_OC.e(TAG, result.toString());
-            throw new FileNotFoundException("Failed to rename document with documentId " + documentId + ": " +
-                                                result.getException());
+            if (!result.isSuccess()) {
+                Log_OC.e(TAG, result.toString());
+                throw new FileNotFoundException("Failed to rename document with documentId " + documentId + ": " +
+                                                    result.getException());
+            }
+
+            Context context = getNonNullContext();
+            context.getContentResolver().notifyChange(toNotifyUri(document.getParent()), null, false);
+
+            return null;
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-
-        Context context = getNonNullContext();
-        context.getContentResolver().notifyChange(toNotifyUri(document.getParent()), null, false);
-
-        return null;
     }
 
     @Override
@@ -405,46 +411,52 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         Document document = toDocument(sourceDocumentId);
         FileDataStorageManager storageManager = document.getStorageManager();
-        final var result = new CopyFileOperation(document.getRemotePath(),
-                                                             targetFolder.getRemotePath(),
-                                                             document.getStorageManager())
-            .execute(document.getClient());
 
-        if (!result.isSuccess()) {
-            Log_OC.e(TAG, result.toString());
-            throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
-                                                + " to " + targetParentDocumentId);
+        final long token = Binder.clearCallingIdentity();
+        try {
+            final var result = new CopyFileOperation(document.getRemotePath(),
+                                                                 targetFolder.getRemotePath(),
+                                                                 document.getStorageManager())
+                .execute(document.getClient());
+
+            if (!result.isSuccess()) {
+                Log_OC.e(TAG, result.toString());
+                throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
+                                                    + " to " + targetParentDocumentId);
+            }
+
+            Context context = getNonNullContext();
+            User user = document.getUser();
+
+            final var updateParent = new RefreshFolderOperation(targetFolder.getFile(),
+                                                                            System.currentTimeMillis(),
+                                                                            false,
+                                                                            false,
+                                                                            true,
+                                                                            storageManager,
+                                                                            user,
+                                                                            context)
+                .execute(targetFolder.getClient());
+
+            if (!updateParent.isSuccess()) {
+                Log_OC.e(TAG, updateParent.toString());
+                throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
+                                                    + " to " + targetParentDocumentId);
+            }
+
+            String newPath = targetFolder.getRemotePath() + document.getFile().getFileName();
+
+            if (document.getFile().isFolder()) {
+                newPath = newPath + PATH_SEPARATOR;
+            }
+            Document newFile = new Document(storageManager, newPath);
+
+            context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+
+            return newFile.getDocumentId();
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-
-        Context context = getNonNullContext();
-        User user = document.getUser();
-
-        final var updateParent = new RefreshFolderOperation(targetFolder.getFile(),
-                                                                        System.currentTimeMillis(),
-                                                                        false,
-                                                                        false,
-                                                                        true,
-                                                                        storageManager,
-                                                                        user,
-                                                                        context)
-            .execute(targetFolder.getClient());
-
-        if (!updateParent.isSuccess()) {
-            Log_OC.e(TAG, updateParent.toString());
-            throw new FileNotFoundException("Failed to copy document with documentId " + sourceDocumentId
-                                                + " to " + targetParentDocumentId);
-        }
-
-        String newPath = targetFolder.getRemotePath() + document.getFile().getFileName();
-
-        if (document.getFile().isFolder()) {
-            newPath = newPath + PATH_SEPARATOR;
-        }
-        Document newFile = new Document(storageManager, newPath);
-
-        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
-
-        return newFile.getDocumentId();
     }
 
     @Override
@@ -467,24 +479,29 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return null;
         }
 
-        final var result = new MoveFileOperation(document.getRemotePath(),
-                                                             targetFolder.getRemotePath(),
-                                                             document.getStorageManager())
-            .execute(document.getClient());
+        final long token = Binder.clearCallingIdentity();
+        try {
+            final var result = new MoveFileOperation(document.getRemotePath(),
+                                                                 targetFolder.getRemotePath(),
+                                                                 document.getStorageManager())
+                .execute(document.getClient());
 
-        if (!result.isSuccess()) {
-            Log_OC.e(TAG, result.toString());
-            throw new FileNotFoundException("Failed to move document with documentId " + sourceDocumentId
-                                                + " to " + targetParentDocumentId);
+            if (!result.isSuccess()) {
+                Log_OC.e(TAG, result.toString());
+                throw new FileNotFoundException("Failed to move document with documentId " + sourceDocumentId
+                                                    + " to " + targetParentDocumentId);
+            }
+
+            Document sourceFolder = toDocument(sourceParentDocumentId);
+
+            Context context = getNonNullContext();
+            context.getContentResolver().notifyChange(toNotifyUri(sourceFolder), null, false);
+            context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
+
+            return sourceDocumentId;
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-
-        Document sourceFolder = toDocument(sourceParentDocumentId);
-
-        Context context = getNonNullContext();
-        context.getContentResolver().notifyChange(toNotifyUri(sourceFolder), null, false);
-        context.getContentResolver().notifyChange(toNotifyUri(targetFolder), null, false);
-
-        return sourceDocumentId;
     }
 
     @Override
@@ -533,10 +550,15 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return null;
         }
 
-        if (DocumentsContract.Document.MIME_TYPE_DIR.equalsIgnoreCase(mimeType)) {
-            return createFolder(folderDocument, displayName);
-        } else {
-            return createFile(folderDocument, displayName, mimeType);
+        final long token = Binder.clearCallingIdentity();
+        try {
+            if (DocumentsContract.Document.MIME_TYPE_DIR.equalsIgnoreCase(mimeType)) {
+                return createFolder(folderDocument, displayName);
+            } else {
+                return createFile(folderDocument, displayName, mimeType);
+            }
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
     }
 
@@ -675,18 +697,24 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         recursiveRevokePermission(document);
 
         OCFile file = document.getStorageManager().getFileByPath(document.getRemotePath());
-        final var result = new RemoveFileOperation(file,
-                                                               false,
-                                                               document.getUser(),
-                                                               true,
-                                                               context,
-                                                               document.getStorageManager())
-            .execute(document.getClient());
 
-        if (!result.isSuccess()) {
-            throw new FileNotFoundException("Failed to delete document with documentId " + documentId);
+        final long token = Binder.clearCallingIdentity();
+        try {
+            final var result = new RemoveFileOperation(file,
+                                                                   false,
+                                                                   document.getUser(),
+                                                                   true,
+                                                                   context,
+                                                                   document.getStorageManager())
+                .execute(document.getClient());
+
+            if (!result.isSuccess()) {
+                throw new FileNotFoundException("Failed to delete document with documentId " + documentId);
+            }
+            context.getContentResolver().notifyChange(toNotifyUri(parentFolder), null, false);
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-        context.getContentResolver().notifyChange(toNotifyUri(parentFolder), null, false);
     }
 
     private void recursiveRevokePermission(Document document) {

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -111,23 +111,28 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     @Override
     public Cursor queryRoots(String[] projection) {
 
-        // always recreate storage manager collection, as it will change after account creation/removal
-        // and we need to serve document(tree)s with persist permissions
-        initiateStorageMap();
+        final long token = Binder.clearCallingIdentity();
+        try {
+            // always recreate storage manager collection, as it will change after account creation/removal
+            // and we need to serve document(tree)s with persist permissions
+            initiateStorageMap();
 
-        Context context = MainApp.getAppContext();
-        AppPreferences preferences = AppPreferencesImpl.fromContext(context);
-        if (SettingsActivity.LOCK_PASSCODE.equals(preferences.getLockPreference()) ||
-            SettingsActivity.LOCK_DEVICE_CREDENTIALS.equals(preferences.getLockPreference())) {
-            return new FileCursor();
+            Context context = MainApp.getAppContext();
+            AppPreferences preferences = AppPreferencesImpl.fromContext(context);
+            if (SettingsActivity.LOCK_PASSCODE.equals(preferences.getLockPreference()) ||
+                SettingsActivity.LOCK_DEVICE_CREDENTIALS.equals(preferences.getLockPreference())) {
+                return new FileCursor();
+            }
+
+            final RootCursor result = new RootCursor(projection);
+            for (FileDataStorageManager manager : rootIdToStorageManager.values()) {
+                result.addRoot(new Document(manager, ROOT_PATH), getContext());
+            }
+
+            return result;
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-
-        final RootCursor result = new RootCursor(projection);
-        for(FileDataStorageManager manager: rootIdToStorageManager.values()) {
-            result.addRoot(new Document(manager, ROOT_PATH), getContext());
-        }
-
-        return result;
     }
 
     public static void notifyRootsChanged(Context context) {
@@ -140,12 +145,17 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
         Log_OC.d(TAG, "queryDocument(), id=" + documentId);
 
-        Document document = toDocument(documentId);
+        final long token = Binder.clearCallingIdentity();
+        try {
+            Document document = toDocument(documentId);
 
-        final FileCursor result = new FileCursor(projection);
-        result.addFile(document);
+            final FileCursor result = new FileCursor(projection);
+            result.addFile(document);
 
-        return result;
+            return result;
+        } finally {
+            Binder.restoreCallingIdentity(token);
+        }
     }
 
     @SuppressLint("LongLogTag")
@@ -154,45 +164,50 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         throws FileNotFoundException {
         Log_OC.d(TAG, "queryChildDocuments(), id=" + parentDocumentId);
 
-        Context context = getNonNullContext();
-        Document parentFolder = toDocument(parentDocumentId);
-        final FileCursor resultCursor = new FileCursor(projection);
+        final long token = Binder.clearCallingIdentity();
+        try {
+            Context context = getNonNullContext();
+            Document parentFolder = toDocument(parentDocumentId);
+            final FileCursor resultCursor = new FileCursor(projection);
 
-        if (!parentFolder.getFile().canRead()) {
-            showToast(R.string.document_storage_provider_cannot_read);
-            return resultCursor;
-        }
-
-        if (parentFolder.getFile().isEncrypted() &&
-            !FileOperationsHelper.isEndToEndEncryptionSetup(context, parentFolder.getUser())) {
-            showToast(R.string.e2e_not_yet_setup);
-            return resultCursor;
-        }
-
-        FileDataStorageManager storageManager = parentFolder.getStorageManager();
-
-        for (OCFile file : storageManager.getFolderContent(parentFolder.getFile(), false)) {
-            if (file.canRead()) {
-                resultCursor.addFile(new Document(storageManager, file));
-            } else {
-                Log_OC.w(TAG,"Skipping file, doesn't have read permission. RemotePath: " + file.getRemotePath());
+            if (!parentFolder.getFile().canRead()) {
+                showToast(R.string.document_storage_provider_cannot_read);
+                return resultCursor;
             }
-        }
 
-        boolean isLoading = false;
-        if (parentFolder.isExpired()) {
-            final ReloadFolderDocumentTask task = new ReloadFolderDocumentTask(parentFolder, result ->
-                context.getContentResolver().notifyChange(toNotifyUri(parentFolder), null, false));
-            task.executeOnExecutor(executor);
-            resultCursor.setLoadingTask(task);
-            isLoading = true;
-        }
+            if (parentFolder.getFile().isEncrypted() &&
+                !FileOperationsHelper.isEndToEndEncryptionSetup(context, parentFolder.getUser())) {
+                showToast(R.string.e2e_not_yet_setup);
+                return resultCursor;
+            }
 
-        final Bundle extra = new Bundle();
-        extra.putBoolean(DocumentsContract.EXTRA_LOADING, isLoading);
-        resultCursor.setExtras(extra);
-        resultCursor.setNotificationUri(context.getContentResolver(), toNotifyUri(parentFolder));
-        return resultCursor;
+            FileDataStorageManager storageManager = parentFolder.getStorageManager();
+
+            for (OCFile file : storageManager.getFolderContent(parentFolder.getFile(), false)) {
+                if (file.canRead()) {
+                    resultCursor.addFile(new Document(storageManager, file));
+                } else {
+                    Log_OC.w(TAG, "Skipping file, doesn't have read permission. RemotePath: " + file.getRemotePath());
+                }
+            }
+
+            boolean isLoading = false;
+            if (parentFolder.isExpired()) {
+                final ReloadFolderDocumentTask task = new ReloadFolderDocumentTask(parentFolder, result ->
+                    context.getContentResolver().notifyChange(toNotifyUri(parentFolder), null, false));
+                task.executeOnExecutor(executor);
+                resultCursor.setLoadingTask(task);
+                isLoading = true;
+            }
+
+            final Bundle extra = new Bundle();
+            extra.putBoolean(DocumentsContract.EXTRA_LOADING, isLoading);
+            resultCursor.setExtras(extra);
+            resultCursor.setNotificationUri(context.getContentResolver(), toNotifyUri(parentFolder));
+            return resultCursor;
+        } finally {
+            Binder.restoreCallingIdentity(token);
+        }
     }
 
     @SuppressLint("LongLogTag")
@@ -206,84 +221,91 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             return null;
         }
 
-        Document document = toDocument(documentId);
-        Context context = getNonNullContext();
+        final long token = Binder.clearCallingIdentity();
+        try {
+            Document document = toDocument(documentId);
+            Context context = getNonNullContext();
 
-        OCFile ocFile = document.getFile();
-        User user = document.getUser();
+            OCFile ocFile = document.getFile();
+            User user = document.getUser();
 
-        int accessMode = ParcelFileDescriptor.parseMode(mode);
-        boolean writeOnly = (accessMode & MODE_WRITE_ONLY) != 0;
-        boolean needsDownload = !ocFile.existsOnDevice() || (!writeOnly && hasServerChange(document));
-        if (needsDownload) {
-            if (ocFile.getLocalModificationTimestamp() > ocFile.getLastSyncDateForData()) {
-                // TODO show a conflict notification with a pending intent that shows a ConflictResolveDialog
-                Log_OC.w(TAG, "Conflict found!");
-            } else {
-                // dirty threading workaround for client apps which call openDocument on the main thread, thus causing
-                // a NetworkOnMainThreadException
-                final AtomicBoolean downloadResult = new AtomicBoolean(false);
-                final Thread downloadThread = new Thread(() -> {
-                    DownloadFileOperation downloadFileOperation = new DownloadFileOperation(user, ocFile, context);
-                    final var result = downloadFileOperation.execute(document.getClient());
-                    if (!result.isSuccess()) {
-                        if (ocFile.isDown()) {
-                            Handler handler = new Handler(Looper.getMainLooper());
-                            handler.post(() -> showToast(R.string.file_not_synced));
-                            downloadResult.set(true);
+            int accessMode = ParcelFileDescriptor.parseMode(mode);
+            boolean writeOnly = (accessMode & MODE_WRITE_ONLY) != 0;
+            boolean needsDownload = !ocFile.existsOnDevice() || (!writeOnly && hasServerChange(document));
+            if (needsDownload) {
+                if (ocFile.getLocalModificationTimestamp() > ocFile.getLastSyncDateForData()) {
+                    // TODO show a conflict notification with a pending intent that shows a ConflictResolveDialog
+                    Log_OC.w(TAG, "Conflict found!");
+                } else {
+                    // dirty threading workaround for client apps which call openDocument on the main thread,
+                    // thus causing a NetworkOnMainThreadException. The download runs on a fresh (non-binder) thread,
+                    // which already carries the app's own identity, so no extra clearCallingIdentity() is needed there.
+                    final AtomicBoolean downloadResult = new AtomicBoolean(false);
+                    final Thread downloadThread = new Thread(() -> {
+                        var downloadFileOperation = new DownloadFileOperation(user, ocFile, context);
+                        final var result = downloadFileOperation.execute(document.getClient());
+                        if (!result.isSuccess()) {
+                            if (ocFile.isDown()) {
+                                Handler handler = new Handler(Looper.getMainLooper());
+                                handler.post(() -> showToast(R.string.file_not_synced));
+                                downloadResult.set(true);
+                            } else {
+                                Log_OC.e(TAG, result.toString());
+                            }
                         } else {
-                            Log_OC.e(TAG, result.toString());
+                            saveDownloadedFile(document.getStorageManager(), downloadFileOperation, ocFile);
+                            downloadResult.set(true);
                         }
-                    } else {
-                        saveDownloadedFile(document.getStorageManager(), downloadFileOperation, ocFile);
-                        downloadResult.set(true);
-                    }
-                });
-                downloadThread.start();
+                    });
+                    downloadThread.start();
 
-                try {
-                    downloadThread.join();
-                    if (!downloadResult.get()) {
+                    try {
+                        downloadThread.join();
+                        if (!downloadResult.get()) {
+                            throw new FileNotFoundException("Error downloading file: " + ocFile.getFileName());
+                        }
+                    } catch (InterruptedException e) {
                         throw new FileNotFoundException("Error downloading file: " + ocFile.getFileName());
                     }
-                } catch (InterruptedException e) {
-                    throw new FileNotFoundException("Error downloading file: " + ocFile.getFileName());
                 }
             }
-        }
 
-        File file = new File(ocFile.getStoragePath());
+            File file = new File(ocFile.getStoragePath());
 
-        if (accessMode != MODE_READ_ONLY) {
-            // The calling thread is not guaranteed to have a Looper, so we can't block it with the OnCloseListener.
-            // Thus, we are unable to do a synchronous upload and have to start an asynchronous one.
-            Handler handler = new Handler(context.getMainLooper());
-            try {
-                return ParcelFileDescriptor.open(file, accessMode, handler, error -> {
-                    if (error == null) {
-                        // no error
-                        // As we can't upload the file synchronously, let's at least update its metadata here already.
-                        ocFile.setFileLength(file.length());
-                        ocFile.setModificationTimestamp(System.currentTimeMillis());
-                        document.getStorageManager().saveFile(ocFile);
+            if (accessMode != MODE_READ_ONLY) {
+                // The calling thread is not guaranteed to have a Looper, so we can't block it with the
+                // OnCloseListener. Thus, we are unable to do a synchronous upload and have to start an
+                // asynchronous one.
+                Handler handler = new Handler(context.getMainLooper());
+                try {
+                    return ParcelFileDescriptor.open(file, accessMode, handler, error -> {
+                        if (error == null) {
+                            // no error
+                            // As we can't upload the file synchronously, let's at least update its metadata already.
+                            ocFile.setFileLength(file.length());
+                            ocFile.setModificationTimestamp(System.currentTimeMillis());
+                            document.getStorageManager().saveFile(ocFile);
 
-                        // TODO disable upload notifications as DocumentsProvider users already show them
-                        // upload file with FileUploader service (off main thread)
-                        FileUploadHelper.Companion.instance().uploadUpdatedFile(
-                            user,
-                            new OCFile[]{ ocFile },
-                            FileUploadWorker.LOCAL_BEHAVIOUR_DELETE,
-                            NameCollisionPolicy.OVERWRITE);
-                    } else {
-                        // error, no upload needed
-                        Log_OC.e(TAG, "File was closed with an error: " + ocFile.getFileName(), error);
-                    }
-                });
-            } catch (IOException e) {
-                throw new FileNotFoundException("Failed to open document for writing " + ocFile.getFileName());
+                            // TODO disable upload notifications as DocumentsProvider users already show them
+                            // upload file with FileUploader service (off main thread)
+                            FileUploadHelper.Companion.instance().uploadUpdatedFile(
+                                user,
+                                new OCFile[]{ ocFile },
+                                FileUploadWorker.LOCAL_BEHAVIOUR_DELETE,
+                                NameCollisionPolicy.OVERWRITE);
+                        } else {
+                            // error, no upload needed
+                            Log_OC.e(TAG, "File was closed with an error: " + ocFile.getFileName(), error);
+                        }
+                    });
+                } catch (IOException e) {
+                    throw new FileNotFoundException("Failed to open document for writing " + ocFile.getFileName());
+                }
+            } else {
+                return ParcelFileDescriptor.open(file, accessMode);
             }
-        } else {
-            return ParcelFileDescriptor.open(file, accessMode);
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
     }
 
@@ -350,18 +372,23 @@ public class DocumentsStorageProvider extends DocumentsProvider {
         throws FileNotFoundException {
         Log_OC.d(TAG, "openDocumentThumbnail(), id=" + documentId);
 
-        Document document = toDocument(documentId);
-        OCFile file = document.getFile();
+        final long token = Binder.clearCallingIdentity();
+        try {
+            Document document = toDocument(documentId);
+            OCFile file = document.getFile();
 
-        boolean exists = ThumbnailsCacheManager.containsBitmap(ThumbnailsCacheManager.PREFIX_THUMBNAIL
-                                                                   + file.getRemoteId());
-        if (!exists) {
-            ThumbnailsCacheManager.generateThumbnailFromOCFile(file, document.getUser(), getContext());
+            boolean exists = ThumbnailsCacheManager.containsBitmap(ThumbnailsCacheManager.PREFIX_THUMBNAIL
+                                                                       + file.getRemoteId());
+            if (!exists) {
+                ThumbnailsCacheManager.generateThumbnailFromOCFile(file, document.getUser(), getContext());
+            }
+
+            return new AssetFileDescriptor(DiskLruImageCacheFileProvider.getParcelFileDescriptorForOCFile(file),
+                                           0,
+                                           file.getFileLength());
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-
-        return new AssetFileDescriptor(DiskLruImageCacheFileProvider.getParcelFileDescriptorForOCFile(file),
-                                       0,
-                                       file.getFileLength());
     }
 
     @Override
@@ -514,18 +541,23 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public Cursor querySearchDocuments(String rootId, String query, String[] projection) {
         Log_OC.d(TAG, "querySearchDocuments(), rootId=" + rootId);
 
-        FileCursor result = new FileCursor(projection);
+        final long token = Binder.clearCallingIdentity();
+        try {
+            FileCursor result = new FileCursor(projection);
 
-        FileDataStorageManager storageManager = getStorageManager(rootId);
-        if (storageManager == null) {
+            FileDataStorageManager storageManager = getStorageManager(rootId);
+            if (storageManager == null) {
+                return result;
+            }
+
+            for (Document d : findFiles(new Document(storageManager, ROOT_PATH), query)) {
+                result.addFile(d);
+            }
+
             return result;
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
-
-        for (Document d : findFiles(new Document(storageManager, ROOT_PATH), query)) {
-            result.addFile(d);
-        }
-
-        return result;
     }
 
     private OCCapability getCapabilities() {
@@ -597,7 +629,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         if (!updateParent.isSuccess()) {
             Log_OC.e(TAG, updateParent.toString());
-            throw new FileNotFoundException("Failed to create document with documentId " + targetFolder.getDocumentId());
+            throw new FileNotFoundException("Failed to create document with documentId "
+                                                + targetFolder.getDocumentId());
         }
 
         Document newFolder = new Document(storageManager, newDirPath);
@@ -670,7 +703,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         if (!updateParent.isSuccess()) {
             Log_OC.e(TAG, updateParent.toString());
-            throw new FileNotFoundException("Failed to create document with documentId " + targetFolder.getDocumentId());
+            throw new FileNotFoundException("Failed to create document with documentId "
+                                                + targetFolder.getDocumentId());
         }
 
         Document newFile = new Document(targetFolder.getStorageManager(), newFilePath);
@@ -739,6 +773,7 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     public boolean isChildDocument(String parentDocumentId, String documentId) {
         Log_OC.d(TAG, "isChildDocument(), parent=" + parentDocumentId + ", id=" + documentId);
 
+        final long token = Binder.clearCallingIdentity();
         try {
             // get file for parent document
             Document parentDocument = toDocument(parentDocumentId);
@@ -768,6 +803,8 @@ public class DocumentsStorageProvider extends DocumentsProvider {
 
         } catch (FileNotFoundException e) {
             Log_OC.e(TAG, "failed to check for child document", e);
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
 
         return false;

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -290,16 +290,22 @@ public class DocumentsStorageProvider extends DocumentsProvider {
     private boolean hasServerChange(Document document) throws FileNotFoundException {
         Context context = getNonNullContext();
         OCFile ocFile = document.getFile();
-        RemoteOperationResult result = new CheckEtagRemoteOperation(ocFile.getRemotePath(), ocFile.getEtag())
-            .execute(document.getUser(), context);
-        return switch (result.getCode()) {
-            case ETAG_CHANGED -> result.getData() != null;
-            case ETAG_UNCHANGED -> false;
-            default -> {
-                Log_OC.e(TAG, result.toString());
-                throw new FileNotFoundException("Error synchronizing file: " + ocFile.getFileName());
-            }
-        };
+
+        final long token = Binder.clearCallingIdentity();
+        try {
+            RemoteOperationResult result = new CheckEtagRemoteOperation(ocFile.getRemotePath(), ocFile.getEtag())
+                .execute(document.getUser(), context);
+            return switch (result.getCode()) {
+                case ETAG_CHANGED -> result.getData() != null;
+                case ETAG_UNCHANGED -> false;
+                default -> {
+                    Log_OC.e(TAG, result.toString());
+                    throw new FileNotFoundException("Error synchronizing file: " + ocFile.getFileName());
+                }
+            };
+        } finally {
+            Binder.restoreCallingIdentity(token);
+        }
     }
 
     /**

--- a/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
+++ b/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java
@@ -227,6 +227,11 @@ public class DocumentsStorageProvider extends DocumentsProvider {
             Context context = getNonNullContext();
 
             OCFile ocFile = document.getFile();
+            if (ocFile.isFolder()) {
+                Log_OC.w(TAG, "openDocument called on a folder, which is not openable: " + documentId);
+                return null;
+            }
+
             User user = document.getUser();
 
             int accessMode = ParcelFileDescriptor.parseMode(mode);


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue: https://github.com/nextcloud/android/issues/17258

caller identity needs to be cleared before trying to access `URI`

<img width="644" height="297" alt="Screenshot 2026-07-02 at 08 58 42" src="https://github.com/user-attachments/assets/04af0bc4-35f3-4d31-a795-ace1c8be38fc" />

```
E  Writing exception to parcel

java.lang.SecurityException: Permission Denial: reading
com.owncloud.android.providers.FileContentProvider
URI: content://org.nextcloud/capabilities
from pid=7734, uid=10069
requires false, or grantUriPermission()

    at android.content.ContentProvider.enforceReadPermissionInner(ContentProvider.java:1028)
    at android.content.ContentProvider$Transport.enforceReadPermission(ContentProvider.java:823)
    at android.content.ContentProvider$Transport.query(ContentProvider.java:257)
    at android.content.ContentResolver.query(ContentResolver.java:1231)
    at android.content.ContentResolver.query(ContentResolver.java:1163)
    at android.content.ContentResolver.query(ContentResolver.java:1119)
    at com.owncloud.android.datamodel.FileDataStorageManager.getCapabilityCursorForAccount(FileDataStorageManager.java:2437)
    at com.owncloud.android.datamodel.FileDataStorageManager.getCapability(FileDataStorageManager.java:2474)
    at com.owncloud.android.datamodel.FileDataStorageManager.getCapability(FileDataStorageManager.java:2468)
    at com.owncloud.android.datamodel.FileDataStorageManager.getE2EEVersionObject(FileDataStorageManager.java:2461)
    at com.owncloud.android.operations.RefreshFolderOperation.synchronizeData(RefreshFolderOperation.java:552)
    at com.owncloud.android.operations.RefreshFolderOperation.fetchAndSyncRemoteFolder(RefreshFolderOperation.java:464)
    at com.owncloud.android.operations.RefreshFolderOperation.run(RefreshFolderOperation.java:275)
    at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:193)
    at com.owncloud.android.providers.DocumentsStorageProvider.createFile(DocumentsStorageProvider.java:641)
    at com.owncloud.android.providers.DocumentsStorageProvider.createDocument(DocumentsStorageProvider.java:539)
    at android.provider.DocumentsProvider.callUnchecked(DocumentsProvider.java:1153)
    at android.provider.DocumentsProvider.call(DocumentsProvider.java:1091)
    at android.content.ContentProvider.call(ContentProvider.java:2709)
    at android.content.ContentProvider$Transport.call(ContentProvider.java:638)
    at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:307)
    at android.os.Binder.execTransactInternal(Binder.java:1421)
    at android.os.Binder.execTransact(Binder.java:1365)
```