### PR TITLE
fix(upload): prevent crash from duplicate stable IDs in local file list

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -78,6 +78,11 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     private static final int PAGE_SIZE = 50;
     private int currentOffset = 0;
 
+    // Stable IDs for the header and footer. File IDs come from int hashCodes, so these
+    // Long values below Integer.MIN_VALUE can never collide with a real file's ID.
+    private static final long HEADER_ID = Long.MIN_VALUE;
+    private static final long FOOTER_ID = Long.MIN_VALUE + 1;
+
     public LocalFileListAdapter(boolean localFolderPickerMode,
                                 LocalFileListFragmentInterface localFileListFragmentInterface,
                                 AppPreferences preferences,
@@ -153,12 +158,22 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     @Override
     public long getItemId(int position) {
-        if (position >= mFiles.size()) {
-            return RecyclerView.NO_ID;
+        int headerOffset = shouldShowHeader() ? 1 : 0;
+        return getStableItemId(position, headerOffset, mFiles);
+    }
+
+    @VisibleForTesting
+    static long getStableItemId(int position, int headerOffset, List<File> files) {
+        if (headerOffset == 1 && position == 0) {
+            return HEADER_ID;
         }
 
-        File file = mFiles.get(position);
-        return file.getAbsolutePath().hashCode();
+        int fileIndex = position - headerOffset;
+        if (fileIndex < 0 || fileIndex >= files.size()) {
+            return FOOTER_ID;
+        }
+
+        return files.get(fileIndex).getAbsolutePath().hashCode();
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -78,8 +78,6 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
     private static final int PAGE_SIZE = 50;
     private int currentOffset = 0;
 
-    // Stable IDs for the header and footer. File IDs come from int hashCodes, so these
-    // Long values below Integer.MIN_VALUE can never collide with a real file's ID.
     private static final long HEADER_ID = Long.MIN_VALUE;
     private static final long FOOTER_ID = Long.MIN_VALUE + 1;
 

--- a/app/src/test/java/com/owncloud/android/ui/adapter/LocalFileListAdapterTest.kt
+++ b/app/src/test/java/com/owncloud/android/ui/adapter/LocalFileListAdapterTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.ui.adapter
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class LocalFileListAdapterTest {
+
+    private fun sampleFiles(): List<File> = listOf(File("/sdcard/a.jpg"), File("/sdcard/b.png"), File("/sdcard/c.mp4"))
+
+    private fun assertAllPositionsHaveUniqueIds(headerOffset: Int, files: List<File>) {
+        val itemCount = files.size + 1 + headerOffset
+
+        val ids = mutableSetOf<Long>()
+        for (position in 0 until itemCount) {
+            val id = LocalFileListAdapter.getStableItemId(position, headerOffset, files)
+            assertTrue("Duplicate stable ID $id at position $position", ids.add(id))
+        }
+        assertEquals("Every position must produce a distinct stable ID", itemCount, ids.size)
+    }
+
+    @Test
+    fun stableIdsAreUniqueWhenHeaderIsVisible() {
+        assertAllPositionsHaveUniqueIds(headerOffset = 1, files = sampleFiles())
+    }
+
+    @Test
+    fun stableIdsAreUniqueWhenHeaderIsHidden() {
+        assertAllPositionsHaveUniqueIds(headerOffset = 0, files = sampleFiles())
+    }
+
+    @Test
+    fun headerAndFooterKeepDedicatedIds() {
+        val files = sampleFiles()
+
+        val headerId = LocalFileListAdapter.getStableItemId(0, 1, files)
+        val footerId = LocalFileListAdapter.getStableItemId(files.size + 1, 1, files)
+
+        assertEquals(Long.MIN_VALUE, headerId)
+        assertEquals(Long.MIN_VALUE + 1, footerId)
+    }
+}


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue



```
Exception in thread "main" java.lang.IllegalStateException: Two different ViewHolders have the same stable ID. Stable IDs in your adapter MUST BE unique and SHOULD NOT change. ViewHolder
1:LocalFileListFooterViewHolder(9ed48d1 position=7 id=-1, oldPos=-1, pLpos:-1 not recyclable(1)} View Holder 2:LocalFileListItemViewHolder{406ed79 position=6 id=-1, oldPos=-1, pLpos:-1}
com.owncloud.android.ui. Empty RecyclerView{1d40cfe VFED...........ID 0,0-1080,1514 #7f0a038e app:id/ list_root), adapter:com.owncloud.android.ui.adapter
.LocalFileListAdapter@f8679e, layout:androidx.recyclerview .widget.LinearLayoutManager@4ac7d91, context:com .owncloud.android.ui.activity.Upload FilesActivity@a06421
at androidx.recyclerview.widget.RecyclerView.handleMissi
ngPreInfoForChangeError(RecyclerView.java:4778)
at androidx.recyclerview.widget.RecyclerView.dispatchLay
outStep3(RecyclerView.java:4702)
at androidx.recyclerview.widget.RecyclerView.dispatchLay
out(RecyclerView.java:4367)
at androidx.recyclerview.widget.RecyclerView.consumePe ndingUpdateOperations (RecyclerView.java:2095)
at androidx.recyclerview.widget.RecyclerView$1.run(Recy clerView.java:468)
at android.view. Choreographer$CallbackRecord.run(Chore ographer.java:1406)
at android.view.Choreographer$CallbackRecord.run(Chore
ographer.java:1415)
at android.view.Choreographer.doCallbacks (Choreograph er.java:1015)
at android.view.Choreographer.doFrame (Choreographer.ja va:941)
at android.view.Choreographer$Frame DisplayEventReceiv er.run(Choreographer.java:1389)
at android.os.Handler.handleCallback(Handler.java:959) at android.os.Handler.dispatchMessage(Handler.java:100) at android.os.Looper.loopOnce (Looper.java:232) at android.os.Looper.loop(Looper.java:317)
at
android.app.ActivityThread.main(ActivityThread.java:8705) at java.lang.reflect.Method.invoke(Native Method) at com.android.internal.os.RuntimeInit$MethodAndArgsC
aller.run(RuntimeInit.java:580)
at
com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)

```

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
