### PR TITLE
fix(navigation): search fragment to root

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1054,7 +1054,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         mFile = target;
         setFileDepth(mFile);
 
-        if (mFile.isRootDirectory() && currentSearchType != NO_SEARCH) {
+        if (mFile.isRootDirectory() && currentSearchType != NO_SEARCH && isSearchEventSet(searchEvent)) {
             searchFragment = true;
         }
 


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Steps to reproduce

1. Download a nested folder
2. Open On-device
3. Navigate to the sub folder
4. Press back button
5. Instead of the root of the On-device it still shows sub-folder