### PR TITLE
Fix missing local path for autouploaded files

### DIFF
--- a/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/app/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -1410,7 +1410,6 @@ public class UploadFileOperation extends SyncOperation {
 
             default:
                 Log_OC.d(TAG, "DEFAULT local behaviour will be handled");
-                mFile.setStoragePath("");
                 saveUploadedFile(client);
                 break;
         }


### PR DESCRIPTION
Files uploaded by autoupload do not have their filelist.media_path column populated in the db.
That is not the case for other workflows (i.e. manually uploading a single file).
This field allows them to be retrieved using FileDao.getFileByLocalPath(), in other words makes possible to reconstruct a file's origin.
The consequences of this change are still to be discussed, so marking as Draft.

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
