### PR TITLE
Add menu item to force scan files for auto-upload

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SyncedFoldersActivity.kt
@@ -60,6 +60,8 @@ import com.owncloud.android.ui.dialog.SyncedFolderPreferencesDialogFragment
 import com.owncloud.android.ui.dialog.SyncedFolderPreferencesDialogFragment.OnSyncedFolderPreferenceListener
 import com.owncloud.android.ui.dialog.extensions.themeButtons
 import com.owncloud.android.ui.dialog.parcel.SyncedFolderParcelable
+import com.owncloud.android.utils.DisplayUtils
+import com.owncloud.android.utils.FilesSyncHelper
 import com.owncloud.android.utils.PermissionUtil
 import com.owncloud.android.utils.SyncedFolderUtils
 import kotlinx.coroutines.Dispatchers
@@ -551,6 +553,18 @@ class SyncedFoldersActivity :
         var result = true
         when (item.itemId) {
             android.R.id.home -> finish()
+
+            R.id.action_manual_scan -> {
+                Log_OC.d(TAG, "Manually scanning all enabled synced folders for missing files")
+                DisplayUtils.showSnackMessage(this, R.string.autoupload_manual_scan_started)
+                lifecycleScope.launch(Dispatchers.IO) {
+                    FilesSyncHelper.startAutoUploadForEnabledSyncedFolders(
+                        syncedFolderProvider,
+                        backgroundJobManager,
+                        true
+                    )
+                }
+            }
 
             R.id.action_create_custom_folder -> {
                 Log_OC.d(TAG, "Show custom folder dialog")

--- a/app/src/main/res/menu/activity_synced_folders.xml
+++ b/app/src/main/res/menu/activity_synced_folders.xml
@@ -15,6 +15,10 @@
             android:title="@string/autoupload_custom_folder"/>
 
         <item
+            android:id="@+id/action_manual_scan"
+            android:title="@string/autoupload_manual_scan"/>
+
+        <item
             android:id="@+id/action_disable_power_save_check"
             android:title="@string/autoupload_disable_power_save_check"
             android:visible="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -877,6 +877,8 @@
     <string name="autoupload_hide_folder">Hide folder</string>
     <string name="autoupload_configure">Configure</string>
     <string name="synced_folders_configure_folders">Configure folders</string>
+    <string name="autoupload_manual_scan">Manual scan</string>
+    <string name="autoupload_manual_scan_started">Scanning for missing files…</string>
 
     <string name="empty" translatable="false"></string>
     <string name="test_server_button">Test server connection</string>

--- a/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.kt
+++ b/app/src/test/java/com/owncloud/android/utils/FilesSyncHelperTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.utils
+
+import com.nextcloud.client.jobs.BackgroundJobManager
+import com.owncloud.android.datamodel.SyncedFolder
+import com.owncloud.android.datamodel.SyncedFolderProvider
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class FilesSyncHelperTest {
+
+    private val jobManager: BackgroundJobManager = mock()
+    private val provider: SyncedFolderProvider = mock()
+    private val enabled: SyncedFolder = mock()
+    private val disabled: SyncedFolder = mock()
+
+    @Before
+    fun setup() {
+        whenever(enabled.isEnabled) doReturn true
+        whenever(disabled.isEnabled) doReturn false
+        whenever(provider.syncedFolders) doReturn mutableListOf(enabled, disabled)
+    }
+
+    @Test
+    fun `starts auto upload only for enabled folders, passing override power saving through`() {
+        FilesSyncHelper.startAutoUploadForEnabledSyncedFolders(provider, jobManager, true)
+
+        verify(jobManager).startAutoUpload(enabled, true)
+        verify(jobManager, never()).startAutoUpload(eq(disabled), any())
+    }
+}


### PR DESCRIPTION
Demonstration PR to argue for approving #15782 . I commented there that this supports users through a lot of failure modes, and it is trivially easy to implement. This PR is an example of how. Note: I'm a developer, but not for android, so I'm trusting Claude on what's idiomatic here.

When the content observer misses a file for any reason, the file stays unuploaded indefinitely. This PR adds a **Manual scan** item to the Auto upload screen's overflow menu that calls the existing `FilesSyncHelper.startAutoUploadForEnabledSyncedFolders(..., overridePowerSaving = true)` for every enabled synced folder. This is the same code path already exercised by `ContentObserverWork`, so it already respects the pre-existing files config, files with  `filesystem.fileSentForUpload = 1`, and existing queues.

Implementation is 20 lines of adding a menu item to trigger an existing code path with a snack message. But that code path was untested, so I included 43 lines to assert powerSavingOverride and isEnabled filter behavior.

I didn't add a screenshot since I couldn't find anywhere else that tests specific submenu items that way. Existing screenshot tests just include the collapsed menu, so nothing should change.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI

- [x] The content of this PR was partly or fully generated using AI

Generated with Claude Code, signed off by me; both commits carry an `Assisted-by:` trailer. 