### PR TITLE
fix(notification): empty state

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/fragment/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/notifications/NotificationsFragment.kt
@@ -352,6 +352,9 @@ class NotificationsFragment :
         // after any action successfully completed remove the notification
         if (isSuccess) {
             adapter?.removeNotification(notification.notificationId)
+            if (adapter?.itemCount == 0) {
+                state = NotificationsUIState.Empty
+            }
         } else {
             adapter?.bindButtons(holder, notification)
             DisplayUtils.showSnackMessage(requireActivity(), getString(R.string.notification_action_failed))


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Issue

When a user has a notification with a primary and secondary action and presses one of them, the empty state of the notification fragment is not set correctly.

### Changes

Fix the empty state of the notification list.