### PR TITLE
perf(file-list): db pagination

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
+++ b/app/src/main/java/com/nextcloud/client/database/dao/FileDao.kt
@@ -41,11 +41,31 @@ interface FileDao {
     @Query("SELECT * FROM filelist WHERE remote_id = :remoteId LIMIT 1")
     suspend fun getFileByRemoteId(remoteId: String): FileEntity?
 
-    @Query("SELECT * FROM filelist WHERE parent = :parentId ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}")
-    fun getFolderContent(parentId: Long): List<FileEntity>
+    @Query(
+        """
+    SELECT ${ProviderTableMeta._ID}
+    FROM filelist
+    WHERE parent = :parentId
+    ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}
+    """
+    )
+    fun getFolderContentIds(parentId: Long): List<Long>
 
-    @Query("SELECT * FROM filelist WHERE parent = :parentId ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}")
-    suspend fun getFolderContentSuspended(parentId: Long): List<FileEntity>
+    @Query(
+        """
+    SELECT ${ProviderTableMeta._ID}
+    FROM filelist
+    WHERE parent = :parentId
+    ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}
+    """
+    )
+    suspend fun getFolderContentIdsSuspended(parentId: Long): List<Long>
+
+    @Query("SELECT * FROM filelist WHERE ${ProviderTableMeta._ID} IN (:ids)")
+    fun getFilesByIds(ids: List<Long>): List<FileEntity>
+
+    @Query("SELECT * FROM filelist WHERE ${ProviderTableMeta._ID} IN (:ids)")
+    suspend fun getFilesByIdsSuspended(ids: List<Long>): List<FileEntity>
 
     @Query(
         "SELECT * FROM filelist WHERE modified >= :startDate" +
@@ -145,7 +165,7 @@ interface FileDao {
 
     @Query(
         """
-    SELECT *
+    SELECT ${ProviderTableMeta._ID}
     FROM filelist
     WHERE file_owner = :accountName
       AND (
@@ -156,18 +176,18 @@ interface FileDao {
     ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}
     """
     )
-    suspend fun getSharedFiles(accountName: String): List<FileEntity>
+    suspend fun getSharedFileIds(accountName: String): List<Long>
 
     @Query(
         """
-    SELECT * 
+    SELECT ${ProviderTableMeta._ID}
     FROM filelist 
     WHERE file_owner = :fileOwner 
       AND favorite = 1
     ORDER BY ${ProviderTableMeta.FILE_DEFAULT_SORT_ORDER}
     """
     )
-    suspend fun getFavoriteFiles(fileOwner: String): List<FileEntity>
+    suspend fun getFavoriteFileIds(fileOwner: String): List<Long>
 
     @Query(
         """

--- a/app/src/main/java/com/nextcloud/utils/extensions/FileDataStorageManagerExtensions.kt
+++ b/app/src/main/java/com/nextcloud/utils/extensions/FileDataStorageManagerExtensions.kt
@@ -8,6 +8,7 @@
 package com.nextcloud.utils.extensions
 
 import com.nextcloud.client.database.dao.FileDao
+import com.nextcloud.client.database.entity.FileEntity
 import com.nextcloud.client.database.entity.model.ShareeKey
 import com.nextcloud.client.database.entity.toOCCapability
 import com.owncloud.android.datamodel.FileDataStorageManager
@@ -248,4 +249,29 @@ private fun FileDao.moveFilesInDb(
 
     updateAll(updated)
     return originalMediaPaths
+}
+
+private const val FILE_ID_CHUNK_SIZE = 100
+
+private fun List<Long>.toEntitiesInOrder(loadChunk: (List<Long>) -> List<FileEntity>): List<FileEntity> {
+    val byId = chunked(FILE_ID_CHUNK_SIZE).flatMap(loadChunk).associateBy { it.id }
+    return mapNotNull { byId[it] }
+}
+
+fun FileDataStorageManager.getFolderContentEntities(parentId: Long): List<FileEntity> =
+    fileDao.getFolderContentIds(parentId).toEntitiesInOrder(fileDao::getFilesByIds)
+
+suspend fun FileDataStorageManager.getFolderContentEntitiesSuspended(parentId: Long): List<FileEntity> =
+    fileDao.getFolderContentIdsSuspended(parentId).toEntitiesInOrderSuspended(this)
+
+suspend fun FileDataStorageManager.getSharedFileEntities(accountName: String): List<FileEntity> =
+    fileDao.getSharedFileIds(accountName).toEntitiesInOrderSuspended(this)
+
+suspend fun FileDataStorageManager.getFavoriteFileEntities(accountName: String): List<FileEntity> =
+    fileDao.getFavoriteFileIds(accountName).toEntitiesInOrderSuspended(this)
+
+private suspend fun List<Long>.toEntitiesInOrderSuspended(storageManager: FileDataStorageManager): List<FileEntity> {
+    val entities = chunked(FILE_ID_CHUNK_SIZE).flatMap { storageManager.fileDao.getFilesByIdsSuspended(it) }
+    val byId = entities.associateBy { it.id }
+    return mapNotNull { byId[it] }
 }

--- a/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1216,7 +1216,7 @@ public class FileDataStorageManager {
         Log_OC.d(TAG, "getFolderContent - start");
         List<OCFile> folderContent = new ArrayList<>();
 
-        List<FileEntity> files = fileDao.getFolderContent(parentId);
+        List<FileEntity> files = FileDataStorageManagerExtensionsKt.getFolderContentEntities(this, parentId);
         for (FileEntity fileEntity : files) {
             OCFile child = createFileInstance(fileEntity);
             if (!onlyOnDevice || child.existsOnDevice()) {

--- a/app/src/main/java/com/owncloud/android/datamodel/OCFileListAdapterDataProviderImpl.kt
+++ b/app/src/main/java/com/owncloud/android/datamodel/OCFileListAdapterDataProviderImpl.kt
@@ -8,6 +8,7 @@
 package com.owncloud.android.datamodel
 
 import com.nextcloud.client.database.entity.FileEntity
+import com.nextcloud.utils.extensions.getFolderContentEntitiesSuspended
 import com.owncloud.android.ui.adapter.helper.OCFileListAdapterDataProvider
 
 @Suppress("ReturnCount")
@@ -17,7 +18,7 @@ class OCFileListAdapterDataProviderImpl(private val storageManager: FileDataStor
         storageManager.offlineOperationsRepository.convertToOCFiles(id)
 
     override suspend fun getFolderContent(id: Long): List<FileEntity> =
-        storageManager.fileDao.getFolderContentSuspended(id)
+        storageManager.getFolderContentEntitiesSuspended(id)
 
     override fun createFileInstance(entity: FileEntity): OCFile = storageManager.createFileInstance(entity)
 }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListSearchTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListSearchTask.kt
@@ -15,6 +15,8 @@ import android.content.ContentValues
 import androidx.lifecycle.lifecycleScope
 import com.nextcloud.client.account.User
 import com.nextcloud.client.preferences.AppPreferences
+import com.nextcloud.utils.extensions.getFavoriteFileEntities
+import com.nextcloud.utils.extensions.getSharedFileEntities
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.datamodel.OCFile
@@ -113,9 +115,9 @@ class OCFileListSearchTask(
         fragment: OCFileListFragment
     ): List<OCFile> {
         val files = if (searchType == SearchRemoteOperation.SearchType.SHARED_FILTER) {
-            storageManager.fileDao.getSharedFiles(currentUser.accountName)
+            storageManager.getSharedFileEntities(currentUser.accountName)
         } else {
-            storageManager.fileDao.getFavoriteFiles(currentUser.accountName)
+            storageManager.getFavoriteFileEntities(currentUser.accountName)
         }.mapNotNull { storageManager.createFileInstance(it) }
 
         return sortSearchData(files, fragmentSearchType, fragment)


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

When user have a lot of files and/or folder in directory app crashes. Due to fetching all files at once from DB.


```json
{
      "header": {
        "logLevel": "ERROR",
        "pid": 7829,
        "tid": 7849,
        "applicationId": "com.nextcloud.client",
        "processName": "com.nextcloud.client",
        "tag": "CursorWindow",
        "timestamp": {
          "seconds": 1787142876,
          "nanos": 504903577
        }
      },
      "message": "Failed to read row 615, column 5 from a window with 615 rows, 52 columns"
},
```

### Changes

- Fetch batch by batch. Batch size is 100.
- Return ID from DB instead of `FileEntity`.

### How to reproduce crash?

1. Have 2K files and 2K folders in root directory.
2. Keep scroll
3. Crash