### PR TITLE
fix(synchronize-file): sync with server npe

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/FetchServerFileResult.kt
+++ b/app/src/main/java/com/owncloud/android/operations/FetchServerFileResult.kt
@@ -1,0 +1,16 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.operations
+
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.common.operations.RemoteOperationResult
+
+internal sealed interface FetchServerFileResult {
+    data class Found(val file: OCFile) : FetchServerFileResult
+    data object Missing : FetchServerFileResult
+    data class Failed(val result: RemoteOperationResult<*>) : FetchServerFileResult
+}

--- a/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.kt
@@ -119,29 +119,36 @@ class SynchronizeFileOperation : SyncOperation {
     }
 
     private fun syncWithServer(client: OwnCloudClient?): RemoteOperationResult<*> {
-        serverFile = serverFile ?: fetchServerFile(client).let { (result, file) ->
-            if (file == null) return result!!
-            file
+        val givenServerFile = serverFile
+        if (givenServerFile != null) {
+            return resolveChanges(givenServerFile)
         }
 
-        return serverFile
-            ?.let { resolveChanges(it) }
-            ?: handleMissingRemoteFile()
+        return when (val fetchResult = fetchServerFile(client)) {
+            is FetchServerFileResult.Failed -> fetchResult.result
+
+            is FetchServerFileResult.Missing -> handleMissingRemoteFile()
+
+            is FetchServerFileResult.Found -> {
+                serverFile = fetchResult.file
+                resolveChanges(fetchResult.file)
+            }
+        }
     }
 
-    private fun fetchServerFile(client: OwnCloudClient?): Pair<RemoteOperationResult<*>?, OCFile?> {
+    private fun fetchServerFile(client: OwnCloudClient?): FetchServerFileResult {
         val result = ReadFileRemoteOperation(remotePath).execute(client)
         return when {
             result?.isSuccess == true -> {
                 val file = FileStorageUtils.fillOCFile(result.data[0] as RemoteFile?).apply {
                     lastSyncDateForProperties = System.currentTimeMillis()
                 }
-                null to file
+                FetchServerFileResult.Found(file)
             }
 
-            result?.code == RemoteOperationResult.ResultCode.FILE_NOT_FOUND -> null to null
+            result?.code == RemoteOperationResult.ResultCode.FILE_NOT_FOUND -> FetchServerFileResult.Missing
 
-            else -> result to null
+            else -> FetchServerFileResult.Failed(result)
         }
     }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception java.lang.NullPointerException:
  at com.owncloud.android.operations.SynchronizeFileOperation.syncWithServer (SynchronizeFileOperation.kt:123)
  at com.owncloud.android.operations.SynchronizeFileOperation.run (SynchronizeFileOperation.kt:109)
  at com.owncloud.android.lib.common.operations.RemoteOperation.execute (RemoteOperation.java:132)
  at com.owncloud.android.lib.common.operations.RemoteOperation.execute (RemoteOperation.java:141)
  at com.owncloud.android.operations.common.SyncOperation.execute (SyncOperation.java:51)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.lambda$openFile$5 (FileOperationsHelper.java:316)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.$r8$lambda$jabfbfrZtwxQHoPvL8OpbirU-7s (FileOperationsHelper.java)
  at com.owncloud.android.ui.helpers.FileOperationsHelper$$ExternalSyntheticLambda9.run (D8$$SyntheticClass)
  at java.lang.Thread.run (Thread.java:1572)
```

### Changes

Fixes NPE
Simplifies execution flow with `FetchServerFileResult`