### PR TITLE
fix(file-data-storage-manager): save file with parent network on main thread

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1130,7 +1130,9 @@ class FileDisplayActivity :
                         )
                     }
                 } else {
-                    fileDataStorageManager.addCreateFileOfflineOperation(filePaths, decryptedRemotePaths)
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        fileDataStorageManager.addCreateFileOfflineOperation(filePaths, decryptedRemotePaths)
+                    }
                 }
             }
         } else {

--- a/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.kt
@@ -19,6 +19,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.common.collect.Sets
@@ -40,6 +41,9 @@ import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.KeyboardUtils
 import com.owncloud.android.utils.theme.ViewThemeUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -198,13 +202,17 @@ class CreateFolderDialogFragment :
                     componentGetter?.fileOperationsHelper?.createFolder(path, encrypted)
                 } else {
                     Log_OC.d(TAG, "Network not available, creating offline operation")
-                    fileDataStorageManager.addCreateFolderOfflineOperation(
-                        path,
-                        newFolderName,
-                        parentFolder?.fileId
-                    )
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        fileDataStorageManager.addCreateFolderOfflineOperation(
+                            path,
+                            newFolderName,
+                            parentFolder?.fileId
+                        )
 
-                    fda?.refreshCurrentDirectory()
+                        withContext(Dispatchers.Main) {
+                            fda?.refreshCurrentDirectory()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
… thread exception

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception com.owncloud.android.operations.RemoteOperationFailedException:
  at com.owncloud.android.datamodel.FileDataStorageManager.saveFileWithParent (FileDataStorageManager.java:625)
  at com.owncloud.android.datamodel.FileDataStorageManager.createPendingFile (FileDataStorageManager.java:237)
  at com.owncloud.android.datamodel.FileDataStorageManager.addCreateFileOfflineOperation (FileDataStorageManager.java:202)
  at com.owncloud.android.ui.activity.FileDisplayActivity.requestUploadOfFilesFromFileSystem$lambda$0 (FileDisplayActivity.kt:1133)
  at com.owncloud.android.ui.activity.FileDisplayActivity$$ExternalSyntheticLambda16.onComplete (D8$$SyntheticClass)
  at com.nextcloud.client.network.ConnectivityServiceImpl.lambda$isNetworkAndServerAvailable$0 (ConnectivityServiceImpl.java:78)
  at com.nextcloud.client.network.ConnectivityServiceImpl$$ExternalSyntheticLambda1.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1029)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:274)
  at android.os.Looper.loop (Looper.java:369)
  at android.app.ActivityThread.main (ActivityThread.java:10090)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:616)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1137)
Caused by android.os.NetworkOnMainThreadException:
  at android.os.StrictMode$AndroidBlockGuardPolicy.onNetwork (StrictMode.java:1737)
  at java.net.SocketInputStream.read (SocketInputStream.java:172)
  at java.net.SocketInputStream.read (SocketInputStream.java:143)
  at java.io.BufferedInputStream.fill (BufferedInputStream.java:239)
  at java.io.BufferedInputStream.read (BufferedInputStream.java:258)
  at org.apache.commons.httpclient.HttpConnection.isStale (HttpConnection.java:506)
  at org.apache.commons.httpclient.HttpConnection.closeIfStale (HttpConnection.java:431)
  at org.apache.commons.httpclient.MultiThreadedHttpConnectionManager$HttpConnectionAdapter.closeIfStale (MultiThreadedHttpConnectionManager.java:1313)
  at org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry (HttpMethodDirector.java:382)
  at org.apache.commons.httpclient.HttpMethodDirector.executeMethod (HttpMethodDirector.java:171)
  at org.apache.commons.httpclient.HttpClient.executeMethod (HttpClient.java:397)
  at org.apache.commons.httpclient.HttpClient.executeMethod (HttpClient.java:323)
  at com.owncloud.android.lib.common.OwnCloudClient.executeMethod (OwnCloudClient.java:192)
  at com.owncloud.android.lib.common.OwnCloudClient.executeMethod (OwnCloudClient.java:155)
  at com.owncloud.android.lib.resources.files.ReadFileRemoteOperation.run (ReadFileRemoteOperation.java:72)
  at com.owncloud.android.lib.common.operations.RemoteOperation.execute (RemoteOperation.java:132)
  at com.owncloud.android.lib.common.operations.RemoteOperation.execute (RemoteOperation.java:141)
  at com.owncloud.android.datamodel.FileDataStorageManager.saveFileWithParent (FileDataStorageManager.java:611)
```