### PR TITLE
feat(auto-upload): add manual rescan for files missing on the server

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/DatabaseModule.kt
+++ b/app/src/main/java/com/nextcloud/client/database/DatabaseModule.kt
@@ -11,7 +11,9 @@ import android.content.Context
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.database.dao.ArbitraryDataDao
 import com.nextcloud.client.database.dao.FileDao
+import com.nextcloud.client.database.dao.FileSystemDao
 import com.nextcloud.client.database.dao.OfflineOperationDao
+import com.nextcloud.client.database.dao.UploadDao
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -32,4 +34,10 @@ class DatabaseModule {
     @Provides
     fun offlineOperationsDao(nextcloudDatabase: NextcloudDatabase): OfflineOperationDao =
         nextcloudDatabase.offlineOperationDao()
+
+    @Provides
+    fun fileSystemDao(nextcloudDatabase: NextcloudDatabase): FileSystemDao = nextcloudDatabase.fileSystemDao()
+
+    @Provides
+    fun uploadDao(nextcloudDatabase: NextcloudDatabase): UploadDao = nextcloudDatabase.uploadDao()
 }

--- a/app/src/main/java/com/nextcloud/client/database/dao/FileSystemDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/FileSystemDao.kt
@@ -14,6 +14,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.nextcloud.client.database.entity.FilesystemEntity
 import com.owncloud.android.db.ProviderMeta
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
 
 @Dao
 interface FileSystemDao {
@@ -107,4 +108,25 @@ interface FileSystemDao {
     """
     )
     suspend fun hasPendingFiles(syncedFolderId: String): Boolean
+
+    /**
+     * Queues every file of the given folder again that was marked as sent for upload but has no successful upload
+     * to prove it. Files with a successful upload keep their state so a rescan never uploads them twice.
+     */
+    @Query(
+        """
+    UPDATE ${ProviderTableMeta.FILESYSTEM_TABLE_NAME}
+    SET ${ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD} = 0
+    WHERE ${ProviderTableMeta.FILESYSTEM_SYNCED_FOLDER_ID} = :syncedFolderId
+      AND ${ProviderTableMeta.FILESYSTEM_FILE_SENT_FOR_UPLOAD} = 1
+      AND ${ProviderTableMeta.FILESYSTEM_FILE_IS_FOLDER} = 0
+      AND NOT EXISTS (
+          SELECT 1 FROM ${ProviderTableMeta.UPLOADS_TABLE_NAME} upload
+          WHERE upload.${ProviderTableMeta.UPLOADS_LOCAL_PATH} =
+                ${ProviderTableMeta.FILESYSTEM_TABLE_NAME}.${ProviderTableMeta.FILESYSTEM_FILE_LOCAL_PATH}
+            AND upload.${ProviderTableMeta.UPLOADS_STATUS} = :succeededStatus
+      )
+    """
+    )
+    suspend fun requeueFilesWithoutSuccessfulUpload(syncedFolderId: String, succeededStatus: Int): Int
 }

--- a/app/src/main/java/com/nextcloud/client/database/dao/UploadDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/UploadDao.kt
@@ -112,4 +112,25 @@ interface UploadDao {
         status: Int,
         nameCollisionPolicy: Int? = null
     ): List<UploadEntity>
+
+    /**
+     * Drops every upload record below the given local folder that did not succeed. Auto-upload refuses to retry a file
+     * whose last result is non-retryable, and a record left behind in progress by a killed worker keeps its default
+     * [com.owncloud.android.db.UploadResult.UNKNOWN] result, which counts as non-retryable as well. A manual rescan
+     * therefore forgets these records so the files get a fresh attempt. Successful uploads are kept so a rescan never
+     * uploads the same file twice.
+     */
+    @Query(
+        """
+    DELETE FROM ${ProviderTableMeta.UPLOADS_TABLE_NAME}
+    WHERE ${ProviderTableMeta.UPLOADS_ACCOUNT_NAME} = :accountName
+      AND ${ProviderTableMeta.UPLOADS_STATUS} != :succeededStatus
+      AND ${ProviderTableMeta.UPLOADS_LOCAL_PATH} LIKE :localPathPrefix || '%'
+"""
+    )
+    suspend fun deleteUnsuccessfulUploadsInFolder(
+        accountName: String,
+        localPathPrefix: String,
+        succeededStatus: Int
+    ): Int
 }

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManager.kt
@@ -120,7 +120,15 @@ interface BackgroundJobManager {
 
     fun startImmediateFilesExportJob(files: Collection<OCFile>): LiveData<JobInfo?>
 
-    fun startAutoUpload(syncedFolder: SyncedFolder, overridePowerSaving: Boolean = false)
+    /**
+     * @param fullRescan re-reads the folder from disk instead of relying on the MediaStore and replaces an already
+     * enqueued run for this folder. Used by the manual rescan the user can trigger from the auto-upload screen.
+     */
+    fun startAutoUpload(
+        syncedFolder: SyncedFolder,
+        overridePowerSaving: Boolean = false,
+        fullRescan: Boolean = false
+    )
 
     fun cancelTwoWaySyncJob()
 

--- a/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt
@@ -482,11 +482,12 @@ internal class BackgroundJobManagerImpl(
         workManager.enqueueUniqueWork(JOB_CONTENT_OBSERVER, ExistingWorkPolicy.REPLACE, request)
     }
 
-    override fun startAutoUpload(syncedFolder: SyncedFolder, overridePowerSaving: Boolean) {
+    override fun startAutoUpload(syncedFolder: SyncedFolder, overridePowerSaving: Boolean, fullRescan: Boolean) {
         val syncedFolderID = syncedFolder.id
 
         val arguments = Data.Builder()
             .putBoolean(AutoUploadWorker.OVERRIDE_POWER_SAVING, overridePowerSaving)
+            .putBoolean(AutoUploadWorker.FULL_RESCAN, fullRescan)
             .putLong(AutoUploadWorker.SYNCED_FOLDER_ID, syncedFolderID)
             .build()
 
@@ -508,9 +509,12 @@ internal class BackgroundJobManagerImpl(
             )
             .build()
 
+        // a manual rescan must not be dropped in favour of an already enqueued run that does not carry the flag
+        val existingWorkPolicy = if (fullRescan) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP
+
         workManager.enqueueUniqueWork(
             JOB_IMMEDIATE_FILES_SYNC + "_" + syncedFolderID,
-            ExistingWorkPolicy.KEEP,
+            existingWorkPolicy,
             request
         )
     }

--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadHelper.kt
@@ -30,22 +30,38 @@ class AutoUploadHelper(private val repository: FileSystemRepository) {
         private const val MAX_DEPTH = 100
     }
 
-    fun insertEntries(folder: SyncedFolder) {
+    @JvmOverloads
+    fun insertEntries(folder: SyncedFolder, fullRescan: Boolean = false) {
         when (folder.type) {
             MediaFolderType.IMAGE -> {
                 repository.insertFromUri(MediaStore.Images.Media.INTERNAL_CONTENT_URI, folder)
                 repository.insertFromUri(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, folder)
+                walkFolderIfFullRescan(folder, fullRescan)
             }
 
             MediaFolderType.VIDEO -> {
                 repository.insertFromUri(MediaStore.Video.Media.INTERNAL_CONTENT_URI, folder)
                 repository.insertFromUri(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, folder)
+                walkFolderIfFullRescan(folder, fullRescan)
             }
 
             else -> {
                 insertCustomFolderIntoDB(folder)
             }
         }
+    }
+
+    /**
+     * Media folders are normally scanned through the MediaStore, which occasionally does not list a file that is
+     * present on disk. A manual rescan therefore also walks the folder itself so those files are picked up.
+     */
+    private fun walkFolderIfFullRescan(folder: SyncedFolder, fullRescan: Boolean) {
+        if (!fullRescan) {
+            return
+        }
+
+        val fileCount = insertCustomFolderIntoDB(folder, checkFileType = true)
+        Log_OC.d(TAG, "Full rescan walked ${folder.localPath}, $fileCount files visited")
     }
 
     /**
@@ -75,7 +91,8 @@ class AutoUploadHelper(private val repository: FileSystemRepository) {
         return true
     }
 
-    fun insertCustomFolderIntoDB(folder: SyncedFolder): Int {
+    @JvmOverloads
+    fun insertCustomFolderIntoDB(folder: SyncedFolder, checkFileType: Boolean = false): Int {
         val path = Paths.get(folder.localPath)
 
         if (!Files.exists(path)) {
@@ -118,7 +135,7 @@ class AutoUploadHelper(private val repository: FileSystemRepository) {
                             val creationTime = attrs?.creationTime()?.toMillis()
                             val localPath = file.toLocalPath()
 
-                            repository.insertOrReplace(localPath, lastModified, creationTime, folder)
+                            repository.insertOrReplace(localPath, lastModified, creationTime, folder, checkFileType)
 
                             fileCount++
 

--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadRescanHelper.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadRescanHelper.kt
@@ -1,0 +1,91 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.jobs.autoUpload
+
+import com.nextcloud.client.database.dao.FileSystemDao
+import com.nextcloud.client.database.dao.UploadDao
+import com.nextcloud.client.jobs.BackgroundJobManager
+import com.owncloud.android.datamodel.SyncedFolder
+import com.owncloud.android.datamodel.SyncedFolderProvider
+import com.owncloud.android.datamodel.UploadsStorageManager.UploadStatus
+import com.owncloud.android.lib.common.utils.Log_OC
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Puts the auto-upload bookkeeping of every enabled folder back into a state where files that never made it to the
+ * server are picked up again. This is the manual counterpart to deleting and recreating an auto-upload configuration.
+ *
+ * A file is queued again when it is marked as sent for upload but no successful upload backs that claim. Files with a
+ * successful upload are left untouched so a rescan never produces duplicates on the server.
+ *
+ * Dropping the unsuccessful upload records can hit a record of an upload that is running at this very moment. The
+ * upload itself keeps going, only its bookkeeping row is gone, and the rescan queues the file again. That is the
+ * accepted price for freeing the far more common case of a record left behind in progress by a killed worker.
+ */
+class AutoUploadRescanHelper @Inject constructor(
+    private val fileSystemDao: FileSystemDao,
+    private val uploadDao: UploadDao,
+    private val syncedFolderProvider: SyncedFolderProvider,
+    private val backgroundJobManager: BackgroundJobManager
+) {
+    companion object {
+        private const val TAG = "AutoUploadRescanHelper"
+    }
+
+    /**
+     * @return the number of folders a rescan was started for
+     */
+    suspend fun rescan(accountName: String): Int = withContext(Dispatchers.IO) {
+        val folders = syncedFolderProvider.syncedFolders.filter { it.isEnabled && it.account == accountName }
+
+        Log_OC.d(TAG, "Rescan requested for ${folders.size} enabled folders of $accountName")
+
+        folders.forEach { rescanFolder(it) }
+
+        folders.size
+    }
+
+    private suspend fun rescanFolder(syncedFolder: SyncedFolder) {
+        val removedUploads = clearUnsuccessfulUploads(syncedFolder)
+        val requeuedFiles = fileSystemDao.requeueFilesWithoutSuccessfulUpload(
+            syncedFolderId = syncedFolder.id.toString(),
+            succeededStatus = UploadStatus.UPLOAD_SUCCEEDED.value
+        )
+
+        // forget the last scan so the worker starts right away and does not skip unchanged files
+        syncedFolder.lastScanTimestampMs = SyncedFolder.NOT_SCANNED_YET
+        syncedFolderProvider.updateSyncFolder(syncedFolder)
+
+        backgroundJobManager.startAutoUpload(syncedFolder, overridePowerSaving = true, fullRescan = true)
+
+        Log_OC.d(
+            TAG,
+            "Rescanning ${syncedFolder.localPath}: $requeuedFiles files queued again, " +
+                "$removedUploads unsuccessful uploads dropped"
+        )
+    }
+
+    private suspend fun clearUnsuccessfulUploads(syncedFolder: SyncedFolder): Int {
+        val localPath = syncedFolder.localPath
+        if (localPath.isNullOrEmpty()) {
+            Log_OC.w(TAG, "Cannot clear uploads, local path is missing for folder ${syncedFolder.id}")
+            return 0
+        }
+
+        val localPathPrefix = if (localPath.endsWith(File.separator)) localPath else localPath + File.separator
+
+        return uploadDao.deleteUnsuccessfulUploadsInFolder(
+            accountName = syncedFolder.account,
+            localPathPrefix = localPathPrefix,
+            succeededStatus = UploadStatus.UPLOAD_SUCCEEDED.value
+        )
+    }
+}

--- a/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/autoUpload/AutoUploadWorker.kt
@@ -72,6 +72,7 @@ class AutoUploadWorker(
     companion object {
         const val TAG = "🔄📤" + "AutoUpload"
         const val OVERRIDE_POWER_SAVING = "overridePowerSaving"
+        const val FULL_RESCAN = "fullRescan"
         const val SYNCED_FOLDER_ID = "syncedFolderId"
         const val NOTIFICATION_ID = 266
     }
@@ -103,7 +104,7 @@ class AutoUploadWorker(
             }
 
             // insert entries based on selected local storage path
-            autoUploadHelper.insertEntries(syncedFolder)
+            autoUploadHelper.insertEntries(syncedFolder, inputData.getBoolean(FULL_RESCAN, false))
             uploadFiles(syncedFolder)
 
             // only update last scan time after uploading files

--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -31,6 +31,7 @@ import com.nextcloud.client.device.PowerManagementService
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.jobs.MediaFoldersDetectionWork
 import com.nextcloud.client.jobs.NotificationWork
+import com.nextcloud.client.jobs.autoUpload.AutoUploadRescanHelper
 import com.nextcloud.client.jobs.upload.FileUploadWorker
 import com.nextcloud.client.preferences.SubFolderRule
 import com.nextcloud.ui.component.UploadWarningCard
@@ -59,6 +60,7 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment
 import com.owncloud.android.ui.dialog.SyncedFolderPreferencesDialogFragment
 import com.owncloud.android.ui.dialog.SyncedFolderPreferencesDialogFragment.OnSyncedFolderPreferenceListener
 import com.owncloud.android.ui.dialog.parcel.SyncedFolderParcelable
+import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.PermissionUtil
 import com.owncloud.android.utils.SyncedFolderUtils
 import kotlinx.coroutines.Dispatchers
@@ -152,6 +154,9 @@ class SyncedFoldersActivity :
 
     @Inject
     lateinit var appInfo: AppInfo
+
+    @Inject
+    lateinit var autoUploadRescanHelper: AutoUploadRescanHelper
 
     private var uploadWarningCard: UploadWarningCard? = null
 
@@ -581,9 +586,48 @@ class SyncedFoldersActivity :
                 result = super.onOptionsItemSelected(item)
             }
 
+            R.id.action_rescan_for_missing_files -> showRescanConfirmationDialog()
+
             else -> result = super.onOptionsItemSelected(item)
         }
         return result
+    }
+
+    private fun showRescanConfirmationDialog() {
+        if (!PermissionUtil.checkStoragePermission(this)) {
+            PermissionUtil.requestStoragePermissionIfNeeded(this)
+            return
+        }
+
+        val builder = MaterialAlertDialogBuilder(this, R.style.Theme_ownCloud_Dialog)
+            .setTitle(R.string.auto_upload_rescan_dialog_title)
+            .setMessage(R.string.auto_upload_rescan_dialog_message)
+            .setPositiveButton(R.string.auto_upload_rescan_action) { _, _ -> startRescan() }
+            .setNegativeButton(R.string.common_cancel, null)
+
+        viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, builder)
+
+        val dialog = builder.show()
+
+        viewThemeUtils.platform.colorTextButtons(
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE),
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+        )
+    }
+
+    private fun startRescan() {
+        lifecycleScope.launch {
+            val rescannedFolders = autoUploadRescanHelper.rescan(userAccountManager.user.accountName)
+            Log_OC.d(TAG, "manual rescan started for $rescannedFolders folders")
+
+            val message = if (rescannedFolders > 0) {
+                R.string.auto_upload_rescan_started
+            } else {
+                R.string.auto_upload_rescan_no_folders
+            }
+
+            DisplayUtils.showSnackMessage(this@SyncedFoldersActivity, message)
+        }
     }
 
     override fun onSyncFolderSettingsClick(section: Int, syncedFolderDisplayItem: SyncedFolderDisplayItem?) {

--- a/app/src/main/res/menu/activity_synced_folders.xml
+++ b/app/src/main/res/menu/activity_synced_folders.xml
@@ -15,6 +15,10 @@
             android:title="@string/autoupload_custom_folder"/>
 
         <item
+            android:id="@+id/action_rescan_for_missing_files"
+            android:title="@string/auto_upload_rescan_action"/>
+
+        <item
             android:id="@+id/action_disable_power_save_check"
             android:title="@string/autoupload_disable_power_save_check"
             android:visible="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1497,6 +1497,11 @@
     <string name="auto_upload_background_activity_action">Allow background activity</string>
     <string name="auto_upload_delete_dialog_description">This will remove the folder and auto-upload configuration. Any unfinished uploads will be canceled.</string>
     <string name="auto_upload_sub_folder_warning">This folder is already included in the parent folder’s sync, which may cause duplicate uploads</string>
+    <string name="auto_upload_rescan_action">Scan for missing files</string>
+    <string name="auto_upload_rescan_dialog_title">Scan for missing files?</string>
+    <string name="auto_upload_rescan_dialog_message">Nextcloud checks all enabled auto-upload folders again and uploads the files that are missing on the server. Files that were already uploaded are not uploaded again.</string>
+    <string name="auto_upload_rescan_started">Scanning for missing files</string>
+    <string name="auto_upload_rescan_no_folders">Enable auto-upload for a folder first</string>
     <string name="sync_anyway">Sync anyway</string>
     <string name="sync_duplication">Sync duplication</string>
     <string name="server_not_reachable">Could not load content</string>

--- a/app/src/test/java/com/nextcloud/client/jobs/autoUpload/AutoUploadRescanHelperTest.kt
+++ b/app/src/test/java/com/nextcloud/client/jobs/autoUpload/AutoUploadRescanHelperTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nextcloud.client.jobs.autoUpload
+
+import com.nextcloud.client.database.dao.FileSystemDao
+import com.nextcloud.client.database.dao.UploadDao
+import com.nextcloud.client.jobs.BackgroundJobManager
+import com.nextcloud.client.preferences.SubFolderRule
+import com.owncloud.android.datamodel.MediaFolderType
+import com.owncloud.android.datamodel.SyncedFolder
+import com.owncloud.android.datamodel.SyncedFolderProvider
+import com.owncloud.android.datamodel.UploadsStorageManager.UploadStatus
+import com.owncloud.android.files.services.NameCollisionPolicy
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AutoUploadRescanHelperTest {
+
+    companion object {
+        private const val ACCOUNT = "user@nextcloud.test"
+        private const val OTHER_ACCOUNT = "other@nextcloud.test"
+        private const val CAMERA_PATH = "/storage/emulated/0/DCIM/Camera"
+        private const val ENABLED_FOLDER_ID = 1L
+        private const val DISABLED_FOLDER_ID = 2L
+        private const val FOREIGN_FOLDER_ID = 3L
+        private const val LAST_SCAN_TIMESTAMP_MS = 1_700_000_000_000L
+    }
+
+    @Mock
+    lateinit var fileSystemDao: FileSystemDao
+
+    @Mock
+    lateinit var uploadDao: UploadDao
+
+    @Mock
+    lateinit var syncedFolderProvider: SyncedFolderProvider
+
+    @Mock
+    lateinit var backgroundJobManager: BackgroundJobManager
+
+    private lateinit var helper: AutoUploadRescanHelper
+
+    @Before
+    fun setUp() = runBlocking {
+        MockitoAnnotations.openMocks(this@AutoUploadRescanHelperTest)
+        whenever(fileSystemDao.requeueFilesWithoutSuccessfulUpload(any(), any())).thenReturn(0)
+        whenever(uploadDao.deleteUnsuccessfulUploadsInFolder(any(), any(), any())).thenReturn(0)
+        helper = AutoUploadRescanHelper(fileSystemDao, uploadDao, syncedFolderProvider, backgroundJobManager)
+    }
+
+    @Test
+    fun `rescan queues files without successful upload and starts a full rescan`() = runBlocking {
+        val folder = syncedFolder(ENABLED_FOLDER_ID, CAMERA_PATH, ACCOUNT, enabled = true)
+        whenever(syncedFolderProvider.syncedFolders).thenReturn(mutableListOf(folder))
+
+        val rescannedFolders = helper.rescan(ACCOUNT)
+
+        assertEquals(1, rescannedFolders)
+        verify(fileSystemDao).requeueFilesWithoutSuccessfulUpload(
+            syncedFolderId = ENABLED_FOLDER_ID.toString(),
+            succeededStatus = UploadStatus.UPLOAD_SUCCEEDED.value
+        )
+        verify(uploadDao).deleteUnsuccessfulUploadsInFolder(
+            accountName = ACCOUNT,
+            localPathPrefix = "$CAMERA_PATH/",
+            succeededStatus = UploadStatus.UPLOAD_SUCCEEDED.value
+        )
+        verify(backgroundJobManager).startAutoUpload(
+            syncedFolder = folder,
+            overridePowerSaving = true,
+            fullRescan = true
+        )
+    }
+
+    @Test
+    fun `rescan forgets the last scan so the worker does not skip unchanged files`() = runBlocking {
+        val folder = syncedFolder(ENABLED_FOLDER_ID, CAMERA_PATH, ACCOUNT, enabled = true)
+        whenever(syncedFolderProvider.syncedFolders).thenReturn(mutableListOf(folder))
+
+        helper.rescan(ACCOUNT)
+
+        assertEquals(SyncedFolder.NOT_SCANNED_YET, folder.lastScanTimestampMs)
+        verify(syncedFolderProvider).updateSyncFolder(folder)
+    }
+
+    @Test
+    fun `rescan skips disabled folders and folders of other accounts`() = runBlocking {
+        val enabledFolder = syncedFolder(ENABLED_FOLDER_ID, CAMERA_PATH, ACCOUNT, enabled = true)
+        val disabledFolder = syncedFolder(DISABLED_FOLDER_ID, "$CAMERA_PATH/Disabled", ACCOUNT, enabled = false)
+        val foreignFolder = syncedFolder(FOREIGN_FOLDER_ID, "$CAMERA_PATH/Foreign", OTHER_ACCOUNT, enabled = true)
+        whenever(syncedFolderProvider.syncedFolders)
+            .thenReturn(mutableListOf(enabledFolder, disabledFolder, foreignFolder))
+
+        val rescannedFolders = helper.rescan(ACCOUNT)
+
+        assertEquals(1, rescannedFolders)
+        verify(fileSystemDao, never()).requeueFilesWithoutSuccessfulUpload(
+            eq(DISABLED_FOLDER_ID.toString()),
+            any()
+        )
+        verify(fileSystemDao, never()).requeueFilesWithoutSuccessfulUpload(
+            eq(FOREIGN_FOLDER_ID.toString()),
+            any()
+        )
+        verify(backgroundJobManager).startAutoUpload(eq(enabledFolder), eq(true), eq(true))
+    }
+
+    @Test
+    fun `rescan still starts the worker when the local path is unusable`() = runBlocking {
+        val folder = syncedFolder(ENABLED_FOLDER_ID, "", ACCOUNT, enabled = true)
+        whenever(syncedFolderProvider.syncedFolders).thenReturn(mutableListOf(folder))
+
+        val rescannedFolders = helper.rescan(ACCOUNT)
+
+        assertEquals(1, rescannedFolders)
+        verify(uploadDao, never()).deleteUnsuccessfulUploadsInFolder(any(), any(), any())
+        verify(backgroundJobManager).startAutoUpload(eq(folder), eq(true), eq(true))
+    }
+
+    private fun syncedFolder(id: Long, localPath: String, account: String, enabled: Boolean): SyncedFolder =
+        SyncedFolder(
+            id,
+            localPath,
+            "/InstantUpload",
+            true,
+            false,
+            true,
+            false,
+            account,
+            0,
+            NameCollisionPolicy.ASK_USER.serialize(),
+            enabled,
+            LAST_SCAN_TIMESTAMP_MS,
+            MediaFolderType.IMAGE,
+            false,
+            SubFolderRule.YEAR_MONTH,
+            false,
+            LAST_SCAN_TIMESTAMP_MS
+        )
+}


### PR DESCRIPTION
Auto-upload permanently loses files in three ways: a file marked as sent for upload without ever being uploaded is skipped by every later scan, an upload record left behind in progress by a killed worker keeps its default UNKNOWN result which counts as non-retryable, and media folders are scanned through the MediaStore only, which occasionally does not list a file that is present on disk. Users work around this by deleting and recreating the auto-upload configuration.

Add "Scan for missing files" to the auto-upload screen. It queues the files of every enabled folder again that have no successful upload to prove they made it to the server, forgets the unsuccessful upload records blocking a retry, and starts a scan that walks the folder on disk instead of trusting the MediaStore. Files with a successful upload keep their state, so a rescan never uploads the same file twice.

Assisted-by: ClaudeCode:Claude Opus 5


Claude-Session: https://claude.ai/code/session_01FKT6mDcztem3pyZJiJQoLB

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
