### PR TITLE
fix(unified-search): handle slow server search for loader spinner

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapterIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapterIT.kt
@@ -169,7 +169,7 @@ class UnifiedSearchListAdapterIT : AbstractIT() {
             viewThemeUtils = sut.viewThemeUtils,
             currentDirItemAction = noopCurrentDirAction,
             thumbnailGenerator = thumbnailGenerator,
-            user = sut.user.get(),
+            user = sut.user.get()
         )
 
         adapter.shouldShowFooters(true)

--- a/app/src/androidTest/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapterIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapterIT.kt
@@ -21,6 +21,7 @@ import com.owncloud.android.ui.interfaces.UnifiedSearchCurrentDirItemAction
 import com.owncloud.android.ui.interfaces.UnifiedSearchListInterface
 import com.owncloud.android.ui.unifiedsearch.ProviderID
 import com.owncloud.android.ui.unifiedsearch.UnifiedSearchSection
+import com.owncloud.android.ui.unifiedsearch.toUnifiedSearchEntry
 import com.owncloud.android.utils.MimeType
 import com.owncloud.android.utils.ScreenshotTest
 import com.nextcloud.utils.thumbnail.FileThumbnailGenerator
@@ -101,7 +102,7 @@ class UnifiedSearchListAdapterIT : AbstractIT() {
             UnifiedSearchSection(
                 providerID = name.lowercase().replace(" ", "_"),
                 name = name,
-                entries = entries,
+                entries = entries.map { it.toUnifiedSearchEntry(storageManager) },
                 hasMoreResults = false
             )
         }
@@ -111,7 +112,7 @@ class UnifiedSearchListAdapterIT : AbstractIT() {
             UnifiedSearchSection(
                 providerID = name.lowercase().replace(" ", "_"),
                 name = name,
-                entries = entries,
+                entries = entries.map { it.toUnifiedSearchEntry(storageManager) },
                 hasMoreResults = true
             )
         }
@@ -164,12 +165,11 @@ class UnifiedSearchListAdapterIT : AbstractIT() {
                     onClientReady: (com.nextcloud.common.NextcloudClient) -> Unit
                 ) = Unit
             },
-            user = sut.user.get(),
             context = sut,
             viewThemeUtils = sut.viewThemeUtils,
-            appPreferences = preferences,
             currentDirItemAction = noopCurrentDirAction,
-            thumbnailGenerator = thumbnailGenerator
+            thumbnailGenerator = thumbnailGenerator,
+            user = sut.user.get(),
         )
 
         adapter.shouldShowFooters(true)

--- a/app/src/androidTest/java/com/owncloud/android/ui/fragment/UnifiedSearchFragmentIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/ui/fragment/UnifiedSearchFragmentIT.kt
@@ -19,6 +19,7 @@ import com.owncloud.android.AbstractIT
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.lib.common.SearchResultEntry
 import com.owncloud.android.ui.unifiedsearch.UnifiedSearchSection
+import com.owncloud.android.ui.unifiedsearch.toUnifiedSearchEntry
 import com.owncloud.android.ui.unifiedsearch.UnifiedSearchViewModel
 import org.junit.Test
 import java.io.File
@@ -47,7 +48,7 @@ class UnifiedSearchFragmentIT : AbstractIT() {
                                     "http://localhost/nc/index.php/apps/files/?dir=/Files&scrollto=Test",
                                     "icon",
                                     false
-                                )
+                                ).toUnifiedSearchEntry(storageManager)
                             ),
                             hasMoreResults = false
                         )

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchItemViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchItemViewHolder.kt
@@ -15,8 +15,6 @@ import androidx.core.widget.ImageViewCompat
 import com.afollestad.sectionedrecyclerview.SectionedViewHolder
 import com.bumptech.glide.Glide
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
-import com.nextcloud.client.account.User
-import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.common.NextcloudClient
 import com.nextcloud.model.SearchResultEntryType
 import com.nextcloud.utils.CalendarEventManager
@@ -24,28 +22,26 @@ import com.nextcloud.utils.ContactManager
 import com.nextcloud.utils.GlideHelper
 import com.nextcloud.utils.extensions.getType
 import com.nextcloud.utils.extensions.setVisibleIf
+import com.nextcloud.utils.thumbnail.ThumbnailGenerator
 import com.owncloud.android.R
 import com.owncloud.android.databinding.UnifiedSearchItemBinding
-import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.lib.common.SearchResultEntry
 import com.owncloud.android.ui.interfaces.UnifiedSearchListInterface
+import com.owncloud.android.ui.unifiedsearch.UnifiedSearchEntry
 import com.owncloud.android.utils.MimeTypeUtil
-import com.nextcloud.utils.thumbnail.ThumbnailGenerator
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
 @Suppress("LongParameterList")
 class UnifiedSearchItemViewHolder(
     private val supportsOpeningCalendarContactsLocally: Boolean,
     val binding: UnifiedSearchItemBinding,
-    private val storageManager: FileDataStorageManager,
     private val listInterface: UnifiedSearchListInterface,
     private val filesAction: FilesAction,
     val context: Context,
     private val viewThemeUtils: ViewThemeUtils,
     private val thumbnailGenerator: ThumbnailGenerator,
-    private val user: User,
-    private val preferences: AppPreferences
+    private val isE2EEActivate: Boolean
 ) : SectionedViewHolder(binding.root) {
 
     interface FilesAction {
@@ -56,14 +52,17 @@ class UnifiedSearchItemViewHolder(
     private val contactManager = ContactManager(context)
     private val calendarEventManager = CalendarEventManager(context)
 
-    fun bind(entry: SearchResultEntry) {
+    fun bind(unifiedSearchEntry: UnifiedSearchEntry) {
+        val entry = unifiedSearchEntry.searchResult
+        val file = unifiedSearchEntry.localFile
+
         bindTextView(binding.title, entry.title)
         bindTextView(binding.subline, entry.subline)
-        bindLocalFileIndicator(entry)
+        bindLocalFileIndicator(entry, file)
 
         val entryType = entry.getType()
-        bindThumbnail(entry, entryType)
-        bindMoreButton(entry)
+        bindThumbnail(entry, file, entryType)
+        bindMoreButton(entry, file)
         binding.unifiedSearchItemLayout.setOnClickListener {
             searchEntryOnClick(entry, entryType)
         }
@@ -78,14 +77,11 @@ class UnifiedSearchItemViewHolder(
         }
     }
 
-    private fun bindLocalFileIndicator(entry: SearchResultEntry) {
-        val showLocalFileIndicator =
-            (entry.isFile && storageManager.getFileByDecryptedRemotePath(entry.remotePath()) != null)
-        binding.localFileIndicator.setVisibleIf(showLocalFileIndicator)
+    private fun bindLocalFileIndicator(entry: SearchResultEntry, file: OCFile?) {
+        binding.localFileIndicator.setVisibleIf(entry.isFile && file != null)
     }
 
-    private fun bindThumbnail(entry: SearchResultEntry, entryType: SearchResultEntryType) {
-        val file = storageManager.getFileByRemotePath(entry.remotePath())
+    private fun bindThumbnail(entry: SearchResultEntry, file: OCFile?, entryType: SearchResultEntryType) {
         Glide.with(context).clear(binding.thumbnail)
         binding.thumbnailOverlayIcon.setVisibleIf(false)
 
@@ -148,8 +144,8 @@ class UnifiedSearchItemViewHolder(
         }
     }
 
-    private fun bindMoreButton(entry: SearchResultEntry) {
-        if (entry.isFile) {
+    private fun bindMoreButton(entry: SearchResultEntry, file: OCFile?) {
+        if (entry.isFile && file?.isEncrypted == false || (file?.isEncrypted == true && isE2EEActivate)) {
             binding.more.visibility = View.VISIBLE
             binding.more.setOnClickListener {
                 filesAction.showFilesAction(entry)

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchItemViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchItemViewHolder.kt
@@ -145,13 +145,11 @@ class UnifiedSearchItemViewHolder(
     }
 
     private fun bindMoreButton(entry: SearchResultEntry, file: OCFile?) {
-        if (entry.isFile && file?.isEncrypted == false || (file?.isEncrypted == true && isE2EEActivate)) {
-            binding.more.visibility = View.VISIBLE
-            binding.more.setOnClickListener {
-                filesAction.showFilesAction(entry)
-            }
-        } else {
-            binding.more.visibility = View.GONE
+        val isEncryptedWithoutKeys = file?.isEncrypted == true && !isE2EEActivate
+        binding.more.setVisibleIf(entry.isFile && !isEncryptedWithoutKeys)
+
+        binding.more.setOnClickListener {
+            filesAction.showFilesAction(entry)
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchListAdapter.kt
@@ -18,7 +18,7 @@ import com.afollestad.sectionedrecyclerview.SectionedRecyclerViewAdapter
 import com.afollestad.sectionedrecyclerview.SectionedViewHolder
 import com.bumptech.glide.Glide
 import com.nextcloud.client.account.User
-import com.nextcloud.client.preferences.AppPreferences
+import com.nextcloud.utils.thumbnail.ThumbnailGenerator
 import com.owncloud.android.R
 import com.owncloud.android.databinding.UnifiedSearchCurrentDirectoryItemBinding
 import com.owncloud.android.databinding.UnifiedSearchEmptyBinding
@@ -28,11 +28,11 @@ import com.owncloud.android.databinding.UnifiedSearchItemBinding
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
+import com.owncloud.android.ui.helpers.FileOperationsHelper
 import com.owncloud.android.ui.interfaces.UnifiedSearchCurrentDirItemAction
 import com.owncloud.android.ui.interfaces.UnifiedSearchListInterface
 import com.owncloud.android.ui.unifiedsearch.UnifiedSearchSection
 import com.owncloud.android.utils.DisplayUtils
-import com.nextcloud.utils.thumbnail.ThumbnailGenerator
 import com.owncloud.android.utils.theme.ViewThemeUtils
 
 /**
@@ -44,12 +44,11 @@ class UnifiedSearchListAdapter(
     private val storageManager: FileDataStorageManager,
     private val listInterface: UnifiedSearchListInterface,
     private val filesAction: UnifiedSearchItemViewHolder.FilesAction,
-    private val user: User,
     private val context: Context,
     private val viewThemeUtils: ViewThemeUtils,
-    private val appPreferences: AppPreferences,
     private val currentDirItemAction: UnifiedSearchCurrentDirItemAction,
-    private val thumbnailGenerator: ThumbnailGenerator
+    private val thumbnailGenerator: ThumbnailGenerator,
+    private val user: User
 ) : SectionedRecyclerViewAdapter<SectionedViewHolder>() {
     companion object {
         private const val VIEW_TYPE_EMPTY = Int.MAX_VALUE
@@ -77,7 +76,7 @@ class UnifiedSearchListAdapter(
             val index = getSectionIndex(section)
             sections.getOrNull(index)
                 ?.entries
-                ?.getOrNull(position)?.hashCode()?.toLong() ?: RecyclerView.NO_ID
+                ?.getOrNull(position)?.searchResult?.hashCode()?.toLong() ?: RecyclerView.NO_ID
         }
     }
 
@@ -132,14 +131,12 @@ class UnifiedSearchListAdapter(
                 UnifiedSearchItemViewHolder(
                     supportsOpeningCalendarContactsLocally,
                     binding,
-                    storageManager,
                     listInterface,
                     filesAction,
                     context,
                     viewThemeUtils,
                     thumbnailGenerator,
-                    user,
-                    appPreferences
+                    FileOperationsHelper.isEndToEndEncryptionSetup(context, user)
                 )
             }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -400,12 +400,11 @@ class UnifiedSearchFragment :
             storageManager,
             this@UnifiedSearchFragment,
             this@UnifiedSearchFragment,
-            currentAccountProvider.user,
             requireContext(),
             viewThemeUtils,
-            appPreferences,
             this@UnifiedSearchFragment,
-            thumbnailGenerator
+            thumbnailGenerator,
+            currentAccountProvider.user
         )
 
         adapter.shouldShowFooters(true)

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -41,6 +41,7 @@ import com.nextcloud.utils.extensions.getTypedActivity
 import com.nextcloud.utils.extensions.searchFilesByName
 import com.nextcloud.utils.extensions.setVisibleIf
 import com.nextcloud.utils.extensions.typedActivity
+import com.nextcloud.utils.thumbnail.ThumbnailGenerator
 import com.owncloud.android.R
 import com.owncloud.android.databinding.ListFragmentBinding
 import com.owncloud.android.datamodel.FileDataStorageManager
@@ -62,12 +63,14 @@ import com.owncloud.android.ui.unifiedsearch.UnifiedSearchViewModel
 import com.owncloud.android.ui.unifiedsearch.filterOutHiddenFiles
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.PermissionUtil
-import com.nextcloud.utils.thumbnail.ThumbnailGenerator
 import com.owncloud.android.utils.theme.ViewThemeUtils
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Starts query to all capable unified search providers and displays them Opens result in our app, redirect to other
@@ -93,6 +96,7 @@ class UnifiedSearchFragment :
         private const val ARG_QUERY = "ARG_QUERY"
         private const val ARG_HIDDEN_FILES = "ARG_HIDDEN_FILES"
         private const val CURRENT_DIR_PATH = "CURRENT_DIR"
+        private const val SEARCH_TIMEOUT_MS = 30_000L
 
         fun newInstance(
             query: String?,
@@ -143,6 +147,7 @@ class UnifiedSearchFragment :
     private var showMoreActions = false
     private var currentDir: OCFile? = null
     private var initialQuery: String? = null
+    private var searchJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -319,6 +324,11 @@ class UnifiedSearchFragment :
         vm.searchResults.observe(viewLifecycleOwner, this::onSearchResultChanged)
         vm.isLoading.observe(viewLifecycleOwner) { loading ->
             binding.swipeContainingList.isRefreshing = loading
+            if (loading) {
+                startSearchTimeout()
+            } else {
+                searchJob?.cancel()
+            }
         }
         vm.screenState.observe(viewLifecycleOwner) {
             handleScreenState(it)
@@ -350,6 +360,19 @@ class UnifiedSearchFragment :
         }
         vm.file.observe(viewLifecycleOwner) {
             showFile(it, showMoreActions)
+        }
+    }
+
+    private fun startSearchTimeout() {
+        searchJob?.cancel()
+        searchJob = viewLifecycleOwner.lifecycleScope.launch {
+            delay(SEARCH_TIMEOUT_MS.milliseconds)
+            val currentBinding = _binding ?: return@launch
+            currentBinding.swipeContainingList.isRefreshing = false
+            DisplayUtils.showSnackMessage(
+                currentBinding.root,
+                R.string.unified_search_fragment_search_takes_long
+            )
         }
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchEntry.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchEntry.kt
@@ -1,0 +1,16 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.ui.unifiedsearch
+
+import com.owncloud.android.datamodel.FileDataStorageManager
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.lib.common.SearchResultEntry
+
+data class UnifiedSearchEntry(val searchResult: SearchResultEntry, val localFile: OCFile?)
+
+fun SearchResultEntry.toUnifiedSearchEntry(storageManager: FileDataStorageManager): UnifiedSearchEntry =
+    UnifiedSearchEntry(this, storageManager.getFileByRemotePath(remotePath()))

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchModel.kt
@@ -7,21 +7,19 @@
  */
 package com.owncloud.android.ui.unifiedsearch
 
-import com.owncloud.android.lib.common.SearchResultEntry
-
 typealias ProviderID = String
 
 data class UnifiedSearchSection(
     val providerID: ProviderID,
     val name: String,
-    val entries: List<SearchResultEntry>,
+    val entries: List<UnifiedSearchEntry>,
     val hasMoreResults: Boolean
 )
 
 fun List<UnifiedSearchSection>.filterOutHiddenFiles(listOfHiddenFiles: List<String>): List<UnifiedSearchSection> =
     map { searchSection ->
         val entriesWithoutHiddenFiles = searchSection.entries.filterNot { entry ->
-            listOfHiddenFiles.contains(entry.title)
+            listOfHiddenFiles.contains(entry.searchResult.title)
         }
 
         searchSection.copy(entries = entriesWithoutHiddenFiles)

--- a/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
+++ b/app/src/main/java/com/owncloud/android/ui/unifiedsearch/UnifiedSearchViewModel.kt
@@ -28,6 +28,9 @@ import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.ui.asynctasks.GetRemoteFileTask
 import com.owncloud.android.ui.fragment.UnifiedSearchFragmentScreenState
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Suppress("LongParameterList")
 class UnifiedSearchViewModel(application: Application) :
@@ -54,6 +57,7 @@ class UnifiedSearchViewModel(application: Application) :
 
     private lateinit var repository: IUnifiedSearchRepository
     private var results: MutableMap<ProviderID, UnifiedSearchMetadata> = mutableMapOf()
+    private var searchResultsVersion = 0
 
     override val screenState: MutableLiveData<UnifiedSearchFragmentScreenState> =
         MutableLiveData(UnifiedSearchFragmentScreenState.ShowingContent)
@@ -93,6 +97,7 @@ class UnifiedSearchViewModel(application: Application) :
     override fun initialQuery() {
         doWithConnectivityCheck {
             results = mutableMapOf()
+            searchResultsVersion++
             searchResults.value = mutableListOf()
             val queryTerm = query.value.orEmpty()
 
@@ -197,16 +202,35 @@ class UnifiedSearchViewModel(application: Application) :
     }
 
     private fun genSearchResultsFromMeta() {
-        searchResults.value = results
+        val snapshot = results
             .filter { it.value.results.isNotEmpty() }
-            .map { (key, value) ->
-                val isLastEntryHaveValue = results[key]?.results?.last()?.entries?.isEmpty() != true
+            .mapValues { (_, metadata) -> metadata.copy(results = metadata.results.toMutableList()) }
 
+        val version = ++searchResultsVersion
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val sections = buildSections(snapshot)
+
+            withContext(Dispatchers.Main) {
+                if (version == searchResultsVersion) {
+                    searchResults.value = sections
+                }
+            }
+        }
+    }
+
+    private fun buildSections(snapshot: Map<ProviderID, UnifiedSearchMetadata>): List<UnifiedSearchSection> {
+        val storageManager = FileDataStorageManager(currentAccountProvider.user, context.contentResolver)
+
+        return snapshot
+            .map { (providerID, metadata) ->
                 UnifiedSearchSection(
-                    providerID = key,
-                    name = value.name()!!,
-                    entries = value.results.flatMap { it.entries },
-                    hasMoreResults = isLastEntryHaveValue && results[key]?.nextCursor() != null
+                    providerID = providerID,
+                    name = metadata.name()!!,
+                    entries = metadata.results
+                        .flatMap { it.entries }
+                        .map { it.toUnifiedSearchEntry(storageManager) },
+                    hasMoreResults = metadata.results.last().entries.isNotEmpty() && metadata.nextCursor() != null
                 )
             }
             .sortedWith { o1, o2 ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1458,6 +1458,7 @@
     <string name="unified_search_fragment_calendar_event_not_found">Event not found, you can always sync to update. Redirecting to web…</string>
     <string name="unified_search_fragment_contact_not_found">Contact not found, you can always sync to update. Redirecting to web…</string>
     <string name="unified_search_fragment_permission_needed">Permissions are required to open search result otherwise it will redirected to web…</string>
+    <string name="unified_search_fragment_search_takes_long">Search is taking longer than usual. Results will appear as soon as the server responds</string>
     <string name="file_name_validator_current_path_is_invalid">Current folder name is invalid, please rename the folder. Redirecting home…</string>
     <string name="file_name_validator_rename_before_move_or_copy">%s. Please rename the file before moving or copying</string>
     <string name="file_name_validator_error_contains_reserved_names_or_invalid_characters">Folder path contains reserved names or invalid characters</string>


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

In slow server instance spinner always showed and files are loading in main thread.

### Changes

Loading spinner has max ceiling value
Loads the file in IO thread
Bind function directly takes `OCFile` thus no need for each bind database operation