### PR TITLE
fix(upload): limited file access

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,9 +49,10 @@
     -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" /> <!-- Runtime permissions introduced in Android 13 (API level 33) -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"
-        tools:ignore="PhotoAndVideoPolicy,SelectedPhotoAccess" />
+        tools:ignore="PhotoAndVideoPolicy" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"
-        tools:ignore="PhotoAndVideoPolicy,SelectedPhotoAccess" /> <!-- Needed for Android 14 (API level 34) -->
+        tools:ignore="PhotoAndVideoPolicy" /> <!-- Needed for Android 14 (API level 34) -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <!--

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -58,6 +58,7 @@ import com.owncloud.android.utils.PermissionUtil;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
@@ -117,6 +118,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     private SearchView mSearchView;
     private UploadFilesLayoutBinding binding;
     private boolean isWithinEncryptedFolder = false;
+    private String[] mChosenFilePaths;
 
     public LocalFileListFragment getFileListFragment() {
         return mFileListFragment;
@@ -523,13 +525,7 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
 
                 preferences.setUploaderBehaviour(FileUploadWorker.LOCAL_BEHAVIOUR_DELETE);
             } else {
-                final var chosenFiles = mFileListFragment.getCheckedFilePaths();
-                if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
-                    FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
-                    return;
-                }
-
-                data.putExtra(EXTRA_CHOSEN_FILES, chosenFiles);
+                data.putExtra(EXTRA_CHOSEN_FILES, filesToUpload);
                 data.putExtra(LOCAL_BASE_PATH, mCurrentDir.getAbsolutePath());
 
                 // set result code
@@ -688,15 +684,25 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
                     finish();
                 }
             } else {
-                final var chosenFiles = mFileListFragment.getCheckedFilePaths();
-                if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
-                    FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
-                    return;
-                }
-                boolean isPositionZero = (binding.uploadFilesSpinnerBehaviour.getSelectedItemPosition() == 0);
-                new CheckAvailableSpaceTask(this, chosenFiles).execute(isPositionZero);
+                collectChosenFiles(chosenFiles -> {
+                    boolean isPositionZero = (binding.uploadFilesSpinnerBehaviour.getSelectedItemPosition() == 0);
+                    new CheckAvailableSpaceTask(this, chosenFiles).execute(isPositionZero);
+                });
             }
         }
+    }
+
+    private void collectChosenFiles(Consumer<String[]> onCollected) {
+        mFileListFragment.collectCheckedFilePaths(chosenFiles -> {
+            if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
+                FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
+                return Unit.INSTANCE;
+            }
+
+            mChosenFilePaths = chosenFiles;
+            onCollected.accept(chosenFiles);
+            return Unit.INSTANCE;
+        });
     }
 
     private void showSubFolderWarningDialog() {
@@ -735,17 +741,12 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     @Override
     public void onConfirmation(String callerTag) {
         Log_OC.d(TAG, "Positive button in dialog was clicked; dialog tag is " + callerTag);
-        final var chosenFiles = mFileListFragment.getCheckedFilePaths();
-        if (chosenFiles.length > FileUploadHelper.MAX_FILE_COUNT) {
-            FileUploadHelper.Companion.instance().showFileUploadLimitMessage(this);
-            return;
-        }
 
-        if (QUERY_TO_MOVE_DIALOG_TAG.equals(callerTag)) {
+        if (QUERY_TO_MOVE_DIALOG_TAG.equals(callerTag) && mChosenFilePaths != null) {
             // return the list of selected files to the caller activity (success),
             // signaling that they should be moved to the ownCloud folder, instead of copied
             Intent data = new Intent();
-            data.putExtra(EXTRA_CHOSEN_FILES, chosenFiles);
+            data.putExtra(EXTRA_CHOSEN_FILES, mChosenFilePaths);
             data.putExtra(LOCAL_BASE_PATH, mCurrentDir.getAbsolutePath());
             setResult(RESULT_OK_AND_MOVE, data);
             finish();

--- a/app/src/main/java/com/owncloud/android/ui/adapter/localFileList/LocalFileListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/localFileList/LocalFileListAdapter.kt
@@ -90,13 +90,6 @@ class LocalFileListAdapter(
     val filesCount: Int
         get() = visibleEntries.size
 
-    val checkedFilesPath: Array<String>
-        get() {
-            val result = FileHelper.listFilesRecursive(checkedFiles)
-            Log_OC.d(TAG, "Returning ${result.size} selected files")
-            return result.toTypedArray()
-        }
-
     fun isCheckedFile(file: File): Boolean = checkedFiles.contains(file)
 
     fun onItemCheckboxClicked(file: File) {
@@ -142,10 +135,10 @@ class LocalFileListAdapter(
         return if (index < 0) RecyclerView.NO_POSITION else index + headerOffset
     }
 
-    private fun shouldShowHeader(): Boolean = !PermissionUtil.checkStoragePermission(activity)
+    private var showsPermissionBanner = !PermissionUtil.checkStoragePermission(activity)
 
     private val headerOffset: Int
-        get() = if (shouldShowHeader()) HEADER_ITEM_COUNT else 0
+        get() = if (showsPermissionBanner) HEADER_ITEM_COUNT else 0
 
     override fun getItemCount(): Int = visibleEntries.size + FOOTER_ITEM_COUNT + headerOffset
 
@@ -377,6 +370,25 @@ class LocalFileListAdapter(
     @VisibleForTesting
     fun setFiles(newFiles: List<File>) {
         showFirstPage(newFiles)
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun refreshPermissionBanner() {
+        showsPermissionBanner = !PermissionUtil.checkStoragePermission(activity)
+        notifyDataSetChanged()
+    }
+
+    fun collectCheckedFilePaths(onCompleted: (Array<String>) -> Unit) {
+        val selection = checkedFiles.toList()
+
+        backgroundScope.launch {
+            val paths = FileHelper.listFilesRecursive(selection).toTypedArray()
+            Log_OC.d(TAG, "Collected ${paths.size} selected files")
+
+            withContext(Dispatchers.Main) {
+                onCompleted(paths)
+            }
+        }
     }
 
     fun cleanup() {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/localfilelist/LocalFileListFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/localfilelist/LocalFileListFragment.kt
@@ -7,7 +7,6 @@
 
 package com.owncloud.android.ui.fragment.localfilelist
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.os.Environment
@@ -191,8 +190,7 @@ class LocalFileListFragment :
     //endregion
 
     //region File selection
-    val checkedFilePaths: Array<String>
-        get() = adapter.checkedFilesPath
+    fun collectCheckedFilePaths(onCompleted: (Array<String>) -> Unit) = adapter.collectCheckedFilePaths(onCompleted)
 
     val checkedFilesCount: Int
         get() = adapter.checkedFilesCount()
@@ -266,9 +264,8 @@ class LocalFileListFragment :
         adapter.setFiles(newFiles)
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     fun setupStoragePermissionWarningBanner() {
-        adapter.notifyDataSetChanged()
+        adapter.refreshPermissionBanner()
     }
     //endregion
 

--- a/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
+++ b/app/src/main/java/com/owncloud/android/utils/PermissionUtil.kt
@@ -175,25 +175,27 @@ object PermissionUtil {
 
     // region Storage permission checks
 
-    /**
-     * Checks if the application has storage/media access permissions.
-     *
-     * - Android 11+ (API 30+): Checks for MANAGE_EXTERNAL_STORAGE (all files system access)
-     * - Android 13+ (API 33+): Checks for granular media permissions (READ_MEDIA_IMAGES, READ_MEDIA_VIDEO)
-     * - Android 14+ (API 34+): Also checks for limited/partial media access (READ_MEDIA_VISUAL_USER_SELECTED)
-     * - Below Android 11: Uses legacy WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE permission
-     */
     @JvmStatic
-    fun checkStoragePermission(context: Context): Boolean = checkAllFilesAccess() || checkMediaAccess(context)
+    fun checkStoragePermission(context: Context): Boolean =
+        checkAllFilesAccess() || checkMediaAccess(context) || checkPartialMediaAccess(context)
 
     @JvmStatic
     fun checkAllFilesAccess(): Boolean =
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager()
 
-    fun checkMediaAccess(context: Context): Boolean = checkPermissions(context, getRequiredStoragePermissions())
+    fun checkMediaAccess(context: Context): Boolean = checkPermissions(context, getFullMediaAccessPermissions())
+
+    @JvmStatic
+    fun checkPartialMediaAccess(context: Context): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            checkSelfPermission(context, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)
 
     private fun getRequiredStoragePermissions() = when {
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> getApiLevel34StoragePermissions()
+        else -> getFullMediaAccessPermissions()
+    }
+
+    private fun getFullMediaAccessPermissions() = when {
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getApiLevel33StoragePermissions()
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> getApiLevel29StoragePermissions()
         else -> getLegacyStoragePermissions()


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

### Steps to reproduce

1. Clean install of the app
2. Storage permissions popup select "Media read-only"
3. Select "Allow limited access" for some specific files
4. Tap FAB button that opens local file listing
5. Select same media previously allowed and observe while select / unselect / select all media file
6. Tap upload button


**Actual Result:**

1. When selecting/deselecting media files or using the **Select All** option, the UI appears to hang. In some cases, media files cannot be manually selected or deselected.
2. Clicking the **Upload** button is unresponsive, and the upload process does not start. Only the **Cancel** button works.
3. The **Upload** option is also not clickable when accessed from the footer section.

**Expected Result:**
With **Read-Only** and **Limited Access** permissions, users should be able to upload files without any issues.

### Changes

- Fixes UI lag
- If user selects limited file access do not shows storage permission banner