### PR TITLE
fix(file-display-activity): commit fragment

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -714,17 +714,12 @@ class FileDisplayActivity :
         }
 
         prepareFragmentBeforeCommit(showSortListGroup)
-        commitFragment(
-            fragment,
-            object : CompletionCallback {
-                override fun onComplete(isFragmentCommitted: Boolean) {
-                    Log_OC.d(
-                        TAG,
-                        "Left fragment committed: $isFragmentCommitted"
-                    )
-                }
-            }
-        )
+        commitFragment(fragment) {
+            Log_OC.d(
+                TAG,
+                "Left fragment committed: $it"
+            )
+        }
     }
 
     private fun prepareFragmentBeforeCommit(showSortListGroup: Boolean) {
@@ -737,17 +732,20 @@ class FileDisplayActivity :
         showSortListGroup(showSortListGroup)
     }
 
-    private fun commitFragment(fragment: Fragment, callback: CompletionCallback) {
+    private fun commitFragment(fragment: Fragment, callback: (Boolean) -> Unit) {
         val fragmentManager = supportFragmentManager
-        if (this.isActive() && !fragmentManager.isDestroyed) {
-            val transaction = fragmentManager.beginTransaction()
-            transaction.addToBackStack(null)
-            transaction.replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES)
-            transaction.commit()
-            callback.onComplete(true)
-        } else {
-            callback.onComplete(false)
+        if (!isActive() || fragmentManager.isDestroyed || fragmentManager.isStateSaved) {
+            callback(false)
+            return
         }
+
+        fragmentManager.beginTransaction().run {
+            addToBackStack(null)
+            replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES)
+            commit()
+        }
+
+        callback(true)
     }
 
     private fun getOCFileListFragmentFromFile(transaction: TransactionInterface) {
@@ -767,24 +765,19 @@ class FileDisplayActivity :
             val fm = supportFragmentManager
             if (!fm.isStateSaved && !fm.isDestroyed) {
                 prepareFragmentBeforeCommit(true)
-                commitFragment(
-                    listOfFiles,
-                    object : CompletionCallback {
-                        override fun onComplete(value: Boolean) {
-                            if (value) {
-                                Log_OC.d(TAG, "OCFileListFragment committed, executing pending transaction")
-                                fm.executePendingTransactions()
-                                transaction.onOCFileListFragmentComplete(listOfFiles)
-                            } else {
-                                Log_OC.d(
-                                    TAG,
-                                    "OCFileListFragment not committed, skipping executing " +
-                                        "pending transaction"
-                                )
-                            }
-                        }
+                commitFragment(listOfFiles) {
+                    if (it) {
+                        Log_OC.d(TAG, "OCFileListFragment committed, executing pending transaction")
+                        fm.executePendingTransactions()
+                        transaction.onOCFileListFragmentComplete(listOfFiles)
+                    } else {
+                        Log_OC.d(
+                            TAG,
+                            "OCFileListFragment not committed, skipping executing " +
+                                "pending transaction"
+                        )
                     }
-                )
+                }
             }
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -714,12 +714,7 @@ class FileDisplayActivity :
         }
 
         prepareFragmentBeforeCommit(showSortListGroup)
-        commitFragment(fragment) {
-            Log_OC.d(
-                TAG,
-                "Left fragment committed: $it"
-            )
-        }
+        commitFragment(fragment)
     }
 
     private fun prepareFragmentBeforeCommit(showSortListGroup: Boolean) {
@@ -732,20 +727,21 @@ class FileDisplayActivity :
         showSortListGroup(showSortListGroup)
     }
 
-    private fun commitFragment(fragment: Fragment, callback: (Boolean) -> Unit) {
+    private fun commitFragment(fragment: Fragment): Boolean {
         val fragmentManager = supportFragmentManager
         if (!isActive() || fragmentManager.isDestroyed || fragmentManager.isStateSaved) {
-            callback(false)
-            return
+            Log_OC.d(TAG, "${fragment.javaClass.simpleName} not committed, skipping")
+            return false
         }
 
-        fragmentManager.beginTransaction().run {
-            addToBackStack(null)
-            replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES)
-            commit()
-        }
+        fragmentManager.beginTransaction()
+            .addToBackStack(null)
+            .replace(R.id.left_fragment_container, fragment, TAG_LIST_OF_FILES)
+            .commit()
 
-        callback(true)
+        Log_OC.d(TAG, "${fragment.javaClass.simpleName} committed, pending transaction")
+
+        return true
     }
 
     private fun getOCFileListFragmentFromFile(transaction: TransactionInterface) {
@@ -765,18 +761,9 @@ class FileDisplayActivity :
             val fm = supportFragmentManager
             if (!fm.isStateSaved && !fm.isDestroyed) {
                 prepareFragmentBeforeCommit(true)
-                commitFragment(listOfFiles) {
-                    if (it) {
-                        Log_OC.d(TAG, "OCFileListFragment committed, executing pending transaction")
-                        fm.executePendingTransactions()
-                        transaction.onOCFileListFragmentComplete(listOfFiles)
-                    } else {
-                        Log_OC.d(
-                            TAG,
-                            "OCFileListFragment not committed, skipping executing " +
-                                "pending transaction"
-                        )
-                    }
+                if (commitFragment(listOfFiles)) {
+                    fm.executePendingTransactions()
+                    transaction.onOCFileListFragmentComplete(listOfFiles)
                 }
             }
         }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
  at androidx.fragment.app.FragmentManager.checkStateLoss (FragmentManager.java:1862)
  at androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1902)
  at androidx.fragment.app.BackStackRecord.commitInternal (BackStackRecord.java:342)
  at androidx.fragment.app.BackStackRecord.commit (BackStackRecord.java:306)
  at com.owncloud.android.ui.activity.FileDisplayActivity.commitFragment (FileDisplayActivity.kt:746)
  at com.owncloud.android.ui.activity.FileDisplayActivity.setLeftFragment (FileDisplayActivity.kt:717)
  at com.owncloud.android.ui.activity.FileDisplayActivity.setLeftFragment (FileDisplayActivity.kt:807)
  at com.owncloud.android.ui.activity.FileDisplayActivity.onFileRequestResult (FileDisplayActivity.kt:3181)
  at com.owncloud.android.ui.activity.FileDisplayActivity.openFileByPath$lambda$0 (FileDisplayActivity.kt:3164)
  at com.owncloud.android.ui.activity.FileDisplayActivity$$ExternalSyntheticLambda3.invoke (D8$$SyntheticClass)
  at com.nextcloud.client.core.Task.run$lambda$1 (Task.kt:42)
  at com.nextcloud.client.core.Task$$ExternalSyntheticLambda1.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8296)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:559)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:954)
```