### PR TITLE
refactor(setup-encryption-dialog): download key

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/setupEncryption/SetupEncryptionDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/setupEncryption/SetupEncryptionDialogFragment.kt
@@ -36,6 +36,7 @@ import com.owncloud.android.lib.resources.users.GetPublicKeyRemoteOperation
 import com.owncloud.android.lib.resources.users.GetServerPublicKeyRemoteOperation
 import com.owncloud.android.lib.resources.users.SendCSRRemoteOperation
 import com.owncloud.android.lib.resources.users.StorePrivateKeyRemoteOperation
+import com.owncloud.android.ui.dialog.setupEncryption.model.DownloadKeyResult
 import com.owncloud.android.utils.ClipboardUtil
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.EncryptionUtils
@@ -49,9 +50,6 @@ import java.io.IOException
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 
-/*
- *  Dialog to setup encryption
- */
 class SetupEncryptionDialogFragment :
     DialogFragment(),
     Injectable {
@@ -177,10 +175,6 @@ class SetupEncryptionDialogFragment :
                 }
 
                 val privateKey = (downloadKeyResult as DownloadKeyResult.Success).privateKey
-                if (privateKey.isNullOrEmpty()) {
-                    Log_OC.e(TAG, "privateKey is null or empty")
-                    return@launch
-                }
                 val mnemonicUnchanged = binding.encryptionPasswordInput.text.toString().trim()
                 val mnemonic =
                     binding.encryptionPasswordInput.text.toString().replace("\\s".toRegex(), "")
@@ -283,30 +277,6 @@ class SetupEncryptionDialogFragment :
         super.onSaveInstanceState(outState)
     }
 
-    sealed class DownloadKeyResult(open val descriptionId: Int? = null) {
-        data class CertificateVerificationFailed(
-            override val descriptionId: Int = R.string.end_to_end_encryption_certificate_verification_failed
-        ) : DownloadKeyResult(descriptionId)
-
-        data class ServerPublicKeyUnavailable(
-            override val descriptionId: Int = R.string.end_to_end_encryption_server_public_key_unavailable
-        ) : DownloadKeyResult(descriptionId)
-
-        data class ServerPrivateKeyUnavailable(
-            override val descriptionId: Int = R.string.end_to_end_encryption_server_private_key_unavailable
-        ) : DownloadKeyResult(descriptionId)
-
-        data class CertificateUnavailable(
-            override val descriptionId: Int = R.string.end_to_end_encryption_certificate_unavailable
-        ) : DownloadKeyResult(descriptionId)
-
-        data class UnexpectedError(
-            override val descriptionId: Int = R.string.end_to_end_encryption_unexpected_error_occurred
-        ) : DownloadKeyResult(descriptionId)
-
-        data class Success(val privateKey: String?) : DownloadKeyResult()
-    }
-
     private suspend fun downloadKeys() {
         binding.encryptionStatus.setText(R.string.end_to_end_encryption_retrieving_keys)
         positiveButton?.visibility = View.INVISIBLE
@@ -323,7 +293,7 @@ class SetupEncryptionDialogFragment :
                 // The certificate might not be available on the server yet.
                 // Therefore, the user needs to generate a new passphrase first, send csr.
                 return@withContext if (certificateResult.httpCode == HttpStatus.SC_NOT_FOUND) {
-                    DownloadKeyResult.Success(null)
+                    DownloadKeyResult.GeneratePassphraseSendCSR
                 } else {
                     DownloadKeyResult.CertificateUnavailable()
                 }
@@ -355,15 +325,19 @@ class SetupEncryptionDialogFragment :
                 Log_OC.d(TAG, "private key successful downloaded for " + user.accountName)
                 keyResult = KEY_EXISTING_USED
                 val privateKey = privateKeyResult.resultData?.getKey()
-                DownloadKeyResult.Success(privateKey)
+                if (privateKey == null) {
+                    DownloadKeyResult.ServerPrivateKeyUnavailable()
+                } else {
+                    DownloadKeyResult.Success(privateKey)
+                }
             } else {
                 DownloadKeyResult.ServerPrivateKeyUnavailable()
             }
         }
 
         downloadKeyResult?.let { result ->
-            if (result is DownloadKeyResult.Success) {
-                handlePrivateKey(result.privateKey)
+            if (result is DownloadKeyResult.Success || result is DownloadKeyResult.GeneratePassphraseSendCSR) {
+                handlePrivateKey(result)
             } else {
                 val descriptionId = result.descriptionId ?: return
                 val description = getString(descriptionId)
@@ -373,23 +347,28 @@ class SetupEncryptionDialogFragment :
         }
     }
 
-    private fun handlePrivateKey(privateKey: String?) {
-        if (privateKey == null) {
-            // first show info
-            try {
-                if (keyWords == null || keyWords!!.isEmpty()) {
-                    keyWords = EncryptionUtils.getRandomWords(NUMBER_OF_WORDS, context)
-                }
-                showMnemonicInfo()
-            } catch (e: IOException) {
-                binding.encryptionStatus.setText(R.string.common_error)
+    private fun handlePrivateKey(result: DownloadKeyResult) {
+        when (result) {
+            is DownloadKeyResult.Success -> {
+                binding.encryptionStatus.setText(R.string.end_to_end_encryption_enter_passphrase_to_access_files)
+                binding.encryptionPasswordInputContainer.visibility = View.VISIBLE
+                positiveButton?.visibility = View.VISIBLE
             }
-        } else if (privateKey.isNotEmpty()) {
-            binding.encryptionStatus.setText(R.string.end_to_end_encryption_enter_passphrase_to_access_files)
-            binding.encryptionPasswordInputContainer.visibility = View.VISIBLE
-            positiveButton?.visibility = View.VISIBLE
-        } else {
-            Log_OC.e(TAG, "Got empty private key string")
+
+            is DownloadKeyResult.GeneratePassphraseSendCSR -> {
+                try {
+                    if (keyWords.isNullOrEmpty()) {
+                        keyWords = EncryptionUtils.getRandomWords(NUMBER_OF_WORDS, context)
+                    }
+                    showMnemonicInfo()
+                } catch (_: IOException) {
+                    binding.encryptionStatus.setText(R.string.common_error)
+                }
+            }
+
+            else -> {
+                Log_OC.e(TAG, "Got empty private key string")
+            }
         }
     }
 
@@ -574,15 +553,12 @@ class SetupEncryptionDialogFragment :
         private const val KEY_GENERATE = "KEY_GENERATE"
 
         @JvmStatic
-        fun newInstance(user: User?, filePath: String?): SetupEncryptionDialogFragment {
-            val bundle = Bundle().apply {
-                putParcelable(ARG_USER, user)
-                putString(ARG_FILE_PATH, filePath)
+        fun newInstance(user: User?, filePath: String?): SetupEncryptionDialogFragment =
+            SetupEncryptionDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable(ARG_USER, user)
+                    putString(ARG_FILE_PATH, filePath)
+                }
             }
-
-            return SetupEncryptionDialogFragment().apply {
-                arguments = bundle
-            }
-        }
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/setupEncryption/model/DownloadKeyResult.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/setupEncryption/model/DownloadKeyResult.kt
@@ -1,0 +1,36 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.owncloud.android.ui.dialog.setupEncryption.model
+
+import com.owncloud.android.R
+
+sealed class DownloadKeyResult(open val descriptionId: Int? = null) {
+    data class CertificateVerificationFailed(
+        override val descriptionId: Int = R.string.end_to_end_encryption_certificate_verification_failed
+    ) : DownloadKeyResult(descriptionId)
+
+    data class ServerPublicKeyUnavailable(
+        override val descriptionId: Int = R.string.end_to_end_encryption_server_public_key_unavailable
+    ) : DownloadKeyResult(descriptionId)
+
+    data class ServerPrivateKeyUnavailable(
+        override val descriptionId: Int = R.string.end_to_end_encryption_server_private_key_unavailable
+    ) : DownloadKeyResult(descriptionId)
+
+    data class CertificateUnavailable(
+        override val descriptionId: Int = R.string.end_to_end_encryption_certificate_unavailable
+    ) : DownloadKeyResult(descriptionId)
+
+    data class UnexpectedError(
+        override val descriptionId: Int = R.string.end_to_end_encryption_unexpected_error_occurred
+    ) : DownloadKeyResult(descriptionId)
+
+    data object GeneratePassphraseSendCSR : DownloadKeyResult()
+
+    data class Success(val privateKey: String) : DownloadKeyResult()
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Changes

- Adds `GeneratePassphraseSendCSR`
- Makes `Success` non-nullable String