### PR TITLE
Allow icon-only and clear-at-only status updates

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/SetStatusMessageBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/SetStatusMessageBottomSheet.kt
@@ -279,9 +279,14 @@ class SetStatusMessageBottomSheet(val user: User, val currentStatus: Status?) :
                 { dismiss(it) }
             )
         } else {
+            // The server rejects a status update whose message field is empty,
+            // even when the caller is only changing the icon or clearAt. Fall
+            // back to a single space so those single-field updates go through.
+            // Matches the fix applied in nextcloud/talk-android@a89c5952fa.
+            val message = binding.customStatusInput.text.toString().ifEmpty { " " }
             asyncRunner.postQuickTask(
                 SetUserDefinedCustomStatusTask(
-                    binding.customStatusInput.text.toString(),
+                    message,
                     binding.emoji.text.toString(),
                     clearAt,
                     accountManager.currentOwnCloudAccount?.savedAccount,


### PR DESCRIPTION
Fixes #9855.

The server rejects a status update whose message field is empty, even when the caller is only changing the icon or the clear-at time. That silently blocks the "only icon" and "only clear at" paths from the status dialog.

Substituting a single space when the input is empty lets the API accept those single-field updates, matching the fix that was already applied on the talk-android side: nextcloud/talk-android@a89c5952fa.

### Repro (from the issue)

1. Open the Status dialog with no existing custom message.
2. Pick an emoji, or pick a "Clear status message after" option — leave the message field blank.
3. Tap **Set status**.

Before: dialog closes but neither the icon nor the clear-at value is persisted.
After: the chosen icon and/or clear-at is stored server-side; the message field shows as a single space, which is what talk-android has been shipping for the same reason.