### PR TITLE
fix(send-share-dialog): on send button click crash

### DIFF
--- a/app/src/main/java/com/nextcloud/client/jobs/download/SendShareDownloader.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/SendShareDownloader.kt
@@ -1,0 +1,136 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.nextcloud.client.jobs.download
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Bundle
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.nextcloud.client.utils.IntentUtil.createSendIntent
+import com.nextcloud.utils.extensions.getParcelableArgument
+import com.owncloud.android.R
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.common.utils.Log_OC
+import com.owncloud.android.ui.activity.FileActivity
+import com.owncloud.android.ui.dialog.SendShareDialog
+import com.owncloud.android.ui.fragment.OCFileListFragment
+
+/**
+ * Downloads a file that is not stored on the device yet and sends it to the app the user picked in
+ * [SendShareDialog], as soon as the download finishes.
+ *
+ * Register it as a lifecycle observer, so that it listens for finished downloads only while the host activity is
+ * started:
+ *
+ * ```
+ * private val sendShareDownloader by lazy { SendShareDownloader(this) }
+ *
+ * override fun onCreate(savedInstanceState: Bundle?) {
+ *     lifecycle.addObserver(sendShareDownloader)
+ * }
+ * ```
+ */
+class SendShareDownloader(
+    private val activity: FileActivity,
+    private val localBroadcastManager: LocalBroadcastManager = LocalBroadcastManager.getInstance(activity)
+) : DefaultLifecycleObserver,
+    SendShareDialog.SendShareDialogDownloader {
+
+    private var fileWaitingToSend: OCFile? = null
+
+    private val downloadCompletedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            onDownloadCompleted(intent)
+        }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        val filter = IntentFilter(FileDownloadEventBroadcaster.ACTION_DOWNLOAD_COMPLETED)
+        localBroadcastManager.registerReceiver(downloadCompletedReceiver, filter)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        localBroadcastManager.unregisterReceiver(downloadCompletedReceiver)
+    }
+
+    override fun downloadFile(file: OCFile, packageName: String, activityName: String) {
+        val user = activity.user.orElse(null) ?: return
+        fileWaitingToSend = file
+
+        val fileDownloadHelper = FileDownloadHelper.instance()
+        if (fileDownloadHelper.isDownloading(user, file)) {
+            return
+        }
+
+        fileDownloadHelper.downloadFile(
+            user = user,
+            ocFile = file,
+            behaviour = OCFileListFragment.DOWNLOAD_SEND,
+            activityName = activityName,
+            packageName = packageName
+        )
+    }
+
+    fun saveState(outState: Bundle) {
+        outState.putParcelable(KEY_FILE_WAITING_TO_SEND, fileWaitingToSend)
+    }
+
+    fun restoreState(savedInstanceState: Bundle?) {
+        fileWaitingToSend = savedInstanceState?.getParcelableArgument(KEY_FILE_WAITING_TO_SEND, OCFile::class.java)
+    }
+
+    @Suppress("ReturnCount")
+    private fun onDownloadCompleted(intent: Intent) {
+        val waitingToSend = fileWaitingToSend ?: return
+
+        if (OCFileListFragment.DOWNLOAD_SEND !=
+            intent.getStringExtra(FileDownloadEventBroadcaster.EXTRA_DOWNLOAD_BEHAVIOUR)
+        ) {
+            return
+        }
+
+        if (activity.account?.name != intent.getStringExtra(FileDownloadEventBroadcaster.EXTRA_ACCOUNT_NAME)) {
+            return
+        }
+
+        val remotePath = intent.getStringExtra(FileDownloadEventBroadcaster.EXTRA_REMOTE_PATH) ?: return
+        val downloadedFile = activity.storageManager?.getFileByEncryptedRemotePath(remotePath) ?: return
+        if (downloadedFile.fileId != waitingToSend.fileId) {
+            return
+        }
+
+        fileWaitingToSend = null
+
+        if (!downloadedFile.isDown) {
+            Log_OC.e(TAG, "File cannot be sent, download failed: " + downloadedFile.remotePath)
+            return
+        }
+
+        val packageName = intent.getStringExtra(FileDownloadEventBroadcaster.EXTRA_PACKAGE_NAME) ?: return
+        val activityName = intent.getStringExtra(FileDownloadEventBroadcaster.EXTRA_ACTIVITY_NAME) ?: return
+        send(downloadedFile, packageName, activityName)
+    }
+
+    private fun send(file: OCFile, packageName: String, activityName: String) {
+        val sendIntent = createSendIntent(activity, file).apply {
+            component = ComponentName(packageName, activityName)
+        }
+
+        val title = activity.getString(R.string.activity_chooser_send_file_title)
+        activity.startActivity(Intent.createChooser(sendIntent, title))
+    }
+
+    companion object {
+        private val TAG = SendShareDownloader::class.java.simpleName
+        private const val KEY_FILE_WAITING_TO_SEND = "KEY_FILE_WAITING_TO_SEND"
+    }
+}

--- a/app/src/main/java/com/nextcloud/client/jobs/download/SendShareDownloader.kt
+++ b/app/src/main/java/com/nextcloud/client/jobs/download/SendShareDownloader.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud - Android Client
  *
- * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 package com.nextcloud.client.jobs.download

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1493,10 +1493,8 @@ class FileDisplayActivity :
         ocFileListFragment?.fileListLayoutManager?.sortFiles(selection)
     }
 
-    override fun downloadFile(file: OCFile?, packageName: String?, activityName: String?) {
-        if (packageName != null && activityName != null) {
-            startDownloadForSending(file, OCFileListFragment.DOWNLOAD_SEND, packageName, activityName)
-        }
+    override fun downloadFile(file: OCFile, packageName: String, activityName: String) {
+        startDownloadForSending(file, OCFileListFragment.DOWNLOAD_SEND, packageName, activityName)
     }
 
     // region SyncBroadcastReceiver

--- a/app/src/main/java/com/owncloud/android/ui/adapter/sendButton/SendButtonAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/sendButton/SendButtonAdapter.kt
@@ -8,7 +8,6 @@
 package com.owncloud.android.ui.adapter.sendButton
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.owncloud.android.databinding.SendButtonBinding
@@ -35,26 +34,15 @@ class SendButtonAdapter(
     class ViewHolder(private val binding: SendButtonBinding, private val clickListener: ClickListener) :
         RecyclerView.ViewHolder(
             binding.getRoot()
-        ),
-        View.OnClickListener {
-        private var sendButtonDataData: SendButtonData? = null
-
-        init {
-            itemView.setOnClickListener(this)
-        }
-
+        ) {
         fun bind(item: SendButtonData) {
-            sendButtonDataData = item
             binding.sendButton.icon = item.drawable
             binding.sendButton.text = item.title
-        }
-
-        override fun onClick(v: View) {
-            clickListener.onSendButtonClick(sendButtonDataData)
+            itemView.setOnClickListener { clickListener.onSendButtonClick(item) }
         }
     }
 
     interface ClickListener {
-        fun onSendButtonClick(sendButtonData: SendButtonData?)
+        fun onSendButtonClick(sendButtonData: SendButtonData)
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/sendButton/SendButtonData.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/sendButton/SendButtonData.kt
@@ -10,8 +10,8 @@ package com.owncloud.android.ui.adapter.sendButton
 import android.graphics.drawable.Drawable
 
 data class SendButtonData(
-    @JvmField val drawable: Drawable?,
-    @JvmField val title: CharSequence?,
-    val packageName: String?,
-    val activityName: String?
+    @JvmField val drawable: Drawable,
+    @JvmField val title: CharSequence,
+    val packageName: String,
+    val activityName: String
 )

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SendFilesDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SendFilesDialog.kt
@@ -105,14 +105,10 @@ class SendFilesDialog :
         return sendButtonDataList
     }
 
-    @Suppress("ReturnCount")
-    override fun onSendButtonClick(sendButtonData: SendButtonData?) {
-        sendButtonData ?: return
-        sendIntent ?: return
+    override fun onSendButtonClick(sendButtonData: SendButtonData) {
+        val sendIntent = sendIntent ?: return
 
-        val packageName = sendButtonData.packageName ?: return
-        val activityName = sendButtonData.activityName ?: return
-        sendIntent?.component = ComponentName(packageName, activityName)
+        sendIntent.component = ComponentName(sendButtonData.packageName, sendButtonData.activityName)
         requireActivity().startActivity(Intent.createChooser(sendIntent, getString(R.string.send)))
         dismiss()
     }

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.kt
@@ -217,9 +217,9 @@ class SendShareDialog :
     }
 
     @Suppress("ReturnCount")
-    override fun onSendButtonClick(sendButtonData: SendButtonData?) {
-        val packageName = sendButtonData?.packageName ?: return
-        val activityName = sendButtonData.activityName ?: return
+    override fun onSendButtonClick(sendButtonData: SendButtonData) {
+        val packageName = sendButtonData.packageName
+        val activityName = sendButtonData.activityName
         val file = file ?: return
 
         try {
@@ -236,15 +236,20 @@ class SendShareDialog :
             }
 
             Log_OC.d(TAG, file.remotePath + ": File must be downloaded")
-            val activity = activity as? SendShareDialogDownloader
-            activity?.downloadFile(file, packageName, activityName)
+            val downloader = activity as? SendShareDialogDownloader
+            if (downloader == null) {
+                Log_OC.e(TAG, "Host activity does not implement SendShareDialogDownloader: $activity")
+                return
+            }
+
+            downloader.downloadFile(file, packageName, activityName)
         } finally {
             dismiss()
         }
     }
 
     interface SendShareDialogDownloader {
-        fun downloadFile(file: OCFile?, packageName: String?, activityName: String?)
+        fun downloadFile(file: OCFile, packageName: String, activityName: String)
     }
 
     companion object {

--- a/app/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/SendShareDialog.kt
@@ -220,22 +220,27 @@ class SendShareDialog :
     override fun onSendButtonClick(sendButtonData: SendButtonData?) {
         val packageName = sendButtonData?.packageName ?: return
         val activityName = sendButtonData.activityName ?: return
+        val file = file ?: return
 
-        if (MimeTypeUtil.isImage(file) && !file!!.isDown) {
-            fileOperationsHelper?.sendCachedImage(file, packageName, activityName)
-        } else {
-            // Obtain the file
-            if (file!!.isDown) {
-                sendIntent?.component = ComponentName(packageName, activityName)
-                requireActivity().startActivity(Intent.createChooser(sendIntent, getString(R.string.send)))
-            } else { // Download the file
-                Log_OC.d(TAG, file!!.remotePath + ": File must be downloaded")
-                (requireActivity() as SendShareDialogDownloader)
-                    .downloadFile(file, packageName, activityName)
+        try {
+            if (MimeTypeUtil.isImage(file) && !file.isDown) {
+                fileOperationsHelper?.sendCachedImage(file, packageName, activityName)
+                return
             }
-        }
 
-        dismiss()
+            if (file.isDown) {
+                val activity = activity ?: return
+                sendIntent?.component = ComponentName(packageName, activityName)
+                activity.startActivity(Intent.createChooser(sendIntent, getString(R.string.send)))
+                return
+            }
+
+            Log_OC.d(TAG, file.remotePath + ": File must be downloaded")
+            val activity = activity as? SendShareDialogDownloader
+            activity?.downloadFile(file, packageName, activityName)
+        } finally {
+            dismiss()
+        }
     }
 
     interface SendShareDialogDownloader {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -32,6 +32,7 @@ import com.nextcloud.client.editimage.EditImageActivity
 import com.nextcloud.client.jobs.download.FileDownloadEventBroadcaster
 import com.nextcloud.client.jobs.download.FileDownloadHelper
 import com.nextcloud.client.jobs.download.FileDownloadWorker
+import com.nextcloud.client.jobs.download.SendShareDownloader
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.model.WorkerState
 import com.nextcloud.utils.extensions.getParcelableArgument
@@ -51,6 +52,7 @@ import com.owncloud.android.operations.SynchronizeFileOperation
 import com.owncloud.android.ui.activity.FileActivity
 import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.activity.OnFilesRemovedListener
+import com.owncloud.android.ui.dialog.SendShareDialog
 import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.fragment.GalleryFragment
 import com.owncloud.android.ui.preview.model.PreviewImageActivityState
@@ -71,11 +73,14 @@ class PreviewImageActivity :
     FileFragment.ContainerActivity,
     OnRemoteOperationListener,
     OnFilesRemovedListener,
+    SendShareDialog.SendShareDialogDownloader,
     Injectable {
     private var livePhotoFile: OCFile? = null
     private var viewPager: ViewPager2? = null
     private var previewMediaPagerAdapter: PreviewMediaPagerAdapter? = null
     private var savedPosition: Int? = null
+
+    private val sendShareDownloader by lazy { SendShareDownloader(this, localBroadcastManager) }
 
     private val downloadStartReceiver = DownloadStartReceiver()
     private val downloadFinishReceiver = DownloadFinishReceiver()
@@ -131,6 +136,13 @@ class PreviewImageActivity :
         observeWorkerState()
         applyDisplayCutOutTopPadding()
         handleBackPress()
+
+        lifecycle.addObserver(sendShareDownloader)
+        sendShareDownloader.restoreState(savedInstanceState)
+    }
+
+    override fun downloadFile(file: OCFile, packageName: String, activityName: String) {
+        sendShareDownloader.downloadFile(file, packageName, activityName)
     }
 
     override fun getMenuItemId(): Int = R.id.nav_gallery
@@ -309,6 +321,7 @@ class PreviewImageActivity :
         super.onSaveInstanceState(outState)
         outState.putBoolean(KEY_WAITING_FOR_BINDER, screenState == PreviewImageActivityState.WaitingForBinder)
         outState.putBoolean(KEY_SYSTEM_VISIBLE, isSystemUIVisible)
+        sendShareDownloader.saveState(outState)
     }
 
     override fun onRemoteOperationFinish(operation: RemoteOperation<*>?, result: RemoteOperationResult<*>) {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -60,6 +60,7 @@ import com.google.common.util.concurrent.MoreExecutors
 import com.nextcloud.client.account.User
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.jobs.download.FileDownloadHelper
+import com.nextcloud.client.jobs.download.SendShareDownloader
 import com.nextcloud.client.media.BackgroundPlayerService
 import com.nextcloud.client.media.ErrorFormat
 import com.nextcloud.client.media.ExoplayerListener
@@ -92,7 +93,6 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment
 import com.owncloud.android.ui.dialog.SendShareDialog
 import com.owncloud.android.ui.fragment.FileFragment
-import com.owncloud.android.ui.fragment.OCFileListFragment
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.ErrorMessageAdapter
 import com.owncloud.android.utils.MimeTypeUtil
@@ -126,6 +126,8 @@ class PreviewMediaActivity :
     private var streamUri: Uri? = null
     private var nextcloudClient: NextcloudClient? = null
 
+    private val sendShareDownloader by lazy { SendShareDownloader(this) }
+
     private lateinit var binding: ActivityPreviewMediaBinding
     private var emptyListView: ViewGroup? = null
     private var videoPlayer: ExoPlayer? = null
@@ -157,6 +159,10 @@ class PreviewMediaActivity :
         configureSystemBars()
         emptyListView = binding.emptyView.emptyListView
         showProgressLayout()
+
+        lifecycle.addObserver(sendShareDownloader)
+        sendShareDownloader.restoreState(savedInstanceState)
+
         if (file == null) {
             return
         }
@@ -286,6 +292,7 @@ class PreviewMediaActivity :
             bundle.putParcelable(EXTRA_USER, user)
             saveMediaInstanceState(bundle)
         }
+        sendShareDownloader.saveState(outState)
     }
 
     private fun saveMediaInstanceState(bundle: Bundle) {
@@ -606,7 +613,7 @@ class PreviewMediaActivity :
             }
 
             R.id.action_download_file -> {
-                requestForDownload(file, null)
+                requestForDownload(file)
             }
         }
     }
@@ -636,16 +643,11 @@ class PreviewMediaActivity :
         }
     }
 
-    override fun downloadFile(file: OCFile?, packageName: String?, activityName: String?) {
-        requestForDownload(file, OCFileListFragment.DOWNLOAD_SEND, packageName, activityName)
+    override fun downloadFile(file: OCFile, packageName: String, activityName: String) {
+        sendShareDownloader.downloadFile(file, packageName, activityName)
     }
 
-    private fun requestForDownload(
-        file: OCFile?,
-        downloadBehavior: String? = null,
-        packageName: String? = null,
-        activityName: String? = null
-    ) {
+    private fun requestForDownload(file: OCFile?) {
         val fileDownloadHelper = FileDownloadHelper.instance()
 
         if (fileDownloadHelper.isDownloading(user, file)) {
@@ -654,14 +656,7 @@ class PreviewMediaActivity :
 
         user?.let { user ->
             file?.let { file ->
-                fileDownloadHelper.downloadFile(
-                    user,
-                    file,
-                    downloadBehavior ?: "",
-                    DownloadType.DOWNLOAD,
-                    packageName ?: "",
-                    activityName ?: ""
-                )
+                fileDownloadHelper.downloadFile(user, file, downloadType = DownloadType.DOWNLOAD)
             }
         }
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Crash

```
Exception java.lang.ClassCastException:
  at com.owncloud.android.ui.dialog.SendShareDialog.onSendButtonClick (SendShareDialog.kt:233)
  at com.owncloud.android.ui.adapter.sendButton.SendButtonAdapter$ViewHolder.onClick (SendButtonAdapter.kt:53)
  at android.view.View.performClick (View.java:8234)
  at com.google.android.material.button.MaterialButton.performClick (MaterialButton.java:1786)
  at android.view.View.performClickInternal (View.java:8211)
  at android.view.View.-$$Nest$mperformClickInternal (View.java)
  at android.view.View$PerformClick.run (View.java:32873)
  at android.os.Handler.handleCallback (Handler.java:959)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.app.ActivityThread.main (ActivityThread.java:9682)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:625)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:944)
```

### Changes

- Fixes crash
- Implement missing cases
- Make arguments non-nullable