### PR TITLE
fix(copy-and-upload): ANR

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -1062,7 +1062,11 @@ public class ReceiveExternalFilesActivity extends FileActivity
         preferences.setLastUploadPath(mUploadPath);
 
         if (resultCode == UriUploader.UriUploaderResultCode.OK) {
-            finish();
+            // While content:// URIs are copied to temporary files this Activity has to stay alive, otherwise its
+            // temporary read permission for those URIs is revoked. onTmpFilesCopied() finishes it once done.
+            if (!uploader.isTmpCopyInProgress()) {
+                finish();
+            }
         } else {
 
             int messageResTitle = R.string.uploader_error_title_file_cannot_be_uploaded;

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
-import java.io.InputStream
 import java.lang.ref.WeakReference
 
 @Suppress("TooGenericExceptionCaught")
@@ -50,20 +49,8 @@ class CopyAndUploadContentUrisTask(
         behaviour: Int,
         contentResolver: ContentResolver
     ) {
-        val inputStreams: List<InputStream?> = try {
-            sourceUris.map { contentResolver.openInputStream(it) }
-        } catch (e: FileNotFoundException) {
-            Log_OC.e(TAG, "Source file not found", e)
-            dispatchResult(ResultCode.LOCAL_FILE_NOT_FOUND)
-            return
-        } catch (e: SecurityException) {
-            Log_OC.e(TAG, "Insufficient permissions to open source URIs", e)
-            dispatchResult(ResultCode.FORBIDDEN)
-            return
-        }
-
         scope.launch(Dispatchers.IO) {
-            val result = performCopy(user, sourceUris, remotePaths, behaviour, contentResolver, inputStreams)
+            val result = performCopy(user, sourceUris, remotePaths, behaviour, contentResolver)
             withContext(Dispatchers.Main) {
                 dispatchResult(result)
             }
@@ -75,8 +62,7 @@ class CopyAndUploadContentUrisTask(
         sourceUris: Array<Uri>,
         remotePaths: Array<String>,
         behaviour: Int,
-        contentResolver: ContentResolver,
-        inputStreams: List<InputStream?>
+        contentResolver: ContentResolver
     ): ResultCode {
         val localPaths = arrayOfNulls<String>(sourceUris.size)
         val resolvedRemotePaths = arrayOfNulls<String>(sourceUris.size)
@@ -95,7 +81,7 @@ class CopyAndUploadContentUrisTask(
                 }
                 Log_OC.d(TAG, "Cache file creation result: ${cacheFile.createNewFile()}")
 
-                inputStreams[index]?.use { input ->
+                contentResolver.openInputStream(uri)?.use { input ->
                     FileOutputStream(currentTempPath).use { output ->
                         input.copyTo(output)
                     }

--- a/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
+++ b/app/src/main/java/com/owncloud/android/ui/helpers/UriUploader.kt
@@ -64,6 +64,16 @@ class UriUploader @JvmOverloads constructor(
         ERROR_SENSITIVE_PATH
     }
 
+    /**
+     * True when content:// URIs are being copied to temporary files in the background.
+     *
+     * The temporary read permission for those URIs belongs to the calling Activity and is revoked once that Activity is
+     * destroyed. Callers must therefore stay alive until [OnCopyTmpFilesTaskListener.onTmpFilesCopied] is invoked,
+     * otherwise opening the URIs fails with a SecurityException.
+     */
+    var isTmpCopyInProgress: Boolean = false
+        private set
+
     @Suppress("NestedBlockDepth")
     fun uploadUris(): UriUploaderResultCode {
         var code = UriUploaderResultCode.OK
@@ -165,6 +175,7 @@ class UriUploader @JvmOverloads constructor(
         val taskRetainerFragment =
             fm.findFragmentByTag(TaskRetainerFragment.FTAG_TASK_RETAINER_FRAGMENT) as TaskRetainerFragment?
         taskRetainerFragment?.setTask(copyTask)
+        isTmpCopyInProgress = true
         copyTask.execute(
             user,
             sourceUris,


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

```
main" tid=1 Native
  #00  pc 0x00000000000de9c8  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+8)
  #01  pc 0x0000000000082c1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005f194  /system/lib64/libbinder.so (android::IPCThreadState::transact+1428)
  #03  pc 0x0000000000085428  /system/lib64/libbinder.so (android::BpBinder::transact+280)
  #04  pc 0x00000000001d72e8  /system/lib64/libandroid_runtime.so (android_os_BinderProxy_transact+152)
  at android.os.BinderProxy.transactNative (Native method)
  at android.os.BinderProxy.transact (BinderProxy.java:602)
  at android.content.ContentProviderProxy.openTypedAssetFile (ContentProviderNative.java:814)
  at android.content.ContentResolver.openTypedAssetFileDescriptor (ContentResolver.java:2114)
  at android.content.ContentResolver.openAssetFileDescriptor (ContentResolver.java:1912)
  at android.content.ContentResolver.openInputStream (ContentResolver.java:1574)
  at com.owncloud.android.ui.asynctasks.CopyAndUploadContentUrisTask.execute (CopyAndUploadContentUrisTask.kt:54)
  at com.owncloud.android.ui.helpers.UriUploader.copyThenUpload (UriUploader.kt:168)
  at com.owncloud.android.ui.helpers.UriUploader.uploadUris (UriUploader.kt:102)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.uploadFiles (ReceiveExternalFilesActivity.java:1059)
  at com.owncloud.android.ui.activity.ReceiveExternalFilesActivity.onClick (ReceiveExternalFilesActivity.java:710)
  at android.view.View.performClick (View.java:8229)
  at com.google.android.material.button.MaterialButton.performClick (MaterialButton.java:1786)
  at android.view.View.performClickInternal (View.java:8206)
  at android.view.View.-$$Nest$mperformClickInternal (unavailable)
  at android.view.View$PerformClick.run (View.java:32007)
  at android.os.Handler.handleCallback (Handler.java:1095)
  at android.os.Handler.dispatchMessageImpl (Handler.java:135)
  at android.os.Handler.dispatchMessage (Handler.java:125)
  at android.os.Looper.loopOnce (Looper.java:269)
  at android.os.Looper.loop (Looper.java:367)
  at android.app.ActivityThread.main (ActivityThread.java:9333)
  at java.lang.reflect.Method.invoke (Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:566)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:929)
```
