### PR TITLE
fix: upload to Android-invalid folder paths

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/utils/FileStorageUtilsIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/utils/FileStorageUtilsIT.kt
@@ -135,12 +135,33 @@ class FileStorageUtilsIT : AbstractIT() {
     @Test
     fun testPathToUserFriendlyDisplay() {
         assertEquals("/", pathToUserFriendlyDisplay("/"))
-        assertEquals("/sdcard/", pathToUserFriendlyDisplay("/sdcard/"))
-        assertEquals("/sdcard/test/1/", pathToUserFriendlyDisplay("/sdcard/test/1/"))
+        assertPathEquals("/sdcard/", "sdcard/", pathToUserFriendlyDisplay("/sdcard/"))
+        assertPathEquals("/sdcard/test/1/", "sdcard/test/1/", pathToUserFriendlyDisplay("/sdcard/test/1/"))
         assertEquals("Internal storage/Movies/", pathToUserFriendlyDisplay("/storage/emulated/0/Movies/"))
         assertEquals("Internal storage/", pathToUserFriendlyDisplay("/storage/emulated/0/"))
     }
 
+    @Test
+    fun testSanitizedAndroidLocalPathCanBeCreatedOnDevice() {
+        val rawRemotePath = "/test : test/London -> Brussel/file?name>.txt"
+        val sanitizedPath = FileStorageUtils.sanitizeAndroidLocalPath(rawRemotePath)
+        val targetFile = openFile("android-local-path-test/${sanitizedPath.trimStart('/')}")
+
+        try {
+            assertFalse(FileStorageUtils.isValidAndroidLocalPath(rawRemotePath))
+            assertTrue(FileStorageUtils.isValidAndroidLocalPath(sanitizedPath))
+            assertTrue(targetFile.parentFile?.mkdirs() == true || targetFile.parentFile?.isDirectory == true)
+            assertTrue(targetFile.createNewFile())
+            assertEquals("file_name_.txt", targetFile.name)
+        } finally {
+            targetFile.parentFile?.parentFile?.deleteRecursively()
+        }
+    }
+
     private fun pathToUserFriendlyDisplay(path: String): String =
         pathToUserFriendlyDisplay(path, targetContext, targetContext.resources)
+
+    private fun assertPathEquals(unrecognizedPath: String, recognizedPath: String, actualPath: String) {
+        assertTrue(actualPath == unrecognizedPath || actualPath == recognizedPath)
+    }
 }

--- a/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
+++ b/app/src/main/java/com/nextcloud/utils/fileNameValidator/FileNameValidator.kt
@@ -115,9 +115,9 @@ object FileNameValidator {
 
     fun checkParentRemotePaths(filePaths: List<OCFile>, capability: OCCapability, context: Context): Boolean =
         filePaths.all {
-            if (it.parentRemotePath != StringConstants.SLASH) {
-                val parentFolderName = it.parentRemotePath.replace(StringConstants.SLASH, "")
-                checkFileName(parentFolderName, capability, context) == null
+            val parentRemotePath = it.parentRemotePath
+            if (parentRemotePath != null && parentRemotePath != StringConstants.SLASH) {
+                checkFolderPath(parentRemotePath, capability, context)
             } else {
                 true
             }

--- a/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.kt
+++ b/app/src/main/java/com/owncloud/android/operations/DownloadFileOperation.kt
@@ -120,7 +120,7 @@ class DownloadFileOperation(
             if (cancellationRequested.get()) return RemoteOperationResult(OperationCancelledException())
         }
 
-        if (!FileStorageUtils.isValidExtFilename(file.fileName)) {
+        if (!FileStorageUtils.isValidAndroidLocalPath(file.remotePath)) {
             mainThreadHandler.post { context.get()?.showToast(R.string.download_download_invalid_local_file_name) }
             return RemoteOperationResult(RemoteOperationResult.ResultCode.INVALID_CHARACTER_IN_NAME)
         }

--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -752,7 +752,7 @@ public class UploadFileOperation extends SyncOperation {
             // this basically means that the file is on SD card
             // try to copy file to temporary dir if it doesn't exist
             String temporalPath = FileStorageUtils.getInternalTemporalPath(user.getAccountName(), mContext) +
-                mFile.getRemotePath();
+                FileStorageUtils.sanitizeAndroidLocalPath(mFile.getRemotePath());
             mFile.setStoragePath(temporalPath);
             e2eFiles.setTemporalFile(new File(temporalPath));
 

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.kt
@@ -87,7 +87,7 @@ class CopyAndUploadContentUrisTask(
                 val remotePath = remotePaths[index]
                 val lastModified = queryLastModified(contentResolver, uri)
 
-                currentTempPath = "${FileStorageUtils.getTemporalPath(user.accountName)}$remotePath"
+                currentTempPath = FileStorageUtils.getTemporalPathForRemotePath(user.accountName, remotePath)
                 val cacheFile = File(currentTempPath)
 
                 cacheFile.parentFile?.takeIf { !it.exists() }?.let {

--- a/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -139,16 +139,41 @@ public final class FileStorageUtils {
     }
 
     /**
-     * Checks whether the given character is valid in an extended file name.
-     * <p>
-     * Reference: <a href="https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/FileUtils.java;l=997">
-     * android.os.FileUtils#isValidExtFilenameChar(char)
-     * </a> from the Android Open Source Project.
-     *
-     * @param c the character to validate
-     * @return true if the character is valid in a filename, false otherwise
+     * Validate each path segment before using a remote path as a local Android path.
      */
+    public static boolean isValidAndroidLocalPath(String path) {
+        String[] segments = path.split(OCFile.PATH_SEPARATOR, -1);
+        for (String segment : segments) {
+            if (!segment.isEmpty() && !isValidExtFilename(segment)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static String sanitizeAndroidLocalPath(String path) {
+        StringBuilder sanitizedPath = new StringBuilder(path.length());
+        String[] segments = path.split(OCFile.PATH_SEPARATOR, -1);
+        for (int segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
+            if (segmentIndex > 0) {
+                sanitizedPath.append(OCFile.PATH_SEPARATOR);
+            }
+            sanitizedPath.append(sanitizeAndroidLocalFilename(segments[segmentIndex]));
+        }
+        return sanitizedPath.toString();
+    }
+
+    private static String sanitizeAndroidLocalFilename(String name) {
+        StringBuilder sanitizedName = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            sanitizedName.append(isValidExtFilenameChar(c) ? c : '_');
+        }
+        return sanitizedName.toString();
+    }
+
     private static boolean isValidExtFilenameChar(char c) {
+        // Match Android's hidden FAT filename rules for external storage.
         if ((int) c <= 0x1F) {
             return false;
         }
@@ -197,6 +222,14 @@ public final class FileStorageUtils {
                 + Uri.encode(accountName, "@");
         // URL encoding is an 'easy fix' to overcome that NTFS and FAT32 don't allow ":" in file names,
         // that can be in the accountName since 0.1.190B
+    }
+
+    public static String getTemporalPathForRemotePath(String accountName, String remotePath) {
+        String sanitizedRemotePath = sanitizeAndroidLocalPath(remotePath);
+        if (sanitizedRemotePath.startsWith(OCFile.PATH_SEPARATOR)) {
+            return getTemporalPath(accountName) + sanitizedRemotePath;
+        }
+        return getTemporalPath(accountName) + OCFile.PATH_SEPARATOR + sanitizedRemotePath;
     }
 
     public static String getTemporalEncryptedFolderPath(String accountName) {

--- a/app/src/test/java/com/nextcloud/client/utils/FileStorageUtilsTest.kt
+++ b/app/src/test/java/com/nextcloud/client/utils/FileStorageUtilsTest.kt
@@ -39,6 +39,26 @@ class FileStorageUtilsTest {
     }
 
     @Test
+    fun testValidAndroidLocalPath() {
+        assertTrue(FileStorageUtils.isValidAndroidLocalPath("/Documents/Holidays/file.txt"))
+        assertTrue(FileStorageUtils.isValidAndroidLocalPath("Documents/Holidays/file.txt"))
+    }
+
+    @Test
+    fun testInvalidAndroidLocalPathWithInvalidParentSegment() {
+        assertFalse(FileStorageUtils.isValidAndroidLocalPath("/test : test/file.txt"))
+        assertFalse(FileStorageUtils.isValidAndroidLocalPath("/Documents/London -> Brussel/file.txt"))
+    }
+
+    @Test
+    fun testSanitizeAndroidLocalPathReplacesInvalidFilenameCharacters() {
+        assertEquals(
+            "/test _ test/London -_ Brussel/file_name_.txt",
+            FileStorageUtils.sanitizeAndroidLocalPath("/test : test/London -> Brussel/file?name>.txt")
+        )
+    }
+
+    @Test
     fun testFilenamesWithControlCharacters() {
         assertFalse(FileStorageUtils.isValidExtFilename("file\u0001name"))
         assertFalse(FileStorageUtils.isValidExtFilename("file\u001Fname"))

--- a/app/src/test/java/com/nextcloud/utils/FileNameValidatorUnitTest.kt
+++ b/app/src/test/java/com/nextcloud/utils/FileNameValidatorUnitTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils
+
+import android.content.Context
+import com.nextcloud.utils.fileNameValidator.FileNameValidator
+import com.owncloud.android.R
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.resources.status.CapabilityBooleanType
+import com.owncloud.android.lib.resources.status.NextcloudVersion
+import com.owncloud.android.lib.resources.status.OCCapability
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FileNameValidatorUnitTest {
+
+    private val context = mockk<Context> {
+        every {
+            getString(R.string.file_name_validator_error_reserved_names, "con")
+        } returns "reserved con"
+    }
+
+    private val capability = OCCapability().apply {
+        versionMayor = NextcloudVersion.nextcloud_32.majorVersionNumber
+        isWCFEnabled = CapabilityBooleanType.TRUE
+        forbiddenFilenameBaseNamesJson = """["con"]"""
+    }
+
+    @Test
+    fun checkParentRemotePathsRejectsReservedPathSegment() {
+        val file = OCFile("/CON/Folder/document.txt")
+
+        val result = FileNameValidator.checkParentRemotePaths(listOf(file), capability, context)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun checkParentRemotePathsAcceptsValidNestedParentPath() {
+        val file = OCFile("/Projects/Notes/document.txt")
+
+        val result = FileNameValidator.checkParentRemotePaths(listOf(file), capability, context)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun checkParentRemotePathsAcceptsRootParentPath() {
+        val file = OCFile("/document.txt")
+
+        val result = FileNameValidator.checkParentRemotePaths(listOf(file), capability, context)
+
+        assertTrue(result)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix uploads into server folders whose names contain characters Android cannot use in local path segments.
- Sanitize only the temporary local upload path derived from the remote path; the remote destination path is unchanged.
- Validate local download paths segment-by-segment before creating Android files.

Fixes #14711.

## Testing
Manual validation against a local Nextcloud 31 server:
- Created a server folder named `test <3`.
- Logged into the Android app and opened that folder.
- Uploaded `nextcloud-pr7-video-upload.txt` from local device storage into `test <3`.
- Confirmed the uploaded file appeared in the app alongside the seed file.
- Verified the uploaded file over WebDAV and checked the downloaded content matched the local file.

### 🖼️ Screenshots

Uploaded file inside `test <3` after the fix:
<img width="360" alt="Uploaded file inside test <3 after the fix" src="https://github.com/user-attachments/assets/3bd800f7-95ab-4504-8f1f-5b6e0b114c1b">

### 🎥 Videos

User-flow upload into `test <3` (21 seconds):

https://github.com/user-attachments/assets/3c6111f0-5193-4d2c-bf27-61b967336dc2


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- Milestone: maintainers can add one if needed.
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

