### PR TITLE
Clarify contacts and calendar backup preference subtitle

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="prefs_davx5_setup_error">Unexpected error while setting up DAVx⁵ (formerly known as DAVdroid)</string>
     <string name="prefs_calendar_contacts_no_store_error">Neither F-Droid nor Google Play is installed</string>
     <string name="prefs_calendar_contacts_sync_setup_successful">Calendar and contacts sync set up</string>
-    <string name="prefs_daily_backup_summary">Daily backup of your calendar and contacts</string>
+    <string name="prefs_daily_backup_summary">Configure automatic or one-time backups.</string>
     <string name="prefs_daily_contact_backup_summary">Daily backup of your contacts</string>
     <string name="prefs_sycned_folders_summary">Manage folders for auto upload</string>
 


### PR DESCRIPTION
## Summary
- Change `prefs_daily_backup_summary` so it no longer implies daily backups are already enabled.
- Use the wording suggested on the issue: configure automatic or one-time backups.

Fixes #4020

## Test plan
- [ ] Open Settings → Contacts & calendar backup with daily backup unset and confirm the subtitle does not claim daily backup is active.
- [ ] Confirm the preference still opens the backup setup screen as before.
- [ ] String-only change in `values/strings.xml` (translations update via the usual process).
