### PR TITLE
fix(tags): apply server theme colors to manage tags UI

### DIFF
--- a/app/src/main/java/com/nextcloud/ui/tags/TagManagementBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/tags/TagManagementBottomSheet.kt
@@ -57,6 +57,8 @@ class TagManagementBottomSheet :
         bottomSheetDialog.behavior.skipCollapsed = true
 
         viewThemeUtils.platform.colorViewBackground(binding.bottomSheet, ColorRole.SURFACE)
+        viewThemeUtils.material.colorTextInputLayout(binding.searchInputLayout)
+        viewThemeUtils.material.colorProgressBar(binding.loadingIndicator)
 
         setupAdapter()
         setupSearch()
@@ -71,6 +73,7 @@ class TagManagementBottomSheet :
 
     private fun setupAdapter() {
         tagAdapter = TagListAdapter(
+            viewThemeUtils = viewThemeUtils,
             onTagChecked = { tag, isChecked ->
                 if (isChecked) {
                     viewModel.assignTag(tag)

--- a/app/src/main/java/com/nextcloud/ui/tags/adapter/TagListAdapter.kt
+++ b/app/src/main/java/com/nextcloud/ui/tags/adapter/TagListAdapter.kt
@@ -14,9 +14,13 @@ import com.nextcloud.ui.tags.adapter.viewholder.CreateTagViewHolder
 import com.nextcloud.ui.tags.adapter.viewholder.TagViewHolder
 import com.owncloud.android.R
 import com.owncloud.android.lib.resources.tags.Tag
+import com.owncloud.android.utils.theme.ViewThemeUtils
 
-class TagListAdapter(private val onTagChecked: (Tag, Boolean) -> Unit, private val onCreateTag: (String) -> Unit) :
-    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class TagListAdapter(
+    private val viewThemeUtils: ViewThemeUtils,
+    private val onTagChecked: (Tag, Boolean) -> Unit,
+    private val onCreateTag: (String) -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var tags: List<Tag> = emptyList()
     private var assignedTagIds: Set<String> = emptySet()
@@ -56,7 +60,7 @@ class TagListAdapter(private val onTagChecked: (Tag, Boolean) -> Unit, private v
             CreateTagViewHolder(view, onCreateTag)
         } else {
             val view = inflater.inflate(R.layout.tag_list_item, parent, false)
-            TagViewHolder(view, onTagChecked)
+            TagViewHolder(view, viewThemeUtils, onTagChecked)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/ui/tags/adapter/viewholder/TagViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/ui/tags/adapter/viewholder/TagViewHolder.kt
@@ -14,15 +14,20 @@ import androidx.core.graphics.toColorInt
 import androidx.recyclerview.widget.RecyclerView
 import com.owncloud.android.R
 import com.owncloud.android.lib.resources.tags.Tag
+import com.owncloud.android.utils.theme.ViewThemeUtils
 
-class TagViewHolder(itemView: View, private val onTagChecked: (Tag, Boolean) -> Unit) :
-    RecyclerView.ViewHolder(itemView) {
+class TagViewHolder(
+    itemView: View,
+    private val viewThemeUtils: ViewThemeUtils,
+    private val onTagChecked: (Tag, Boolean) -> Unit
+) : RecyclerView.ViewHolder(itemView) {
     private val colorDot: View = itemView.findViewById(R.id.tag_color_dot)
     private val tagName: TextView = itemView.findViewById(R.id.tag_name)
     private val checkBox: CheckBox = itemView.findViewById(R.id.tag_checkbox)
 
     fun bind(tag: Tag, isAssigned: Boolean) {
         tagName.text = tag.name
+        viewThemeUtils.platform.themeCheckbox(checkBox)
 
         val tagColor = tag.color
         if (tagColor != null) {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -330,6 +330,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener,
                                              .build());
         editChip.setEnsureMinTouchTargetSize(false);
         viewThemeUtils.material.themeChipSuggestion(editChip);
+        editChip.setChipIconTint(editChip.getTextColors());
         editChip.setOnClickListener(v -> {
             TagManagementBottomSheet bottomSheet = TagManagementBottomSheet.Companion.newInstance(
                 getFile().getLocalId(),


### PR DESCRIPTION
The manage tags edit chip icon was hardcoded black, making it invisible in dark mode, and the bottom sheet's search field, loading indicator, and checkboxes ignored the server's accent color, always rendering in Material's default blue.

Closes #17579

Assisted-by: ClaudeCode:claude-sonnet-5

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (N/A)
