### PR TITLE
perf(file-list): initial load, refresh 🚀 

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -263,10 +263,10 @@ public class RefreshFolderOperation extends RemoteOperation {
             return new RemoteOperationResult<>(ResultCode.FILE_NOT_FOUND);
         }
 
-        if (OCFile.ROOT_PATH.equals(mLocalFolder.getRemotePath()) && !mSyncFullAccount && !mOnlyFileMetadata) {
-            updateOCVersion(client);
-            updateUserProfile();
-        }
+        // Account metadata is refreshed after the folder listing so that it never delays the file list. It is not
+        // needed to render the folder, and blocking on it adds several sequential requests before the first PROPFIND.
+        final boolean updateAccountMetadata =
+            OCFile.ROOT_PATH.equals(mLocalFolder.getRemotePath()) && !mSyncFullAccount && !mOnlyFileMetadata;
 
         result = checkForChanges(client);
 
@@ -312,6 +312,11 @@ public class RefreshFolderOperation extends RemoteOperation {
 
         if (!mSyncFullAccount && mLocalFolder != null && !isMetadataSyncWorkerRunning) {
             sendLocalBroadcast(EVENT_SINGLE_FOLDER_SHARES_SYNCED, mLocalFolder.getRemotePath(), result);
+        }
+
+        if (updateAccountMetadata) {
+            updateOCVersion(client);
+            updateUserProfile();
         }
 
         return result;

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -144,8 +144,6 @@ public abstract class FileActivity extends DrawerActivity
     public static final int REQUEST_CODE__UPDATE_CREDENTIALS = 0;
     public static final int REQUEST_CODE__LAST_SHARED = REQUEST_CODE__UPDATE_CREDENTIALS;
 
-    protected static final long DELAY_TO_REQUEST_OPERATIONS_LATER = 200;
-
     /* Dialog tags */
     private static final String DIALOG_UNTRUSTED_CERT = "DIALOG_UNTRUSTED_CERT";
     private static final String DIALOG_CERT_NOT_SAVED = "DIALOG_CERT_NOT_SAVED";

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -216,6 +216,8 @@ class FileDisplayActivity :
             setEmptyListState()
         }
 
+    private var pendingSyncFolderOperation: Runnable? = null
+
     private var mWaitingToSend: OCFile? = null
 
     private var mDrawerMenuItemstoShowHideList: MutableCollection<MenuItem>? = null
@@ -2528,43 +2530,61 @@ class FileDisplayActivity :
     fun startSyncFolderOperation(folder: OCFile?, ignoreETag: Boolean, ignoreFocus: Boolean = false) {
         Log_OC.d(TAG, "startSyncFolderOperation called, ignoreEtag: $ignoreETag, ignoreFocus: $ignoreFocus")
 
-        // the execution is slightly delayed to allow the activity get the window focus if it's being started
-        // or if the method is called from a dialog that is being dismissed
-
-        if (TextUtils.isEmpty(searchQuery) && user.isPresent) {
-            mSyncInProgress = true
-
-            handler.postDelayed({
-                val user = getUser()
-                if ((!ignoreFocus && !hasWindowFocus()) || !user.isPresent) {
-                    // do not refresh if the user rotates the device while another window has focus
-                    // or if the current user is no longer valid
-                    mSyncInProgress = false
-                    return@postDelayed
-                }
-
-                val currentSyncTime = System.currentTimeMillis()
-
-                val operation = RefreshFolderOperation(
-                    folder,
-                    currentSyncTime,
-                    false,
-                    ignoreETag,
-                    storageManager,
-                    user.get(),
-                    applicationContext
-                )
-                operation.execute(
-                    account,
-                    MainApp.getAppContext(),
-                    this@FileDisplayActivity,
-                    null,
-                    null
-                )
-
-                fetchRecommendedFilesIfNeeded(ignoreETag, folder)
-            }, DELAY_TO_REQUEST_REFRESH_OPERATION_LATER)
+        if (!TextUtils.isEmpty(searchQuery) || !user.isPresent) {
+            return
         }
+
+        val syncFolder = Runnable { executeSyncFolderOperation(folder, ignoreETag) }
+
+        // The refresh must not run while another window floats over the activity, e.g. a dialog that is being
+        // dismissed or a rotation. Rather than waiting a fixed delay run right away when it already has focus
+        // and replay the request on the next focus gain.
+        if (ignoreFocus || hasWindowFocus()) {
+            pendingSyncFolderOperation = null
+            syncFolder.run()
+        } else {
+            pendingSyncFolderOperation = syncFolder
+        }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+
+        if (!hasFocus) {
+            return
+        }
+
+        pendingSyncFolderOperation?.let {
+            pendingSyncFolderOperation = null
+            it.run()
+        }
+    }
+
+    private fun executeSyncFolderOperation(folder: OCFile?, ignoreETag: Boolean) {
+        val user = getUser()
+        if (!user.isPresent) {
+            return
+        }
+
+        mSyncInProgress = true
+
+        RefreshFolderOperation(
+            folder,
+            System.currentTimeMillis(),
+            false,
+            ignoreETag,
+            storageManager,
+            user.get(),
+            applicationContext
+        ).execute(
+            account,
+            MainApp.getAppContext(),
+            this@FileDisplayActivity,
+            null,
+            null
+        )
+
+        fetchRecommendedFilesIfNeeded(ignoreETag, folder)
     }
 
     private fun fetchRecommendedFilesIfNeeded(ignoreETag: Boolean, folder: OCFile?) {
@@ -3293,8 +3313,6 @@ class FileDisplayActivity :
 
         @JvmField
         val REQUEST_CODE__SELECT_CONTENT_FROM_APPS_AUTO_RENAME: Int = REQUEST_CODE__LAST_SHARED + 7
-
-        protected val DELAY_TO_REQUEST_REFRESH_OPERATION_LATER: Long = DELAY_TO_REQUEST_OPERATIONS_LATER + 350
 
         private val TAG: String = FileDisplayActivity::class.java.getSimpleName()
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Changes

- Update user profile and oc version after refresh events thus no need to wait those calls since they are not needed for file list
- Remove hardcoded delay to execute refresh folder operation use instead `onWindowFocusChanged`

