### PR TITLE
fix(upload): prevent crash and duplicate retries when retrying failed uploads

### DIFF
--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManager.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManager.java
@@ -9,6 +9,7 @@ package com.nextcloud.client.account;
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import com.owncloud.android.MainApp;
@@ -29,6 +30,9 @@ public interface UserAccountManager extends CurrentAccountProvider {
     int ACCOUNT_VERSION_WITH_PROPER_ID = 2;
     String ACCOUNT_USES_STANDARD_PASSWORD = "ACCOUNT_USES_STANDARD_PASSWORD";
     String PENDING_FOR_REMOVAL = "PENDING_FOR_REMOVAL";
+
+    @Nullable
+    Context getContext();
 
     @Nullable
     OwnCloudAccount getCurrentOwnCloudAccount();

--- a/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
+++ b/app/src/main/java/com/nextcloud/client/account/UserAccountManagerImpl.java
@@ -55,7 +55,7 @@ public class UserAccountManagerImpl implements UserAccountManager {
     private static final String TAG = UserAccountManagerImpl.class.getSimpleName();
     private static final String PREF_SELECT_OC_ACCOUNT = "select_oc_account";
 
-    private Context context;
+    private final Context context;
     private final AccountManager accountManager;
 
     public static UserAccountManagerImpl fromContext(Context context) {
@@ -303,6 +303,12 @@ public class UserAccountManagerImpl implements UserAccountManager {
     @Override
     public User getAnonymousUser() {
         return AnonymousUser.fromContext(context);
+    }
+
+    @Nullable
+    @Override
+    public Context getContext() {
+        return context;
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/client/di/DispatcherModule.kt
+++ b/app/src/main/java/com/nextcloud/client/di/DispatcherModule.kt
@@ -1,17 +1,23 @@
 /*
  * Nextcloud - Android Client
  *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-FileCopyrightText: 2022 Álvaro Brey <alvaro@alvarobrey.com>
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH
  * SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
  */
 package com.nextcloud.client.di
 
+import com.owncloud.android.lib.common.utils.Log_OC
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import javax.inject.Qualifier
+import javax.inject.Singleton
 
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
@@ -25,8 +31,15 @@ annotation class IoDispatcher
 @Qualifier
 annotation class MainDispatcher
 
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class ApplicationScope
+
 @Module
 object DispatcherModule {
+
+    private const val APPLICATION_SCOPE_TAG = "ApplicationScope"
+
     @DefaultDispatcher
     @Provides
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
@@ -38,4 +51,19 @@ object DispatcherModule {
     @MainDispatcher
     @Provides
     fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    /**
+     * A process-lifetime [CoroutineScope] for singletons that outlive any single Android component.
+     */
+    @ApplicationScope
+    @Provides
+    @Singleton
+    fun provideApplicationScope(@IoDispatcher dispatcher: CoroutineDispatcher): CoroutineScope =
+        CoroutineScope(
+            SupervisorJob() +
+                dispatcher +
+                CoroutineExceptionHandler { _, throwable ->
+                    Log_OC.e(APPLICATION_SCOPE_TAG, "Uncaught exception in application coroutine scope", throwable)
+                }
+        )
 }

--- a/app/src/main/java/com/nextcloud/client/di/DispatcherModule.kt
+++ b/app/src/main/java/com/nextcloud/client/di/DispatcherModule.kt
@@ -58,12 +58,11 @@ object DispatcherModule {
     @ApplicationScope
     @Provides
     @Singleton
-    fun provideApplicationScope(@IoDispatcher dispatcher: CoroutineDispatcher): CoroutineScope =
-        CoroutineScope(
-            SupervisorJob() +
-                dispatcher +
-                CoroutineExceptionHandler { _, throwable ->
-                    Log_OC.e(APPLICATION_SCOPE_TAG, "Uncaught exception in application coroutine scope", throwable)
-                }
-        )
+    fun provideApplicationScope(@IoDispatcher dispatcher: CoroutineDispatcher): CoroutineScope = CoroutineScope(
+        SupervisorJob() +
+            dispatcher +
+            CoroutineExceptionHandler { _, throwable ->
+                Log_OC.e(APPLICATION_SCOPE_TAG, "Uncaught exception in application coroutine scope", throwable)
+            }
+    )
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -19,6 +19,7 @@ import com.nextcloud.client.database.entity.toOCUpload
 import com.nextcloud.client.database.entity.toUploadEntity
 import com.nextcloud.client.device.BatteryStatus
 import com.nextcloud.client.device.PowerManagementService
+import com.nextcloud.client.di.ApplicationScope
 import com.nextcloud.client.jobs.BackgroundJobManager
 import com.nextcloud.client.network.Connectivity
 import com.nextcloud.client.network.ConnectivityService
@@ -52,10 +53,8 @@ import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.adapter.uploadList.helper.ConflictHandlingResult
 import com.owncloud.android.ui.adapter.uploadList.helper.UploadListAdapterActionHandler
 import com.owncloud.android.utils.DisplayUtils
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -77,13 +76,9 @@ class FileUploadHelper {
     @Inject
     lateinit var fileStorageManager: FileDataStorageManager
 
-    private val ioScope = CoroutineScope(
-        SupervisorJob() +
-            Dispatchers.IO +
-            CoroutineExceptionHandler { _, throwable ->
-                Log_OC.e(TAG, "Uncaught exception in FileUploadHelper coroutine", throwable)
-            }
-    )
+    @Inject
+    @ApplicationScope
+    lateinit var appScope: CoroutineScope
 
     init {
         MainApp.getAppComponent().inject(this)
@@ -140,7 +135,7 @@ class FileUploadHelper {
         var isUploadStarted = false
         val capability = fileStorageManager.getCapability(accountManager.user)
 
-        ioScope.launch {
+        appScope.launch {
             try {
                 val uploads = getUploadsByStatus(null, UploadStatus.UPLOAD_FAILED, capability)
                 if (uploads.isNotEmpty()) {
@@ -360,7 +355,7 @@ class FileUploadHelper {
         status: UploadStatus,
         onCompleted: () -> Unit = {}
     ) {
-        ioScope.launch {
+        appScope.launch {
             uploadsStorageManager.uploadDao.updateStatus(remotePath, accountName, status.value)
             onCompleted()
         }
@@ -546,7 +541,7 @@ class FileUploadHelper {
      * @param user Needed for creating client
      */
     fun removeDuplicatedFile(duplicatedFile: OCFile, client: OwnCloudClient, user: User, onCompleted: () -> Unit) {
-        ioScope.launch {
+        appScope.launch {
             val removeFileOperation = RemoveFileOperation(
                 duplicatedFile,
                 false,

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -216,7 +216,7 @@ class FileUploadHelper {
 
             if (uploadResult != UploadResult.UPLOADED) {
                 if (upload.lastResult != uploadResult) {
-                    // Setting Upload status else cancelled uploads will behave wrong, when retrying
+                    // Setting Upload status else canceled uploads will behave wrong, when retrying
                     // Needs to happen first since lastResult wil be overwritten by setter
                     upload.uploadStatus = UploadStatus.UPLOAD_FAILED
 

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -25,8 +25,8 @@ import com.nextcloud.client.network.Connectivity
 import com.nextcloud.client.network.ConnectivityService
 import com.nextcloud.client.notifications.AppWideNotificationManager
 import com.nextcloud.utils.extensions.checkWCFRestrictions
+import com.nextcloud.utils.extensions.createOwncloudClient
 import com.nextcloud.utils.extensions.getUploadIds
-import com.nextcloud.utils.extensions.isAnonymous
 import com.nextcloud.utils.extensions.isLastResultConflictError
 import com.nextcloud.utils.extensions.isSame
 import com.owncloud.android.MainApp
@@ -39,8 +39,6 @@ import com.owncloud.android.db.OCUpload
 import com.owncloud.android.db.UploadResult
 import com.owncloud.android.files.services.NameCollisionPolicy
 import com.owncloud.android.lib.common.OwnCloudClient
-import com.owncloud.android.lib.common.OwnCloudClientFactory
-import com.owncloud.android.lib.common.accounts.AccountUtils
 import com.owncloud.android.lib.common.network.OnDatatransferProgressListener
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.lib.common.utils.Log_OC
@@ -185,24 +183,13 @@ class FileUploadHelper {
         val batteryStatus = powerManagementService.battery
 
         val uploadsToRetry = mutableListOf<Long>()
-
-        val currentAccount = accountManager.currentAccount
-        val context = MainApp.getAppContext()
-        var ownCloudClient: OwnCloudClient? = null
-        if (!currentAccount.isAnonymous(context)) {
-            ownCloudClient = try {
-                OwnCloudClientFactory.createOwnCloudClient(accountManager.currentAccount, MainApp.getAppContext())
-            } catch (e: AccountUtils.AccountNotFoundException) {
-                Log_OC.e(TAG, "Cannot create client, account not found; skipping conflict handling", e)
-                null
-            }
-        }
+        val client = accountManager.createOwncloudClient()
 
         for (upload in uploads) {
             if (upload.isLastResultConflictError()) {
-                ownCloudClient?.let {
+                client?.let {
                     conflictHandlingResult =
-                        uploadActionHandler.handleConflict(upload, ownCloudClient, uploadsStorageManager)
+                        uploadActionHandler.handleConflict(upload, client = it, uploadsStorageManager)
                 }
                 continue
             }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -91,13 +91,11 @@ class FileUploadHelper {
 
         val mBoundListeners = HashMap<String, OnDatatransferProgressListener>()
 
-        private var instance: FileUploadHelper? = null
-
         private val retryFailedUploadsSemaphore = Semaphore(1)
 
-        fun instance(): FileUploadHelper = instance ?: synchronized(this) {
-            instance ?: FileUploadHelper().also { instance = it }
-        }
+        private val sharedInstance: FileUploadHelper by lazy { FileUploadHelper() }
+
+        fun instance(): FileUploadHelper = sharedInstance
 
         fun buildRemoteName(accountName: String, remotePath: String): String = accountName + remotePath
     }

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -58,7 +58,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -91,7 +91,7 @@ class FileUploadHelper {
 
         val mBoundListeners = HashMap<String, OnDatatransferProgressListener>()
 
-        private val retryFailedUploadsSemaphore = Semaphore(1)
+        private val retryInProgress = AtomicBoolean(false)
 
         private val sharedInstance: FileUploadHelper by lazy { FileUploadHelper() }
 
@@ -124,21 +124,17 @@ class FileUploadHelper {
         connectivityService: ConnectivityService,
         accountManager: UserAccountManager,
         powerManagementService: PowerManagementService
-    ): Boolean {
-        if (!retryFailedUploadsSemaphore.tryAcquire()) {
+    ) {
+        if (!retryInProgress.compareAndSet(false, true)) {
             Log_OC.d(TAG, "skipping retryFailedUploads, already running")
-            return true
+            return
         }
 
-        var isUploadStarted = false
         val capability = fileStorageManager.getCapability(accountManager.user)
 
         appScope.launch {
             try {
                 val uploads = getUploadsByStatus(null, UploadStatus.UPLOAD_FAILED, capability)
-                if (uploads.isNotEmpty()) {
-                    isUploadStarted = true
-                }
 
                 retryUploads(
                     uploadsStorageManager,
@@ -148,13 +144,11 @@ class FileUploadHelper {
                     uploads
                 )
             } finally {
-                // Release only after retry processing has completely finished so the semaphore guards
+                // Reset only after retry processing has completely finished so the guard covers
                 // coroutine execution, not just its launch. This keeps a single retry running at a time.
-                retryFailedUploadsSemaphore.release()
+                retryInProgress.set(false)
             }
         }
-
-        return isUploadStarted
     }
 
     suspend fun retryCancelledUploads(

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -84,6 +84,8 @@ class FileUploadHelper {
         MainApp.getAppComponent().inject(this)
     }
 
+    private val uploadActionHandler = UploadListAdapterActionHandler()
+
     companion object {
         private val TAG = FileUploadWorker::class.java.simpleName
 
@@ -195,7 +197,6 @@ class FileUploadHelper {
                 null
             }
         }
-        val uploadActionHandler = UploadListAdapterActionHandler()
 
         for (upload in uploads) {
             if (upload.isLastResultConflictError()) {

--- a/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/upload/FileUploadHelper.kt
@@ -39,6 +39,7 @@ import com.owncloud.android.db.UploadResult
 import com.owncloud.android.files.services.NameCollisionPolicy
 import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.OwnCloudClientFactory
+import com.owncloud.android.lib.common.accounts.AccountUtils
 import com.owncloud.android.lib.common.network.OnDatatransferProgressListener
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.lib.common.utils.Log_OC
@@ -51,8 +52,10 @@ import com.owncloud.android.operations.UploadFileOperation
 import com.owncloud.android.ui.adapter.uploadList.helper.ConflictHandlingResult
 import com.owncloud.android.ui.adapter.uploadList.helper.UploadListAdapterActionHandler
 import com.owncloud.android.utils.DisplayUtils
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -74,7 +77,13 @@ class FileUploadHelper {
     @Inject
     lateinit var fileStorageManager: FileDataStorageManager
 
-    private val ioScope = CoroutineScope(Dispatchers.IO)
+    private val ioScope = CoroutineScope(
+        SupervisorJob() +
+            Dispatchers.IO +
+            CoroutineExceptionHandler { _, throwable ->
+                Log_OC.e(TAG, "Uncaught exception in FileUploadHelper coroutine", throwable)
+            }
+    )
 
     init {
         MainApp.getAppComponent().inject(this)
@@ -131,8 +140,8 @@ class FileUploadHelper {
         var isUploadStarted = false
         val capability = fileStorageManager.getCapability(accountManager.user)
 
-        try {
-            ioScope.launch {
+        ioScope.launch {
+            try {
                 val uploads = getUploadsByStatus(null, UploadStatus.UPLOAD_FAILED, capability)
                 if (uploads.isNotEmpty()) {
                     isUploadStarted = true
@@ -145,9 +154,11 @@ class FileUploadHelper {
                     powerManagementService,
                     uploads
                 )
+            } finally {
+                // Release only after retry processing has completely finished so the semaphore guards
+                // coroutine execution, not just its launch. This keeps a single retry running at a time.
+                retryFailedUploadsSemaphore.release()
             }
-        } finally {
-            retryFailedUploadsSemaphore.release()
         }
 
         return isUploadStarted
@@ -190,8 +201,12 @@ class FileUploadHelper {
         val context = MainApp.getAppContext()
         var ownCloudClient: OwnCloudClient? = null
         if (!currentAccount.isAnonymous(context)) {
-            ownCloudClient =
+            ownCloudClient = try {
                 OwnCloudClientFactory.createOwnCloudClient(accountManager.currentAccount, MainApp.getAppContext())
+            } catch (e: AccountUtils.AccountNotFoundException) {
+                Log_OC.e(TAG, "Cannot create client, account not found; skipping conflict handling", e)
+                null
+            }
         }
         val uploadActionHandler = UploadListAdapterActionHandler()
 

--- a/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
@@ -11,28 +11,34 @@ import com.nextcloud.client.account.UserAccountManager
 import com.owncloud.android.MainApp
 import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.OwnCloudClientFactory
+import com.owncloud.android.lib.common.accounts.AccountUtils
 import com.owncloud.android.lib.common.utils.Log_OC
 
 private const val TAG = "UserAccountManagerExtensions"
 
-@Suppress("TooGenericExceptionCaught", "ReturnCount")
-fun UserAccountManager.createOwncloudClient(): OwnCloudClient? {
+fun UserAccountManager.createOwncloudClient(): OwnCloudClient? = createOwncloudClient(currentAccount.name)
+
+@Suppress("TooGenericExceptionCaught", "ReturnCount", "DEPRECATION")
+fun UserAccountManager.createOwncloudClient(accountName: String): OwnCloudClient? {
     val context = context ?: MainApp.getAppContext()
     if (context == null) {
         Log_OC.e(TAG, "app context is null, cannot create client")
         return null
     }
 
-    val account = currentAccount
-    if (account.isAnonymous(context)) {
-        Log_OC.e(TAG, "current account is anonymous, cannot create client")
+    val user = getUser(accountName).orElse(null)
+    if (user == null || user.isAnonymous) {
+        Log_OC.e(TAG, "account is not registered, cannot create client for: $accountName")
         return null
     }
 
     return try {
-        val result = OwnCloudClientFactory.createOwnCloudClient(account, context)
+        val result = OwnCloudClientFactory.createOwnCloudClient(user.toPlatformAccount(), context)
         Log_OC.i(TAG, "client created")
         result
+    } catch (e: AccountUtils.AccountNotFoundException) {
+        Log_OC.e(TAG, "account removed while creating client for: $accountName", e)
+        null
     } catch (e: Exception) {
         Log_OC.e(TAG, "cannot create client: ", e)
         null

--- a/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
@@ -22,13 +22,14 @@ fun UserAccountManager.createOwncloudClient(): OwnCloudClient? {
         return null
     }
 
-    if (currentAccount.isAnonymous(context)) {
+    val account = currentAccount
+    if (account.isAnonymous(context)) {
         Log_OC.e(TAG, "current account is anonymous, cannot create client")
         return null
     }
 
     return try {
-        val result = OwnCloudClientFactory.createOwnCloudClient(currentAccount, context)
+        val result = OwnCloudClientFactory.createOwnCloudClient(account, context)
         Log_OC.i(TAG, "client created")
         result
     } catch (e: Exception) {

--- a/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
@@ -1,0 +1,38 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import com.nextcloud.client.account.UserAccountManager
+import com.owncloud.android.MainApp
+import com.owncloud.android.lib.common.OwnCloudClient
+import com.owncloud.android.lib.common.OwnCloudClientFactory
+import com.owncloud.android.lib.common.utils.Log_OC
+
+private const val TAG = "UserAccountManagerExtensions"
+
+fun UserAccountManager.createOwncloudClient(): OwnCloudClient? {
+    val context = context ?: MainApp.getAppContext()
+    if (context == null) {
+        Log_OC.e(TAG, "app context is null, cannot create client")
+        return null
+    }
+
+    if (currentAccount.isAnonymous(context)) {
+        Log_OC.e(TAG, "current account is anonymous, cannot create client")
+        return null
+    }
+
+    return try {
+        val result = OwnCloudClientFactory.createOwnCloudClient(currentAccount, context)
+        Log_OC.i(TAG, "client created")
+        result
+    } catch (e: Exception) {
+        Log_OC.e(TAG, "cannot create client: ", e)
+        null
+    }
+}

--- a/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/UserAccountManagerExtensions.kt
@@ -15,6 +15,7 @@ import com.owncloud.android.lib.common.utils.Log_OC
 
 private const val TAG = "UserAccountManagerExtensions"
 
+@Suppress("TooGenericExceptionCaught", "ReturnCount")
 fun UserAccountManager.createOwncloudClient(): OwnCloudClient? {
     val context = context ?: MainApp.getAppContext()
     if (context == null) {

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.kt
@@ -168,16 +168,12 @@ class UploadListActivity :
     }
 
     private fun refresh() {
-        val isUploadStarted = FileUploadHelper.instance().retryFailedUploads(
+        FileUploadHelper.instance().retryFailedUploads(
             uploadsStorageManager,
             connectivityService,
             accountManager,
             powerManagementService
         )
-
-        if (!isUploadStarted) {
-            uploadListAdapter.loadUploadItemsFromDb { swipeListRefreshLayout?.isRefreshing = false }
-        }
     }
 
     override fun onStart() {

--- a/app/src/test/java/com/nextcloud/utils/extensions/UserAccountManagerExtensionsTest.kt
+++ b/app/src/test/java/com/nextcloud/utils/extensions/UserAccountManagerExtensionsTest.kt
@@ -7,12 +7,20 @@
 
 package com.nextcloud.utils.extensions
 
+import android.accounts.Account
 import android.content.Context
 import com.nextcloud.client.account.User
 import com.nextcloud.client.account.UserAccountManager
+import com.owncloud.android.lib.common.OwnCloudClient
+import com.owncloud.android.lib.common.OwnCloudClientFactory
+import com.owncloud.android.lib.common.accounts.AccountUtils
+import org.junit.After
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.Optional
@@ -22,11 +30,43 @@ class UserAccountManagerExtensionsTest {
     private val accountName = "test@server.com"
 
     private lateinit var accountManager: UserAccountManager
+    private lateinit var context: Context
+    private lateinit var platformAccount: Account
+    private lateinit var client: OwnCloudClient
+    private lateinit var clientFactory: MockedStatic<OwnCloudClientFactory>
 
     @Before
     fun setUp() {
+        context = mock()
+        platformAccount = mock()
+        client = mock()
+
         accountManager = mock()
-        whenever(accountManager.context).thenReturn(mock<Context>())
+        whenever(accountManager.context).thenReturn(context)
+
+        clientFactory = Mockito.mockStatic(OwnCloudClientFactory::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clientFactory.close()
+    }
+
+    @Test
+    fun `client is created for a registered account`() {
+        givenRegisteredAccount()
+        givenClientIsCreatedFor(platformAccount, context)
+
+        assertSame(client, accountManager.createOwncloudClient(accountName))
+    }
+
+    @Test
+    fun `client is created for the current account when no account name is given`() {
+        whenever(accountManager.currentAccount).thenReturn(accountNamed(accountName))
+        givenRegisteredAccount()
+        givenClientIsCreatedFor(platformAccount, context)
+
+        assertSame(client, accountManager.createOwncloudClient())
     }
 
     @Test
@@ -34,6 +74,8 @@ class UserAccountManagerExtensionsTest {
         whenever(accountManager.getUser(accountName)).thenReturn(Optional.empty())
 
         assertNull(accountManager.createOwncloudClient(accountName))
+
+        clientFactory.verifyNoInteractions()
     }
 
     @Test
@@ -43,5 +85,36 @@ class UserAccountManagerExtensionsTest {
         whenever(accountManager.getUser(accountName)).thenReturn(Optional.of(anonymousUser))
 
         assertNull(accountManager.createOwncloudClient(accountName))
+
+        clientFactory.verifyNoInteractions()
+    }
+
+    @Test
+    fun `no client is created when the account is removed while the client is created`() {
+        givenRegisteredAccount()
+        clientFactory.`when`<OwnCloudClient> {
+            OwnCloudClientFactory.createOwnCloudClient(platformAccount, context)
+        }.thenThrow(AccountUtils.AccountNotFoundException(platformAccount, "Account not found", null))
+
+        assertNull(accountManager.createOwncloudClient(accountName))
+    }
+
+    private fun givenClientIsCreatedFor(account: Account, appContext: Context) {
+        clientFactory.`when`<OwnCloudClient> {
+            OwnCloudClientFactory.createOwnCloudClient(account, appContext)
+        }.thenReturn(client)
+    }
+
+    // Account.name is a public final field, so it cannot be stubbed and has to be written directly
+    private fun accountNamed(name: String): Account = mock<Account>().also { account ->
+        Account::class.java.getField("name").apply { isAccessible = true }.set(account, name)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun givenRegisteredAccount() {
+        val user = mock<User>()
+        whenever(user.isAnonymous).thenReturn(false)
+        whenever(user.toPlatformAccount()).thenReturn(platformAccount)
+        whenever(accountManager.getUser(accountName)).thenReturn(Optional.of(user))
     }
 }

--- a/app/src/test/java/com/nextcloud/utils/extensions/UserAccountManagerExtensionsTest.kt
+++ b/app/src/test/java/com/nextcloud/utils/extensions/UserAccountManagerExtensionsTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.utils.extensions
+
+import android.content.Context
+import com.nextcloud.client.account.User
+import com.nextcloud.client.account.UserAccountManager
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+class UserAccountManagerExtensionsTest {
+
+    private val accountName = "test@server.com"
+
+    private lateinit var accountManager: UserAccountManager
+
+    @Before
+    fun setUp() {
+        accountManager = mock()
+        whenever(accountManager.context).thenReturn(mock<Context>())
+    }
+
+    @Test
+    fun `no client is created for an unknown account`() {
+        whenever(accountManager.getUser(accountName)).thenReturn(Optional.empty())
+
+        assertNull(accountManager.createOwncloudClient(accountName))
+    }
+
+    @Test
+    fun `no client is created while the account has no base url yet`() {
+        val anonymousUser = mock<User>()
+        whenever(anonymousUser.isAnonymous).thenReturn(true)
+        whenever(accountManager.getUser(accountName)).thenReturn(Optional.of(anonymousUser))
+
+        assertNull(accountManager.createOwncloudClient(accountName))
+    }
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Changes
                                                                                                                                                                                                                                                                                                                                                                       
- Catch `AccountUtils.AccountNotFoundException` around `createOwnCloudClient`                                                                                                                                                     
- Run retries on an injected application-scoped CoroutineScope                                                                                                                                                                                                                                                                                                                                                     
- Replace the launch-only `Semaphore` with an `AtomicBoolean`                                                                                                                                                                            
- Provide `@ApplicationScope` `CoroutineScope` via `DispatcherModule`                                                                                                                                                                          
- Use `by lazy` for the singleton and drop the broken `isUploadStarted` return value since events are used in worker.
- Implements `createOwncloudClient` for `UserAccountManager` and add tests
