### PR TITLE
feat(auth): add direct login with app-specific password (#15739)

### DIFF
--- a/app/src/androidTest/java/com/owncloud/android/authentication/DirectLoginIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/authentication/DirectLoginIT.kt
@@ -1,0 +1,153 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.authentication
+
+import android.accounts.AccountManager
+import android.view.KeyEvent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.pressKey
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nextcloud.client.account.UserAccountManagerImpl
+import com.nextcloud.test.RetryTestRule
+import com.owncloud.android.AbstractOnServerIT
+import com.owncloud.android.R
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@LargeTest
+class DirectLoginIT : AbstractOnServerIT() {
+
+    @get:Rule
+    var retryTestRule = RetryTestRule()
+
+    private lateinit var scenario: ActivityScenario<AuthenticatorActivity>
+
+    @Before
+    fun setUp() {
+        AccountManager.get(targetContext).removeAccountExplicitly(account)
+        scenario = ActivityScenario.launch(AuthenticatorActivity::class.java)
+    }
+
+    @After
+    override fun after() {
+        scenario.close()
+        AccountManager.get(targetContext).removeAccountExplicitly(account)
+        super.after()
+    }
+
+    @Test
+    fun directLoginSectionHiddenInitially() {
+        onView(withId(R.id.direct_login_section)).check(matches(not(isDisplayed())))
+        onView(withId(R.id.direct_login_toggle)).check(matches(not(isDisplayed())))
+        onView(withId(R.id.browser_login_button)).check(matches(not(isDisplayed())))
+    }
+
+    @Test
+    fun directLoginToggleAppearsAfterServerValidation() {
+        submitServerUrl()
+
+        onView(withId(R.id.direct_login_toggle)).check(matches(isDisplayed()))
+        onView(withId(R.id.browser_login_button)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun directLoginShowsFormOnToggleClick() {
+        showDirectLoginForm()
+
+        onView(withId(R.id.direct_login_section)).check(matches(isDisplayed()))
+        onView(withId(R.id.direct_login_username)).check(matches(isDisplayed()))
+        onView(withId(R.id.direct_login_password)).check(matches(isDisplayed()))
+        onView(withId(R.id.direct_login_button)).check(matches(isDisplayed()))
+        onView(withId(R.id.browser_login_button)).check(matches(not(isDisplayed())))
+    }
+
+    @Test
+    fun directLoginEmptyFieldsShowsErrors() {
+        showDirectLoginForm()
+        onView(withId(R.id.direct_login_button)).perform(click())
+
+        onView(withText(R.string.direct_login_username_required)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun directLoginEmptyPasswordShowsError() {
+        showDirectLoginForm()
+        onView(withId(R.id.direct_login_username)).perform(typeText("testuser"), closeSoftKeyboard())
+        onView(withId(R.id.direct_login_button)).perform(click())
+
+        onView(withText(R.string.direct_login_password_required)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun directLoginWrongCredentialsShowsError() {
+        showDirectLoginForm()
+        onView(withId(R.id.direct_login_username)).perform(typeText("wronguser"), closeSoftKeyboard())
+        onView(withId(R.id.direct_login_password)).perform(typeText("wrongpass"), closeSoftKeyboard())
+        onView(withId(R.id.direct_login_button)).perform(click())
+        Thread.sleep(AUTHENTICATION_DELAY_MILLIS)
+
+        onView(withText(R.string.auth_unauthorized)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun directLoginWithValidAppPasswordCreatesAccount() {
+        showDirectLoginForm()
+        onView(withId(R.id.direct_login_username)).perform(typeText(testServerUsername()), closeSoftKeyboard())
+        onView(withId(R.id.direct_login_password)).perform(typeText(testServerAppPassword()), closeSoftKeyboard())
+        onView(withId(R.id.direct_login_button)).perform(click())
+        Thread.sleep(AUTHENTICATION_DELAY_MILLIS)
+
+        assertTrue(UserAccountManagerImpl.fromContext(targetContext).accounts.isNotEmpty())
+    }
+
+    private fun showDirectLoginForm() {
+        submitServerUrl()
+        onView(withId(R.id.direct_login_toggle)).perform(click())
+    }
+
+    private fun submitServerUrl() {
+        onView(withId(R.id.host_url_input)).perform(
+            typeText(testServerUrl()),
+            pressKey(KeyEvent.KEYCODE_ENTER),
+            closeSoftKeyboard()
+        )
+        Thread.sleep(SERVER_VALIDATION_DELAY_MILLIS)
+    }
+
+    private fun testServerUrl(): String = testServerArgument("TEST_SERVER_URL", "server URL")
+
+    private fun testServerUsername(): String = testServerArgument("TEST_SERVER_USERNAME", "username")
+
+    private fun testServerAppPassword(): String =
+        testServerArgument("TEST_SERVER_PASSWORD", "dedicated test user's app-specific password")
+
+    private fun testServerArgument(argumentName: String, description: String): String {
+        val value = InstrumentationRegistry.getArguments().getString(argumentName)
+        require(!value.isNullOrBlank() && value != "null") {
+            "$argumentName must be configured with the $description"
+        }
+        return value
+    }
+
+    companion object {
+        private const val SERVER_VALIDATION_DELAY_MILLIS = 5_000L
+        private const val AUTHENTICATION_DELAY_MILLIS = 10_000L
+    }
+}

--- a/app/src/androidTest/java/com/owncloud/android/authentication/DirectLoginScreenshotIT.kt
+++ b/app/src/androidTest/java/com/owncloud/android/authentication/DirectLoginScreenshotIT.kt
@@ -1,0 +1,41 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.authentication
+
+import android.view.View
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import com.owncloud.android.AbstractIT
+import com.owncloud.android.utils.ScreenshotTest
+import org.junit.Test
+
+class DirectLoginScreenshotIT : AbstractIT() {
+    private val testClassName = "com.owncloud.android.authentication.DirectLoginScreenshotIT"
+
+    @Test
+    @ScreenshotTest
+    fun directLoginForm() {
+        ActivityScenario.launch(AuthenticatorActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.accountSetupBinding.apply {
+                    hostUrlInput.setText("https://cloud.example.com")
+                    requireNotNull(browserLoginButton).visibility = View.GONE
+                    requireNotNull(directLoginToggle).visibility = View.GONE
+                    requireNotNull(directLoginSection).visibility = View.VISIBLE
+                }
+            }
+
+            onView(isRoot()).check(matches(isDisplayed()))
+            scenario.onActivity { activity ->
+                screenshotViaName(activity, createName("${testClassName}_directLoginForm", ""))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/app/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -178,6 +178,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     private static final String KEY_USERNAME = "USERNAME";
     private static final String KEY_PASSWORD = "PASSWORD";
     private static final String KEY_ASYNC_TASK_IN_PROGRESS = "AUTH_IN_PROGRESS";
+    private static final String KEY_DIRECT_LOGIN_ACTIVE = "DIRECT_LOGIN_ACTIVE";
 
     public static final String WEB_LOGIN = "/index.php/login/v2";
 
@@ -298,6 +299,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         if (savedInstanceState != null) {
             mWaitingForOpId = savedInstanceState.getLong(KEY_WAITING_FOR_OP_ID);
             mIsFirstAuthAttempt = savedInstanceState.getBoolean(KEY_AUTH_IS_FIRST_ATTEMPT_TAG);
+            isDirectLoginActive = savedInstanceState.getBoolean(KEY_DIRECT_LOGIN_ACTIVE);
         }
 
         boolean webViewLoginMethod = false;
@@ -404,6 +406,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     private final ScheduledExecutorService loginFlowExecutorService = Executors.newSingleThreadScheduledExecutor();
     private boolean isLoginProcessCompleted = false;
     private boolean isRedirectedToTheDefaultBrowser = false;
+    private boolean isDirectLoginActive = false;
     private String baseUrl;
 
     private void poolLogin() {
@@ -805,6 +808,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
         /// authentication
         outState.putBoolean(KEY_AUTH_IS_FIRST_ATTEMPT_TAG, mIsFirstAuthAttempt);
+        outState.putBoolean(KEY_DIRECT_LOGIN_ACTIVE, isDirectLoginActive);
 
         /// AsyncTask (User and password)
         if (mAsyncTask != null) {
@@ -1024,6 +1028,74 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         mAsyncTask.execute(params);
     }
 
+    private void showLoginChoice() {
+        if (accountSetupBinding == null) {
+            return;
+        }
+        accountSetupBinding.browserLoginButton.setVisibility(View.VISIBLE);
+        accountSetupBinding.directLoginToggle.setVisibility(View.VISIBLE);
+        accountSetupBinding.browserLoginButton.setOnClickListener(v -> launchBrowserLogin());
+        accountSetupBinding.directLoginToggle.setOnClickListener(v -> {
+            isDirectLoginActive = true;
+            accountSetupBinding.browserLoginButton.setVisibility(View.GONE);
+            showDirectLoginSection();
+        });
+    }
+
+    private void showDirectLoginSection() {
+        if (accountSetupBinding == null) {
+            return;
+        }
+        accountSetupBinding.directLoginToggle.setVisibility(View.GONE);
+        accountSetupBinding.directLoginSection.setVisibility(View.VISIBLE);
+        accountSetupBinding.directLoginButton.setOnClickListener(v -> performDirectLogin());
+        accountSetupBinding.directLoginUsername.requestFocus();
+    }
+
+    private void launchBrowserLogin() {
+        accountSetupWebviewBinding = AccountSetupWebviewBinding.inflate(getLayoutInflater());
+        setContentView(accountSetupWebviewBinding.getRoot());
+
+        if (!isLoginProcessCompleted) {
+            if (!isRedirectedToTheDefaultBrowser) {
+                anonymouslyPostLoginRequest(mServerInfo.mBaseUrl + WEB_LOGIN);
+                isRedirectedToTheDefaultBrowser = true;
+            } else {
+                initLoginInfoView();
+            }
+        }
+    }
+
+    private void performDirectLogin() {
+        if (accountSetupBinding == null) {
+            return;
+        }
+
+        CharSequence username = accountSetupBinding.directLoginUsername.getText();
+        CharSequence password = accountSetupBinding.directLoginPassword.getText();
+        DirectLoginCredentials credentials = new DirectLoginCredentials(
+            username == null ? null : username.toString(),
+            password == null ? null : password.toString()
+        );
+
+        if (credentials.isUsernameEmpty()) {
+            accountSetupBinding.directLoginUsernameContainer.setError(getString(R.string.direct_login_username_required));
+            return;
+        }
+
+        if (credentials.isPasswordEmpty()) {
+            accountSetupBinding.directLoginPasswordContainer.setError(getString(R.string.direct_login_password_required));
+            return;
+        }
+
+        accountSetupBinding.directLoginUsernameContainer.setError(null);
+        accountSetupBinding.directLoginPasswordContainer.setError(null);
+
+        webViewUser = credentials.getUsername();
+        webViewPassword = credentials.getPassword();
+        checkBasicAuthorization(webViewUser, webViewPassword);
+    }
+
     /**
      * Callback method invoked when a RemoteOperation executed by this Activity finishes.
      * <p>
@@ -1093,18 +1165,10 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             if (webViewUser != null && !webViewUser.isEmpty() &&
                 webViewPassword != null && !webViewPassword.isEmpty()) {
                 checkBasicAuthorization(webViewUser, webViewPassword);
+            } else if (isDirectLoginActive) {
+                showDirectLoginSection();
             } else {
-                accountSetupWebviewBinding = AccountSetupWebviewBinding.inflate(getLayoutInflater());
-                setContentView(accountSetupWebviewBinding.getRoot());
-
-                if (!isLoginProcessCompleted) {
-                    if (!isRedirectedToTheDefaultBrowser) {
-                        anonymouslyPostLoginRequest(mServerInfo.mBaseUrl + WEB_LOGIN);
-                        isRedirectedToTheDefaultBrowser = true;
-                    } else {
-                        initLoginInfoView();
-                    }
-                }
+                showLoginChoice();
             }
         } else {
             updateServerStatusIconAndText(result);
@@ -1385,7 +1449,11 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
             }
 
         } else {    // authorization fail due to client side - probably wrong credentials
-            if (accountSetupWebviewBinding != null) {
+            if (isDirectLoginActive) {
+                mAuthStatusIcon = R.drawable.ic_alert;
+                mAuthStatusText = getString(R.string.auth_unauthorized);
+                showAuthStatus();
+            } else if (accountSetupWebviewBinding != null) {
                 anonymouslyPostLoginRequest(mServerInfo.mBaseUrl + WEB_LOGIN);
             } else {
                 DisplayUtils.showSnackMessage(this, R.string.auth_access_failed, result.getLogMessage(this));

--- a/app/src/main/java/com/owncloud/android/authentication/DirectLoginCredentials.java
+++ b/app/src/main/java/com/owncloud/android/authentication/DirectLoginCredentials.java
@@ -1,0 +1,37 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.authentication;
+
+public final class DirectLoginCredentials {
+    private final String username;
+    private final String password;
+
+    public DirectLoginCredentials(String username, String password) {
+        this.username = normalize(username);
+        this.password = normalize(password);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public boolean isUsernameEmpty() {
+        return username.isEmpty();
+    }
+
+    public boolean isPasswordEmpty() {
+        return password.isEmpty();
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/app/src/main/res/layout/account_setup.xml
+++ b/app/src/main/res/layout/account_setup.xml
@@ -132,6 +132,98 @@
                 android:textColor="@color/login_text_color"
                 app:drawableStartCompat="@android:drawable/stat_notify_sync" />
 
+            <LinearLayout
+                android:id="@+id/direct_login_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/direct_login_username_container"
+                    style="@style/Widget.App.Login.TextInputLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_padding"
+                    android:hint="@string/direct_login_username_hint"
+                    android:theme="@style/TextInputLayoutLogin">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/direct_login_username"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:lines="1"
+                        android:minLines="1"
+                        android:paddingStart="@dimen/standard_padding"
+                        android:paddingEnd="@dimen/standard_padding"
+                        android:textColor="@color/login_text_color" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/direct_login_password_helper"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_half_padding"
+                    android:paddingStart="@dimen/standard_padding"
+                    android:paddingEnd="@dimen/standard_padding"
+                    android:text="@string/direct_login_password_helper_text"
+                    android:textColor="@color/white_helper_text"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/direct_login_password_container"
+                    style="@style/Widget.App.Login.TextInputLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_quarter_padding"
+                    android:hint="@string/direct_login_password_hint"
+                    android:theme="@style/TextInputLayoutLogin"
+                    app:endIconMode="password_toggle"
+                    app:endIconTint="@color/login_text_color">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/direct_login_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textPassword"
+                        android:lines="1"
+                        android:minLines="1"
+                        android:paddingStart="@dimen/standard_padding"
+                        android:paddingEnd="@dimen/standard_padding"
+                        android:textColor="@color/login_text_color" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/direct_login_button"
+                    style="@style/OutlineLoginButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_padding"
+                    android:text="@string/direct_login_button_label" />
+
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/browser_login_button"
+                style="@style/OutlineLoginButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_padding"
+                android:text="@string/browser_login_button_label"
+                android:visibility="gone" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/direct_login_toggle"
+                style="@style/Button.Borderless.Login"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_half_padding"
+                android:text="@string/direct_login_toggle_label"
+                android:visibility="gone" />
+
             <ImageButton
                 android:id="@+id/scan_qr"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -446,6 +446,15 @@
     <string name="authenticator_activity_please_complete_login_process">Please complete login process in your browser</string>
     <string name="authenticator_activity_login_error">There was an issue processing your login request. Please try again later.</string>
 
+    <string name="direct_login_username_hint">Username</string>
+    <string name="direct_login_password_hint">App password</string>
+    <string name="direct_login_password_helper_text">Do not enter your main password here. Use an app-specific password generated in your server\'s Security settings.</string>
+    <string name="direct_login_button_label">Log in</string>
+    <string name="direct_login_toggle_label">Use app password</string>
+    <string name="direct_login_username_required">Username is required</string>
+    <string name="direct_login_password_required">App password is required</string>
+    <string name="browser_login_button_label">Log in with browser</string>
+
     <string name="favorite">Add to favorites</string>
     <string name="unset_favorite">Remove from favorites</string>
     <string name="encrypted">Set as encrypted</string>

--- a/app/src/test/java/com/owncloud/android/authentication/DirectLoginCredentialsTest.java
+++ b/app/src/test/java/com/owncloud/android/authentication/DirectLoginCredentialsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.authentication;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DirectLoginCredentialsTest {
+    @Test
+    public void trimsCredentials() {
+        DirectLoginCredentials credentials = new DirectLoginCredentials(" user ", " app password ");
+
+        Assert.assertEquals("user", credentials.getUsername());
+        Assert.assertEquals("app password", credentials.getPassword());
+    }
+
+    @Test
+    public void usernameIsEmptyWhenMissing() {
+        DirectLoginCredentials credentials = new DirectLoginCredentials("  ", "app password");
+
+        Assert.assertTrue(credentials.isUsernameEmpty());
+        Assert.assertFalse(credentials.isPasswordEmpty());
+    }
+
+    @Test
+    public void passwordIsEmptyWhenMissing() {
+        DirectLoginCredentials credentials = new DirectLoginCredentials("user", null);
+
+        Assert.assertFalse(credentials.isUsernameEmpty());
+        Assert.assertTrue(credentials.isPasswordEmpty());
+    }
+}


### PR DESCRIPTION
Allow users to log in directly with username and app password without requiring an external browser. After server URL validation, two options are presented: browser login or app password login.

This benefits devices without a full browser available.

Fixes #15739

Assisted-by: Kiro:claude-sonnet-4-20250514

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="500" height="833" alt="nextcloud-dev-500x833-160dpi-login" src="https://github.com/user-attachments/assets/af64edd4-f209-422c-abce-1450e09debba" /> | <img width="500" height="833" alt="screenshot_login_after" src="https://github.com/user-attachments/assets/cc88b3e4-1016-4fc8-81f6-4e020d56f5c4" />

### 🏁 Checklist
- ⛑️ Tests (unit and integration) are included
- 🔙 Backport requests are not needed
- 📅 Milestone is not needed
- 🌸 PR title is meaningful

## 🤖 AI
- The content of this PR was partly or fully generated using AI
