### PR TITLE
Hide the bottom navigation bar when a text file preview is shown

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1380,6 +1380,7 @@ class FileDisplayActivity :
         binding.fabMain.setImageResource(R.drawable.ic_plus)
         resetScrolling(true)
         showSortListGroup(false)
+        showBottomNavigationBar(true)
         supportFragmentManager.popBackStack()
     }
 
@@ -2821,6 +2822,7 @@ class FileDisplayActivity :
             val fragment = PreviewTextFileFragment.create(user, file, searchOpen, searchQuery)
             setLeftFragment(fragment, false)
             configureToolbarForPreview(file)
+            showBottomNavigationBar(false)
         } else {
             val previewIntent = Intent()
             previewIntent.putExtra(EXTRA_FILE, file)


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/17495

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/b3bd2fde-20f8-4da9-accb-d34f72dc1308" /> | <img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/89f7e5fe-4075-436a-be7b-a6968dbadc28" />


### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## Changes

This hides the bottom navigation bar that was covering part of a previewed text file.

How to reproduce:
- download a text file
- open it
- note the bottom bar over the text (on master)