### PR TITLE
fix(media): video player returning from background

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -306,10 +306,9 @@ class PreviewImageActivity :
                 // / Refresh the activity according to the Account and OCFile set
                 setFile(file) // reset after getting it fresh from storageManager
                 updateActionBarTitle(getFile()?.fileName)
-                // if (!stateWasRecovered) {
-                initViewPager(optionalUser.get())
-
-                // }
+                if (previewMediaPagerAdapter == null) {
+                    initViewPager(optionalUser.get())
+                }
             } else {
                 // handled file not in the current Account
                 finish()

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -781,13 +781,9 @@ class PreviewMediaActivity :
 
     override fun onStop() {
         Log_OC.v(TAG, "onStop")
-
-        // While the fullscreen dialog is up it renders on its own surface with this player attached to it.
-        // Releasing here leaves that surface bound to a dead player once the task returns to the foreground.
         if (!isFullscreenActive()) {
             releaseVideoPlayer()
         }
-
         super.onStop()
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaActivity.kt
@@ -138,6 +138,7 @@ class PreviewMediaActivity :
     private var videoMediaSession: MediaSession? = null
     private var audioMediaController: MediaController? = null
     private var mediaControllerFuture: ListenableFuture<MediaController>? = null
+    private var fullscreenDialog: PreviewVideoFullscreenDialog? = null
     private lateinit var windowInsetsController: WindowInsetsControllerCompat
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -319,13 +320,13 @@ class PreviewMediaActivity :
 
     override fun onStart() {
         super.onStart()
-
         Log_OC.v(TAG, "onStart")
-
-        if (MimeTypeUtil.isVideo(file)) {
+        if (MimeTypeUtil.isVideo(file) && videoPlayer == null) {
             initializeVideoPlayer()
         }
     }
+
+    private fun isFullscreenActive(): Boolean = fullscreenDialog?.isShowing == true
 
     private fun initializeVideoPlayer() {
         lifecycleScope.launch(Dispatchers.IO) {
@@ -515,10 +516,12 @@ class PreviewMediaActivity :
         )
             .apply {
                 setOnDismissListener {
+                    fullscreenDialog = null
                     setupVideoView()
                 }
             }
 
+        fullscreenDialog = dialog
         dialog.show()
     }
 
@@ -770,6 +773,7 @@ class PreviewMediaActivity :
 
     override fun onDestroy() {
         mediaControllerFuture?.let { MediaController.releaseFuture(it) }
+        releaseVideoPlayer()
         super.onDestroy()
 
         Log_OC.v(TAG, "onDestroy")
@@ -778,7 +782,12 @@ class PreviewMediaActivity :
     override fun onStop() {
         Log_OC.v(TAG, "onStop")
 
-        releaseVideoPlayer()
+        // While the fullscreen dialog is up it renders on its own surface with this player attached to it.
+        // Releasing here leaves that surface bound to a dead player once the task returns to the foreground.
+        if (!isFullscreenActive()) {
+            releaseVideoPlayer()
+        }
+
         super.onStop()
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -187,6 +187,13 @@ class PreviewMediaFragment :
 
     override fun onResume() {
         super.onResume()
+
+        // The fullscreen dialog holds the player on its own surface, re-binding it to this fragment's
+        // view would leave the visible dialog with a detached player.
+        if (isFullscreenActive) {
+            return
+        }
+
         applyWindowInsets()
         prepareMedia()
     }

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -187,13 +187,9 @@ class PreviewMediaFragment :
 
     override fun onResume() {
         super.onResume()
-
-        // The fullscreen dialog holds the player on its own surface, re-binding it to this fragment's
-        // view would leave the visible dialog with a detached player.
         if (isFullscreenActive) {
             return
         }
-
         applyWindowInsets()
         prepareMedia()
     }


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Steps to reproduce

1. Open video file
2. Put in full screen
3. Put app in background
4. Put app in foreground
5. Video not starts where it left off before