### PR TITLE
Rename folders to match repo names

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
 
 /*
 Needed for local android library
-includeBuild("../android_library") {
+includeBuild("../android-library") {
     dependencySubstitution {
         substitute(module("com.github.nextcloud:android-library"))
             .using(project(":library"))
@@ -55,7 +55,7 @@ includeBuild("../android_library") {
 /*
 Needed for local android common library
 
-includeBuild("../android_common") {
+includeBuild("../android-common") {
     dependencySubstitution {
         substitute(module("com.github.nextcloud.android-common:core"))
             .using(project(":core"))


### PR DESCRIPTION
Usually git clone keeps the repo name, thus
android_library -> android-library
same for android-common

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI (N/A)
