### PR TITLE
fix(preview-text-fragment): finish

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.kt
@@ -162,11 +162,9 @@ abstract class PreviewTextFragment :
         }
     }
 
-    /**
-     * Finishes the preview
-     */
     protected fun finish() {
-        requireActivity().runOnUiThread { requireActivity().onBackPressedDispatcher.onBackPressed() }
+        val activity = activity ?: return
+        activity.runOnUiThread { activity.onBackPressedDispatcher.onBackPressed() }
     }
 
     companion object {


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
Exception java.lang.IllegalStateException:
  at androidx.fragment.app.Fragment.requireActivity (Fragment.java:1005)
  at com.owncloud.android.ui.preview.PreviewTextFragment.finish$lambda$0 (PreviewTextFragment.kt:169)
  at com.owncloud.android.ui.preview.PreviewTextFragment$$ExternalSyntheticLambda0.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1070)
  at android.os.Handler.dispatchMessage (Handler.java:125)
  at android.os.Looper.dispatchMessage (Looper.java:358)
  at android.os.Looper.loopOnce (Looper.java:288)
  at android.os.Looper.loop (Looper.java:392)
  at android.app.ActivityThread.main (ActivityThread.java:10346)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:638)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:972)
```