### PR TITLE
fix(conflict-resolve): thumbnail generation

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.kt
@@ -9,6 +9,7 @@ package com.owncloud.android.ui.dialog
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
+import android.os.AsyncTask
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
@@ -26,9 +27,9 @@ import com.owncloud.android.databinding.ConflictResolveDialogBinding
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.SyncedFolderProvider
+import com.owncloud.android.datamodel.ThumbnailsCacheManager.MediaThumbnailGenerationTask
 import com.owncloud.android.datamodel.ThumbnailsCacheManager.ThumbnailGenerationTask
 import com.owncloud.android.lib.common.utils.Log_OC
-import com.owncloud.android.ui.adapter.LocalFileListAdapter
 import com.owncloud.android.ui.dialog.parcel.ConflictDialogData
 import com.owncloud.android.ui.dialog.parcel.ConflictFileData
 import com.owncloud.android.utils.DisplayUtils
@@ -48,6 +49,7 @@ class ConflictsResolveDialog :
 
     var listener: OnConflictDecisionMadeListener? = null
     private val asyncTasks: MutableList<ThumbnailGenerationTask> = ArrayList()
+    private var localThumbnailTask: MediaThumbnailGenerationTask? = null
     private var positiveButton: MaterialButton? = null
 
     private var data: ConflictDialogData? = null
@@ -131,6 +133,9 @@ class ConflictsResolveDialog :
         super.onSaveInstanceState(outState)
         outState.run {
             putParcelable(ARG_CONFLICT_DATA, data)
+            putSerializable(ARG_LEFT_FILE, leftDataFile)
+            putParcelable(ARG_RIGHT_FILE, rightDataFile)
+            putParcelable(ARG_USER, user)
         }
     }
 
@@ -215,15 +220,9 @@ class ConflictsResolveDialog :
     }
 
     private fun setThumbnailsForFileConflicts() {
-        binding.leftThumbnail.tag = leftDataFile.hashCode()
-        binding.rightThumbnail.tag = rightDataFile.hashCode()
+        val localFile = leftDataFile ?: return
 
-        LocalFileListAdapter.setThumbnail(
-            leftDataFile,
-            binding.leftThumbnail,
-            context,
-            viewThemeUtils
-        )
+        setLocalFileThumbnail(localFile)
 
         DisplayUtils.setThumbnail(
             rightDataFile,
@@ -238,6 +237,26 @@ class ConflictsResolveDialog :
             viewThemeUtils,
             overlayManager
         )
+    }
+
+    /**
+     * [MediaThumbnailGenerationTask] only applies its bitmap when the view tag still equals `file.hashCode()`,
+     * so the tag has to be set before starting it. Unlike the local file list, this also covers videos and falls
+     * back to the mime type icon when no bitmap can be decoded.
+     */
+    private fun setLocalFileThumbnail(localFile: File) {
+        binding.leftThumbnail.run {
+            tag = localFile.hashCode()
+            setImageDrawable(MimeTypeUtil.getFileTypeIcon(null, localFile.name, context, viewThemeUtils))
+
+            if (!MimeTypeUtil.isImageOrVideo(localFile)) {
+                return
+            }
+
+            localThumbnailTask = MediaThumbnailGenerationTask(this, context, viewThemeUtils).also {
+                it.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, localFile)
+            }
+        }
     }
 
     private fun setOnClickListeners() {
@@ -280,8 +299,17 @@ class ConflictsResolveDialog :
         fun conflictDecisionMade(decision: Decision?)
     }
 
-    override fun onStop() {
-        super.onStop()
+    /**
+     * Deliberately not done in `onStop`: the server thumbnail needs a network round trip, and a cancelled
+     * [ThumbnailGenerationTask] never reaches `onPostExecute`. The view would keep the placeholder drawable of the
+     * cancelled task forever, because `cancelPotentialThumbnailWork` then refuses to start a new task for the same
+     * file. Cancelling only once the views are gone lets a backgrounded dialog still receive its thumbnails.
+     */
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        localThumbnailTask?.cancel(true)
+        localThumbnailTask = null
 
         asyncTasks.forEach {
             it.cancel(true)

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.kt
@@ -239,11 +239,6 @@ class ConflictsResolveDialog :
         )
     }
 
-    /**
-     * [MediaThumbnailGenerationTask] only applies its bitmap when the view tag still equals `file.hashCode()`,
-     * so the tag has to be set before starting it. Unlike the local file list, this also covers videos and falls
-     * back to the mime type icon when no bitmap can be decoded.
-     */
     private fun setLocalFileThumbnail(localFile: File) {
         binding.leftThumbnail.run {
             tag = localFile.hashCode()
@@ -299,12 +294,6 @@ class ConflictsResolveDialog :
         fun conflictDecisionMade(decision: Decision?)
     }
 
-    /**
-     * Deliberately not done in `onStop`: the server thumbnail needs a network round trip, and a cancelled
-     * [ThumbnailGenerationTask] never reaches `onPostExecute`. The view would keep the placeholder drawable of the
-     * cancelled task forever, because `cancelPotentialThumbnailWork` then refuses to start a new task for the same
-     * file. Cancelling only once the views are gone lets a backgrounded dialog still receive its thumbnails.
-     */
     override fun onDestroyView() {
         super.onDestroyView()
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Changes

- Uses `MediaThumbnailGenerationTask`
- `onStop` replaced with `onDestroyView`
