### PR TITLE
Keep grid item badges and labels attached to the cell

### DIFF
--- a/app/src/main/res/layout/grid_item.xml
+++ b/app/src/main/res/layout/grid_item.xml
@@ -53,11 +53,11 @@
         android:orientation="horizontal"
         android:padding="@dimen/standard_quarter_padding"
         android:translationZ="4dp"
-        app:layout_constraintBottom_toBottomOf="@+id/thumbnail"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/thumbnail"
+        app:layout_constraintEnd_toEndOf="@id/thumbnail"
         app:layout_constraintHorizontal_bias="0.85"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="@id/thumbnail"
+        app:layout_constraintTop_toTopOf="@id/thumbnail"
         app:layout_constraintVertical_bias="0.85">
 
         <ImageView
@@ -211,11 +211,9 @@
         android:text="@string/placeholder_filename"
         android:textSize="@dimen/grid_item_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintEnd_toStartOf="@id/more"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/thumbnail"
-        app:layout_constraintWidth_percent="0.75"
+        app:layout_constraintTop_toBottomOf="@id/thumbnail"
         tools:visibility="visible" />
 
     <ImageButton

--- a/app/src/main/res/layout/grid_item.xml
+++ b/app/src/main/res/layout/grid_item.xml
@@ -211,9 +211,11 @@
         android:text="@string/placeholder_filename"
         android:textSize="@dimen/grid_item_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/more"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/thumbnail"
+        app:layout_constraintWidth_percent="0.75"
         tools:visibility="visible" />
 
     <ImageButton


### PR DESCRIPTION
### Problem

In grid view the file feature badges (shared, favorite, video, live photo, synced) drift away from the thumbnail as the cell gets wider, and the overflow button drifts away from the file name it belongs to.

The thumbnail is a 1:1 `SquareImageView` whose resolved size is bounded by the cell height, so when a cell is wider than it is tall the drawn image is narrower than the cell. The badge cluster was positioned against the cell:

```xml
app:layout_constraintStart_toStartOf="parent"
app:layout_constraintEnd_toEndOf="parent"
app:layout_constraintHorizontal_bias="0.85"
```

so the 0.85 bias applied across the full cell width rather than across the image, pushing the badges into the empty space to the right of the thumbnail.

The file name had the matching problem from the other side: it was given 75% of the cell and centred, with the overflow button placed in the leftover gap, so on a wide cell the button drifted away from the label.

This is only visible when cells are wide, which is why it shows on tablets and in landscape on phones while looking correct in portrait on a phone, where the cell width is close to the image width.

### Fix

Anchor the badge cluster to the thumbnail so it stays on the image at any cell width, and let the file name take the width the overflow button does not need, which keeps the two together and leaves more room for the name.

Only `grid_item.xml` changes; no behaviour or code changes.

### Testing

Checked on a Samsung S23 and a Lenovo Tab P11 Pro (2nd gen), portrait and landscape, light and dark.