### PR TITLE
fix(drawer): external site links no longer stop working over time

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/activity/DrawerActivityIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/activity/DrawerActivityIT.kt
@@ -10,10 +10,15 @@ package com.owncloud.android.ui.activity
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.content.ContentValues
 import android.net.Uri
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.contrib.DrawerActions
+import androidx.test.espresso.contrib.NavigationViewActions
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -26,6 +31,8 @@ import com.nextcloud.test.RetryTestRule
 import com.owncloud.android.AbstractIT
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
+import com.owncloud.android.lib.common.ExternalLinkType
 import com.owncloud.android.lib.common.accounts.AccountUtils
 import org.hamcrest.Matchers
 import org.junit.Assert
@@ -73,7 +80,71 @@ class DrawerActivityIT : AbstractIT() {
         onView(ViewMatchers.withText(account1?.name)).perform(ViewActions.click())
     }
 
+    /**
+     * External link menu items get the item id [MENU_ITEM_EXTERNAL_LINK] + the link's local database id, and that
+     * id grows without bound because the table is cleared and refilled on every refresh. A link whose id has grown
+     * past the legacy 0-100 window must still open.
+     */
+    @Test
+    fun externalLinkWithIdBeyondLegacyRangeIsOpened() {
+        insertExternalLink()
+
+        Intents.init()
+        try {
+            launchActivity<FileDisplayActivity>().use {
+                waitForIdleSync()
+
+                onView(ViewMatchers.withId(R.id.drawer_layout)).perform(DrawerActions.open())
+                onView(ViewMatchers.withId(R.id.nav_view))
+                    .perform(NavigationViewActions.navigateTo(MENU_ITEM_EXTERNAL_LINK + EXTERNAL_LINK_ID))
+
+                Intents.intended(IntentMatchers.hasComponent(ExternalSiteWebView::class.java.name))
+                Intents.intended(IntentMatchers.hasExtra(ExternalSiteWebView.EXTRA_URL, EXTERNAL_LINK_URL))
+            }
+        } finally {
+            Intents.release()
+            deleteExternalLink()
+        }
+    }
+
+    private fun insertExternalLink() {
+        val values = ContentValues().apply {
+            put(ProviderTableMeta._ID, EXTERNAL_LINK_ID)
+            put(ProviderTableMeta.EXTERNAL_LINKS_ICON_URL, "")
+            put(ProviderTableMeta.EXTERNAL_LINKS_LANGUAGE, "en")
+            put(ProviderTableMeta.EXTERNAL_LINKS_TYPE, ExternalLinkType.LINK.toString())
+            put(ProviderTableMeta.EXTERNAL_LINKS_NAME, EXTERNAL_LINK_NAME)
+            put(ProviderTableMeta.EXTERNAL_LINKS_URL, EXTERNAL_LINK_URL)
+            put(ProviderTableMeta.EXTERNAL_LINKS_REDIRECT, false)
+        }
+
+        val uri = targetContext.contentResolver.insert(ProviderTableMeta.CONTENT_URI_EXTERNAL_LINKS, values)
+        Assert.assertNotNull("External link could not be stored", uri)
+
+        // the whole point of the test is an id outside the legacy window, so fail loudly if it was not honoured
+        Assert.assertTrue(
+            "External link id must exceed the legacy window",
+            EXTERNAL_LINK_ID > LEGACY_EXTERNAL_LINK_RANGE
+        )
+    }
+
+    private fun deleteExternalLink() {
+        targetContext.contentResolver.delete(
+            ProviderTableMeta.CONTENT_URI_EXTERNAL_LINKS,
+            "${ProviderTableMeta._ID} = ?",
+            arrayOf(EXTERNAL_LINK_ID.toString())
+        )
+    }
+
     companion object {
+        // kept in sync with DrawerActivity, where both values are private
+        private const val MENU_ITEM_EXTERNAL_LINK = 111
+        private const val LEGACY_EXTERNAL_LINK_RANGE = 100
+
+        private const val EXTERNAL_LINK_ID = 501
+        private const val EXTERNAL_LINK_NAME = "High ID Test"
+        private const val EXTERNAL_LINK_URL = "https://nextcloud.com"
+
         private var account1: Account? = null
         private var user1: User? = null
         private var account2: Account? = null

--- a/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -639,9 +639,7 @@ public abstract class DrawerActivity extends ToolbarActivity
             intent.setAction(FileDisplayActivity.LIST_GROUPFOLDERS);
             startActivity(intent);
         } else {
-            if (menuItem.getItemId() >= MENU_ITEM_EXTERNAL_LINK &&
-                menuItem.getItemId() <= MENU_ITEM_EXTERNAL_LINK + 100) {
-                // external link clicked
+            if (menuItem.getGroupId() == R.id.drawer_menu_external_links) {
                 externalLinkClicked(menuItem);
             } else {
                 Log_OC.w(TAG, "Unknown drawer menu item clicked: " + menuItem.getTitle());
@@ -791,26 +789,26 @@ public abstract class DrawerActivity extends ToolbarActivity
     }
 
     private void externalLinkClicked(MenuItem menuItem) {
+        int linkId = menuItem.getItemId() - MENU_ITEM_EXTERNAL_LINK;
         externalLinksProvider.getExternalLink(ExternalLinkType.LINK, externalLinks -> {
-            for (ExternalLink link : externalLinks) {
-                final var menuTitle = menuItem.getTitle();
-                if (menuTitle == null) {
-                    continue;
-                }
+            Optional<ExternalLink> optionalLink = externalLinks.stream()
+                .filter(link -> link.getId() == linkId)
+                .findFirst();
 
-                if (!menuTitle.toString().equalsIgnoreCase(link.getName())) {
-                    continue;
-                }
+            if (!optionalLink.isPresent()) {
+                Log_OC.w(TAG, "No external link found for menu item: " + menuItem.getTitle());
+                return Unit.INSTANCE;
+            }
 
-                if (link.getRedirect()) {
-                    DisplayUtils.startLinkIntent(DrawerActivity.this, link.getUrl());
-                } else {
-                    Intent externalWebViewIntent = new Intent(getApplicationContext(), ExternalSiteWebView.class);
-                    externalWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_TITLE, link.getName());
-                    externalWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_URL, link.getUrl());
-                    externalWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_SHOW_SIDEBAR, true);
-                    startActivity(externalWebViewIntent);
-                }
+            ExternalLink link = optionalLink.get();
+            if (link.getRedirect()) {
+                DisplayUtils.startLinkIntent(DrawerActivity.this, link.getUrl());
+            } else {
+                Intent externalWebViewIntent = new Intent(getApplicationContext(), ExternalSiteWebView.class);
+                externalWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_TITLE, link.getName());
+                externalWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_URL, link.getUrl());
+                externalWebViewIntent.putExtra(ExternalSiteWebView.EXTRA_SHOW_SIDEBAR, true);
+                startActivity(externalWebViewIntent);
             }
             return Unit.INSTANCE;
         });


### PR DESCRIPTION
External link menu items are registered with `MENU_ITEM_EXTERNAL_LINK` + the link's local database `_id`. That column is `AUTOINCREMENT` and the link table is cleared and refilled on every refresh, so the IDs grow without bound. The click handler only accepted an offset of 0–100, so once the IDs passed that window every external link silently stopped responding, no error, and it never recovers.

Dispatch on the menu group the items were registered under, and resolve the link by ID instead of by display name. The latter also fixes two links sharing a display name opening the same URL.

Reproduced with a link at local ID 501 (menu item 612): on master the tap logs `Unknown drawer menu item clicked` and nothing happens.

### 🧪 Testing

Verified manually on a device: with a link at local ID 501 in `external_links`, the drawer entry does nothing on master and opens correctly with this change.

Added `DrawerActivityIT#externalLinkWithIdBeyondLegacyRangeIsOpened`, which inserts a link at ID 501 and asserts the drawer entry opens `ExternalSiteWebView` with the link URL.

### 🖼️ Screenshots

🏚️ Before (master)

https://github.com/user-attachments/assets/26bbfb7d-35fd-4698-adae-1db991dbf6ec

🏡 After (this PR)

https://github.com/user-attachments/assets/054f28ad-f8fc-4c95-a8f3-a3695f4085cf

### 🏁 Checklist
 
- [x] ⛑️ Tests included
- [ ] 🔙 Backport: maintainers can request one if needed.
- [ ] 📅 Milestone: maintainers can add one if needed.
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI