### PR TITLE
Fix media view not being refreshed when selecting a different media folder

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.kt
@@ -97,7 +97,16 @@ class GallerySearchTask(
     private fun findLastTimestamp(remoteFiles: List<RemoteFile>): Long =
         remoteFiles.lastOrNull()?.modifiedTimestamp?.div(MILLIS_PER_SECOND) ?: NO_TIMESTAMP
 
-    private fun parseMedia(startDate: Long, endDate: Long, remoteFiles: List<RemoteFile>): Boolean {
+    /**
+     * Sync local media files with theirs remote counterparts for the provided timespan (downloads missing,
+     * deletes removed ones, updates metadata).
+     *
+     * @param startDate start of timespan
+     * @param endDate end of timespan
+     * @param remoteFiles list of remote files in the folder. Only ones in the provided timespan are taken into
+     * consideration.
+     */
+    private fun parseMedia(startDate: Long, endDate: Long, remoteFiles: List<RemoteFile>) {
         val localFiles = storageManager.getGalleryItems(startDate * MILLIS_PER_SECOND, endDate * MILLIS_PER_SECOND)
 
         if (BuildConfig.DEBUG) {
@@ -150,8 +159,6 @@ class GallerySearchTask(
                     " deleted: $filesDeleted unchanged: $unchangedFiles"
             )
         }
-
-        return filesAdded <= 0 && filesUpdated <= 0 && filesDeleted <= 0
     }
 
     private fun enrichFromLocalStorage(file: RemoteFile) {

--- a/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.kt
+++ b/app/src/main/java/com/owncloud/android/ui/asynctasks/GallerySearchTask.kt
@@ -89,7 +89,8 @@ class GallerySearchTask(
     private fun handleSuccess(operationResult: RemoteOperationResult<*>): Result {
         val remoteFiles = operationResult.data.filterIsInstance<RemoteFile>()
         val lastTimestamp = findLastTimestamp(remoteFiles)
-        val emptySearch = parseMedia(lastTimestamp, endDate, remoteFiles)
+        parseMedia(lastTimestamp, endDate, remoteFiles)
+        val emptySearch = remoteFiles.isEmpty()
         return Result(operationResult.code, emptySearch, lastTimestamp)
     }
 


### PR DESCRIPTION
How to reproduce:
- Open app
- Go to media view
- 3 dots menu -> select "Set media folder"
- Choose another media folder
- The view is not refreshed*

* = this may not happen the first time, as the check is successful if there have been changes in the media folder. If you can't reproduce, retry.


### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI (N/A)
