### PR TITLE
Fix ordering filter resetting on refresh in Favorites

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -880,12 +880,11 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             currentDirectory = directory;
         }
 
-        searchType = null;
-
         activity.runOnUiThread(this::notifyDataSetChanged);
     }
 
     public void prepareForSearchData(FileDataStorageManager storageManager, SearchType searchType) {
+        this.searchType = searchType;
         initStorageManagerShowShareAvatar(storageManager);
         clearSearchData(searchType);
     }


### PR DESCRIPTION
Fixes the ordering filter (top left button "A-Z") resetting to default value on Favorites when something triggers the refresh (manual pull to refresh, renaming a file...).
Also fixes the same filter not being retained after navigation away and back to Favorites.

### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI (N/A)
