### PR TITLE
Add a grid density setting

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java
@@ -27,6 +27,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
@@ -966,6 +967,30 @@ public class SettingsActivity extends PreferenceActivity
                 return true;
             });
         }
+
+        setupGridDensityPreference();
+    }
+
+    /**
+     * The grid density shares its stored value with the pinch to zoom gesture in the file list,
+     * so picking a density here and pinching the grid are two ways of setting the same thing.
+     */
+    private void setupGridDensityPreference() {
+        if (!(findPreference("grid_density") instanceof ListPreference densityPref)) {
+            return;
+        }
+
+        densityPref.setValue(String.valueOf(Math.round(preferences.getGridColumns())));
+
+        densityPref.setOnPreferenceChangeListener((preference, newValue) -> {
+            try {
+                preferences.setGridColumns(Float.parseFloat(newValue.toString()));
+            } catch (NumberFormatException e) {
+                Log_OC.w(TAG, "Ignoring unusable grid density value: " + newValue);
+                return false;
+            }
+            return true;
+        });
     }
 
     private void updateThemePreferenceSummary(String themeValue) {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/AutofitGridLayoutManager.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/AutofitGridLayoutManager.kt
@@ -1,0 +1,55 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.owncloud.android.ui.fragment
+
+import android.content.Context
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * A [GridLayoutManager] that works out its own column count from the width it is actually given.
+ *
+ * The width is read during layout rather than from the display metrics, because the metrics are
+ * not a reliable stand in: they describe the display rather than the space this list occupies,
+ * they are not yet meaningful while the view is being created, and they can still describe the
+ * previous orientation while a rotation is being delivered.
+ *
+ * @param columnWidthProvider target width of a single column in pixels, read on every layout so
+ * that a changed preference is picked up without recreating the layout manager.
+ */
+class AutofitGridLayoutManager(context: Context, private val columnWidthProvider: () -> Int) :
+    GridLayoutManager(context, 1) {
+
+    private var lastWidth = 0
+    private var lastColumnWidth = 0
+
+    override fun onLayoutChildren(recycler: RecyclerView.Recycler?, state: RecyclerView.State?) {
+        updateSpanCount()
+        super.onLayoutChildren(recycler, state)
+    }
+
+    private fun updateSpanCount() {
+        val columnWidth = columnWidthProvider()
+        if (width <= 0 || columnWidth <= 0) {
+            return
+        }
+
+        if (width == lastWidth && columnWidth == lastColumnWidth) {
+            return
+        }
+
+        lastWidth = width
+        lastColumnWidth = columnWidth
+        spanCount = max(MIN_COLUMN_COUNT, (width.toFloat() / columnWidth).roundToInt())
+    }
+
+    companion object {
+        private const val MIN_COLUMN_COUNT = 2
+    }
+}

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -86,8 +86,6 @@ open class ExtendedListFragment :
     SearchView.OnQueryTextListener,
     SearchView.OnCloseListener,
     Injectable {
-    private var maxColumnSize = 5
-
     @Inject
     lateinit var preferences: AppPreferences
 
@@ -146,7 +144,7 @@ open class ExtendedListFragment :
 
     open fun switchToGridView() {
         if (!isGridEnabled) {
-            recyclerView?.layoutManager = GridLayoutManager(context, columnsCount)
+            recyclerView?.layoutManager = AutofitGridLayoutManager(requireContext()) { targetColumnWidth }
         }
     }
 
@@ -375,9 +373,8 @@ open class ExtendedListFragment :
                 mScale = gridLayoutManager.spanCount.toFloat()
             }
             mScale *= 2f - scaleFactor
-            mScale = max(MIN_COLUMN_SIZE, min(mScale, maxColumnSize.toFloat()))
-            val scaleInt = mScale.roundToInt()
-            gridLayoutManager.setSpanCount(scaleInt)
+            mScale = max(MIN_COLUMN_SIZE, min(mScale, MAX_COLUMN_SCALE))
+            gridLayoutManager.requestLayout()
             mRecyclerView?.adapter?.notifyDataSetChanged()
         }
     }
@@ -437,13 +434,23 @@ open class ExtendedListFragment :
         preferences.setGridColumns(mScale)
     }
 
-    open val columnsCount: Int
+    /**
+     * Target width of one grid column in pixels.
+     *
+     * [mScale] is a zoom level: asking for more columns than the default means asking for
+     * smaller cells. The column count itself is worked out by [AutofitGridLayoutManager] from
+     * the width the list is actually given.
+     */
+    internal val targetColumnWidth: Int
         get() {
-            if (mScale == -1f) {
-                return AppPreferencesImpl.DEFAULT_GRID_COLUMN.roundToInt()
-            }
-            return mScale.roundToInt()
+            val zoom = (if (mScale > 0f) mScale else AppPreferencesImpl.DEFAULT_GRID_COLUMN) /
+                AppPreferencesImpl.DEFAULT_GRID_COLUMN
+            return (resources.getDimension(R.dimen.grid_item_default_width) / zoom).roundToInt()
         }
+
+    open val columnsCount: Int
+        get() = (recyclerView?.layoutManager as? GridLayoutManager)?.spanCount
+            ?: AppPreferencesImpl.DEFAULT_GRID_COLUMN.roundToInt()
 
     /*
      * Restore index and position
@@ -778,15 +785,7 @@ open class ExtendedListFragment :
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 
-        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            maxColumnSize = 10
-        } else if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {
-            maxColumnSize = 5
-        }
-
-        if (isGridEnabled && columnsCount > maxColumnSize) {
-            (recyclerView?.layoutManager as GridLayoutManager).spanCount = maxColumnSize
-        }
+        // The column count follows the width the list is given, so nothing to do here.
     }
 
     protected fun setLayoutSwitchButton() {
@@ -821,5 +820,10 @@ open class ExtendedListFragment :
         private const val KEY_EMPTY_LIST_MESSAGE = "EMPTY_LIST_MESSAGE"
         private const val KEY_IS_GRID_VISIBLE = "IS_GRID_VISIBLE"
         private const val MIN_COLUMN_SIZE: Float = 2.0f
+
+        /**
+         * Highest number of columns the pinch gesture can select on a reference-width screen.
+         */
+        private const val MAX_COLUMN_SCALE: Float = 5.0f
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.kt
@@ -418,6 +418,21 @@ open class ExtendedListFragment :
         scrollToPosition(referencePosition)
     }
 
+    @SuppressLint("NotifyDataSetChanged")
+    override fun onResume() {
+        super.onResume()
+
+        // The density may have been changed in the settings while this list was in the
+        // background, and the stored value is only read when the view is created.
+        val stored = preferences.getGridColumns()
+        if (stored != mScale) {
+            mScale = stored
+            // The layout manager reads the target column width again on its next layout.
+            recyclerView?.requestLayout()
+            recyclerView?.adapter?.notifyDataSetChanged()
+        }
+    }
+
     override fun onSaveInstanceState(savedInstanceState: Bundle) {
         super.onSaveInstanceState(savedInstanceState)
         Log_OC.d(TAG, "onSaveInstanceState()")

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileListLayoutManager.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileListLayoutManager.kt
@@ -87,7 +87,7 @@ class FileListLayoutManager(private val fragment: OCFileListFragment, private va
 
         val layoutManager: RecyclerView.LayoutManager?
         if (grid) {
-            layoutManager = GridLayoutManager(context, fragment.columnsCount)
+            layoutManager = AutofitGridLayoutManager(context) { fragment.targetColumnWidth }
             layoutManager.spanSizeLookup = object : SpanSizeLookup() {
                 override fun getSpanSize(position: Int): Int = if (position == fragment.adapter.itemCount - 1 ||
                     (position == 0 && fragment.adapter.shouldShowHeader())

--- a/app/src/main/res/values/dims.xml
+++ b/app/src/main/res/values/dims.xml
@@ -46,6 +46,9 @@
     <dimen name="grid_recommended_item_reason_text_size">12sp</dimen>
     <dimen name="grid_bottom_view_height">20dp</dimen>
     <dimen name="grid_layout_item_size">10dp</dimen>
+    <!-- Width a grid cell aims for at the default zoom level; the number of columns
+         is derived from how many of these fit the window. -->
+    <dimen name="grid_item_default_width">140dp</dimen>
     <dimen name="grid_layout_margin_end">2dp</dimen>
     <dimen name="grid_sync_item_layout_next_text_size">22sp</dimen>
     <dimen name="grid_container_margin">2dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1549,4 +1549,15 @@
     <string name="governance_permission_denied">You do not have permission to change this label</string>
     <string name="file_info_governance_section_title">Governance</string>
     <string name="file_info_image_details_section_title">Image details</string>
+    <string name="prefs_grid_density_title">Grid density</string>
+    <string-array name="prefs_grid_density_entries">
+        <item>Spacious</item>
+        <item>Default</item>
+        <item>Compact</item>
+    </string-array>
+    <string-array name="prefs_grid_density_values" translatable="false">
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -48,6 +48,12 @@
             android:defaultValue="true"
             android:title="@string/sort_favorites_first"
             android:key="sort_favorites_first" />
+        <ListPreference
+            android:title="@string/prefs_grid_density_title"
+            android:key="grid_density"
+            android:entries="@array/prefs_grid_density_entries"
+            android:entryValues="@array/prefs_grid_density_values"
+            android:summary="%s" />
     </PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/prefs_category_details" android:key="details">


### PR DESCRIPTION
> **Depends on #17542.** This branch contains that commit as well; it will show only its own change once #17542 is merged. Please review that one first.

### Problem

The grid cell size can only be changed by pinching the file list, which is easy to miss and awkward to land on a particular size.

### Fix

Add a density setting (Spacious / Default / Compact) under Settings → Files. It writes the same stored value the pinch gesture uses, so the two stay in step and neither overrides the other.

The options set how large the cells are rather than a fixed column count, deliberately: a column count that suits a tablet leaves a phone with cells too narrow to read, which is the problem #17542 fixes. Expressed as cell size, one stored value works correctly on every screen.

The file list only read that value while creating its view, so a density picked in the settings did not reach a list that was already open, and the list then wrote its stale value back when it saved its state. It now reads the value again on resume.

### Testing

On a Samsung S23 the three options give 2 / 3 / 4 columns in portrait; on a Lenovo Tab P11 Pro (2nd gen) 4 / 5 / 7. Changing the setting takes effect on returning to the list, and the choice survives a restart.

New strings are added to `values/strings.xml` only.